### PR TITLE
Add geometry surface definitions to runtime

### DIFF
--- a/doc/_static/zotero.bib
+++ b/doc/_static/zotero.bib
@@ -2047,7 +2047,8 @@
   publisher = {IEEE},
   address = {Anaheim, CA, USA},
   doi = {10.1109/NSSMIC.1996.591410},
-  isbn = {978-0-7803-3534-9}
+  isbn = {978-0-7803-3534-9},
+  annotation = {UNIFIED model}
 }
 
 @article{li-gpubasedoptical-2023,

--- a/doc/implementation/geometry/interfaces.rst
+++ b/doc/implementation/geometry/interfaces.rst
@@ -4,6 +4,8 @@
 Interfaces
 ==========
 
+These classes manage access to geometric information throughout the codebase.
+
 .. doxygenclass:: celeritas::VolumeParams
 
 .. doxygenclass:: celeritas::SurfaceParams

--- a/doc/implementation/geometry/interfaces.rst
+++ b/doc/implementation/geometry/interfaces.rst
@@ -6,6 +6,8 @@ Interfaces
 
 .. doxygenclass:: celeritas::VolumeParams
 
+.. doxygenclass:: celeritas::SurfaceParams
+
 .. doxygenclass:: celeritas::GeoParamsInterface
 
 .. doxygenstruct:: celeritas::GeantPhysicalInstance

--- a/src/celeritas/user/SDData.hh
+++ b/src/celeritas/user/SDData.hh
@@ -23,10 +23,7 @@ struct SDParamsData
     Collection<DetectorId, W, M, VolumeId> detector;
 
     //! Whether the data is assigned
-    explicit CELER_FUNCTION operator bool() const
-    {
-        return (!detector.empty());
-    }
+    explicit CELER_FUNCTION operator bool() const { return !detector.empty(); }
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>

--- a/src/celeritas/user/SDParams.hh
+++ b/src/celeritas/user/SDParams.hh
@@ -7,12 +7,10 @@
 #pragma once
 
 #include "corecel/Assert.hh"
-#include "corecel/data/AuxInterface.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/CollectionMirror.hh"
 #include "corecel/data/ParamsDataInterface.hh"
 #include "corecel/io/Label.hh"
-#include "celeritas/user/DetectorSteps.hh"
 
 #include "SDData.hh"
 
@@ -32,10 +30,13 @@ class SDParams final : public ParamsDataInterface<SDParamsData>
 
   public:
     //! Default Constructor
-    SDParams() {};
+    SDParams() {}
 
     //! Construct from volume labels
     SDParams(VecLabel const& volume_labels, GeoParamsInterface const& geo);
+
+    //! Whether any detectors are present
+    bool empty() const { return !static_cast<bool>(mirror_); }
 
     //! Number of detectors
     DetectorId::size_type size() const { return volume_ids_.size(); }

--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND SOURCES
   GeoVolumeFinder.cc
   SurfaceParams.cc
   VolumeParams.cc
+  detail/SurfaceParamsBuilder.cc
   rasterize/Color.cc
   rasterize/Image.cc
   rasterize/ImageIO.json.cc

--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND SOURCES
   GeoParamsInterface.cc
   GeoParamsOutput.cc
   GeoVolumeFinder.cc
+  SurfaceParams.cc
   VolumeParams.cc
   rasterize/Color.cc
   rasterize/Image.cc

--- a/src/geocel/SurfaceData.hh
+++ b/src/geocel/SurfaceData.hh
@@ -1,0 +1,107 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/SurfaceData.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "geocel/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Store surface data corresponding to a volume.
+ *
+ * This stores information about the surfaces (both boundary and interface)
+ * of a volume. The \em boundary is a single optional surface ID, and the
+ * \em interface is an unzipped map \code (pre, post) -> surface \endcode.
+ *
+ * If \c interface_pre and \c interface_post are zipped, the result is \em
+ * sorted.  In other words, the pre-step surface can be searched with
+ * bisection, and the resulting subrange can also be searched with bisection to
+ * find the post-step surface. This then corresponds to the \c SurfaceId of
+ * that interface.
+ */
+struct VolumeSurfaceRecord
+{
+    //! Surface identifier for the volume boundary
+    SurfaceId boundary;
+
+    //! Sorted range of exiting volume instances (from this volume)
+    ItemRange<VolumeInstanceId> interface_pre;
+
+    //! Corresponding range of entering volume instances (to other volumes)
+    ItemRange<VolumeInstanceId> interface_post;
+
+    //! Surface IDs for the pre->post mapping
+    ItemRange<SurfaceId> interface;
+
+    //! True if valid data is present
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return boundary && !interface_pre.empty()
+               && interface_pre.size() == interface_post.size()
+               && interface_pre.size() == interface.size();
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Persistent data for mapping between volumes and their surfaces.
+ *
+ * This structure manages the relationship between volumes and their surfaces,
+ * particularly for tracking optical photons as they cross from one volume
+ * instance to another through shared surfaces.
+ *
+ * If no interface surfaces (aka 'border surface') are present then the backend
+ * storage arrays will be empty.
+ */
+template<Ownership W, MemSpace M>
+struct SurfaceParamsData
+{
+    //// TYPES ////
+
+    template<class T>
+    using VolumeItems = Collection<T, W, M, VolumeId>;
+    template<class T>
+    using Items = Collection<T, W, M>;
+
+    //// DATA ////
+
+    //! Surface properties for logical volumes
+    VolumeItems<VolumeSurfaceRecord> volume_surfaces;
+
+    //! Backend storage for PV->PV mapping
+    Items<VolumeInstanceId> volume_instance_ids;
+
+    //! Backend storage for surface interfaces
+    Items<SurfaceId> surface_ids;
+
+    //// METHODS ////
+
+    //! True if assigned
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return !volume_surfaces.empty();
+    }
+
+    //! Assign from another set of data
+    template<Ownership W2, MemSpace M2>
+    SurfaceParamsData& operator=(SurfaceParamsData<W2, M2> const& other)
+    {
+        CELER_EXPECT(other);
+
+        volume_surfaces = other.volume_surfaces;
+        volume_instance_ids = other.volume_instance_ids;
+
+        CELER_ENSURE(*this);
+        return *this;
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/SurfaceData.hh
+++ b/src/geocel/SurfaceData.hh
@@ -59,6 +59,10 @@ struct VolumeSurfaceRecord
  *
  * If no "interface" surfaces are present then the backend storage arrays will
  * be empty.
+ *
+ * \todo We might want to have separate arrays for boundary and interface
+ * surfaces since models typically have one or the other but not both, and it
+ * could potentially reduce memory access requirements.
  */
 template<Ownership W, MemSpace M>
 struct SurfaceParamsData

--- a/src/geocel/SurfaceData.hh
+++ b/src/geocel/SurfaceData.hh
@@ -39,14 +39,14 @@ struct VolumeSurfaceRecord
     ItemRange<VolumeInstanceId> interface_post;
 
     //! Surface IDs for the pre->post mapping
-    ItemRange<SurfaceId> interface;
+    ItemRange<SurfaceId> surface;
 
     //! True if valid data is present
     explicit CELER_FUNCTION operator bool() const
     {
         return boundary && !interface_pre.empty()
                && interface_pre.size() == interface_post.size()
-               && interface_pre.size() == interface.size();
+               && interface_pre.size() == surface.size();
     }
 };
 
@@ -99,6 +99,7 @@ struct SurfaceParamsData
         num_surfaces = other.num_surfaces;
         volume_surfaces = other.volume_surfaces;
         volume_instance_ids = other.volume_instance_ids;
+        surface_ids = other.surface_ids;
 
         CELER_ENSURE(*this);
         return *this;

--- a/src/geocel/SurfaceData.hh
+++ b/src/geocel/SurfaceData.hh
@@ -44,9 +44,10 @@ struct VolumeSurfaceRecord
     //! True if valid data is present
     explicit CELER_FUNCTION operator bool() const
     {
-        return boundary && !interface_pre.empty()
-               && interface_pre.size() == interface_post.size()
-               && interface_pre.size() == surface.size();
+        return boundary
+               || (!interface_pre.empty()
+                   && interface_pre.size() == interface_post.size()
+                   && interface_pre.size() == surface.size());
     }
 };
 

--- a/src/geocel/SurfaceData.hh
+++ b/src/geocel/SurfaceData.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/Assert.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "geocel/Types.hh"
@@ -53,12 +54,11 @@ struct VolumeSurfaceRecord
 /*!
  * Persistent data for mapping between volumes and their surfaces.
  *
- * This structure manages the relationship between volumes and their surfaces,
- * particularly for tracking optical photons as they cross from one volume
- * instance to another through shared surfaces.
+ * This structure stores device-compatible data relating volumes and their
+ * surfaces, primarily for optical physics at material interfaces.
  *
- * If no interface surfaces (aka 'border surface') are present then the backend
- * storage arrays will be empty.
+ * If no "interface" surfaces are present then the backend storage arrays will
+ * be empty.
  */
 template<Ownership W, MemSpace M>
 struct SurfaceParamsData
@@ -72,6 +72,9 @@ struct SurfaceParamsData
 
     //// DATA ////
 
+    //! Number of surfaces
+    SurfaceId::size_type num_surfaces{0};
+
     //! Surface properties for logical volumes
     VolumeItems<VolumeSurfaceRecord> volume_surfaces;
 
@@ -83,18 +86,17 @@ struct SurfaceParamsData
 
     //// METHODS ////
 
-    //! True if assigned
-    explicit CELER_FUNCTION operator bool() const
-    {
-        return !volume_surfaces.empty();
-    }
+    //! True if surfaces are present
+    explicit CELER_FUNCTION operator bool() const { return num_surfaces != 0; }
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>
     SurfaceParamsData& operator=(SurfaceParamsData<W2, M2> const& other)
     {
         CELER_EXPECT(other);
+        CELER_EXPECT(!other.volume_surfaces.empty());
 
+        num_surfaces = other.num_surfaces;
         volume_surfaces = other.volume_surfaces;
         volume_instance_ids = other.volume_instance_ids;
 

--- a/src/geocel/SurfaceParams.cc
+++ b/src/geocel/SurfaceParams.cc
@@ -1,0 +1,17 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/SurfaceParams.cc
+//---------------------------------------------------------------------------//
+#include "SurfaceParams.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+
+template class CollectionMirror<SurfaceParamsData>;
+template class ParamsDataInterface<SurfaceParamsData>;
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/SurfaceParams.cc
+++ b/src/geocel/SurfaceParams.cc
@@ -6,9 +6,56 @@
 //---------------------------------------------------------------------------//
 #include "SurfaceParams.hh"
 
+#include <algorithm>
+
+#include "corecel/data/CollectionMirror.hh"
+
+#include "SurfaceData.hh"
+#include "VolumeParams.hh"
+
+#include "detail/SurfaceParamsBuilder.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
+
+SurfaceParams::SurfaceParams(inp::Surfaces const& input,
+                             VolumeParams const& volumes)
+{
+    CELER_EXPECT(!input.surfaces.empty());
+
+    // Set up temporary storage
+    std::vector<detail::VolumeSurfaceData> temp_volume_surfaces;
+    std::vector<Label> surface_labels;
+
+    // Process input surfaces
+    detail::SurfaceInputInserter insert_surface(
+        volumes, &surface_labels, &temp_volume_surfaces);
+    std::for_each(input.surfaces.begin(), input.surfaces.end(), insert_surface);
+    labels_ = {"surfaces", std::move(surface_labels)};
+
+    data_ = CollectionMirror<SurfaceParamsData>{[&] {
+        // Convert the temporary data to device-compatible format
+        HostVal<SurfaceParamsData> host_data;
+        host_data.num_surfaces = labels_.size();
+        detail::VolumeSurfaceRecordBuilder build_record(
+            &host_data.volume_surfaces,
+            &host_data.volume_instance_ids,
+            &host_data.surface_ids);
+        std::for_each(temp_volume_surfaces.begin(),
+                      temp_volume_surfaces.end(),
+                      build_record);
+        return host_data;
+    }()};
+
+    CELER_ENSURE(data_);
+    CELER_ENSURE(labels_.size() == this->host_ref().num_surfaces);
+}
+
+SurfaceParams::SurfaceParams()
+{
+    labels_ = {"surfaces", {}};
+}
 
 template class CollectionMirror<SurfaceParamsData>;
 template class ParamsDataInterface<SurfaceParamsData>;

--- a/src/geocel/SurfaceParams.cc
+++ b/src/geocel/SurfaceParams.cc
@@ -30,7 +30,7 @@ SurfaceParams::SurfaceParams(inp::Surfaces const& input,
 
     // Process input surfaces
     detail::SurfaceInputInserter insert_surface(
-        volumes, &surface_labels, &temp_volume_surfaces);
+        volumes, surface_labels, temp_volume_surfaces);
     std::for_each(input.surfaces.begin(), input.surfaces.end(), insert_surface);
     labels_ = {"surfaces", std::move(surface_labels)};
 

--- a/src/geocel/SurfaceParams.hh
+++ b/src/geocel/SurfaceParams.hh
@@ -6,12 +6,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <vector>
-
 #include "corecel/cont/LabelIdMultiMap.hh"
 #include "corecel/data/CollectionMirror.hh"
 #include "corecel/data/ParamsDataInterface.hh"
-#include "corecel/io/Label.hh"
 
 #include "SurfaceData.hh"
 

--- a/src/geocel/SurfaceParams.hh
+++ b/src/geocel/SurfaceParams.hh
@@ -8,8 +8,10 @@
 
 #include <vector>
 
+#include "corecel/cont/LabelIdMultiMap.hh"
 #include "corecel/data/CollectionMirror.hh"
 #include "corecel/data/ParamsDataInterface.hh"
+#include "corecel/io/Label.hh"
 
 #include "SurfaceData.hh"
 
@@ -19,6 +21,7 @@ namespace inp
 {
 struct Surfaces;
 }
+class VolumeParams;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -43,11 +46,26 @@ class SurfaceParams final : public ParamsDataInterface<SurfaceParamsData>
   public:
     //!@{
     //! \name Type aliases
+    using SurfaceMap = LabelIdMultiMap<SurfaceId>;
     //!@}
 
   public:
     // Construct from surface input
-    explicit SurfaceParams(inp::Surfaces const&);
+    SurfaceParams(inp::Surfaces const&, VolumeParams const& volumes);
+
+    // Construct without surfaces
+    SurfaceParams();
+
+    //// METADATA ACCESS ////
+
+    //! Whether any surfaces are present
+    bool empty() const { return !static_cast<bool>(data_); }
+
+    //! Number of surfaces
+    SurfaceId::size_type num_surfaces() const { return labels_.size(); }
+
+    //! Get surface metadata
+    SurfaceMap const& labels() const { return labels_; }
 
     //// DATA ACCESS ////
 
@@ -60,6 +78,8 @@ class SurfaceParams final : public ParamsDataInterface<SurfaceParamsData>
   private:
     // Host/device storage and reference
     CollectionMirror<SurfaceParamsData> data_;
+    // Metadata: surface labels
+    SurfaceMap labels_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/SurfaceParams.hh
+++ b/src/geocel/SurfaceParams.hh
@@ -24,17 +24,14 @@ class VolumeParams;
 /*!
  * Map volumetric geometry information to surface IDs.
  *
- * A surface is defined as a contiguous area on the boundary of a volume,
- * sometimes on only a single side of the volume. (This is different to the
- * infinite surfaces of ORANGE and the surface frames of VecGeom.) \b Interface
- * surfaces are one-directional surfaces defined as the interface from one
- * volume instance to another, called "border surfaces" in Geant4. \b Boundary
- * surfaces surround an entire volume and are called "skin" in Geant4.
+ * See the introduction to \rstref{the Geometry API section,api_geometry} for
+ * a detailed description of surfaces in the detector geometry description.
  *
  * The specification of \em surfaces using \em volume relationships is required
  * by volume-based geometries such as Geant4 and VecGeom 1, so it is not
  * currently possible to define different properties for the different \em
- * faces of a volume. However, since ORANGE and VecGeom 2 support true surface
+ * faces of a volume unless those faces are surrounded by distinct geometric
+ * volumes. Since ORANGE and VecGeom 2 support true surface
  * definitions, a future extension will allow the user to attach surface
  * properties to, for example, different sides of a cube.
  */

--- a/src/geocel/SurfaceParams.hh
+++ b/src/geocel/SurfaceParams.hh
@@ -1,0 +1,71 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/SurfaceParams.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <vector>
+
+#include "corecel/data/CollectionMirror.hh"
+#include "corecel/data/ParamsDataInterface.hh"
+
+#include "SurfaceData.hh"
+
+namespace celeritas
+{
+namespace inp
+{
+struct Surfaces;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Map volumetric geometry information to surface IDs.
+ *
+ * A surface is defined as a contiguous area on the boundary of a volume,
+ * sometimes on only a single side of the volume. (This is different to the
+ * infinite surfaces of ORANGE and the surface frames of VecGeom.) \b Interface
+ * surfaces are one-directional surfaces defined as the interface from one
+ * volume instance to another, called "border surfaces" in Geant4. \b Boundary
+ * surfaces surround an entire volume and are called "skin" in Geant4.
+ *
+ * The specification of \em surfaces using \em volume relationships is required
+ * by volume-based geometries such as Geant4 and VecGeom 1, so it is not
+ * currently possible to define different properties for the different \em
+ * faces of a volume. However, since ORANGE and VecGeom 2 support true surface
+ * definitions, a future extension will allow the user to attach surface
+ * properties to, for example, different sides of a cube.
+ */
+class SurfaceParams final : public ParamsDataInterface<SurfaceParamsData>
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    //!@}
+
+  public:
+    // Construct from surface input
+    explicit SurfaceParams(inp::Surfaces const&);
+
+    //// DATA ACCESS ////
+
+    //! Reference to CPU geometry data
+    HostRef const& host_ref() const final { return data_.host_ref(); }
+
+    //! Reference to managed GPU geometry data
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
+
+  private:
+    // Host/device storage and reference
+    CollectionMirror<SurfaceParamsData> data_;
+};
+
+//---------------------------------------------------------------------------//
+
+extern template class CollectionMirror<SurfaceParamsData>;
+extern template class ParamsDataInterface<SurfaceParamsData>;
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/Types.hh
+++ b/src/geocel/Types.hh
@@ -49,10 +49,10 @@ using InternalSurfaceId = OpaqueId<struct Surface_>;
 using SurfaceId = OpaqueId<struct Surface_, unsigned int>;
 
 //! Identifier for a geometry volume that may be repeated
-using VolumeId = OpaqueId<struct Volume_>;
+using VolumeId = OpaqueId<struct Volume_, unsigned int>;
 
 //! Identifier for an instance of a geometry volume (aka physical/placed)
-using VolumeInstanceId = OpaqueId<struct VolumeInstance_>;
+using VolumeInstanceId = OpaqueId<struct VolumeInstance_, unsigned int>;
 
 //! Identifier for a unique volume in global space (aka touchable)
 using VolumeUniqueInstanceId = OpaqueId<struct VolumeInstance_, ull_int>;

--- a/src/geocel/VolumeSurfaceView.hh
+++ b/src/geocel/VolumeSurfaceView.hh
@@ -18,7 +18,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Access surface properties attached for volume.
+ * Access surface properties attached to a volume.
  *
  * This class provides a view into surface data for a specific volume, usually
  * an exiting volume, allowing access to its optional boundary surfaces

--- a/src/geocel/VolumeSurfaceView.hh
+++ b/src/geocel/VolumeSurfaceView.hh
@@ -10,6 +10,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
+#include "corecel/math/Algorithms.hh"
 #include "geocel/Types.hh"
 
 #include "SurfaceData.hh"
@@ -47,7 +48,7 @@ class VolumeSurfaceView
     // Check if this volume has least one interface surface
     CELER_FORCEINLINE_FUNCTION bool has_interface() const;
 
-    // Find surface ID for a transition to another volume instances
+    // Find surface ID for a transition to another volume instance
     inline CELER_FUNCTION SurfaceId
     find_interface(VolumeInstanceId pre_id, VolumeInstanceId post_id) const;
 
@@ -87,7 +88,7 @@ CELER_FUNCTION auto VolumeSurfaceView::volume_id() const -> VolumeId
 /*!
  * Get the optional boundary surface ID for this volume.
 
- * If the result is null,
+ * If the result is null, no boundary surface is present.
  */
 CELER_FUNCTION SurfaceId VolumeSurfaceView::boundary_id() const
 {
@@ -109,9 +110,10 @@ CELER_FUNCTION bool VolumeSurfaceView::has_interface() const
  *
  * This searches for the surface ID associated with a pre->post
  * volume instance transition.
- * \todo The current implementation as a linear search, which is unsuitable for
+ *
+ * \todo The current implementation uses linear search, which is unsuitable for
  * complex detectors such as LHCB's RICH, whose pvRichGrandPMTQuartz has 770
- * specific interfaces. We should either implenent an \c equal_range function
+ * specific interfaces. We should either implement an \c equal_range function
  * for searching these sorted arrays, or (better) use a hash lookup for {pre,
  * post} -> surface.
  *

--- a/src/geocel/VolumeSurfaceView.hh
+++ b/src/geocel/VolumeSurfaceView.hh
@@ -1,0 +1,180 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/VolumeSurfaceView.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/data/Collection.hh"
+#include "geocel/Types.hh"
+
+#include "SurfaceData.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Access surface properties attached for volume.
+ *
+ * This class provides a view into surface data for a specific volume, usually
+ * an exiting volume, allowing access to its optional boundary surfaces
+ * (surrounding the entire volume) and optional interface surfaces to an
+ * adjacent volume.
+ */
+class VolumeSurfaceView
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using SurfaceParamsRef = NativeCRef<SurfaceParamsData>;
+    //!@}
+
+  public:
+    // Construct from params and pre-step volume ID
+    inline CELER_FUNCTION
+    VolumeSurfaceView(SurfaceParamsRef const& params, VolumeId id);
+
+    // ID of the Volume
+    CELER_FORCEINLINE_FUNCTION VolumeId volume_id() const;
+
+    // ID of the boundary surface for this volume, if any
+    CELER_FORCEINLINE_FUNCTION SurfaceId boundary_id() const;
+
+    // Check if this volume has least one interface surface
+    CELER_FORCEINLINE_FUNCTION bool has_interface() const;
+
+    // Find surface ID for a transition to another volume instances
+    inline CELER_FUNCTION SurfaceId
+    find_interface(VolumeInstanceId pre_id, VolumeInstanceId post_id) const;
+
+  private:
+    SurfaceParamsRef const& params_;
+    VolumeId volume_;
+
+    // HELPER FUNCTIONS
+
+    CELER_FORCEINLINE_FUNCTION VolumeSurfaceRecord const& volume_record() const;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from surface parameters and volume ID.
+ */
+CELER_FUNCTION
+VolumeSurfaceView::VolumeSurfaceView(SurfaceParamsRef const& params,
+                                     VolumeId id)
+    : params_(params), volume_(id)
+{
+    CELER_EXPECT(id < params.volume_surfaces.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the volume ID being viewed.
+ */
+CELER_FUNCTION auto VolumeSurfaceView::volume_id() const -> VolumeId
+{
+    return volume_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the optional boundary surface ID for this volume.
+
+ * If the result is null,
+ */
+CELER_FUNCTION SurfaceId VolumeSurfaceView::boundary_id() const
+{
+    return this->volume_record().boundary;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Check if this volume has at least one interface surface.
+ */
+CELER_FUNCTION bool VolumeSurfaceView::has_interface() const
+{
+    return !this->volume_record().surface.empty();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find the surface ID for a transition between volume instances.
+ *
+ * This searches for the surface ID associated with a pre->post
+ * volume instance transition.
+ * \todo The current implementation as a linear search, which is unsuitable for
+ * complex detectors such as LHCB's RICH, whose pvRichGrandPMTQuartz has 770
+ * specific interfaces. We should either implenent an \c equal_range function
+ * for searching these sorted arrays, or (better) use a hash lookup for {pre,
+ * post} -> surface.
+ *
+ * \return The surface ID if found, or an invalid ID if not found.
+ */
+CELER_FUNCTION SurfaceId VolumeSurfaceView::find_interface(
+    VolumeInstanceId pre_id, VolumeInstanceId post_id) const
+{
+    auto const& record = this->volume_record();
+    auto get_volinst_id
+        = [this](auto item) { return params_.volume_instance_ids[item]; };
+    for (size_type index = 0; index < record.interface_pre.size(); ++index)
+    {
+        {
+            VolumeInstanceId cur_pre_id
+                = get_volinst_id(record.interface_pre[index]);
+            if (pre_id < cur_pre_id)
+            {
+                // Past range of pre-step IDs: volume isn't in array
+                break;
+            }
+            else if (cur_pre_id < pre_id)
+            {
+                // Before range; keep going
+                continue;
+            }
+        }
+        {
+            VolumeInstanceId cur_post_id
+                = get_volinst_id(record.interface_post[index]);
+            if (post_id < cur_post_id)
+            {
+                // Past range of post-step IDs
+                break;
+            }
+            else if (cur_post_id < post_id)
+            {
+                // Before range; keep going
+                continue;
+            }
+        }
+        // Pre and post now match
+        CELER_ASSERT(index < record.surface.size());
+        auto surf_id_offset = record.surface[index];
+        CELER_ASSERT(surf_id_offset < params_.surface_ids.size());
+        auto result = params_.surface_ids[surf_id_offset];
+        CELER_ENSURE(result);
+        return result;
+    }
+    return {};
+}
+
+//---------------------------------------------------------------------------//
+// PRIVATE METHODS
+//---------------------------------------------------------------------------//
+/*!
+ * Get the volume surface record for the current volume.
+ */
+CELER_FUNCTION VolumeSurfaceRecord const&
+VolumeSurfaceView::volume_record() const
+{
+    return params_.volume_surfaces[volume_];
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/detail/SurfaceParamsBuilder.cc
+++ b/src/geocel/detail/SurfaceParamsBuilder.cc
@@ -1,0 +1,210 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/detail/SurfaceParamsBuilder.cc
+//---------------------------------------------------------------------------//
+#include "SurfaceParamsBuilder.hh"
+
+#include "corecel/Assert.hh"
+#include "corecel/OpaqueId.hh"
+#include "corecel/io/Logger.hh"
+#include "geocel/Types.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+// SurfaceInputInserter INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Get the next surface ID to be added.
+ */
+SurfaceId SurfaceInputInserter::next_surface_id() const
+{
+    return id_cast<SurfaceId>(labels_->size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the label for a volume ID.
+ */
+Label const& SurfaceInputInserter::label(VolumeId vol_id) const
+{
+    CELER_EXPECT(vol_id < volumes_.num_volumes());
+    return volumes_.volume_labels().at(vol_id);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the label for a volume instance ID.
+ */
+Label const& SurfaceInputInserter::label(VolumeInstanceId vol_inst_id) const
+{
+    CELER_EXPECT(vol_inst_id < volumes_.num_volume_instances());
+    return volumes_.volume_instance_labels().at(vol_inst_id);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the label for a surface ID.
+ */
+Label const& SurfaceInputInserter::label(SurfaceId surface_id) const
+{
+    CELER_EXPECT(surface_id < labels_->size());
+    return (*labels_)[surface_id.get()];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with pointers to target data and volume params.
+ */
+SurfaceInputInserter::SurfaceInputInserter(
+    VolumeParams const& volumes,
+    std::vector<Label>* labels,
+    std::vector<VolumeSurfaceData>* volume_surfaces)
+    : volumes_(volumes), labels_{labels}, volume_surfaces_(volume_surfaces)
+{
+    CELER_EXPECT(labels_ && volume_surfaces_);
+    CELER_EXPECT(labels_->empty());
+
+    // Resize the vector to match the number of volumes
+    volume_surfaces_->resize(volumes_.num_volumes());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Process an input surface and return its ID.
+ */
+SurfaceId SurfaceInputInserter::operator()(inp::Surface const& surf)
+{
+    CELER_ASSUME(!surf.surface.valueless_by_exception());
+    SurfaceId result;
+    try
+    {
+        result = std::visit(*this, surf.surface);
+    }
+    catch (RuntimeError& e)
+    {
+        CELER_LOG(error) << "While processing surface '" << surf.label << "'";
+        throw;
+    }
+    labels_->push_back(surf.label);
+    CELER_ENSURE(result);
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Process a boundary surface.
+ */
+SurfaceId SurfaceInputInserter::operator()(inp::Surface::Boundary const& vol_id)
+{
+    CELER_EXPECT(vol_id < volumes_.num_volumes());
+
+    auto& vol_data = (*volume_surfaces_)[vol_id.get()];
+
+    // Check if a boundary already exists for this volume
+    SurfaceId surf_id = this->next_surface_id();
+    CELER_VALIDATE(!vol_data.boundary,
+                   << "duplicate boundary surface for volume '"
+                   << this->label(vol_id) << "': existing surface is'"
+                   << this->label(vol_data.boundary) << "'");
+    vol_data.boundary = surf_id;
+    return surf_id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Process an interface surface.
+ */
+SurfaceId
+SurfaceInputInserter::operator()(inp::Surface::Interface const& interface)
+{
+    CELER_EXPECT(interface.first < volumes_.num_volume_instances());
+    CELER_EXPECT(interface.second < volumes_.num_volume_instances());
+
+    // Get the volume associated with the pre-step volume instance
+    VolumeId pre_vol_id = volumes_.volume(interface.first);
+    CELER_ASSERT(pre_vol_id < volume_surfaces_->size());
+    auto& vol_data = (*volume_surfaces_)[pre_vol_id.get()];
+
+    // Try to insert the new mapping
+    SurfaceId surf_id = this->next_surface_id();
+    auto [iter, inserted] = vol_data.interfaces.insert({interface, surf_id});
+    CELER_VALIDATE(inserted,
+                   << "duplicate interface surface between volume instances '"
+                   << this->label(interface.first) << "' and '"
+                   << this->label(interface.second)
+                   << "': existing surface is '" << this->label(iter->second)
+                   << "'");
+
+    return surf_id;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with pointers to target collections.
+ */
+VolumeSurfaceRecordBuilder::VolumeSurfaceRecordBuilder(
+    VolumeItems<VolumeSurfaceRecord>* volume_surfaces,
+    Items<VolumeInstanceId>* volume_instance_ids,
+    Items<SurfaceId>* surface_ids)
+    : volume_surfaces_{volume_surfaces}
+    , volume_instance_ids_{volume_instance_ids}
+    , surface_ids_{surface_ids}
+{
+    CELER_EXPECT(volume_surfaces && volume_instance_ids && surface_ids);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert VolumeSurfaceData to VolumeSurfaceRecord.
+ */
+VolumeId VolumeSurfaceRecordBuilder::operator()(VolumeSurfaceData const& data)
+{
+    VolumeSurfaceRecord record;
+
+    // Set boundary surface ID if it exists
+    record.boundary = data.boundary;
+
+    if (!data.interfaces.empty())
+    {
+        // Flatten the interface map into sorted arrays
+
+        // Save "pre" volume instance IDs
+        auto pre_start = volume_instance_ids_.size_id();
+        for (auto const& [key, surf_id] : data.interfaces)
+        {
+            CELER_DISCARD(surf_id);
+            volume_instance_ids_.push_back(key.first);
+        }
+
+        // Save "post" volume instance IDs and surface IDs
+        auto post_start = volume_instance_ids_.size_id();
+        auto surf_start = surface_ids_.size_id();
+        for (auto const& [key, surf_id] : data.interfaces)
+        {
+            // Add post volume instance ID and surface ID
+            volume_instance_ids_.push_back(key.second);
+            surface_ids_.push_back(surf_id);
+        }
+
+        // Set up ranges in the record
+        record.interface_pre = {pre_start, post_start};
+        record.interface_post = {post_start, volume_instance_ids_.size_id()};
+        record.surface = {surf_start, surface_ids_.size_id()};
+
+        CELER_ASSERT(record.interface_pre.size()
+                     == record.interface_post.size());
+        CELER_ASSERT(record.interface_pre.size() == record.surface.size());
+    }
+
+    // Add the record to the collection
+    return volume_surfaces_.push_back(record);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/geocel/detail/SurfaceParamsBuilder.cc
+++ b/src/geocel/detail/SurfaceParamsBuilder.cc
@@ -23,7 +23,7 @@ namespace detail
  */
 SurfaceId SurfaceInputInserter::next_surface_id() const
 {
-    return id_cast<SurfaceId>(labels_->size());
+    return id_cast<SurfaceId>(labels_.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -52,8 +52,8 @@ Label const& SurfaceInputInserter::label(VolumeInstanceId vol_inst_id) const
  */
 Label const& SurfaceInputInserter::label(SurfaceId surface_id) const
 {
-    CELER_EXPECT(surface_id < labels_->size());
-    return (*labels_)[surface_id.get()];
+    CELER_EXPECT(surface_id < labels_.size());
+    return labels_[surface_id.get()];
 }
 
 //---------------------------------------------------------------------------//
@@ -62,15 +62,14 @@ Label const& SurfaceInputInserter::label(SurfaceId surface_id) const
  */
 SurfaceInputInserter::SurfaceInputInserter(
     VolumeParams const& volumes,
-    std::vector<Label>* labels,
-    std::vector<VolumeSurfaceData>* volume_surfaces)
+    std::vector<Label>& labels,
+    std::vector<VolumeSurfaceData>& volume_surfaces)
     : volumes_(volumes), labels_{labels}, volume_surfaces_(volume_surfaces)
 {
-    CELER_EXPECT(labels_ && volume_surfaces_);
-    CELER_EXPECT(labels_->empty());
+    CELER_EXPECT(labels_.empty());
 
     // Resize the vector to match the number of volumes
-    volume_surfaces_->resize(volumes_.num_volumes());
+    volume_surfaces_.resize(volumes_.num_volumes());
 }
 
 //---------------------------------------------------------------------------//
@@ -90,7 +89,7 @@ SurfaceId SurfaceInputInserter::operator()(inp::Surface const& surf)
         CELER_LOG(error) << "While processing surface '" << surf.label << "'";
         throw;
     }
-    labels_->push_back(surf.label);
+    labels_.push_back(surf.label);
     CELER_ENSURE(result);
     return result;
 }
@@ -103,7 +102,7 @@ SurfaceId SurfaceInputInserter::operator()(inp::Surface::Boundary const& vol_id)
 {
     CELER_EXPECT(vol_id < volumes_.num_volumes());
 
-    auto& vol_data = (*volume_surfaces_)[vol_id.get()];
+    auto& vol_data = volume_surfaces_[vol_id.get()];
 
     // Check if a boundary already exists for this volume
     SurfaceId surf_id = this->next_surface_id();
@@ -127,8 +126,8 @@ SurfaceInputInserter::operator()(inp::Surface::Interface const& interface)
 
     // Get the volume associated with the pre-step volume instance
     VolumeId pre_vol_id = volumes_.volume(interface.first);
-    CELER_ASSERT(pre_vol_id < volume_surfaces_->size());
-    auto& vol_data = (*volume_surfaces_)[pre_vol_id.get()];
+    CELER_ASSERT(pre_vol_id < volume_surfaces_.size());
+    auto& vol_data = volume_surfaces_[pre_vol_id.get()];
 
     // Try to insert the new mapping
     SurfaceId surf_id = this->next_surface_id();

--- a/src/geocel/detail/SurfaceParamsBuilder.hh
+++ b/src/geocel/detail/SurfaceParamsBuilder.hh
@@ -1,0 +1,130 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/detail/SurfaceParamsBuilder.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "corecel/Assert.hh"
+#include "corecel/Types.hh"
+#include "corecel/data/Collection.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/data/DedupeCollectionBuilder.hh"
+#include "corecel/io/Label.hh"
+#include "geocel/SurfaceData.hh"
+#include "geocel/Types.hh"
+#include "geocel/VolumeParams.hh"
+#include "geocel/inp/Model.hh"
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Temporary data structure to hold surface information for a volume.
+ *
+ * This is an intermediate representation of VolumeSurfaceRecord that uses
+ * STL containers for easier construction before being converted to the
+ * device-compatible format.
+ */
+struct VolumeSurfaceData
+{
+    //! Type for interface key (pre/post volume instance ID)
+    using Interface = std::pair<VolumeInstanceId, VolumeInstanceId>;
+
+    //! Surface identifier for the volume boundary (if any)
+    SurfaceId boundary;
+
+    //! Map of pre/post volume instance pairs to surface IDs
+    std::map<Interface, SurfaceId> interfaces;
+
+    //! True if any data is present
+    explicit operator bool() const { return boundary || !interfaces.empty(); }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Process input surfaces and build VolumeSurfaceData structures.
+ *
+ * This class processes inp::Surface data and constructs the necessary
+ * VolumeSurfaceData objects that map surfaces to volumes and their interfaces.
+ * It performs error checking against duplicate surface assignments.
+ */
+class SurfaceInputInserter
+{
+  public:
+    // Construct with pointers to target data and volume params
+    SurfaceInputInserter(VolumeParams const& volumes,
+                         std::vector<Label>* labels,
+                         std::vector<VolumeSurfaceData>* volume_surfaces);
+
+    // Process an input surface and return its ID
+    SurfaceId operator()(inp::Surface const& surf);
+
+    // Process a boundary surface
+    SurfaceId operator()(inp::Surface::Boundary const& boundary);
+
+    // Process an interface surface
+    SurfaceId operator()(inp::Surface::Interface const& interface);
+
+  private:
+    VolumeParams const& volumes_;
+    std::vector<Label>* labels_;
+    std::vector<VolumeSurfaceData>* volume_surfaces_;
+
+    //// HELPER FUNCTIONS ////
+
+    // Get the next surface ID to be added
+    SurfaceId next_surface_id() const;
+    // Get the label for a volume ID
+    Label const& label(VolumeId vol_id) const;
+    // Get the label for a volume instance ID
+    Label const& label(VolumeInstanceId vol_inst_id) const;
+    // Get the label for a surface ID
+    Label const& label(SurfaceId surface_id) const;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert VolumeSurfaceData to VolumeSurfaceRecord for device storage.
+ *
+ * This class takes the temporary VolumeSurfaceData structure and converts it
+ * to the device-compatible VolumeSurfaceRecord format, flattening the maps
+ * into sorted arrays.
+ */
+class VolumeSurfaceRecordBuilder
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    template<class T>
+    using Items = Collection<T, Ownership::value, MemSpace::host>;
+    template<class T>
+    using VolumeItems
+        = Collection<T, Ownership::value, MemSpace::host, VolumeId>;
+    //!@}
+
+    // Construct with pointers to target collections
+    VolumeSurfaceRecordBuilder(VolumeItems<VolumeSurfaceRecord>* volume_surfaces,
+                               Items<VolumeInstanceId>* volume_instance_ids,
+                               Items<SurfaceId>* surface_ids);
+
+    // Convert VolumeSurfaceData to VolumeSurfaceRecord
+    VolumeId operator()(VolumeSurfaceData const& data);
+
+  private:
+    CollectionBuilder<VolumeSurfaceRecord, MemSpace::host, VolumeId>
+        volume_surfaces_;
+    DedupeCollectionBuilder<VolumeInstanceId> volume_instance_ids_;
+    DedupeCollectionBuilder<SurfaceId> surface_ids_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/geocel/detail/SurfaceParamsBuilder.hh
+++ b/src/geocel/detail/SurfaceParamsBuilder.hh
@@ -61,8 +61,8 @@ class SurfaceInputInserter
   public:
     // Construct with pointers to target data and volume params
     SurfaceInputInserter(VolumeParams const& volumes,
-                         std::vector<Label>* labels,
-                         std::vector<VolumeSurfaceData>* volume_surfaces);
+                         std::vector<Label>& labels,
+                         std::vector<VolumeSurfaceData>& volume_surfaces);
 
     // Process an input surface and return its ID
     SurfaceId operator()(inp::Surface const& surf);
@@ -75,8 +75,8 @@ class SurfaceInputInserter
 
   private:
     VolumeParams const& volumes_;
-    std::vector<Label>* labels_;
-    std::vector<VolumeSurfaceData>* volume_surfaces_;
+    std::vector<Label>& labels_;
+    std::vector<VolumeSurfaceData>& volume_surfaces_;
 
     //// HELPER FUNCTIONS ////
 

--- a/src/geocel/inp/Model.hh
+++ b/src/geocel/inp/Model.hh
@@ -102,6 +102,9 @@ struct Surfaces
     using VecSurface = std::vector<Surface>;
 
     VecSurface surfaces;
+
+    //! True if at least one surface is defined
+    explicit operator bool() const { return !surfaces.empty(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/DetectorSteps.test.cc
+++ b/test/celeritas/user/DetectorSteps.test.cc
@@ -126,7 +126,7 @@ class DetectorStepsTest : public ::celeritas::test::Test
                         VolumeInstanceId val;
                         if (j <= depth)
                         {
-                            val = VolumeInstanceId{(j + i) % 8};
+                            val = id_cast<VolumeInstanceId>((j + i) % 8);
                         }
                         ViId vi_id{result.volume_instance_depth
                                        * tid.unchecked_get()

--- a/test/corecel/cont/LabelIdMultiMapUtils.hh
+++ b/test/corecel/cont/LabelIdMultiMapUtils.hh
@@ -1,0 +1,32 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/cont/LabelIdMultiMapUtils.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "corecel/cont/LabelIdMultiMap.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+template<class I>
+inline auto get_multimap_labels(LabelIdMultiMap<I> const& multimap)
+{
+    std::vector<std::string> result;
+    for (auto id : range(id_cast<I>(multimap.size())))
+    {
+        result.push_back(to_string(multimap.at(id)));
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -66,6 +66,7 @@ celeritas_setup_tests(SERIAL
 celeritas_add_test(BoundingBox.test.cc
   LINK_LIBRARIES nlohmann_json::nlohmann_json
 )
+celeritas_add_test(Surface.test.cc)
 celeritas_add_test(Volume.test.cc)
 
 celeritas_add_test(random/IsotropicDistribution.test.cc)

--- a/test/geocel/Surface.test.cc
+++ b/test/geocel/Surface.test.cc
@@ -1,0 +1,219 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/Surface.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/Config.hh"
+
+#include "corecel/Assert.hh"
+#include "corecel/ScopedLogStorer.hh"
+#include "corecel/cont/LabelIdMultiMapUtils.hh"
+#include "corecel/io/Logger.hh"
+#include "geocel/SurfaceParams.hh"
+#include "geocel/Types.hh"
+#include "geocel/VolumeParams.hh"
+#include "geocel/VolumeSurfaceView.hh"
+#include "geocel/inp/Model.hh"
+
+#include "TestMacros.hh"
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+using inp::Surface;
+using inp::Surfaces;
+using Boundary = Surface::Boundary;
+using Interface = Surface::Interface;
+using VolInstId = VolumeInstanceId;
+
+//---------------------------------------------------------------------------//
+
+//! Helper to create a boundary surface
+Surface make_surface(std::string&& label, VolumeId vol)
+{
+    Surface surface;
+    surface.label = std::move(label);
+    surface.surface = vol;
+    return surface;
+}
+
+//! Helper to create an interface surface
+Surface make_surface(std::string&& label, VolInstId pre, VolInstId post)
+{
+    Surface surface;
+    surface.label = std::move(label);
+    surface.surface = Interface{pre, post};
+    return surface;
+}
+
+//---------------------------------------------------------------------------//
+
+class SurfacesTest : public ::celeritas::test::Test
+{
+  protected:
+    /*!
+     * Volumes: parent -> daughter [instance]
+     * A -> B [0]
+     * A -> C [1]
+     * B -> C [2]
+     * B -> C [3]
+     * C -> D [4]
+     * C -> E [5]
+     */
+    VolumeParams make_volume_params() const
+    {
+        return VolumeParams([] {
+            using namespace inp;
+            Volumes in;
+
+            // Helper to create volumes
+            auto add_volume
+                = [&in](std::string label, std::vector<VolInstId> children) {
+                      Volume v;
+                      v.label = std::move(label);
+                      v.material = id_cast<GeoMatId>(in.volumes.size());
+                      v.children = std::move(children);
+                      in.volumes.push_back(v);
+                  };
+            auto add_instance = [&in](VolumeId vol_id) {
+                VolumeInstance vi;
+                vi.label = std::to_string(in.volume_instances.size());
+                vi.volume = vol_id;
+                in.volume_instances.push_back(vi);
+            };
+
+            add_volume("A", {VolInstId{0}, VolInstId{1}});
+            add_volume("B", {VolInstId{2}, VolInstId{3}});
+            add_volume("C", {VolInstId{4}, VolInstId{5}});
+            add_volume("D", {});
+            add_volume("E", {});
+
+            add_instance(VolumeId{1});  // 0 -> B
+            add_instance(VolumeId{2});  // 1 -> C
+            add_instance(VolumeId{2});  // 2 -> C
+            add_instance(VolumeId{2});  // 3 -> C
+            add_instance(VolumeId{3});  // 4 -> D
+            add_instance(VolumeId{4});  // 5 -> E
+
+            return in;
+        }());
+    }
+};
+
+TEST_F(SurfacesTest, none)
+{
+    SurfaceParams sp;
+    EXPECT_TRUE(sp.empty());
+    EXPECT_EQ(0, sp.num_surfaces());
+    EXPECT_EQ(0, sp.labels().size());
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(VolumeSurfaceView(sp.host_ref(), VolumeId{0}), DebugError);
+    }
+}
+
+TEST_F(SurfacesTest, errors)
+{
+    ScopedLogStorer scoped_log_{&celeritas::world_logger()};
+
+    auto volumes = this->make_volume_params();
+    // Duplicate boundary surface
+    EXPECT_THROW(SurfaceParams(Surfaces{{
+                                   make_surface("ok", VolumeId{1}),
+                                   make_surface("bad", VolumeId{1}),
+                               }},
+                               volumes),
+                 RuntimeError);
+
+    // Duplicate interface surface
+    EXPECT_THROW(
+        SurfaceParams(Surfaces{{
+                          make_surface("ok2", VolInstId{1}, VolInstId{2}),
+                          make_surface("bad2", VolInstId{1}, VolInstId{2}),
+                      }},
+                      volumes),
+        RuntimeError);
+
+    static char const* const expected_log_messages[] = {
+        "While processing surface 'bad'", "While processing surface 'bad2'"};
+    EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages());
+    static char const* const expected_log_levels[] = {"error", "error"};
+    EXPECT_VEC_EQ(expected_log_levels, scoped_log_.levels());
+}
+
+TEST_F(SurfacesTest, borders)
+{
+    SurfaceParams sp{Surfaces{{
+                         make_surface("b", VolumeId{1}),
+                         make_surface("d", VolumeId{3}),
+                         make_surface("e", VolumeId{4}),
+                     }},
+                     this->make_volume_params()};
+
+    EXPECT_FALSE(sp.empty());
+    EXPECT_EQ(3, sp.num_surfaces());
+    static char const* const expected_labels[] = {"b", "d", "e"};
+    EXPECT_VEC_EQ(expected_labels, get_multimap_labels(sp.labels()));
+
+    {
+        VolumeSurfaceView vsv(sp.host_ref(), VolumeId{0});
+        EXPECT_EQ(VolumeId{0}, vsv.volume_id());
+        EXPECT_EQ(SurfaceId{}, vsv.boundary_id());
+        EXPECT_FALSE(vsv.has_interface());
+        EXPECT_EQ(SurfaceId{}, vsv.find_interface(VolInstId{0}, VolInstId{0}));
+    }
+    {
+        VolumeSurfaceView vsv(sp.host_ref(), VolumeId{1});
+        EXPECT_EQ(SurfaceId{0}, vsv.boundary_id());
+        EXPECT_FALSE(vsv.has_interface());
+    }
+    {
+        VolumeSurfaceView vsv(sp.host_ref(), VolumeId{3});
+        EXPECT_EQ(SurfaceId{1}, vsv.boundary_id());
+        EXPECT_FALSE(vsv.has_interface());
+    }
+}
+
+TEST_F(SurfacesTest, interfaces)
+{
+    SurfaceParams sp{Surfaces{{
+                         make_surface("c2b", VolInstId{2}, VolInstId{0}),
+                         make_surface("c2c2", VolInstId{2}, VolInstId{2}),
+                         make_surface("b", VolumeId{1}),
+                         make_surface("cc2", VolInstId{1}, VolInstId{2}),
+                         make_surface("c3c", VolInstId{3}, VolInstId{1}),
+                         make_surface("bc", VolInstId{0}, VolInstId{1}),
+                         make_surface("bc2", VolInstId{0}, VolInstId{2}),
+                         make_surface("ec", VolInstId{5}, VolInstId{1}),
+                         make_surface("db", VolInstId{4}, VolInstId{1}),
+                     }},
+                     this->make_volume_params()};
+    {
+        VolumeSurfaceView vsv(sp.host_ref(), VolumeId{0});  // A -> any
+        EXPECT_FALSE(vsv.has_interface());
+    }
+    {
+        VolumeSurfaceView vsv(sp.host_ref(), VolumeId{1});  // B -> any
+        EXPECT_EQ(SurfaceId{2}, vsv.boundary_id());
+        EXPECT_TRUE(vsv.has_interface());
+        EXPECT_EQ(SurfaceId{}, vsv.find_interface(VolInstId{0}, VolInstId{0}));
+        EXPECT_EQ(SurfaceId{5}, vsv.find_interface(VolInstId{0}, VolInstId{1}));
+        EXPECT_EQ(SurfaceId{6}, vsv.find_interface(VolInstId{0}, VolInstId{2}));
+    }
+    {
+        VolumeSurfaceView vsv(sp.host_ref(), VolumeId{2});  // C -> any
+        EXPECT_EQ(SurfaceId{0}, vsv.find_interface(VolInstId{2}, VolInstId{0}));
+        EXPECT_EQ(SurfaceId{1}, vsv.find_interface(VolInstId{2}, VolInstId{2}));
+        EXPECT_EQ(SurfaceId{3}, vsv.find_interface(VolInstId{1}, VolInstId{2}));
+        EXPECT_EQ(SurfaceId{}, vsv.find_interface(VolInstId{2}, VolInstId{1}));
+        EXPECT_EQ(SurfaceId{4}, vsv.find_interface(VolInstId{3}, VolInstId{1}));
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -4,9 +4,8 @@
 //---------------------------------------------------------------------------//
 //! \file geocel/Volume.test.cc
 //---------------------------------------------------------------------------//
-#include <type_traits>
-
 #include "corecel/OpaqueIdUtils.hh"
+#include "corecel/cont/LabelIdMultiMapUtils.hh"
 #include "geocel/Types.hh"
 #include "geocel/VolumeParams.hh"
 #include "geocel/inp/Model.hh"
@@ -18,23 +17,6 @@ namespace celeritas
 {
 namespace test
 {
-namespace
-{
-//---------------------------------------------------------------------------//
-template<class T>
-auto get_mm_labels(T const& multimap)
-{
-    using IdType = typename T::IdT;
-    std::vector<std::string> result;
-    for (auto id : range(id_cast<IdType>(multimap.size())))
-    {
-        result.push_back(multimap.at(id).name);
-    }
-    return result;
-}
-
-}  // namespace
-
 //---------------------------------------------------------------------------//
 /*!
  * Note in the following tests:
@@ -143,9 +125,9 @@ TEST_F(VolumeTest, complex_hierarchy)
 
     // Check volume labels
     EXPECT_VEC_EQ(expected_volume_labels,
-                  get_mm_labels(params.volume_labels()));
+                  get_multimap_labels(params.volume_labels()));
     EXPECT_VEC_EQ(expected_volume_instance_labels,
-                  get_mm_labels(params.volume_instance_labels()));
+                  get_multimap_labels(params.volume_instance_labels()));
 
     std::vector<std::vector<int>> children;
     std::vector<std::vector<int>> parents;


### PR DESCRIPTION
This defines device-friendly storage, access, and setup for mapping between volumes and surface IDs. The key data structure to use in the downstream physics is the `VolumeSurfaceView`: from a pre-step volume ID, it gives the boundary surface of that volume, and lets you search from the pre-step volume instance to a post-step volume.

In our surface physics, we'll end up storing the pre-step volume and volume instance ID, and post-step VI ID, then looking through the boundary and interface surfaces accordingly.

The current implementation uses a linear search for the interface map lookup, so it will be slow for LHCb which has hundreds of pre->post pairs from the same volume.

Needed for #1351.

