### PR TITLE
Add options to forcibly disable Cherenkov and scintillation

### DIFF
--- a/app/celer-sim/RunnerInput.cc
+++ b/app/celer-sim/RunnerInput.cc
@@ -204,6 +204,13 @@ inp::Problem load_problem(RunnerInput const& ri)
             return sc;
         }();
         p.tracking.limits.optical_step_iters = ri.optical.max_steps;
+
+        p.physics.optical = [&ri] {
+            inp::OpticalPhysics op;
+            op.cherenkov = ri.optical.cherenkov;
+            op.scintillation = ri.optical.scintillation;
+            return op;
+        }();
     }
 
     // Simple calorimeter scoring

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -67,6 +67,10 @@ struct RunnerInput
                                  //!< launching optical tracking loop
         size_type max_steps = static_cast<size_type>(-1);  //!< Step iterations
 
+        // Optical photon generation
+        bool cherenkov{true};
+        bool scintillation{true};
+
         explicit operator bool() const
         {
             return num_track_slots > 0 && buffer_capacity > 0

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -227,6 +227,8 @@ void from_json(nlohmann::json const& j, app::RunnerInput::OpticalOptions& oo)
     }
     CELER_JSON_LOAD_REQUIRED(j, oo, auto_flush);
     CELER_JSON_LOAD_OPTION(j, oo, max_steps);
+    CELER_JSON_LOAD_OPTION(j, oo, cherenkov);
+    CELER_JSON_LOAD_OPTION(j, oo, scintillation);
 }
 
 void to_json(nlohmann::json& j, app::RunnerInput::OpticalOptions const& oo)
@@ -237,6 +239,8 @@ void to_json(nlohmann::json& j, app::RunnerInput::OpticalOptions const& oo)
         CELER_JSON_PAIR(oo, initializer_capacity),
         CELER_JSON_PAIR(oo, auto_flush),
         CELER_JSON_PAIR(oo, max_steps),
+        CELER_JSON_PAIR(oo, cherenkov),
+        CELER_JSON_PAIR(oo, scintillation),
     };
 }
 

--- a/src/celeritas/inp/Physics.hh
+++ b/src/celeritas/inp/Physics.hh
@@ -59,6 +59,15 @@ struct EmPhysics
  */
 struct OpticalPhysics
 {
+    //!@{
+    //! \name Optical photon generation
+
+    //! Generate Cherenkov photons
+    bool cherenkov{true};
+
+    //! Generate scintillation photons
+    bool scintillation{true};
+    //!@}
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/inp/Physics.hh
+++ b/src/celeritas/inp/Physics.hh
@@ -62,6 +62,10 @@ struct OpticalPhysics
     //!@{
     //! \name Optical photon generation
 
+    /*! \todo Replace with a mapping of \c VolumeId to \c ScintillationPhysics
+     * or \c CherenkovPhysics
+     */
+
     //! Generate Cherenkov photons
     bool cherenkov{true};
 

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -334,8 +334,10 @@ auto build_optical_offload(inp::Problem const& p,
     CELER_VALIDATE(
         !imported.optical_materials.empty(),
         << R"(an optical tracking loop was requested but no optical materials are present)");
+    CELER_VALIDATE(p.physics.optical,
+                   << "optical physics options are required to construct an "
+                      "optical tracking loop");
 
-    CELER_ASSERT(p.physics.optical);
     inp::OpticalPhysics const& opt = *p.physics.optical;
     OpticalCollector::Input oc_inp;
     oc_inp.material = MaterialParams::from_import(

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -335,12 +335,22 @@ auto build_optical_offload(inp::Problem const& p,
         !imported.optical_materials.empty(),
         << R"(an optical tracking loop was requested but no optical materials are present)");
 
+    CELER_ASSERT(p.physics.optical);
+    inp::OpticalPhysics const& opt = *p.physics.optical;
     OpticalCollector::Input oc_inp;
     oc_inp.material = MaterialParams::from_import(
         imported, *params.geomaterial(), *params.material());
-    oc_inp.cherenkov = std::make_shared<CherenkovParams>(*oc_inp.material);
-    oc_inp.scintillation
-        = ScintillationParams::from_import(imported, params.particle());
+    if (opt.cherenkov)
+    {
+        oc_inp.cherenkov = std::make_shared<CherenkovParams>(*oc_inp.material);
+    }
+    if (opt.scintillation)
+    {
+        oc_inp.scintillation
+            = ScintillationParams::from_import(imported, params.particle());
+        CELER_VALIDATE(oc_inp.scintillation,
+                       << "failed to construct scintillation process");
+    }
 
     // Map from optical capacity
     CELER_ASSERT(p.control.optical_capacity);


### PR DESCRIPTION
Currently we always enable Cherenkov in the optical loop and enable scintillation if the necessary optical properties are present. This makes it an input option instead.