### PR TITLE
Read and export Geant4 surface definitions

### DIFF
--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       GHA_JOB_NAME: "${{matrix.runner}}-${{matrix.compiler}}-${{matrix.version}}${{matrix.cxxstd && format('-c++{0}', matrix.cxxstd) || ''}}"
       CCACHE_DIR: "${{github.workspace}}/.ccache"
-      CCACHE_MAXSIZE: "100Mi"
+      CCACHE_MAXSIZE: "200Mi"
       CMAKE_PRESET: fast
       CC: ${{matrix.compiler}}-${{matrix.version}}
       CXX: ${{matrix.compiler == 'gcc' && 'g++' || 'clang++'}}-${{matrix.version}}
@@ -151,7 +151,7 @@ jobs:
         shell: pwsh
     env:
       CCACHE_DIR: "${{github.workspace}}\\.ccache"
-      CCACHE_MAXSIZE: "100Mi"
+      CCACHE_MAXSIZE: "200Mi"
       CMAKE_PRESET: fast
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -71,7 +71,7 @@ jobs:
             geant: "11.2"
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
-      CCACHE_MAXSIZE: "${{matrix.build_type == 'reldebinfo' && '400' || '200'}}Mi"
+      CCACHE_MAXSIZE: "${{matrix.build_type == 'reldebinfo' && '500' || '300'}}Mi"
       CMAKE_PRESET: >-
         ${{format('{0}-{1}{2}{3}',
                   matrix.build_type,

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -13,7 +13,7 @@ jobs:
     name: ultralite-ubuntu
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
-      CCACHE_MAXSIZE: "50Mi"
+      CCACHE_MAXSIZE: "100Mi"
       CMAKE_PRESET: ultralite
     runs-on: ubuntu-24.04
     steps:

--- a/doc/implementation/geometry.rst
+++ b/doc/implementation/geometry.rst
@@ -87,11 +87,12 @@ Unique instance
 Surface
    A *surface* is defined as a contiguous area on the boundary of a volume,
    sometimes on only a single side of the volume. Note that this definition
-   different to the infinite surfaces of ORANGE and the surface frames of
+   differs from the infinite surfaces of ORANGE and the surface frames of
    VecGeom. Surfaces currently are defined in two ways: *Interface* surfaces
-   are one-directional surfaces defined as the interface from one
-   volume instance to another, called "border surfaces" in Geant4. *Boundary*
-   surfaces surrounding an entire volume and are called "skin" in Geant4.
+   ("border" surfaces in Geant4) are one-directional surfaces defined as the
+   interface from one volume instance to another. *Boundary* surfaces ("skin"
+   surfaces in Geant4) surround an entire volume, and their properties apply
+   symmetrically to tracks entering or exiting.
 
 
 .. [#cn] A *volume instance* has a one-to-one mapping for ``G4PVPlacement``,

--- a/doc/implementation/geometry.rst
+++ b/doc/implementation/geometry.rst
@@ -18,28 +18,38 @@ their enclosing parent volume.
 
 .. table:: Celeritas nomenclature tends toward computer science terminology.
 
-   +------------------+------------------------+----------------+--------------------+
-   | Celeritas        | Geant4                 | VecGeom        | KENO [#sc]_        |
-   +==================+========================+================+====================+
-   | (not used)       | Solid                  | Unplaced       | Shape              |
-   +------------------+------------------------+----------------+--------------------+
-   | Volume           | Logical volume         | Logical volume | Unit/array/media   |
-   +------------------+------------------------+----------------+--------------------+
-   | Volume instance  | Physical volume [#cn]_ | Placed volume  | Hole/array element |
-   +------------------+------------------------+----------------+--------------------+
-   | Child            | Daughter               | Daughter       | Hole/placement     |
-   +------------------+------------------------+----------------+--------------------+
-   | Parent           | Mother                 | Mother         | ---                |
-   +------------------+------------------------+----------------+--------------------+
+   +------------------+-------------------------+----------------+--------------------+
+   | Celeritas        | Geant4                  | VecGeom        | KENO [#sc]_        |
+   +==================+=========================+================+====================+
+   | (not used)       | Solid                   | Unplaced       | Shape              |
+   +------------------+-------------------------+----------------+--------------------+
+   | Volume           | Logical volume          | Logical volume | Unit/array/media   |
+   +------------------+-------------------------+----------------+--------------------+
+   | Volume instance  | Physical volume [#cn]_  | Placed volume  | Hole/array element |
+   +------------------+-------------------------+----------------+--------------------+
+   | Child            | Daughter                | Daughter       | Hole/placement     |
+   +------------------+-------------------------+----------------+--------------------+
+   | Parent           | Mother                  | Mother         | ---                |
+   +------------------+-------------------------+----------------+--------------------+
+   | Interface        | Border surface          | ---            | Hole/array element |
+   +------------------+-------------------------+----------------+--------------------+
+   | Boundary         | Skin surface            | ---            | Hole/placement     |
+   +------------------+-------------------------+----------------+--------------------+
+   | Surface          | Surface property [#sp]_ | ---            | ---                |
+   +------------------+-------------------------+----------------+--------------------+
 
 .. [#sc] The KENO geometry package in SCALE :cite:`scale-632` differs
    substantially from Geant4 geometry definitions. In KENO-VI :cite:`kenovi`
    geometry, parent units mask (rather than strictly contain) child units.
 
+.. [#sp] Surface properties in Geant4 can be referenced by multiple surfaces.
+   Celeritas will duplicate these (although lower-level data deduplication may
+   result in the referencing the same data again at runtime).
+
 Celeritas defines abstract geometry concepts, indexed as IDs, to support
 multiple geometry applications [#ga]_ and to make the code backend-agnostic for
 integrating with physics. These include "volumes" (known in some other
-fields as "cells").
+fields as "cells") and "surfaces" defined by the relationships between volumes.
 
 .. [#ga] In the future the use of these abstract concepts will enable detector
    descriptions, and geometry models for other applications, that are *not*
@@ -73,6 +83,16 @@ Unique instance
    encoded uniquely as a single integer by pre-calculating the number of direct
    and indirect children for each node.  Celeritas always uses 64-bit integers
    to store the ``VolumeUniqueInstanceId``.
+
+Surface
+   A *surface* is defined as a contiguous area on the boundary of a volume,
+   sometimes on only a single side of the volume. Note that this definition
+   different to the infinite surfaces of ORANGE and the surface frames of
+   VecGeom. Surfaces currently are defined in two ways: *Interface* surfaces
+   are one-directional surfaces defined as the interface from one
+   volume instance to another, called "border surfaces" in Geant4. *Boundary*
+   surfaces surrounding an entire volume and are called "skin" in Geant4.
+
 
 .. [#cn] A *volume instance* has a one-to-one mapping for ``G4PVPlacement``,
    but "replica" and "parameterized" volumes in Geant4 use a single physical

--- a/doc/implementation/optical-physics.rst
+++ b/doc/implementation/optical-physics.rst
@@ -107,24 +107,29 @@ optical materials.
 .. doxygenclass:: celeritas::optical::RayleighModel
 .. doxygenclass:: celeritas::optical::RayleighMfpCalculator
 
+.. _surface_processes:
+
 Surface processes
 =================
 
-Optical photons also have special interactions at material boundaries. These
-boundaries are imported from Geant4 using the "skin" (boundary between two
-logical volumes) and "border" (the one-sided boundary exiting one physical volume
-and entering another)
-surface definitions that specify properties of a volume's outer surface or of
-the surface between two specific volumes.
+Optical photons also have special interactions at material boundaries,
+specified largely by user-provided material properties. The surface
+definitions are translated from Geant4 "skin" and "border" surfaces to
+Celeritas "boundary" and "interface" surfaces, respectively (see
+:ref:`_api_geometry`). The "boundary" of a volume is currently defined, from
+Geant4 input, as a *directional* property.
 
-Given a pair of (old, new) physical volumes (P0, P1) corresponding to logical
-volumes (L0, L1), the surface properties are determined in decreasing
-precedence:
+Celeritas surface physics currently uses the following heuristic to reproduce
+Geant4 boundary physics behavior.  Given a pair of old→new volume instances
+P0→P1 corresponding to volumes L0→L1, the surface properties are determined in
+decreasing precedence by:
 
-1. Ordered (P0, P1) border surface
-2. Skin surface of L1 if it's the daughter of L0
-3. Skin surface of L0
-4. Skin surface of L1
+1. The interface surface from P0 to P1
+2. If L1 is the child of L0 (crossing into an "enclosed" volume), then the
+   boundary surface of L1
+3. The boundary surface of L0
+4. The boundary surface of L1
+5. The volumetric material properties of L0 and L1
 
-.. todo:: Add this section once surface models are implemented. Move the
-   precedence above into a surface property params.
+.. todo:: Once surface models are implemented, move the
+   precedence above into SurfacePhysics documentation.

--- a/doc/implementation/optical-physics.rst
+++ b/doc/implementation/optical-physics.rst
@@ -116,7 +116,7 @@ Optical photons also have special interactions at material boundaries,
 specified largely by user-provided material properties. The surface
 definitions are translated from Geant4 "skin" and "border" surfaces to
 Celeritas "boundary" and "interface" surfaces, respectively (see
-:ref:`_api_geometry`). The "boundary" of a volume is currently defined, from
+:ref:`api_geometry`). The "boundary" of a volume is currently defined, from
 Geant4 input, as a *directional* property.
 
 Celeritas surface physics currently uses the following heuristic to reproduce

--- a/doc/usage/input/model.rst
+++ b/doc/usage/input/model.rst
@@ -6,7 +6,8 @@
 Model
 =====
 
-This specifies the problem geometry and material properties.
+This specifies the problem geometry and material properties. See
+:ref:`api_geometry` for details on the definition of volumes and surfaces.
 
 .. doxygenstruct:: celeritas::inp::Model
    :members:

--- a/doc/usage/input/model.rst
+++ b/doc/usage/input/model.rst
@@ -37,3 +37,7 @@ Surfaces are defined by the relationship between volumes.
 .. doxygenstruct:: celeritas::inp::Surfaces
    :members:
    :no-link:
+
+.. doxygenstruct:: celeritas::inp::Surface
+   :members:
+   :no-link:

--- a/doc/usage/input/model.rst
+++ b/doc/usage/input/model.rst
@@ -28,3 +28,12 @@ These input classes describe the volume hierarchy.
 .. doxygenstruct:: celeritas::inp::VolumeInstance
    :members:
    :no-link:
+
+Surfaces
+--------
+
+Surfaces are defined by the relationship between volumes.
+
+.. doxygenstruct:: celeritas::inp::Surfaces
+   :members:
+   :no-link:

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -192,8 +192,7 @@ void append_border_surfaces(GeantGeoParams const& geo,
 #endif
     {
 #if G4VERSION_NUMBER < 1060
-        std::pair<G4VPhysicalVolume*, G4VPhysicalVolume*> key{
-            surf->GetVolume1(), surf->GetVolume2()};
+        std::pair key{surf->GetVolume1(), surf->GetVolume2()};
 #endif
         CELER_ASSERT(key.first);
         auto before = geo.geant_to_id(*key.first);

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -10,6 +10,8 @@
 #include <unordered_map>
 #include <vector>
 #include <G4GeometryManager.hh>
+#include <G4LogicalBorderSurface.hh>
+#include <G4LogicalSkinSurface.hh>
 #include <G4LogicalVolume.hh>
 #include <G4LogicalVolumeStore.hh>
 #include <G4Material.hh>
@@ -133,6 +135,99 @@ std::vector<Label> make_physical_vol_labels(G4VPhysicalVolume const& world,
 
 //---------------------------------------------------------------------------//
 /*!
+ * Push back an ordered list of "skin" (boundary) surfaces.
+ */
+void append_skin_surfaces(GeantGeoParams const& geo,
+                          std::vector<G4LogicalSurface const*>& result)
+{
+    // Translate "skin" (boundary) surfaces
+    using G4Surface = G4LogicalSkinSurface;
+    std::map<VolumeId, G4Surface const*> temp;
+    auto const* table = G4Surface::GetSurfaceTable();
+    CELER_ASSERT(table);
+#if G4VERSION_NUMBER >= 1120
+    for (auto&& [lv, surf] : *table)
+#else
+    for (auto const* surf : *table)
+#endif
+    {
+#if G4VERSION_NUMBER < 1120
+        auto* lv = surf->GetLogicalVolume();
+#endif
+
+        {
+            CELER_ASSERT(lv);
+            auto vol_id = geo.geant_to_id(*lv);
+            CELER_ASSERT(vol_id);
+            auto iter_inserted = temp.insert({vol_id, surf});
+            CELER_ASSERT(iter_inserted.second);
+        }
+    }
+
+    // Append to table in order
+    result.reserve(table->size());
+    for (auto const& kv : temp)
+    {
+        result.push_back(kv.second);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Push back an ordered list of "border" (interface) surfaces.
+ */
+void append_border_surfaces(GeantGeoParams const& geo,
+                            std::vector<G4LogicalSurface const*>& result)
+{
+    CELER_EXPECT(geo.volume_instances());
+    // Translate "border" (interface) surfaces
+    using G4Surface = G4LogicalBorderSurface;
+    std::map<std::pair<VolumeInstanceId, VolumeInstanceId>, G4Surface const*> temp;
+    auto const* table = G4Surface::GetSurfaceTable();
+    CELER_ASSERT(table);
+#if G4VERSION_NUMBER >= 1060
+    for (auto&& [key, surf] : *table)
+#else
+    for (auto const* surf : *table)
+#endif
+    {
+#if G4VERSION_NUMBER < 1060
+        std::pair<G4VPhysicalVolume*, G4VPhysicalVolume*> key{
+            surf->GetVolume1(), surf->GetVolume2()};
+#endif
+        CELER_ASSERT(key.first);
+        auto before = geo.geant_to_id(*key.first);
+        CELER_ASSERT(before);
+        CELER_ASSERT(key.second);
+        auto after = geo.geant_to_id(*key.second);
+        CELER_ASSERT(after);
+        auto iter_inserted = temp.insert({{before, after}, surf});
+        CELER_ASSERT(iter_inserted.second);
+    }
+
+    // Add to table in order
+    result.reserve(result.size() + table->size());
+    for (auto const& kv : temp)
+    {
+        result.push_back(kv.second);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get a reproducible list of surfaces.
+ */
+std::vector<G4LogicalSurface const*> make_surface_vec(GeantGeoParams const& geo)
+{
+    std::vector<G4LogicalSurface const*> result;
+    append_skin_surfaces(geo, result);
+    append_border_surfaces(geo, result);
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct a volume input from a Geant4 logical volume by mapping IDs.
  */
 inp::Volume inp_from_geant(GeantGeoParams const& geo,
@@ -238,6 +333,48 @@ make_inp_volume_instances(GeantGeoParams const& geo)
             continue;
         }
         result[vol_inst_id.get()] = inp_from_geant(geo, label, *g4pv_inst.pv);
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create surfaces input from Geant4 surfaces.
+ */
+std::vector<inp::Surface> make_inp_surfaces(GeantGeoParams const& geo)
+{
+    // Process surfaces
+    std::vector<inp::Surface> result(geo.num_surfaces());
+
+    for (auto surf_id : range(SurfaceId{geo.num_surfaces()}))
+    {
+        G4LogicalSurface const* surf_base = geo.id_to_geant(surf_id);
+        CELER_ASSERT(surf_base);
+
+        // TODO: deduplicate labels if needed
+        result[surf_id.get()].label = surf_base->GetName();
+
+        // Construct surface
+        auto& inp_surf = result[surf_id.get()].surface;
+        if (auto* surf = dynamic_cast<G4LogicalSkinSurface const*>(surf_base))
+        {
+            auto* lv = surf->GetLogicalVolume();
+            CELER_ASSERT(lv);
+            inp_surf = inp::Surface::Boundary{geo.geant_to_id(*lv)};
+        }
+        else if (auto* surf
+                 = dynamic_cast<G4LogicalBorderSurface const*>(surf_base))
+        {
+            auto* pv_enter = surf->GetVolume1();
+            auto* pv_exit = surf->GetVolume2();
+            CELER_ASSERT(pv_enter && pv_exit);
+            inp_surf = inp::Surface::Interface{geo.geant_to_id(*pv_enter),
+                                               geo.geant_to_id(*pv_exit)};
+        }
+        else
+        {
+            CELER_ASSERT_UNREACHABLE();
+        }
     }
     return result;
 }
@@ -425,6 +562,11 @@ inp::Model GeantGeoParams::make_model_input() const
         result.volumes = make_inp_volumes(*this);
         result.volume_instances = make_inp_volume_instances(*this);
 
+        return result;
+    }();
+    result.surfaces = [this] {
+        inp::Surfaces result;
+        result.surfaces = make_inp_surfaces(*this);
         return result;
     }();
 
@@ -649,6 +791,7 @@ void GeantGeoParams::build_metadata()
     vol_instances_ = VolInstanceMap{
         "volume instance",
         make_physical_vol_labels(*this->world(), this->pv_offset())};
+    surfaces_ = make_surface_vec(*this);
     max_depth_ = get_max_depth(*this->world());
 
     auto clhep_bbox = this->get_clhep_bbox();

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -155,13 +155,11 @@ void append_skin_surfaces(GeantGeoParams const& geo,
         auto* lv = surf->GetLogicalVolume();
 #endif
 
-        {
-            CELER_ASSERT(lv);
-            auto vol_id = geo.geant_to_id(*lv);
-            CELER_ASSERT(vol_id);
-            auto iter_inserted = temp.insert({vol_id, surf});
-            CELER_ASSERT(iter_inserted.second);
-        }
+        CELER_ASSERT(lv);
+        auto vol_id = geo.geant_to_id(*lv);
+        CELER_ASSERT(vol_id);
+        auto iter_inserted = temp.insert({vol_id, surf});
+        CELER_ASSERT(iter_inserted.second);
     }
 
     // Append to table in order
@@ -185,13 +183,13 @@ void append_border_surfaces(GeantGeoParams const& geo,
     std::map<std::pair<VolumeInstanceId, VolumeInstanceId>, G4Surface const*> temp;
     auto const* table = G4Surface::GetSurfaceTable();
     CELER_ASSERT(table);
-#if G4VERSION_NUMBER >= 1060
+#if G4VERSION_NUMBER >= 1070
     for (auto&& [key, surf] : *table)
 #else
     for (auto const* surf : *table)
 #endif
     {
-#if G4VERSION_NUMBER < 1060
+#if G4VERSION_NUMBER < 1070
         std::pair key{surf->GetVolume1(), surf->GetVolume2()};
 #endif
         CELER_ASSERT(key.first);

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -46,6 +46,15 @@ namespace celeritas
  * placements, a single PV may correspond to multiple spatial placements and is
  * disambiguated with \c ReplicaId , which corresponds to the PV's "copy
  * number".
+ *
+ * Each \c SurfaceId maps to a \c G4LogicalSurface instance, which is ether a
+ * \c G4LogicalBorderSurface (an "interface" surface between two volume
+ * instances) or a \c G4LogicalSkinSurface (a "boundary" surrounding a single
+ * logical volume). To ensure reproducible surface IDs across runs, we put
+ * boundaries before interfaces, and sort within each set by IDs (not by
+ * Geant4 object pointers, which is how the implementations store in a table).
+ * Surface labels are accessed via the SurfaceParams object which can be
+ * created by the model input returned by this class.
  */
 class GeantGeoParams final : public GeoParamsInterface,
                              public ParamsDataInterface<GeantGeoParamsData>
@@ -64,6 +73,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     explicit GeantGeoParams(std::string const& gdml_filename);
 
     // Create a VecGeom model from an already-loaded Geant4 geometry
+    // TODO: also take model input? see #1815
     explicit GeantGeoParams(G4VPhysicalVolume const* world);
 
     CELER_DEFAULT_MOVE_DELETE_COPY(GeantGeoParams);
@@ -101,6 +111,14 @@ class GeantGeoParams final : public GeoParamsInterface,
 
     // Get the Geant4 logical volume corresponding to a volume ID
     G4LogicalVolume const* id_to_geant(VolumeId vol_id) const;
+
+    //// SURFACES ////
+
+    //! Get the number of surfaces (TODO: maybe live in surface params?)
+    SurfaceId::size_type num_surfaces() const { return surfaces_.size(); }
+
+    // Get the Geant4 logical volume corresponding to a volume ID
+    inline G4LogicalSurface const* id_to_geant(SurfaceId surf_id) const;
 
     // DEPRECATED
     using GeoParamsInterface::find_volume;
@@ -162,6 +180,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     // Host metadata/access
     VolumeMap volumes_;
     VolInstanceMap vol_instances_;
+    std::vector<G4LogicalSurface const*> surfaces_;
     BBox bbox_;
     LevelId::size_type max_depth_{0};
 
@@ -206,6 +225,21 @@ auto GeantGeoParams::volumes() const -> VolumeMap const&
 auto GeantGeoParams::volume_instances() const -> VolInstanceMap const&
 {
     return vol_instances_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the Geant4 logical volume corresponding to a volume ID.
+ */
+G4LogicalSurface const* GeantGeoParams::id_to_geant(SurfaceId id) const
+{
+    CELER_EXPECT(!id || id < surfaces_.size());
+    if (!id)
+    {
+        return {};
+    }
+
+    return surfaces_[id.unchecked_get()];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -51,10 +51,10 @@ namespace celeritas
  * \c G4LogicalBorderSurface (an "interface" surface between two volume
  * instances) or a \c G4LogicalSkinSurface (a "boundary" surrounding a single
  * logical volume). To ensure reproducible surface IDs across runs, we put
- * boundaries before interfaces, and sort within each set by IDs (not by
- * Geant4 object pointers, which is how the implementations store in a table).
- * Surface labels are accessed via the SurfaceParams object which can be
- * created by the model input returned by this class.
+ * boundaries before interfaces, and sort within each set by volume IDs (not by
+ * Geant4 object pointers, which is what the Geant4 implementation stores in a
+ * table).  Surface labels are accessed via the SurfaceParams object, which can
+ * be created by the model input returned by this class.
  */
 class GeantGeoParams final : public GeoParamsInterface,
                              public ParamsDataInterface<GeantGeoParamsData>
@@ -117,7 +117,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     //! Get the number of surfaces (TODO: maybe live in surface params?)
     SurfaceId::size_type num_surfaces() const { return surfaces_.size(); }
 
-    // Get the Geant4 logical volume corresponding to a volume ID
+    // Get the Geant4 logical surface corresponding to a surface ID
     inline G4LogicalSurface const* id_to_geant(SurfaceId surf_id) const;
 
     // DEPRECATED
@@ -229,7 +229,7 @@ auto GeantGeoParams::volume_instances() const -> VolInstanceMap const&
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the Geant4 logical volume corresponding to a volume ID.
+ * Get the Geant4 logical surface corresponding to a surface ID.
  */
 G4LogicalSurface const* GeantGeoParams::id_to_geant(SurfaceId id) const
 {

--- a/src/geocel/Types.hh
+++ b/src/geocel/Types.hh
@@ -45,6 +45,9 @@ using GeoMatId = OpaqueId<struct GeoMaterial_>;
 //! Implementation detail surface (for surface-based geometries)
 using InternalSurfaceId = OpaqueId<struct Surface_>;
 
+//! Combined boundary/interface surface identifier
+using SurfaceId = OpaqueId<struct Surface_, unsigned int>;
+
 //! Identifier for a geometry volume that may be repeated
 using VolumeId = OpaqueId<struct Volume_>;
 

--- a/src/geocel/inp/Model.hh
+++ b/src/geocel/inp/Model.hh
@@ -81,6 +81,36 @@ struct Volumes
 
 //---------------------------------------------------------------------------//
 /*!
+ * Define a single surface, the boundary around or between volumes.
+ *
+ * An "interface" surface is an (exiting, entering) pair of volume instances.
+ * A "boundary" surface is the entire surface of a volume.
+ *
+ * See \c SurfaceParams . These are typically loaded from Geant4 via \c
+ * celeritas::setup::load_geant .
+ */
+struct Surface
+{
+    using Interface = std::pair<VolumeInstanceId, VolumeInstanceId>;
+    using Boundary = VolumeId;
+
+    std::variant<Interface, Boundary> surface;
+    Label label;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * List all surfaces in a problem.
+ */
+struct Surfaces
+{
+    using VecSurface = std::vector<Surface>;
+
+    VecSurface surfaces;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Set up geometry/material model.
  *
  * The geometry filename should almost always be a GDML path. As a temporary
@@ -98,6 +128,7 @@ struct Model
     // TODO: Materials
     // TODO: Regions
     Volumes volumes;
+    Surfaces surfaces;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/inp/Model.hh
+++ b/src/geocel/inp/Model.hh
@@ -65,8 +65,6 @@ struct VolumeInstance
 //---------------------------------------------------------------------------//
 /*!
  * Define a graph of geometry elements.
- *
- * \todo Construct from in-memory Geant4
  */
 struct Volumes
 {
@@ -85,9 +83,6 @@ struct Volumes
  *
  * An "interface" surface is an (exiting, entering) pair of volume instances.
  * A "boundary" surface is the entire surface of a volume.
- *
- * See \c SurfaceParams . These are typically loaded from Geant4 via \c
- * celeritas::setup::load_geant .
  */
 struct Surface
 {

--- a/test/geocel/GenericGeoResults.hh
+++ b/test/geocel/GenericGeoResults.hh
@@ -114,6 +114,11 @@ struct GenericGeoModelInp
         std::vector<std::string> labels;
         std::vector<int> volumes;
     } volume_instance;
+    struct
+    {
+        std::vector<std::string> labels;
+        std::vector<std::string> volumes;
+    } surface;
 
     static GenericGeoModelInp from_model_input(inp::Model const& in);
     void print_expected() const;

--- a/test/geocel/GeoTests.hh
+++ b/test/geocel/GeoTests.hh
@@ -102,6 +102,27 @@ class MultiLevelGeoTest
 
 //---------------------------------------------------------------------------//
 /*!
+ * Test the optical surfaces geometry.
+ */
+class OpticalSurfacesGeoTest
+{
+  public:
+    static std::string_view geometry_basename() { return "optical-surfaces"; }
+
+    //! Construct with a reference to the GoogleTest
+    OpticalSurfacesGeoTest(GenericGeoTestInterface* geo_test) : test_{geo_test}
+    {
+    }
+
+    void test_model() const;
+    void test_trace() const;
+
+  private:
+    GenericGeoTestInterface* test_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Test a bunch of polyhedra.
  */
 class PolyhedraGeoTest

--- a/test/geocel/data/optical-surfaces.gdml
+++ b/test/geocel/data/optical-surfaces.gdml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define>
+    <matrix name="RINDEX_Air"     coldim="2" values="1.65e-06 1.59 1e-05 1.59"/>
+    <matrix name="RINDEX_LAr"     coldim="2" values="1.88e-06 1.22 1e-05 1.22"/>
+    <matrix name="RINDEX_Acrylic" coldim="2" values="4.13e-09 1.50 8.45e-09 1.50"/>
+    <matrix name="REFLECTIVITY_lo"    coldim="2" values="1.65e-06 0.6 1e-05 0.6"/>
+    <matrix name="REFLECTIVITY_lomid" coldim="2" values="1.65e-06 0.7 1e-05 0.7"/>
+    <matrix name="REFLECTIVITY_mid"   coldim="2" values="1.65e-06 0.8 1e-05 0.8"/>
+    <matrix name="REFLECTIVITY_hi"    coldim="2" values="1.65e-06 0.9 1e-05 0.9"/>
+    <matrix name="ABSLENGTH_Acrylic" coldim="2" values="1.13e-09 263.1 1.24e-09 263 1.55e-09 263 1.77e-09 250 2.07e-09 227 2.48e-09 200 3.10e-09 131 4.13e-09  161 4.96e-09 74 5.51e-09 13 5.90e-09 1 6.20e-09 0"/>
+  </define>
+  <materials>
+    <element name="C" formula="C" Z="6" N="12">
+      <atom unit="g/mole" value="12.0107"/>
+    </element>
+    <element name="H" formula="H" Z="1" N="1">
+      <atom unit="g/mole" value="1.00794"/>
+    </element>
+    <element name="N" Z="7" formula="N">
+      <atom unit="g/mole" value="14"/>
+    </element>
+    <element name="O" Z="8" formula="O">
+      <atom unit="g/mole" value="16"/>
+    </element>
+    <element name="Ar" Z="18" formula="Ar">
+      <atom unit="g/mole" value="40"/>
+    </element>
+
+    <material name="Air" state="gas">
+      <property name="RINDEX" ref="RINDEX_Air"/>
+      <T unit="K" value="293.15"/>
+      <D value="0.0012"/>
+      <fraction n="0.7" ref="N"/>
+      <fraction n="0.3" ref="O"/>
+    </material>
+    <material name="lAr" state="liquid">
+      <property name="RINDEX" ref="RINDEX_LAr"/>
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar"/>
+    </material>
+    <material name="Acrylic">
+      <property name="RINDEX" ref="RINDEX_Acrylic"/>
+      <property name="ABSLENGTH" ref="ABSLENGTH_Acrylic"/>
+      <D unit="g/cm3" value="1.19"/>
+      <fraction n="0.6" ref="C"/>
+      <fraction n="0.1" ref="H"/>
+      <fraction n="0.3" ref="O"/>
+    </material>
+    <material name="vacuum" state="gas">
+      <T unit="K" value="2.73"/>
+      <P unit="pascal" value="3e-18"/>
+      <MEE unit="eV" value="21.8"/>
+      <D unit="g/cm3" value="1e-25"/>
+      <fraction n="1" ref="H"/>
+    </material>
+  </materials>
+
+  <solids>
+    <sphere lunit="cm" name="sphere" rmax="5.0" deltaphi="360" deltatheta="180" aunit="deg"/>
+    <tube aunit="deg" deltaphi="360" lunit="cm" name="tube1" rmax="10" startphi="0" z="20"/>
+    <tube aunit="deg" deltaphi="360" lunit="cm" name="tube2" rmax="5" startphi="0" z="10"/>
+    <sphere lunit="cm" name="world_sphere" rmin="0.0" rmax="100.0" deltaphi="360" deltatheta="180" aunit="deg"/>
+    <opticalsurface name="sphere_surf" model="glisur" finish="polished" type="dielectric_dielectric" value="1.0"/>
+    <opticalsurface name="tube2_surf" model="glisur" finish="polished" type="dielectric_dielectric" value="1.0">
+      <property name="REFLECTIVITY" ref="REFLECTIVITY_lo"/>
+    </opticalsurface>
+    <opticalsurface name="lomid_surf" model="unified" finish="polished" type="dielectric_metal" value="1.0">
+      <property name="REFLECTIVITY" ref="REFLECTIVITY_lomid"/>
+    </opticalsurface>
+    <opticalsurface name="midlo_surf" model="glisur" finish="polished" type="dielectric_metal" value="1.0">
+      <property name="REFLECTIVITY" ref="REFLECTIVITY_mid"/>
+    </opticalsurface>
+    <opticalsurface name="midhi_surf" model="glisur" finish="polished" type="dielectric_metal" value="1.0">
+      <property name="REFLECTIVITY" ref="REFLECTIVITY_hi"/>
+    </opticalsurface>
+  </solids>
+
+  <structure>
+    <volume name="lar_sphere">
+      <solidref ref="sphere"/>
+      <materialref ref="lAr"/>
+    </volume>
+    <volume name="tube1_mid">
+      <solidref ref="tube1"/>
+      <materialref ref="Acrylic"/>
+    </volume>
+    <volume name="tube2">
+      <solidref ref="tube2"/>
+      <materialref ref="Acrylic"/>
+    </volume>
+    <volume name="world">
+      <solidref ref="world_sphere"/>
+      <materialref ref="vacuum"/>
+      <physvol name="lar_pv">
+        <volumeref ref="lar_sphere"/>
+        <position name="lar_pos" unit="cm" x="20" y="0" z="0"/>
+      </physvol>
+      <physvol name="tube2_below_pv">
+        <volumeref ref="tube2"/>
+        <position name="tube2_below_pos" unit="cm" x="0" y="0" z="-15"/>
+      </physvol>
+      <physvol name="tube1_mid_pv">
+        <volumeref ref="tube1_mid"/>
+      </physvol>
+      <physvol name="tube2_above_pv">
+        <volumeref ref="tube2"/>
+        <position name="tube2_above_pos" unit="cm" x="0" y="0" z="15"/>
+      </physvol>
+    </volume>
+
+    <skinsurface name="sphere_skin" surfaceproperty="sphere_surf">
+      <volumeref ref="lar_sphere"/>
+    </skinsurface>
+    <skinsurface name="tube2_skin" surfaceproperty="tube2_surf">
+      <volumeref ref="tube2"/>
+    </skinsurface>
+
+    <bordersurface name="below_to_1" surfaceproperty="lomid_surf">
+      <physvolref ref="tube2_below_pv"/>
+      <physvolref ref="tube1_mid_pv"/>
+    </bordersurface>
+    <bordersurface name="mid_to_below" surfaceproperty="midlo_surf">
+      <physvolref ref="tube1_mid_pv"/>
+      <physvolref ref="tube2_below_pv"/>
+    </bordersurface>
+    <bordersurface name="mid_to_above" surfaceproperty="midhi_surf">
+      <physvolref ref="tube1_mid_pv"/>
+      <physvolref ref="tube2_above_pv"/>
+    </bordersurface>
+  </structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="world"/>
+  </setup>
+
+</gdml>

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -432,6 +432,20 @@ TEST_F(MultiLevelTest, level_strings)
 }
 
 //---------------------------------------------------------------------------//
+using OpticalSurfacesTest
+    = GenericGeoParameterizedTest<GeantGeoTest, OpticalSurfacesGeoTest>;
+
+TEST_F(OpticalSurfacesTest, model)
+{
+    this->impl().test_model();
+}
+
+TEST_F(OpticalSurfacesTest, trace)
+{
+    this->impl().test_trace();
+}
+
+//---------------------------------------------------------------------------//
 class PincellTest : public GeantGeoTest
 {
     std::string geometry_basename() const override { return "pincell"; }


### PR DESCRIPTION
This maps `G4LogicalSkinSurface` and `G4LogicalBorderSurface` to a reproducible `SurfaceId` by sorting using the linearized Volume[Instance]Ids. It adds a test of translating surface information to and from surface IDs.