### PR TITLE
Rename SurfaceId in preparation for volume-based surface definitions

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -283,6 +283,8 @@ int main(int argc, char* argv[])
                 CELER_LOG(critical)
                     << "Another exception occurred while finalizing output: "
                     << e.what();
+                // Write a null JSON oboject since we didn't output anything;
+                std::cout << "null\n";
             }
         }
         else

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -117,16 +117,7 @@ void log_state(Logger::Message& msg,
         msg << "\n- Volume ID: " << kce.volume();
     }
 
-    if (core_params && kce.surface())
-    {
-        if (auto* geo = dynamic_cast<GeoParamsSurfaceInterface const*>(
-                core_params->geometry().get()))
-        {
-            msg << "\n- Surface: " << geo->surfaces().at(kce.surface())
-                << " (ID=" << kce.surface() << ')';
-        }
-    }
-    else if (kce.surface())
+    if (kce.surface())
     {
         msg << "\n- Surface ID: " << kce.surface();
     }

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -132,7 +132,7 @@ void KernelContextException::initialize(CoreTrackView const& core)
             {
                 volume_ = geo.volume_id();
             }
-            surface_ = geo.surface_id();
+            surface_ = geo.internal_surface_id();
         }
     }
     {

--- a/src/celeritas/global/KernelContextException.hh
+++ b/src/celeritas/global/KernelContextException.hh
@@ -88,7 +88,7 @@ class KernelContextException : public RichContextException
     //! Volume ID
     VolumeId volume() const { return volume_; }
     //! Surface
-    SurfaceId surface() const { return surface_; }
+    InternalSurfaceId surface() const { return surface_; }
     //!@}
 
     //! Label of the kernel that died
@@ -106,7 +106,7 @@ class KernelContextException : public RichContextException
     Real3 pos_;
     Real3 dir_;
     VolumeId volume_;
-    SurfaceId surface_;
+    InternalSurfaceId surface_;
 
     std::string label_;
     std::string what_;

--- a/src/geocel/GeoParamsInterface.cc
+++ b/src/geocel/GeoParamsInterface.cc
@@ -13,8 +13,4 @@ namespace celeritas
 GeoParamsInterface::~GeoParamsInterface() = default;
 
 //---------------------------------------------------------------------------//
-//! Default virtual destructor
-GeoParamsSurfaceInterface::~GeoParamsSurfaceInterface() = default;
-
-//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -107,7 +107,7 @@ class GeoParamsSurfaceInterface : public GeoParamsInterface
   public:
     //!@{
     //! \name Type aliases
-    using SurfaceMap = LabelIdMultiMap<SurfaceId>;
+    using SurfaceMap = LabelIdMultiMap<InternalSurfaceId>;
     //!@}
 
   public:

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -97,30 +97,4 @@ class GeoParamsInterface
 };
 
 //---------------------------------------------------------------------------//
-/*!
- * Interface class for a host geometry that supports surfaces.
- *
- * \todo Remove this interface, use empty surface map instead
- */
-class GeoParamsSurfaceInterface : public GeoParamsInterface
-{
-  public:
-    //!@{
-    //! \name Type aliases
-    using SurfaceMap = LabelIdMultiMap<InternalSurfaceId>;
-    //!@}
-
-  public:
-    // Default destructor
-    ~GeoParamsSurfaceInterface() override = 0;
-
-    //! Get surface metadata
-    virtual SurfaceMap const& surfaces() const = 0;
-
-  protected:
-    GeoParamsSurfaceInterface() = default;
-    CELER_DEFAULT_COPY_MOVE(GeoParamsSurfaceInterface);
-};
-
-//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/GeoParamsOutput.cc
+++ b/src/geocel/GeoParamsOutput.cc
@@ -58,22 +58,6 @@ void GeoParamsOutput::output(JsonPimpl* j) const
         };
     }
 
-    // Save surface names
-    if (auto* surf_geo
-        = dynamic_cast<GeoParamsSurfaceInterface const*>(geo_.get()))
-    {
-        auto label = json::array();
-
-        auto const& surfaces = surf_geo->surfaces();
-        for (auto id : range(InternalSurfaceId{surfaces.size()}))
-        {
-            label.push_back(surfaces.at(id));
-        }
-        obj["surfaces"] = {
-            {"label", std::move(label)},
-        };
-    }
-
     j->obj = std::move(obj);
 }
 

--- a/src/geocel/GeoParamsOutput.cc
+++ b/src/geocel/GeoParamsOutput.cc
@@ -65,7 +65,7 @@ void GeoParamsOutput::output(JsonPimpl* j) const
         auto label = json::array();
 
         auto const& surfaces = surf_geo->surfaces();
-        for (auto id : range(SurfaceId{surfaces.size()}))
+        for (auto id : range(InternalSurfaceId{surfaces.size()}))
         {
             label.push_back(surfaces.at(id));
         }

--- a/src/geocel/Types.hh
+++ b/src/geocel/Types.hh
@@ -43,7 +43,7 @@ using LevelId = OpaqueId<struct Level_>;
 using GeoMatId = OpaqueId<struct GeoMaterial_>;
 
 //! Identifier for a surface (for surface-based geometries)
-using SurfaceId = OpaqueId<struct Surface_>;
+using InternalSurfaceId = OpaqueId<struct Surface_>;
 
 //! Identifier for a geometry volume that may be repeated
 using VolumeId = OpaqueId<struct Volume_>;

--- a/src/geocel/g4/GeantGeoTrackView.hh
+++ b/src/geocel/g4/GeantGeoTrackView.hh
@@ -87,8 +87,8 @@ class GeantGeoTrackView
 
     //!@{
     //! Geant4 states are never "on" a surface
-    SurfaceId surface_id() const { return {}; }
-    SurfaceId next_surface_id() const { return {}; }
+    InternalSurfaceId internal_surface_id() const { return {}; }
+    InternalSurfaceId next_internal_surface_id() const { return {}; }
     //!@}
 
     // Whether the track is outside the valid geometry region

--- a/src/geocel/vg/VecgeomTrackView.hh
+++ b/src/geocel/vg/VecgeomTrackView.hh
@@ -103,7 +103,7 @@ class VecgeomTrackView
 
     //!@{
     //! VecGeom states are never "on" a surface
-    CELER_FUNCTION SurfaceId surface_id() const { return {}; }
+    CELER_FUNCTION InternalSurfaceId internal_surface_id() const { return {}; }
     //!@}
 
     // Whether the track is outside the valid geometry region

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -40,7 +40,7 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
   public:
     //!@{
     //! \name Type aliases
-    using SurfaceMap = LabelIdMultiMap<SurfaceId>;
+    using SurfaceMap = LabelIdMultiMap<InternalSurfaceId>;
     using UniverseMap = LabelIdMultiMap<UniverseId>;
     //!@}
 

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -34,7 +34,7 @@ class GeantGeoParams;
  * This class initializes and manages the data used by ORANGE (surfaces,
  * volumes) and provides a host-based interface for them.
  */
-class OrangeParams final : public GeoParamsSurfaceInterface,
+class OrangeParams final : public GeoParamsInterface,
                            public ParamsDataInterface<OrangeParamsData>
 {
   public:
@@ -72,7 +72,7 @@ class OrangeParams final : public GeoParamsSurfaceInterface,
     //// LABELS AND MAPPING ////
 
     // Get surface metadata
-    inline SurfaceMap const& surfaces() const final;
+    inline SurfaceMap const& surfaces() const;
 
     // Get universe metadata
     inline UniverseMap const& universes() const;

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -87,6 +87,16 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
         return sizes;
     }();
 
+    // Save surface names
+    obj["surfaces"] = [&surfaces = orange_->surfaces()] {
+        auto label = json::array();
+        for (auto id : range(InternalSurfaceId{surfaces.size()}))
+        {
+            label.push_back(to_string(surfaces.at(id)));
+        }
+        return json::object({{"label", std::move(label)}});
+    }();
+
     //! \todo Make universe metadata accessible from ORANGE, and write it
 
     j->obj = std::move(obj);

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -99,9 +99,9 @@ class OrangeTrackView
     inline CELER_FUNCTION void volume_instance_id(Span<VolumeInstanceId>) const;
 
     // The current surface ID
-    inline CELER_FUNCTION SurfaceId surface_id() const;
+    inline CELER_FUNCTION InternalSurfaceId internal_surface_id() const;
     // After 'find_next_step', the next straight-line surface
-    inline CELER_FUNCTION SurfaceId next_surface_id() const;
+    inline CELER_FUNCTION InternalSurfaceId next_internal_surface_id() const;
     // Whether the track is outside the valid geometry region
     inline CELER_FUNCTION bool is_outside() const;
     // Whether the track is exactly on a surface
@@ -496,7 +496,7 @@ OrangeTrackView::volume_instance_id(Span<VolumeInstanceId> levels) const
 /*!
  * The current surface ID.
  */
-CELER_FUNCTION SurfaceId OrangeTrackView::surface_id() const
+CELER_FUNCTION InternalSurfaceId OrangeTrackView::internal_surface_id() const
 {
     if (this->is_on_boundary())
     {
@@ -506,7 +506,7 @@ CELER_FUNCTION SurfaceId OrangeTrackView::surface_id() const
     }
     else
     {
-        return SurfaceId{};
+        return InternalSurfaceId{};
     }
 }
 
@@ -514,7 +514,7 @@ CELER_FUNCTION SurfaceId OrangeTrackView::surface_id() const
 /*!
  * After 'find_next_step', the next straight-line surface.
  */
-CELER_FUNCTION SurfaceId OrangeTrackView::next_surface_id() const
+CELER_FUNCTION InternalSurfaceId OrangeTrackView::next_internal_surface_id() const
 {
     CELER_EXPECT(this->has_next_surface());
     auto lsa = this->make_lsa(this->next_surface_level());

--- a/src/orange/detail/UniverseIndexer.hh
+++ b/src/orange/detail/UniverseIndexer.hh
@@ -51,13 +51,13 @@ class UniverseIndexer
     UniverseIndexer(UniverseIndexerDataRef const& data);
 
     // Local-to-global
-    inline CELER_FUNCTION SurfaceId global_surface(UniverseId uni,
-                                                   LocalSurfaceId surface) const;
+    inline CELER_FUNCTION InternalSurfaceId
+    global_surface(UniverseId uni, LocalSurfaceId surface) const;
     inline CELER_FUNCTION VolumeId global_volume(UniverseId uni,
                                                  LocalVolumeId volume) const;
 
     // Global-to-local
-    inline CELER_FUNCTION LocalSurface local_surface(SurfaceId id) const;
+    inline CELER_FUNCTION LocalSurface local_surface(InternalSurfaceId id) const;
     inline CELER_FUNCTION LocalVolume local_volume(VolumeId id) const;
 
     //! Total number of universes
@@ -112,14 +112,14 @@ UniverseIndexer::UniverseIndexer(UniverseIndexerDataRef const& data)
 /*!
  * Transform local to global surface ID.
  */
-CELER_FUNCTION SurfaceId
+CELER_FUNCTION InternalSurfaceId
 UniverseIndexer::global_surface(UniverseId uni, LocalSurfaceId surf) const
 {
     CELER_EXPECT(uni < this->num_universes());
     CELER_EXPECT(surf < this->local_size(data_.surfaces, uni));
 
-    return SurfaceId(data_.surfaces[SizeId{uni.unchecked_get()}]
-                     + surf.unchecked_get());
+    return InternalSurfaceId(data_.surfaces[SizeId{uni.unchecked_get()}]
+                             + surf.unchecked_get());
 }
 
 //---------------------------------------------------------------------------//
@@ -141,7 +141,7 @@ CELER_FUNCTION VolumeId UniverseIndexer::global_volume(UniverseId uni,
  * Transform global to local surface ID.
  */
 CELER_FUNCTION UniverseIndexer::LocalSurface
-UniverseIndexer::local_surface(SurfaceId id) const
+UniverseIndexer::local_surface(InternalSurfaceId id) const
 {
     CELER_EXPECT(id < this->num_surfaces());
     auto iter = this->find_local(data_.surfaces, id.unchecked_get());

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -143,7 +143,7 @@ TEST_F(KernelContextExceptionTest, typical)
         if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
         {
             EXPECT_EQ(VolumeId{2}, e.volume());
-            EXPECT_EQ(SurfaceId{11}, e.surface());
+            EXPECT_EQ(InternalSurfaceId{11}, e.surface());
         }
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
             && CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)

--- a/test/geocel/GenericGeoTestBase.hh
+++ b/test/geocel/GenericGeoTestBase.hh
@@ -71,7 +71,7 @@ class GenericGeoTestBase : virtual public Test,
     //! Get the name of the current volume
     std::string volume_name(GeoTrackView const& geo) const;
     //! Get the name of the current surface if available
-    std::string surface_name(GeoTrackView const& geo) const;
+    virtual std::string surface_name(GeoTrackView const& geo) const;
     //! Get the stack of volume instances
     std::string all_volume_instance_names(GeoTrackView const& geo) const;
 

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -104,22 +104,10 @@ std::string GenericGeoTestBase<HP>::volume_name(GeoTrackView const& geo) const
 
 //---------------------------------------------------------------------------//
 template<class HP>
-std::string GenericGeoTestBase<HP>::surface_name(GeoTrackView const& geo) const
+std::string GenericGeoTestBase<HP>::surface_name(GeoTrackView const&) const
 {
-    if (!geo.is_on_boundary())
-    {
-        return "---";
-    }
-
-    auto* ptr = dynamic_cast<GeoParamsSurfaceInterface const*>(
-        this->geometry().get());
-    if (!ptr)
-    {
-        return "---";
-    }
-
-    // Only call this function if the geometry supports surfaces
-    return ptr->surfaces().at(geo.internal_surface_id()).name;
+    // TODO: use Surfaces class
+    return "---";
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -119,7 +119,7 @@ std::string GenericGeoTestBase<HP>::surface_name(GeoTrackView const& geo) const
     }
 
     // Only call this function if the geometry supports surfaces
-    return ptr->surfaces().at(geo.surface_id()).name;
+    return ptr->surfaces().at(geo.internal_surface_id()).name;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -244,10 +244,11 @@ VolumeId::size_type OrangeGeoTestBase::num_volumes() const
 /*!
  * Find the surface from its label (nullptr allowed)
  */
-SurfaceId OrangeGeoTestBase::find_surface(std::string const& label) const
+InternalSurfaceId
+OrangeGeoTestBase::find_surface(std::string const& label) const
 {
     CELER_EXPECT(params_);
-    SurfaceId surface_id = params_->surfaces().find_unique(label);
+    InternalSurfaceId surface_id = params_->surfaces().find_unique(label);
     CELER_VALIDATE(surface_id,
                    << "nonexistent surface label '" << label << '\'');
     return surface_id;

--- a/test/orange/OrangeGeoTestBase.hh
+++ b/test/orange/OrangeGeoTestBase.hh
@@ -99,7 +99,7 @@ class OrangeGeoTestBase : public OrangeTestBase
     VolumeId find_volume(std::string const& label) const;
 
     // Find the surface from its label (NULL pointer allowed)
-    SurfaceId find_surface(std::string const& label) const;
+    InternalSurfaceId find_surface(std::string const& label) const;
 
     // Surface name (or sentinel if no surface)
     std::string id_to_label(UniverseId uid, LocalSurfaceId surfid) const;

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -156,7 +156,7 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":3,"max_faces":14,"max_intersections":14,"max_logic_depth":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"inner_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":171,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indices":3,"universe_types":3,"volume_records":12}})json",
+        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":3,"max_faces":14,"max_intersections":14,"max_logic_depth":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"inner_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":171,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indices":3,"universe_types":3,"volume_records":12},"surfaces":{"label":["john.mx@outer","john.px@outer","john.my@outer","john.py@outer","john.mz@outer","john.pz@outer","bob.mx@outer","bob.px@outer","inner_a.my@outer","bob.my@outer","bob.mz@outer","inner_a.pz@outer","bob.pz@outer","bob.py@outer","gamma.mx@inner","inner_c.px@inner","gamma.my@inner","inner_c.py@inner","alpha.mz@inner","alpha.pz@inner","alpha.mx@inner","alpha.px@inner","alpha.my@inner","alpha.py@inner","beta.px@inner"]}})json",
         to_string(out));
 }
 
@@ -613,7 +613,7 @@ TEST_F(HexArrayTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":3,"max_faces":9,"max_intersections":10,"max_logic_depth":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"inner_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":585,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"universe_indices":4,"universe_types":4,"volume_records":58}})json",
+        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":3,"max_faces":9,"max_intersections":10,"max_logic_depth":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"inner_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":585,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"universe_indices":4,"universe_types":4,"volume_records":58},"surfaces":{"label":["outer.mx@global","outer.px@global","outer.my@global","outer.py@global","outer.mz@global","outer.pz@global","cylbound.coz@global","cylbound.mz@global","cylbound.pz@global","chex.p0@rhombarr","chex.p1@rhombarr","chex.p2@rhombarr","bbox_surface.mx@rhombarr","chex.p4@rhombarr","chex.p2@rhombarr","bbox_surface.mz@rhombarr","chex.mz@rhombarr","bbox_surface.pz@rhombarr","chex.p3@rhombarr","chex.p1@rhombarr","dhex.p2@rhombarr","dhex.p3@rhombarr","dhex.p2@rhombarr","chex.p0@rhombarr","chex.p1@rhombarr","chex.p2@rhombarr","chex.p0@rhombarr","chex.p1@rhombarr","dhex.p2@rhombarr","chex.p0@rhombarr","chex.p1@rhombarr","chex.p2@rhombarr","chex.p4@rhombarr","dhex.p4@rhombarr","dhex.p2@rhombarr","chex.p1@rhombarr","chex.p1@rhombarr","chex.p0@rhombarr","chex.p1@rhombarr","chex.p0@rhombarr","chex.p1@rhombarr","chex.p2@rhombarr","chex.p0@rhombarr","chex.p0@rhombarr","chex.p1@rhombarr","dhex.p5@rhombarr","chex.p0@rhombarr","chex.p0@rhombarr","dhex.p1@rhombarr","chex.p5@rhombarr","dhex.p0@rhombarr","bbox_surface.px@rhombarr","chex.p1@rhombarr"]}})json",
         to_string(out));
 }
 
@@ -675,7 +675,7 @@ TEST_F(InputBuilderTest, globalspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":1,"max_faces":2,"max_intersections":4,"max_logic_depth":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"inner_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indices":1,"universe_types":1,"volume_records":3}})json",
+        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":1,"max_faces":2,"max_intersections":4,"max_logic_depth":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"inner_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indices":1,"universe_types":1,"volume_records":3},"surfaces":{"label":["[EXTERIOR]@global","inner@s"]}})json",
         to_string(out));
 }
 
@@ -705,7 +705,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":1,"max_faces":3,"max_intersections":6,"max_logic_depth":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"inner_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indices":1,"universe_types":1,"volume_records":4}})json",
+        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":1,"max_faces":3,"max_intersections":6,"max_logic_depth":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"inner_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indices":1,"universe_types":1,"volume_records":4},"surfaces":{"label":["[EXTERIOR]@global","top@s","bottom@s"]}})json",
         to_string(out));
 }
 
@@ -812,7 +812,7 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":3,"max_faces":8,"max_intersections":14,"max_logic_depth":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"inner_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"universe_indices":7,"universe_types":7,"volume_records":24}})json",
+        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":3,"max_faces":8,"max_intersections":14,"max_logic_depth":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"inner_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"universe_indices":7,"universe_types":7,"volume_records":24},"surfaces":{"label":["[EXTERIOR]@global","d1:ext@s","d2:ext@s","bound@s","bound@mz","bound@pz","bound@cz","leaf1@s","d1:ext@s","d2:ext@s","leaf1@s","leaf2@s","bottom@pz"]}})json",
         to_string(out));
 }
 
@@ -821,7 +821,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":2,"max_faces":6,"max_intersections":6,"max_logic_depth":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"inner_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":38,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"universe_indices":2,"universe_types":2,"volume_records":6}})json",
+        R"json({"_category":"internal","_label":"orange","scalars":{"max_depth":2,"max_faces":6,"max_intersections":6,"max_logic_depth":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"inner_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":38,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"universe_indices":2,"universe_types":2,"volume_records":6},"surfaces":{"label":["[EXTERIOR]@global","bound@s","turd@mz","turd@pz","turd@p0","turd@p1","turd@p2","turd@p3"]}})json",
         to_string(out));
 }
 

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -576,7 +576,7 @@ TEST_F(Geant4Testem15Test, safety)
     EXPECT_VEC_SOFT_EQ(Real3({0, 0, 0}), geo.pos());
     EXPECT_VEC_SOFT_EQ(Real3({1, 0, 0}), geo.dir());
     EXPECT_EQ(VolumeId{1}, geo.volume_id());
-    EXPECT_EQ(SurfaceId{}, geo.surface_id());
+    EXPECT_EQ(InternalSurfaceId{}, geo.internal_surface_id());
     EXPECT_FALSE(geo.is_outside());
 
     // Safety at middle should be to the box boundary

--- a/test/orange/OrangeTestBase.cc
+++ b/test/orange/OrangeTestBase.cc
@@ -17,6 +17,18 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
+std::string OrangeTestBase::surface_name(GeoTrackView const& geo) const
+{
+    if (!geo.is_on_boundary())
+    {
+        return "---";
+    }
+
+    // Only call this function if the geometry supports surfaces
+    return this->geometry()->surfaces().at(geo.internal_surface_id()).name;
+}
+
+//---------------------------------------------------------------------------//
 template class CheckedGeoTrackView<OrangeTrackView>;
 template class GenericGeoTestBase<OrangeParams>;
 

--- a/test/orange/OrangeTestBase.hh
+++ b/test/orange/OrangeTestBase.hh
@@ -19,7 +19,11 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
-using OrangeTestBase = GenericGeoTestBase<OrangeParams>;
+class OrangeTestBase : public GenericGeoTestBase<OrangeParams>
+{
+  public:
+    std::string surface_name(GeoTrackView const& geo) const final;
+};
 
 extern template class CheckedGeoTrackView<OrangeTrackView>;
 extern template class GenericGeoTestBase<OrangeParams>;

--- a/test/orange/detail/UniverseIndexer.test.cc
+++ b/test/orange/detail/UniverseIndexer.test.cc
@@ -55,9 +55,9 @@ TEST_F(UniverseIndexerTest, single)
     EXPECT_EQ(4, indexer.num_surfaces());
     EXPECT_EQ(10, indexer.num_volumes());
 
-    EXPECT_EQ(SurfaceId(0),
+    EXPECT_EQ(InternalSurfaceId(0),
               indexer.global_surface(UniverseId{0}, LocalSurfaceId{0}));
-    EXPECT_EQ(SurfaceId(3),
+    EXPECT_EQ(InternalSurfaceId(3),
               indexer.global_surface(UniverseId{0}, LocalSurfaceId{3}));
 
     EXPECT_EQ(VolumeId(0),
@@ -65,10 +65,10 @@ TEST_F(UniverseIndexerTest, single)
     EXPECT_EQ(VolumeId(9),
               indexer.global_volume(UniverseId{0}, LocalVolumeId{9}));
 
-    auto local_s = indexer.local_surface(SurfaceId{0});
+    auto local_s = indexer.local_surface(InternalSurfaceId{0});
     EXPECT_EQ(UniverseId(0), local_s.universe);
     EXPECT_EQ(LocalSurfaceId(0), local_s.surface);
-    local_s = indexer.local_surface(SurfaceId{3});
+    local_s = indexer.local_surface(InternalSurfaceId{3});
     EXPECT_EQ(UniverseId(0), local_s.universe);
     EXPECT_EQ(LocalSurfaceId(3), local_s.surface);
 
@@ -94,7 +94,7 @@ TEST_F(UniverseIndexerTest, TEST_IF_CELERITAS_DEBUG(errors))
     EXPECT_THROW(indexer.global_volume(UniverseId{1}, LocalVolumeId{0}),
                  DebugError);
 
-    EXPECT_THROW(indexer.local_surface(SurfaceId(4)), DebugError);
+    EXPECT_THROW(indexer.local_surface(InternalSurfaceId(4)), DebugError);
     EXPECT_THROW(indexer.local_volume(VolumeId(10)), DebugError);
 }
 
@@ -119,7 +119,8 @@ TEST_F(UniverseIndexerTest, multi)
 
         for (auto s : range(surfaces_per_uni[u]))
         {
-            auto local = indexer.local_surface(SurfaceId{global_surface});
+            auto local
+                = indexer.local_surface(InternalSurfaceId{global_surface});
             EXPECT_EQ(u, local.universe.unchecked_get());
             EXPECT_EQ(s, local.surface.unchecked_get());
             EXPECT_EQ(global_surface,


### PR DESCRIPTION
For #1351 we need to define surfaces as the interfaces between volumes rather than the internal "infinite" surface definitions currently in use. To support debugging I've renamed it to InternalSurfaceId for now, and I've eliminated the SurfaceGeoInterface class.