### PR TITLE
Rearrange generic geo test interface

### DIFF
--- a/test/geocel/CMakeLists.txt
+++ b/test/geocel/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 set(SOURCES
   LazyGeoManager.cc
   GeantImportVolumeResult.cc
+  GenericGeoResults.cc
   GenericGeoTestInterface.cc
   GeoTests.cc
 )

--- a/test/geocel/GenericGeoResults.cc
+++ b/test/geocel/GenericGeoResults.cc
@@ -1,0 +1,177 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/GenericGeoResults.cc
+//---------------------------------------------------------------------------//
+#include "GenericGeoResults.hh"
+
+#include "corecel/io/Repr.hh"
+#include "corecel/math/SoftEqual.hh"
+
+#include "GenericGeoTestInterface.hh"
+#include "testdetail/TestMacrosImpl.hh"
+
+// DEPRECATED: remove in v0.7
+#define EXPECT_RESULT_EQ(EXPECTED, ACTUAL) EXPECT_REF_EQ(EXPECTED, ACTUAL)
+#define EXPECT_RESULT_NEAR(EXPECTED, ACTUAL, TOL) \
+    EXPECT_REF_NEAR(EXPECTED, ACTUAL, TOL)
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+// TRACKING RESULT
+//---------------------------------------------------------------------------//
+
+#define CELER_REF_ATTR(ATTR) "ref." #ATTR " = " << repr(this->ATTR) << ";\n"
+void GenericGeoTrackingResult::print_expected() const
+{
+    std::cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "GenericGeoTrackingResult ref;\n"
+            CELER_REF_ATTR(volumes)
+            CELER_REF_ATTR(volume_instances)
+            CELER_REF_ATTR(distances)
+            CELER_REF_ATTR(halfway_safeties)
+            CELER_REF_ATTR(bumps)
+            "auto tol = GenericGeoTrackingTolerance::from_test(*test_);\n"
+            "EXPECT_RESULT_NEAR(ref, result, tol);\n"
+            "/*** END CODE ***/\n";
+}
+
+GenericGeoTrackingTolerance
+GenericGeoTrackingTolerance::from_test(GenericGeoTestInterface const& test)
+{
+    GenericGeoTrackingTolerance tol;
+    tol.safety = test.safety_tol();
+    tol.distance = SoftEqual{}.rel();
+    return tol;
+}
+
+::testing::AssertionResult IsRefEq(char const* expr1,
+                                   char const* expr2,
+                                   char const*,
+                                   GenericGeoTrackingResult const& val1,
+                                   GenericGeoTrackingResult const& val2,
+                                   GenericGeoTrackingTolerance const& tol)
+{
+    using ::celeritas::testdetail::IsVecEq;
+    using ::celeritas::testdetail::IsVecSoftEquiv;
+
+    AssertionHelper helper{expr1, expr2};
+
+#define IRE_VEC_EQ(ATTR)                                           \
+    if (auto result = IsVecEq(expr1, #ATTR, val1.ATTR, val2.ATTR); \
+        !static_cast<bool>(result))                                \
+    {                                                              \
+        helper.fail() << result.message();                         \
+    }                                                              \
+    else                                                           \
+        (void)sizeof(char)
+#define IRE_VEC_SOFT_EQ(ATTR, TOL)                                       \
+    if (auto result                                                      \
+        = IsVecSoftEquiv(expr1, #ATTR, #TOL, val1.ATTR, val2.ATTR, TOL); \
+        !static_cast<bool>(result))                                      \
+    {                                                                    \
+        helper.fail() << result.message();                               \
+    }                                                                    \
+    else                                                                 \
+        (void)sizeof(char)
+#define IRE_VEC_SOFT_EQ2(ATTR, REL, ABS)                               \
+    if (auto result = IsVecSoftEquiv(                                  \
+            expr1, #ATTR, #REL, #ABS, val1.ATTR, val2.ATTR, REL, ABS); \
+        !static_cast<bool>(result))                                    \
+    {                                                                  \
+        helper.fail() << result.message();                             \
+    }                                                                  \
+    else                                                               \
+        (void)sizeof(char)
+
+    IRE_VEC_EQ(volumes);
+    IRE_VEC_EQ(volume_instances);
+    IRE_VEC_SOFT_EQ(distances, tol.distance);
+    IRE_VEC_SOFT_EQ2(halfway_safeties, tol.safety, tol.safety);
+    IRE_VEC_SOFT_EQ2(bumps, tol.safety, tol.safety);
+
+#undef IRE_COMPARE
+    return helper;
+}
+
+//---------------------------------------------------------------------------//
+// STACK RESULT
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a stack result from raw geometry output.
+ */
+GenericGeoVolumeStackResult
+GenericGeoVolumeStackResult::from_span(GeoParamsInterface const& geo,
+                                       Span<VolumeInstanceId const> inst_ids)
+{
+    auto const& vol_inst = geo.volume_instances();
+
+    GenericGeoVolumeStackResult result;
+    result.volume_instances.resize(inst_ids.size());
+    result.replicas.assign(inst_ids.size(), -1);
+    for (auto i : range(inst_ids.size()))
+    {
+        auto vi_id = inst_ids[i];
+        if (!vi_id)
+        {
+            result.volume_instances[i] = "<null>";
+            continue;
+        }
+        auto const& label = vol_inst.at(vi_id);
+        if (auto phys_inst = geo.id_to_geant(vi_id))
+        {
+            if (phys_inst.replica)
+            {
+                result.replicas[i] = phys_inst.replica.get();
+            }
+        }
+        // Only write extension if not a replica, because Geant4
+        // effectively gives multiple volume instances the same name+ext
+        result.volume_instances[i] = !result.replicas[i] ? to_string(label)
+                                                         : label.name;
+    }
+
+    return result;
+}
+
+void GenericGeoVolumeStackResult::print_expected() const
+{
+    using std::cout;
+    // clang-format off
+    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
+            "GenericGeoVolumeStackResult ref;\n"
+            CELER_REF_ATTR(volume_instances)
+            CELER_REF_ATTR(replicas)
+            "EXPECT_RESULT_EQ(ref, result);\n"
+            "/*** END CODE ***/\n";
+    // clang-format on
+}
+
+::testing::AssertionResult IsRefEq(char const* expr1,
+                                   char const* expr2,
+                                   GenericGeoVolumeStackResult const& val1,
+                                   GenericGeoVolumeStackResult const& val2)
+{
+    AssertionHelper result{expr1, expr2};
+
+#define IRE_COMPARE(ATTR)                                                  \
+    if (val1.ATTR != val2.ATTR)                                            \
+    {                                                                      \
+        result.fail() << "Actual " #ATTR ": " << repr(val1.ATTR) << " vs " \
+                      << repr(val2.ATTR);                                  \
+    }                                                                      \
+    else                                                                   \
+        (void)sizeof(char)
+    IRE_COMPARE(volume_instances);
+    IRE_COMPARE(replicas);
+#undef IRE_COMPARE
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/geocel/GenericGeoResults.hh
+++ b/test/geocel/GenericGeoResults.hh
@@ -1,0 +1,123 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/GenericGeoResults.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include "corecel/cont/Span.hh"
+#include "geocel/Types.hh"
+
+// DEPRECATED: remove in v0.7
+#define EXPECT_RESULT_EQ(EXPECTED, ACTUAL) EXPECT_REF_EQ(EXPECTED, ACTUAL)
+#define EXPECT_RESULT_NEAR(EXPECTED, ACTUAL, TOL) \
+    EXPECT_REF_NEAR(EXPECTED, ACTUAL, TOL)
+
+namespace celeritas
+{
+class GeoParamsInterface;
+
+namespace inp
+{
+struct Model;
+}
+
+namespace test
+{
+class GenericGeoTestInterface;
+
+//---------------------------------------------------------------------------//
+// TRACKING RESULT
+//---------------------------------------------------------------------------//
+
+//! Get detailed results from tracking from one cell to the next
+struct GenericGeoTrackingResult
+{
+    std::vector<std::string> volumes;
+    std::vector<std::string> volume_instances;
+    std::vector<real_type> distances;  //!< [cm]
+    std::vector<real_type> halfway_safeties;  //!< [cm]
+    // Locations the particle had a very tiny distance in a volume
+    std::vector<real_type> bumps;  //!< [cm * 3]
+
+    void print_expected() const;
+};
+
+//! Loosen strictness for tracking comparison
+struct GenericGeoTrackingTolerance
+{
+    real_type distance{0};
+    real_type safety{0};
+
+    static GenericGeoTrackingTolerance
+    from_test(GenericGeoTestInterface const&);
+};
+
+// Compare tracking results
+::testing::AssertionResult IsRefEq(char const* expected_expr,
+                                   char const* actual_expr,
+                                   char const* tol_expr,
+                                   GenericGeoTrackingResult const& expected,
+                                   GenericGeoTrackingResult const& actual,
+                                   GenericGeoTrackingTolerance const& tol);
+
+//! Compare tracking results with default tolerance
+inline ::testing::AssertionResult
+IsRefEq(char const* expected_expr,
+        char const* actual_expr,
+        GenericGeoTrackingResult const& expected,
+        GenericGeoTrackingResult const& actual)
+{
+    return IsRefEq(expected_expr, actual_expr, "default", expected, actual, {});
+}
+
+//---------------------------------------------------------------------------//
+// STACK RESULT
+//---------------------------------------------------------------------------//
+
+//! Get the volume instances and replica IDs from a point
+struct GenericGeoVolumeStackResult
+{
+    std::vector<std::string> volume_instances;
+    std::vector<int> replicas;
+
+    static GenericGeoVolumeStackResult
+    from_span(GeoParamsInterface const&, Span<VolumeInstanceId const>);
+    void print_expected() const;
+};
+
+::testing::AssertionResult IsRefEq(char const* expected_expr,
+                                   char const* actual_expr,
+                                   GenericGeoVolumeStackResult const& expected,
+                                   GenericGeoVolumeStackResult const& actual);
+
+//---------------------------------------------------------------------------//
+// MODEL INPUT RESULT
+//---------------------------------------------------------------------------//
+
+//! Get the unfolded geometry model input
+struct GenericGeoModelInp
+{
+    std::vector<std::string> volumes;
+    std::vector<std::string> volume_instances;
+    std::vector<std::vector<int>> daughters;
+
+    static GenericGeoModelInp from_model_input(inp::Model const& in);
+    void print_expected() const;
+};
+
+//---------------------------------------------------------------------------//
+
+::testing::AssertionResult IsRefEq(char const* expected_expr,
+                                   char const* actual_expr,
+                                   GenericGeoModelInp const& expected,
+                                   GenericGeoModelInp const& actual);
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/geocel/GenericGeoResults.hh
+++ b/test/geocel/GenericGeoResults.hh
@@ -22,11 +22,6 @@ namespace celeritas
 {
 class GeoParamsInterface;
 
-namespace inp
-{
-struct Model;
-}
-
 namespace test
 {
 class GenericGeoTestInterface;
@@ -95,28 +90,6 @@ struct GenericGeoVolumeStackResult
                                    char const* actual_expr,
                                    GenericGeoVolumeStackResult const& expected,
                                    GenericGeoVolumeStackResult const& actual);
-
-//---------------------------------------------------------------------------//
-// MODEL INPUT RESULT
-//---------------------------------------------------------------------------//
-
-//! Get the unfolded geometry model input
-struct GenericGeoModelInp
-{
-    std::vector<std::string> volumes;
-    std::vector<std::string> volume_instances;
-    std::vector<std::vector<int>> daughters;
-
-    static GenericGeoModelInp from_model_input(inp::Model const& in);
-    void print_expected() const;
-};
-
-//---------------------------------------------------------------------------//
-
-::testing::AssertionResult IsRefEq(char const* expected_expr,
-                                   char const* actual_expr,
-                                   GenericGeoModelInp const& expected,
-                                   GenericGeoModelInp const& actual);
 
 //---------------------------------------------------------------------------//
 }  // namespace test

--- a/test/geocel/GenericGeoTestBase.hh
+++ b/test/geocel/GenericGeoTestBase.hh
@@ -94,9 +94,6 @@ class GenericGeoTestBase : virtual public Test,
     track(Real3 const& pos_cm, Real3 const& dir, int max_step) final;
     VolumeStackResult volume_stack(Real3 const& pos_cm) final;
 
-    // Get the model input from the geometry
-    ModelInpResult model_inp() const final;
-
   private:
     template<Ownership W, MemSpace M>
     using StateData = typename TraitsT::template StateData<W, M>;

--- a/test/geocel/GenericGeoTestBase.hh
+++ b/test/geocel/GenericGeoTestBase.hh
@@ -11,6 +11,7 @@
 #include "corecel/data/CollectionStateStore.hh"
 #include "geocel/GeoTraits.hh"
 
+#include "GenericGeoResults.hh"
 #include "GenericGeoTestInterface.hh"
 #include "LazyGeoManager.hh"
 #include "Test.hh"
@@ -92,6 +93,9 @@ class GenericGeoTestBase : virtual public Test,
     TrackingResult
     track(Real3 const& pos_cm, Real3 const& dir, int max_step) final;
     VolumeStackResult volume_stack(Real3 const& pos_cm) final;
+
+    // Get the model input from the geometry
+    ModelInpResult model_inp() const final;
 
   private:
     template<Ownership W, MemSpace M>

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -339,16 +339,6 @@ auto GenericGeoTestBase<HP>::volume_stack(Real3 const& pos)
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the model input from the geometry.
- */
-template<class HP>
-auto GenericGeoTestBase<HP>::model_inp() const -> ModelInpResult
-{
-    CELER_NOT_IMPLEMENTED("model_inp");
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Get the label for this geometry: Geant4, VecGeom, ORANGE.
  */
 template<class HP>

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -17,6 +17,7 @@
 #include "geocel/GeantGeoParams.hh"
 
 #include "CheckedGeoTrackView.hh"
+#include "GenericGeoResults.hh"
 #include "TestMacros.hh"
 #include "UnitUtils.hh"
 
@@ -324,8 +325,6 @@ auto GenericGeoTestBase<HP>::volume_stack(Real3 const& pos)
     -> VolumeStackResult
 {
     auto geo = this->make_geo_track_view(pos, Real3{0, 0, 1});
-    auto const& geo_params = *this->geometry();
-    auto const& vol_inst = geo_params.volume_instances();
 
     auto level = geo.level();
     if (!level)
@@ -335,31 +334,17 @@ auto GenericGeoTestBase<HP>::volume_stack(Real3 const& pos)
     std::vector<VolumeInstanceId> inst_ids(level.get() + 1);
     geo.volume_instance_id(make_span(inst_ids));
 
-    VolumeStackResult result;
-    result.volume_instances.resize(inst_ids.size());
-    result.replicas.assign(inst_ids.size(), -1);
-    for (auto i : range(inst_ids.size()))
-    {
-        auto vi_id = inst_ids[i];
-        if (!vi_id)
-        {
-            result.volume_instances[i] = "<null>";
-            continue;
-        }
-        auto const& label = vol_inst.at(vi_id);
-        if (auto phys_inst = geo_params.id_to_geant(vi_id))
-        {
-            if (phys_inst.replica)
-            {
-                result.replicas[i] = phys_inst.replica.get();
-            }
-        }
-        // Only write extension if not a replica, because Geant4
-        // effectively gives multiple volume instances the same name+ext
-        result.volume_instances[i] = !result.replicas[i] ? to_string(label)
-                                                         : label.name;
-    }
-    return result;
+    return VolumeStackResult::from_span(*this->geometry(), make_span(inst_ids));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the model input from the geometry.
+ */
+template<class HP>
+auto GenericGeoTestBase<HP>::model_inp() const -> ModelInpResult
+{
+    CELER_NOT_IMPLEMENTED("model_inp");
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -10,11 +10,8 @@
 
 #include "corecel/Config.hh"
 
-#include "corecel/io/Repr.hh"
 #include "corecel/math/SoftEqual.hh"
 #include "geocel/GeantGeoUtils.hh"
-
-#include "testdetail/TestMacrosImpl.hh"
 
 #if CELERITAS_USE_GEANT4
 #    include <G4VPhysicalVolume.hh>
@@ -26,115 +23,6 @@ namespace celeritas
 {
 namespace test
 {
-//---------------------------------------------------------------------------//
-#define CELER_REF_ATTR(ATTR) "ref." #ATTR " = " << repr(this->ATTR) << ";\n"
-void GenericGeoTrackingResult::print_expected()
-{
-    std::cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
-            "GenericGeoTrackingResult ref;\n"
-            CELER_REF_ATTR(volumes)
-            CELER_REF_ATTR(volume_instances)
-            CELER_REF_ATTR(distances)
-            CELER_REF_ATTR(halfway_safeties)
-            CELER_REF_ATTR(bumps)
-            "auto tol = GenericGeoTrackingTolerance::from_test(*test_);\n"
-            "EXPECT_RESULT_NEAR(ref, result, tol);\n"
-            "/*** END CODE ***/\n";
-}
-
-GenericGeoTrackingTolerance
-GenericGeoTrackingTolerance::from_test(GenericGeoTestInterface const& test)
-{
-    GenericGeoTrackingTolerance tol;
-    tol.safety = test.safety_tol();
-    tol.distance = SoftEqual{}.rel();
-    return tol;
-}
-
-::testing::AssertionResult IsRefEq(char const* expr1,
-                                   char const* expr2,
-                                   char const*,
-                                   GenericGeoTrackingResult const& val1,
-                                   GenericGeoTrackingResult const& val2,
-                                   GenericGeoTrackingTolerance const& tol)
-{
-    using ::celeritas::testdetail::IsVecEq;
-    using ::celeritas::testdetail::IsVecSoftEquiv;
-
-    AssertionHelper helper{expr1, expr2};
-
-#define IRE_VEC_EQ(ATTR)                                           \
-    if (auto result = IsVecEq(expr1, #ATTR, val1.ATTR, val2.ATTR); \
-        !static_cast<bool>(result))                                \
-    {                                                              \
-        helper.fail() << result.message();                         \
-    }                                                              \
-    else                                                           \
-        (void)sizeof(char)
-#define IRE_VEC_SOFT_EQ(ATTR, TOL)                                       \
-    if (auto result                                                      \
-        = IsVecSoftEquiv(expr1, #ATTR, #TOL, val1.ATTR, val2.ATTR, TOL); \
-        !static_cast<bool>(result))                                      \
-    {                                                                    \
-        helper.fail() << result.message();                               \
-    }                                                                    \
-    else                                                                 \
-        (void)sizeof(char)
-#define IRE_VEC_SOFT_EQ2(ATTR, REL, ABS)                               \
-    if (auto result = IsVecSoftEquiv(                                  \
-            expr1, #ATTR, #REL, #ABS, val1.ATTR, val2.ATTR, REL, ABS); \
-        !static_cast<bool>(result))                                    \
-    {                                                                  \
-        helper.fail() << result.message();                             \
-    }                                                                  \
-    else                                                               \
-        (void)sizeof(char)
-
-    IRE_VEC_EQ(volumes);
-    IRE_VEC_EQ(volume_instances);
-    IRE_VEC_SOFT_EQ(distances, tol.distance);
-    IRE_VEC_SOFT_EQ2(halfway_safeties, tol.safety, tol.safety);
-    IRE_VEC_SOFT_EQ2(bumps, tol.safety, tol.safety);
-
-#undef IRE_COMPARE
-    return helper;
-}
-
-//---------------------------------------------------------------------------//
-void GenericGeoVolumeStackResult::print_expected()
-{
-    using std::cout;
-    // clang-format off
-    cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
-            "GenericGeoVolumeStackResult ref;\n"
-            CELER_REF_ATTR(volume_instances)
-            CELER_REF_ATTR(replicas)
-            "EXPECT_RESULT_EQ(ref, result);\n"
-            "/*** END CODE ***/\n";
-    // clang-format on
-}
-
-::testing::AssertionResult IsRefEq(char const* expr1,
-                                   char const* expr2,
-                                   GenericGeoVolumeStackResult const& val1,
-                                   GenericGeoVolumeStackResult const& val2)
-{
-    AssertionHelper result{expr1, expr2};
-
-#define IRE_COMPARE(ATTR)                                                  \
-    if (val1.ATTR != val2.ATTR)                                            \
-    {                                                                      \
-        result.fail() << "Actual " #ATTR ": " << repr(val1.ATTR) << " vs " \
-                      << repr(val2.ATTR);                                  \
-    }                                                                      \
-    else                                                                   \
-        (void)sizeof(char)
-    IRE_COMPARE(volume_instances);
-    IRE_COMPARE(replicas);
-#undef IRE_COMPARE
-    return result;
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Get the basename or unique geometry key (defaults to suite name).

--- a/test/geocel/GenericGeoTestInterface.hh
+++ b/test/geocel/GenericGeoTestInterface.hh
@@ -24,7 +24,6 @@ namespace test
 //---------------------------------------------------------------------------//
 struct GenericGeoTrackingResult;
 struct GenericGeoVolumeStackResult;
-struct GenericGeoModelInp;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -43,7 +42,6 @@ class GenericGeoTestInterface
     //! \name Type aliases
     using TrackingResult = GenericGeoTrackingResult;
     using VolumeStackResult = GenericGeoVolumeStackResult;
-    using ModelInpResult = GenericGeoModelInp;
     using SPConstGeoInterface = std::shared_ptr<GeoParamsInterface const>;
     //!@}
 
@@ -60,9 +58,6 @@ class GenericGeoTestInterface
     //! Obtain the "touchable history" at a point
     virtual VolumeStackResult volume_stack(Real3 const& pos_cm) = 0;
     //!@}
-
-    //! Get the model input from the geometry
-    virtual ModelInpResult model_inp() const = 0;
 
     //! Get the label for this geometry: Geant4, VecGeom, ORANGE
     virtual std::string_view geometry_type() const = 0;

--- a/test/geocel/GenericGeoTestInterface.hh
+++ b/test/geocel/GenericGeoTestInterface.hh
@@ -17,72 +17,14 @@
 
 class G4VPhysicalVolume;
 
-// DEPRECATED: remove in v0.7
-#define EXPECT_RESULT_EQ(EXPECTED, ACTUAL) EXPECT_REF_EQ(EXPECTED, ACTUAL)
-#define EXPECT_RESULT_NEAR(EXPECTED, ACTUAL, TOL) \
-    EXPECT_REF_NEAR(EXPECTED, ACTUAL, TOL)
-
 namespace celeritas
 {
 namespace test
 {
-
-class GenericGeoTestInterface;
-
 //---------------------------------------------------------------------------//
-struct GenericGeoTrackingResult
-{
-    std::vector<std::string> volumes;
-    std::vector<std::string> volume_instances;
-    std::vector<real_type> distances;  //!< [cm]
-    std::vector<real_type> halfway_safeties;  //!< [cm]
-    // Locations the particle had a very tiny distance in a volume
-    std::vector<real_type> bumps;  //!< [cm * 3]
-
-    void print_expected();
-};
-
-struct GenericGeoTrackingTolerance
-{
-    real_type distance{0};
-    real_type safety{0};
-
-    static GenericGeoTrackingTolerance
-    from_test(GenericGeoTestInterface const&);
-};
-
-//---------------------------------------------------------------------------//
-struct GenericGeoVolumeStackResult
-{
-    std::vector<std::string> volume_instances;
-    std::vector<int> replicas;
-
-    void print_expected();
-};
-
-//---------------------------------------------------------------------------//
-::testing::AssertionResult IsRefEq(char const* expected_expr,
-                                   char const* actual_expr,
-                                   char const* tol_expr,
-                                   GenericGeoTrackingResult const& expected,
-                                   GenericGeoTrackingResult const& actual,
-                                   GenericGeoTrackingTolerance const& tol);
-
-//---------------------------------------------------------------------------//
-inline ::testing::AssertionResult
-IsRefEq(char const* expected_expr,
-        char const* actual_expr,
-        GenericGeoTrackingResult const& expected,
-        GenericGeoTrackingResult const& actual)
-{
-    return IsRefEq(expected_expr, actual_expr, "default", expected, actual, {});
-}
-
-//---------------------------------------------------------------------------//
-::testing::AssertionResult IsRefEq(char const* expected_expr,
-                                   char const* actual_expr,
-                                   GenericGeoVolumeStackResult const& expected,
-                                   GenericGeoVolumeStackResult const& actual);
+struct GenericGeoTrackingResult;
+struct GenericGeoVolumeStackResult;
+struct GenericGeoModelInp;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -101,6 +43,7 @@ class GenericGeoTestInterface
     //! \name Type aliases
     using TrackingResult = GenericGeoTrackingResult;
     using VolumeStackResult = GenericGeoVolumeStackResult;
+    using ModelInpResult = GenericGeoModelInp;
     using SPConstGeoInterface = std::shared_ptr<GeoParamsInterface const>;
     //!@}
 
@@ -114,9 +57,12 @@ class GenericGeoTestInterface
     //!@}
 
     //!@{
-    // Obtain the "touchable history" at a point
+    //! Obtain the "touchable history" at a point
     virtual VolumeStackResult volume_stack(Real3 const& pos_cm) = 0;
     //!@}
+
+    //! Get the model input from the geometry
+    virtual ModelInpResult model_inp() const = 0;
 
     //! Get the label for this geometry: Geant4, VecGeom, ORANGE
     virtual std::string_view geometry_type() const = 0;

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -13,6 +13,7 @@
 #include "corecel/math/Turn.hh"
 #include "corecel/sys/Version.hh"
 
+#include "GenericGeoResults.hh"
 #include "GenericGeoTestInterface.hh"
 #include "TestMacros.hh"
 #include "UnitUtils.hh"


### PR DESCRIPTION
This is a literal just-moving-code change to simplify the generic geo header file (which is going to be extended in a very short bit for surface/volume metadata). Required for #1815.