### PR TITLE
Speed up CI by not autoupdating man db

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo debconf-set man-db/auto-update false
+          sudo rm /var/lib/man-db/auto-update
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
             ccache \

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo debconf-set man-db/auto-update false
+          sudo rm /var/lib/man-db/auto-update
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
             ccache nlohmann-json3-dev libpng-dev

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,9 +25,11 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-            sudo apt-get -y update
-            sudo apt-get -y install \
-                cmake graphviz ninja-build doxygen nlohmann-json3-dev
+          sudo debconf-set man-db/auto-update false
+          sudo rm /var/lib/man-db/auto-update
+          sudo apt-get -y update
+          sudo apt-get -y install \
+            cmake graphviz ninja-build doxygen nlohmann-json3-dev
       - name: Check out Celeritas
         uses: actions/checkout@v4
         with:
@@ -68,9 +70,11 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-            sudo apt-get -y update
-            sudo apt-get -y install \
-                cmake graphviz ninja-build doxygen nlohmann-json3-dev
+          sudo debconf-set man-db/auto-update false
+          sudo rm /var/lib/man-db/auto-update
+          sudo apt-get -y update
+          sudo apt-get -y install \
+            cmake graphviz ninja-build doxygen nlohmann-json3-dev
       - name: Check out Celeritas
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The user manual job was taking 1.5 minutes to set up, apparently due to an IO-intensive step: see https://askubuntu.com/questions/272248/processing-triggers-for-man-db .  Sometimes that part can take 5 seconds, sometimes 50 seconds. So let's just skip it.