### PR TITLE
Rename solid angle class

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -137,8 +137,9 @@ EnclosedAzi enclosed_azi_from_poly(S const& solid)
  * Get the enclosed polar angle by a solid.
  */
 template<class S>
-EnclosedAzi make_wedge_polar(S const& solid)
+EnclosedAzi enclosed_pol_from(S const& solid)
 {
+    // FIXME: polar angle will be a different class
     return enclosed_azi_radians(solid.GetStartThetaAngle(),
                                 solid.GetDeltaThetaAngle());
 }
@@ -688,7 +689,7 @@ auto SolidConverter::sphere(arg_type solid_base) -> result_type
         inner = Sphere{scale_(inner_r)};
     }
 
-    auto polar_wedge = make_wedge_polar(solid);
+    auto polar_cone = enclosed_pol_from(solid);
     if (!soft_equal(value_as<Turn>(polar_wedge.interior()), 0.5))
     {
         CELER_NOT_IMPLEMENTED("sphere with polar limits");

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -690,7 +690,7 @@ auto SolidConverter::sphere(arg_type solid_base) -> result_type
     }
 
     auto polar_cone = enclosed_pol_from(solid);
-    if (!soft_equal(value_as<Turn>(polar_wedge.interior()), 0.5))
+    if (!soft_equal(value_as<Turn>(polar_cone.interior()), 0.5))
     {
         CELER_NOT_IMPLEMENTED("sphere with polar limits");
     }

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -73,12 +73,12 @@ namespace
 {
 //---------------------------------------------------------------------------//
 /*!
- * Get a SolidEnclosedAngle, avoiding values slightly beyond 1 turn.
+ * Get an EnclosedAzi, avoiding values slightly beyond 1 turn.
  *
  * This constructs from native Geant4 radians and truncates to \c real_type,
  * ensuring that roundoff doesn't push the turn beyond a full one.
  */
-SolidEnclosedAngle make_wedge(double start_rad, double delta_rad)
+EnclosedAzi enclosed_azi_radians(double start_rad, double delta_rad)
 {
     auto start = native_value_to<RealTurn>(start_rad);
     auto delta = native_value_to<RealTurn>(delta_rad);
@@ -87,7 +87,7 @@ SolidEnclosedAngle make_wedge(double start_rad, double delta_rad)
         // Avoid roundoff error
         delta = RealTurn{1};
     }
-    return SolidEnclosedAngle{start, delta};
+    return EnclosedAzi{start, delta};
 }
 
 //---------------------------------------------------------------------------//
@@ -97,9 +97,10 @@ SolidEnclosedAngle make_wedge(double start_rad, double delta_rad)
  * This internally converts from native Geant4 radians.
  */
 template<class S>
-SolidEnclosedAngle make_wedge_azimuthal(S const& solid)
+EnclosedAzi enclosed_azi_from(S const& solid)
 {
-    return make_wedge(solid.GetStartPhiAngle(), solid.GetDeltaPhiAngle());
+    return enclosed_azi_radians(solid.GetStartPhiAngle(),
+                                solid.GetDeltaPhiAngle());
 }
 
 //---------------------------------------------------------------------------//
@@ -111,9 +112,9 @@ SolidEnclosedAngle make_wedge_azimuthal(S const& solid)
  * accessing the start- and delta-phi member variables.
  */
 template<>
-SolidEnclosedAngle make_wedge_azimuthal<G4Torus>(G4Torus const& solid)
+EnclosedAzi enclosed_azi_from<G4Torus>(G4Torus const& solid)
 {
-    return make_wedge(solid.GetSPhi(), solid.GetDPhi());
+    return enclosed_azi_radians(solid.GetSPhi(), solid.GetDPhi());
 }
 
 //---------------------------------------------------------------------------//
@@ -124,11 +125,11 @@ SolidEnclosedAngle make_wedge_azimuthal<G4Torus>(G4Torus const& solid)
  * polyhedra...
  */
 template<class S>
-SolidEnclosedAngle make_wedge_azimuthal_poly(S const& solid)
+EnclosedAzi enclosed_azi_from_poly(S const& solid)
 {
     auto start = solid.GetStartPhi();
     auto stop = solid.GetEndPhi();
-    return make_wedge(start, stop - start);
+    return enclosed_azi_radians(start, stop - start);
 }
 
 //---------------------------------------------------------------------------//
@@ -136,9 +137,10 @@ SolidEnclosedAngle make_wedge_azimuthal_poly(S const& solid)
  * Get the enclosed polar angle by a solid.
  */
 template<class S>
-SolidEnclosedAngle make_wedge_polar(S const& solid)
+EnclosedAzi make_wedge_polar(S const& solid)
 {
-    return make_wedge(solid.GetStartThetaAngle(), solid.GetDeltaThetaAngle());
+    return enclosed_azi_radians(solid.GetStartThetaAngle(),
+                                solid.GetDeltaThetaAngle());
 }
 
 //---------------------------------------------------------------------------//
@@ -218,7 +220,7 @@ template<class CR>
 auto make_solid(G4VSolid const& solid,
                 CR&& interior,
                 std::optional<CR>&& excluded,
-                SolidEnclosedAngle&& enclosed)
+                EnclosedAzi&& enclosed)
 {
     return Solid<CR>::or_shape(std::string{solid.GetName()},
                                std::forward<CR>(interior),
@@ -358,7 +360,7 @@ auto SolidConverter::cons(arg_type solid_base) -> result_type
     }
 
     return make_solid(
-        solid, Cone{outer_r, hh}, std::move(inner), make_wedge_azimuthal(solid));
+        solid, Cone{outer_r, hh}, std::move(inner), enclosed_azi_from(solid));
 }
 
 //---------------------------------------------------------------------------//
@@ -602,7 +604,7 @@ auto SolidConverter::polycone(arg_type solid_base) -> result_type
     return PolyCone::or_solid(
         std::string{solid.GetName()},
         PolySegments{std::move(rmin), std::move(rmax), std::move(zs)},
-        make_wedge_azimuthal_poly(solid));
+        enclosed_azi_from_poly(solid));
 }
 
 //---------------------------------------------------------------------------//
@@ -631,7 +633,7 @@ auto SolidConverter::polyhedra(arg_type solid_base) -> result_type
         rmin.clear();
     }
 
-    auto angle = make_wedge_azimuthal_poly(solid);
+    auto angle = enclosed_azi_from_poly(solid);
     double const orientation
         = std::fmod(params.numSide * angle.start().value(), real_type{1});
 
@@ -695,7 +697,7 @@ auto SolidConverter::sphere(arg_type solid_base) -> result_type
     return make_solid(solid,
                       Sphere{scale_(solid.GetOuterRadius())},
                       std::move(inner),
-                      make_wedge_azimuthal(solid));
+                      enclosed_azi_from(solid));
 }
 
 //---------------------------------------------------------------------------//
@@ -742,7 +744,7 @@ auto SolidConverter::torus(arg_type solid_base) -> result_type
     return make_solid(solid,
                       Cylinder{rtor + rmax, rmax},
                       std::move(inner),
-                      make_wedge_azimuthal(solid));
+                      enclosed_azi_from(solid));
 }
 
 //---------------------------------------------------------------------------//
@@ -819,7 +821,7 @@ auto SolidConverter::tubs(arg_type solid_base) -> result_type
     return make_solid(solid,
                       Cylinder{scale_(solid.GetOuterRadius()), hh},
                       std::move(inner),
-                      make_wedge_azimuthal(solid));
+                      enclosed_azi_from(solid));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/ObjectIO.json.cc
+++ b/src/orange/orangeinp/ObjectIO.json.cc
@@ -77,9 +77,9 @@ void to_json(nlohmann::json& j, PolyCone const& obj)
     j = {{"_type", "polycone"},
          SIO_ATTR_PAIR(obj, label),
          SIO_ATTR_PAIR(obj, segments)};
-    if (auto sea = obj.enclosed_angle())
+    if (auto azi = obj.enclosed_azi())
     {
-        j["enclosed_angle"] = sea;
+        j["enclosed_azi"] = azi;
     }
 }
 
@@ -92,9 +92,9 @@ void to_json(nlohmann::json& j, PolyPrism const& obj)
         SIO_ATTR_PAIR(obj, num_sides),
         SIO_ATTR_PAIR(obj, orientation),
     };
-    if (auto sea = obj.enclosed_angle())
+    if (auto azi = obj.enclosed_azi())
     {
-        j["enclosed_angle"] = sea;
+        j["enclosed_azi"] = azi;
     }
 }
 
@@ -114,9 +114,9 @@ void to_json(nlohmann::json& j, SolidBase const& obj)
     {
         j["excluded"] = *cr;
     }
-    if (auto sea = obj.enclosed_angle())
+    if (auto azi = obj.enclosed_azi())
     {
-        j["enclosed_angle"] = sea;
+        j["enclosed_azi"] = azi;
     }
     if (auto szs = obj.z_slab())
     {
@@ -155,9 +155,9 @@ void to_json(nlohmann::json& j, PolySegments const& ps)
     }
 }
 
-void to_json(nlohmann::json& j, SolidEnclosedAngle const& sea)
+void to_json(nlohmann::json& j, EnclosedAzi const& azi)
 {
-    j = {{"start", sea.start().value()}, {"interior", sea.interior().value()}};
+    j = {{"start", azi.start().value()}, {"interior", azi.interior().value()}};
 }
 
 void to_json(nlohmann::json& j, SolidZSlab const& szs)

--- a/src/orange/orangeinp/ObjectIO.json.hh
+++ b/src/orange/orangeinp/ObjectIO.json.hh
@@ -31,7 +31,7 @@ class StackedExtrudedPolygon;
 class Transformed;
 
 class PolySegments;
-class SolidEnclosedAngle;
+class EnclosedAzi;
 class SolidZSlab;
 
 class IntersectRegionInterface;
@@ -68,7 +68,7 @@ void to_json(nlohmann::json& j, Transformed const&);
 
 // Write helper classes to JSON
 void to_json(nlohmann::json& j, PolySegments const&);
-void to_json(nlohmann::json& j, SolidEnclosedAngle const&);
+void to_json(nlohmann::json& j, EnclosedAzi const&);
 void to_json(nlohmann::json& j, SolidZSlab const&);
 
 // Write intersect regions to JSON

--- a/src/orange/orangeinp/PolySolid.cc
+++ b/src/orange/orangeinp/PolySolid.cc
@@ -89,11 +89,11 @@ template<class T>
                                               detail::VolumeBuilder& vb,
                                               NodeId result)
 {
-    if (auto const& sea = base.enclosed_angle())
+    if (auto const& azi = base.enclosed_azi())
     {
         // The enclosed angle is "true" (specified by the user to truncate the
         // shape azimuthally): construct a wedge to be added or deleted
-        auto&& [sense, wedge] = sea.make_wedge();
+        auto&& [sense, wedge] = azi.make_wedge();
         NodeId wedge_id
             = build_intersect_region(vb, base.label(), "angle", wedge);
         if (sense == Sense::outside)
@@ -154,7 +154,7 @@ PolySegments::PolySegments(VecReal&& inner, VecReal&& outer, VecReal&& z)
  */
 PolySolidBase::PolySolidBase(std::string&& label,
                              PolySegments&& segments,
-                             SolidEnclosedAngle&& enclosed)
+                             EnclosedAzi&& enclosed)
     : label_{std::move(label)}
     , segments_{std::move(segments)}
     , enclosed_{std::move(enclosed)}
@@ -171,7 +171,7 @@ PolySolidBase::~PolySolidBase() = default;
  */
 auto PolyCone::or_solid(std::string&& label,
                         PolySegments&& segments,
-                        SolidEnclosedAngle&& enclosed) -> SPConstObject
+                        EnclosedAzi&& enclosed) -> SPConstObject
 {
     if (segments.size() > 1)
     {
@@ -209,7 +209,7 @@ auto PolyCone::or_solid(std::string&& label,
  */
 PolyCone::PolyCone(std::string&& label,
                    PolySegments&& segments,
-                   SolidEnclosedAngle&& enclosed)
+                   EnclosedAzi&& enclosed)
     : PolySolidBase{std::move(label), std::move(segments), std::move(enclosed)}
 {
 }
@@ -253,7 +253,7 @@ void PolyCone::output(JsonPimpl* j) const
  */
 auto PolyPrism::or_solid(std::string&& label,
                          PolySegments&& segments,
-                         SolidEnclosedAngle&& enclosed,
+                         EnclosedAzi&& enclosed,
                          int num_sides,
                          real_type orientation) -> SPConstObject
 {
@@ -308,7 +308,7 @@ auto PolyPrism::or_solid(std::string&& label,
  */
 PolyPrism::PolyPrism(std::string&& label,
                      PolySegments&& segments,
-                     SolidEnclosedAngle&& enclosed,
+                     EnclosedAzi&& enclosed,
                      int num_sides,
                      real_type orientation)
     : PolySolidBase{std::move(label), std::move(segments), std::move(enclosed)}

--- a/src/orange/orangeinp/PolySolid.cc
+++ b/src/orange/orangeinp/PolySolid.cc
@@ -93,7 +93,7 @@ template<class T>
     {
         // The enclosed angle is "true" (specified by the user to truncate the
         // shape azimuthally): construct a wedge to be added or deleted
-        auto&& [sense, wedge] = azi.make_wedge();
+        auto&& [sense, wedge] = azi.make_sense_region();
         NodeId wedge_id
             = build_intersect_region(vb, base.label(), "angle", wedge);
         if (sense == Sense::outside)

--- a/src/orange/orangeinp/PolySolid.hh
+++ b/src/orange/orangeinp/PolySolid.hh
@@ -128,12 +128,12 @@ class PolySolidBase : public ObjectInterface
     PolySegments const& segments() const { return segments_; }
 
     //! Optional azimuthal angular restriction
-    SolidEnclosedAngle enclosed_angle() const { return enclosed_; }
+    EnclosedAzi enclosed_azi() const { return enclosed_; }
 
   protected:
     PolySolidBase(std::string&& label,
                   PolySegments&& segments,
-                  SolidEnclosedAngle&& enclosed);
+                  EnclosedAzi&& enclosed);
 
     //!@{
     //! Allow construction and assignment only through daughter classes
@@ -143,7 +143,7 @@ class PolySolidBase : public ObjectInterface
   private:
     std::string label_;
     PolySegments segments_;
-    SolidEnclosedAngle enclosed_;
+    EnclosedAzi enclosed_;
 };
 
 //---------------------------------------------------------------------------//
@@ -156,12 +156,12 @@ class PolyCone final : public PolySolidBase
     // Return a polycone *or* a simplified version for only a single segment
     static SPConstObject or_solid(std::string&& label,
                                   PolySegments&& segments,
-                                  SolidEnclosedAngle&& enclosed);
+                                  EnclosedAzi&& enclosed);
 
     // Build with label, axial segments, optional restriction
     PolyCone(std::string&& label,
              PolySegments&& segments,
-             SolidEnclosedAngle&& enclosed);
+             EnclosedAzi&& enclosed);
 
     // Construct a volume from this object
     NodeId build(VolumeBuilder&) const final;
@@ -180,14 +180,14 @@ class PolyPrism final : public PolySolidBase
     // Return a polyprism *or* a simplified version for only a single segment
     static SPConstObject or_solid(std::string&& label,
                                   PolySegments&& segments,
-                                  SolidEnclosedAngle&& enclosed,
+                                  EnclosedAzi&& enclosed,
                                   int num_sides,
                                   real_type orientation);
 
     // Build with label, axial segments, parameters, optional restriction
     PolyPrism(std::string&& label,
               PolySegments&& segments,
-              SolidEnclosedAngle&& enclosed,
+              EnclosedAzi&& enclosed,
               int num_sides,
               real_type orientation);
 

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -39,7 +39,7 @@ EnclosedAzi::EnclosedAzi(Turn start, Turn interior)
 /*!
  * Construct a wedge shape to intersect (inside) or subtract (outside).
  */
-auto EnclosedAzi::make_wedge() const -> SenseWedge
+auto EnclosedAzi::make_sense_region() const -> SenseWedge
 {
     CELER_EXPECT(*this);
     // Get the start value between [0, 1)
@@ -104,7 +104,7 @@ NodeId SolidBase::build(VolumeBuilder& vb) const
     {
         // The enclosed angle is "true" (specified by the user to truncate the
         // shape azimuthally): construct a wedge to be added or deleted
-        auto&& [sense, wedge] = azi.make_wedge();
+        auto&& [sense, wedge] = azi.make_sense_region();
         NodeId wedge_id
             = build_intersect_region(vb, this->label(), "angle", wedge);
         if (sense == Sense::outside)

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -27,7 +27,7 @@ namespace orangeinp
 /*!
  * Construct from a starting angle and interior angle.
  */
-SolidEnclosedAngle::SolidEnclosedAngle(Turn start, Turn interior)
+EnclosedAzi::EnclosedAzi(Turn start, Turn interior)
     : start_{start}, interior_{interior}
 {
     CELER_VALIDATE(interior_ > zero_quantity() && interior_ <= Turn{1},
@@ -39,7 +39,7 @@ SolidEnclosedAngle::SolidEnclosedAngle(Turn start, Turn interior)
 /*!
  * Construct a wedge shape to intersect (inside) or subtract (outside).
  */
-auto SolidEnclosedAngle::make_wedge() const -> SenseWedge
+auto EnclosedAzi::make_wedge() const -> SenseWedge
 {
     CELER_EXPECT(*this);
     // Get the start value between [0, 1)
@@ -100,11 +100,11 @@ NodeId SolidBase::build(VolumeBuilder& vb) const
         nodes.push_back(vb.insert_region({}, Negated{smaller}));
     }
 
-    if (auto const& sea = this->enclosed_angle())
+    if (auto const& azi = this->enclosed_azi())
     {
         // The enclosed angle is "true" (specified by the user to truncate the
         // shape azimuthally): construct a wedge to be added or deleted
-        auto&& [sense, wedge] = sea.make_wedge();
+        auto&& [sense, wedge] = azi.make_wedge();
         NodeId wedge_id
             = build_intersect_region(vb, this->label(), "angle", wedge);
         if (sense == Sense::outside)
@@ -142,7 +142,7 @@ template<class T>
 auto Solid<T>::or_shape(std::string&& label,
                         T&& interior,
                         OptionalRegion&& excluded,
-                        SolidEnclosedAngle&& enclosed) -> SPConstObject
+                        EnclosedAzi&& enclosed) -> SPConstObject
 {
     if (!excluded && !enclosed)
     {
@@ -165,7 +165,7 @@ template<class T>
 Solid<T>::Solid(std::string&& label,
                 T&& interior,
                 OptionalRegion&& excluded,
-                SolidEnclosedAngle&& enclosed)
+                EnclosedAzi&& enclosed)
     : label_{std::move(label)}
     , interior_{std::move(interior)}
     , exclusion_{std::move(excluded)}
@@ -189,7 +189,7 @@ Solid<T>::Solid(std::string&& label, T&& interior, T&& excluded)
     : Solid{std::move(label),
             std::move(interior),
             std::move(excluded),
-            SolidEnclosedAngle{}}
+            EnclosedAzi{}}
 {
 }
 
@@ -198,7 +198,7 @@ Solid<T>::Solid(std::string&& label, T&& interior, T&& excluded)
  * Construct with an enclosed angle.
  */
 template<class T>
-Solid<T>::Solid(std::string&& label, T&& interior, SolidEnclosedAngle&& enclosed)
+Solid<T>::Solid(std::string&& label, T&& interior, EnclosedAzi&& enclosed)
     : Solid{std::move(label),
             std::move(interior),
             std::nullopt,
@@ -219,7 +219,7 @@ Solid<T>::Solid(std::string&& label, T&& interior, SolidZSlab&& z_slab)
     : label_{std::move(label)}
     , interior_{std::move(interior)}
     , exclusion_{std::nullopt}
-    , enclosed_{SolidEnclosedAngle{}}
+    , enclosed_{EnclosedAzi{}}
     , z_slab_{std::move(z_slab)}
 {
 }

--- a/src/orange/orangeinp/Solid.hh
+++ b/src/orange/orangeinp/Solid.hh
@@ -33,12 +33,12 @@ namespace orangeinp
  *
  * \code
   // Truncates a solid to the east-facing quadrant:
-  SolidEnclosedAngle{Turn{-0.125}, Turn{0.25}};
+  EnclosedAzi{Turn{-0.125}, Turn{0.25}};
   // Removes the second quadrant (northwest) from a solid:
-  SolidEnclosedAngle{Turn{0.50}, Turn{0.75}};
+  EnclosedAzi{Turn{0.50}, Turn{0.75}};
   \endcode
  */
-class SolidEnclosedAngle
+class EnclosedAzi
 {
   public:
     //!@{
@@ -48,10 +48,10 @@ class SolidEnclosedAngle
 
   public:
     //! Default to "all angles"
-    SolidEnclosedAngle() = default;
+    EnclosedAzi() = default;
 
     // Construct from a starting angle and interior angle
-    SolidEnclosedAngle(Turn start, Turn interior);
+    EnclosedAzi(Turn start, Turn interior);
 
     // Construct a wedge shape to intersect (inside) or subtract (outside)
     SenseWedge make_wedge() const;
@@ -123,7 +123,7 @@ class SolidBase : public ObjectInterface
     virtual IntersectRegionInterface const* excluded() const = 0;
 
     //! Optional azimuthal angular restriction
-    virtual SolidEnclosedAngle enclosed_angle() const = 0;
+    virtual EnclosedAzi enclosed_azi() const = 0;
 
     //! Optional z-slab restriction
     virtual SolidZSlab z_slab() const = 0;
@@ -174,16 +174,16 @@ class Solid final : public SolidBase
     static SPConstObject or_shape(std::string&& label,
                                   T&& interior,
                                   OptionalRegion&& excluded,
-                                  SolidEnclosedAngle&& enclosed);
+                                  EnclosedAzi&& enclosed);
 
     // Construct with an excluded interior *and/or* enclosed angle
     Solid(std::string&& label,
           T&& interior,
           OptionalRegion&& excluded,
-          SolidEnclosedAngle&& enclosed);
+          EnclosedAzi&& enclosed);
 
     // Construct with only an enclosed angle
-    Solid(std::string&& label, T&& interior, SolidEnclosedAngle&& enclosed);
+    Solid(std::string&& label, T&& interior, EnclosedAzi&& enclosed);
 
     // Construct with only an excluded interior
     Solid(std::string&& label, T&& interior, T&& excluded);
@@ -204,7 +204,7 @@ class Solid final : public SolidBase
     IntersectRegionInterface const* excluded() const final;
 
     //! Optional angular restriction
-    SolidEnclosedAngle enclosed_angle() const final { return enclosed_; }
+    EnclosedAzi enclosed_azi() const final { return enclosed_; }
 
     //! Optional z-slab intersection
     SolidZSlab z_slab() const final { return z_slab_; }
@@ -213,7 +213,7 @@ class Solid final : public SolidBase
     std::string label_;
     T interior_;
     OptionalRegion exclusion_;
-    SolidEnclosedAngle enclosed_;
+    EnclosedAzi enclosed_;
     SolidZSlab z_slab_;
 };
 
@@ -250,7 +250,7 @@ extern template class Solid<Ellipsoid>;
 /*!
  * Whether the enclosed angle is not a full circle.
  */
-SolidEnclosedAngle::operator bool() const
+EnclosedAzi::operator bool() const
 {
     return interior_ != Turn{1};
 }

--- a/src/orange/orangeinp/Solid.hh
+++ b/src/orange/orangeinp/Solid.hh
@@ -54,7 +54,7 @@ class EnclosedAzi
     EnclosedAzi(Turn start, Turn interior);
 
     // Construct a wedge shape to intersect (inside) or subtract (outside)
-    SenseWedge make_wedge() const;
+    SenseWedge make_sense_region() const;
 
     // Whether the enclosed angle is not a full circle
     explicit inline operator bool() const;

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -216,12 +216,12 @@ TEST_F(SolidConverterTest, cons)
                1.0,
                0.17453292519943,
                5.235987755983),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.8333333333333353,"start":0.027777777777777308},"excluded":{"_type":"cone","halfheight":0.1,"radii":[2.0,6.0]},"interior":{"_type":"cone","halfheight":0.1,"radii":[8.0,14.0]},"label":"test10"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.8333333333333353,"start":0.027777777777777308},"excluded":{"_type":"cone","halfheight":0.1,"radii":[2.0,6.0]},"interior":{"_type":"cone","halfheight":0.1,"radii":[8.0,14.0]},"label":"test10"})json");
 
     this->build_and_test(
         G4Cons(
             "aCone", 2 * cm, 6 * cm, 8 * cm, 14 * cm, 10 * cm, 10 * deg, 300 * deg),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.8333333333333334,"start":0.027777777777777776},"excluded":{"_type":"cone","halfheight":10.0,"radii":[2.0,8.0]},"interior":{"_type":"cone","halfheight":10.0,"radii":[6.0,14.0]},"label":"aCone"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.8333333333333334,"start":0.027777777777777776},"excluded":{"_type":"cone","halfheight":10.0,"radii":[2.0,8.0]},"interior":{"_type":"cone","halfheight":10.0,"radii":[6.0,14.0]},"label":"aCone"})json");
 }
 
 TEST_F(SolidConverterTest, displaced)
@@ -537,7 +537,7 @@ TEST_F(SolidConverterTest, polycone)
                        z,
                        rmin,
                        rmax),
-            R"json({"_type":"polycone","enclosed_angle":{"interior":0.03125,"start":0.984375},"label":"EMEC_WideStretchers","segments":[{"outer":[207.0,207.0,207.0,207.0,207.0,207.0],"z":[-16.5,-1.0,-1.0,1.0,1.0,16.5]},["inner",[204.4,204.4,205.05,205.05,204.4,204.4]]]})json",
+            R"json({"_type":"polycone","enclosed_azi":{"interior":0.03125,"start":0.984375},"label":"EMEC_WideStretchers","segments":[{"outer":[207.0,207.0,207.0,207.0,207.0,207.0],"z":[-16.5,-1.0,-1.0,1.0,1.0,16.5]},["inner",[204.4,204.4,205.05,205.05,204.4,204.4]]]})json",
             {{206, 0, 0}, {-206, 0, 0}});
     }
 }
@@ -594,7 +594,7 @@ TEST_F(SolidConverterTest, sphere)
         R"json({"_type":"shape","interior":{"_type":"sphere","radius":5.0},"label":"Solid G4Sphere"})json");
     this->build_and_test(
         G4Sphere("sn1", 0, 50, halfpi, 3. * halfpi, 0, pi),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":0.25},"interior":{"_type":"sphere","radius":5.0},"label":"sn1"})json",
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.75,"start":0.25},"interior":{"_type":"sphere","radius":5.0},"label":"sn1"})json",
         {{-3, 0.05, 0}, {3, 0.5, 0}, {0, -0.01, 4.9}});
     EXPECT_THROW(
         this->build_and_test(G4Sphere("sn12", 0, 50, 0, twopi, 0., 0.25 * pi)),
@@ -611,7 +611,7 @@ TEST_F(SolidConverterTest, sphere)
 
     this->build_and_test(
         G4Sphere("Band (phi segment)", 5, 50, -pi, 3. * pi / 2., 0, twopi),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":-0.5},"excluded":{"_type":"sphere","radius":0.5},"interior":{"_type":"sphere","radius":5.0},"label":"Band (phi segment)"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.75,"start":-0.5},"excluded":{"_type":"sphere","radius":0.5},"interior":{"_type":"sphere","radius":5.0},"label":"Band (phi segment)"})json");
     EXPECT_THROW(
         this->build_and_test(G4Sphere(
             "Patch (phi/theta seg)", 45, 50, -pi / 4, halfpi, pi / 4, halfpi)),
@@ -619,7 +619,7 @@ TEST_F(SolidConverterTest, sphere)
 
     this->build_and_test(
         G4Sphere("John example", 300, 500, 0, 5.76, 0, pi),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.9167324722093171,"start":0.0},"excluded":{"_type":"sphere","radius":30.0},"interior":{"_type":"sphere","radius":50.0},"label":"John example"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.9167324722093171,"start":0.0},"excluded":{"_type":"sphere","radius":30.0},"interior":{"_type":"sphere","radius":50.0},"label":"John example"})json");
 }
 
 TEST_F(SolidConverterTest, subtractionsolid)
@@ -687,7 +687,7 @@ TEST_F(SolidConverterTest, torus)
 {
     G4Torus torus("testTorus", 0 * cm, 20 * cm, 50 * cm, 0 * deg, 270 * deg);
     auto json_str
-        = R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":0.0},"excluded":{"_type":"cylinder","halfheight":20.0,"radius":30.0},"interior":{"_type":"cylinder","halfheight":20.0,"radius":70.0},"label":"testTorus"})json";
+        = R"json({"_type":"solid","enclosed_azi":{"interior":0.75,"start":0.0},"excluded":{"_type":"cylinder","halfheight":20.0,"radius":30.0},"interior":{"_type":"cylinder","halfheight":20.0,"radius":70.0},"label":"testTorus"})json";
 
     SolidConverter convert{scale_, transform_};
     auto obj = convert(torus);
@@ -816,7 +816,7 @@ TEST_F(SolidConverterTest, tubs)
 
     this->build_and_test(
         G4Tubs("Solid Tube #1a", 0, 50 * mm, 50 * mm, 0, 0.5 * pi),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.25,"start":0.0},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Solid Tube #1a"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.25,"start":0.0},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Solid Tube #1a"})json");
 
     this->build_and_test(
         G4Tubs("Hole Tube #2", 45 * mm, 50 * mm, 50 * mm, 0, 2 * pi),
@@ -840,19 +840,19 @@ TEST_F(SolidConverterTest, tubs)
 
     this->build_and_test(
         G4Tubs("Solid Sector #3", 0, 50 * mm, 50 * mm, halfpi, halfpi),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.25,"start":0.25},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Solid Sector #3"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.25,"start":0.25},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Solid Sector #3"})json");
 
     this->build_and_test(
         G4Tubs("Hole Sector #4", 45 * mm, 50 * mm, 50 * mm, halfpi, halfpi),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.25,"start":0.25},"excluded":{"_type":"cylinder","halfheight":5.0,"radius":4.5},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Hole Sector #4"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.25,"start":0.25},"excluded":{"_type":"cylinder","halfheight":5.0,"radius":4.5},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Hole Sector #4"})json");
 
     this->build_and_test(
         G4Tubs("Hole Sector #5", 50 * mm, 100 * mm, 50 * mm, 0.0, 270.0 * deg),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":0.0},"excluded":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"interior":{"_type":"cylinder","halfheight":5.0,"radius":10.0},"label":"Hole Sector #5"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.75,"start":0.0},"excluded":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"interior":{"_type":"cylinder","halfheight":5.0,"radius":10.0},"label":"Hole Sector #5"})json");
 
     this->build_and_test(
         G4Tubs("Solid Sector #3", 0, 50 * mm, 50 * mm, halfpi, 3. * halfpi),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.75,"start":0.25},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Solid Sector #3"})json");
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.75,"start":0.25},"interior":{"_type":"cylinder","halfheight":5.0,"radius":5.0},"label":"Solid Sector #3"})json");
 
     this->build_and_test(
         G4Tubs("Barrel",
@@ -861,7 +861,7 @@ TEST_F(SolidConverterTest, tubs)
                (5640.0 / 2) * mm,
                0 * deg,
                11.25 * deg),
-        R"json({"_type":"solid","enclosed_angle":{"interior":0.03125,"start":0.0},"excluded":{"_type":"cylinder","halfheight":282.0,"radius":228.8},"interior":{"_type":"cylinder","halfheight":282.0,"radius":425.0},"label":"Barrel"})json",
+        R"json({"_type":"solid","enclosed_azi":{"interior":0.03125,"start":0.0},"excluded":{"_type":"cylinder","halfheight":282.0,"radius":228.8},"interior":{"_type":"cylinder","halfheight":282.0,"radius":425.0},"label":"Barrel"})json",
         {{300, 25, 0.1}, {300, -25, 0.1}, {450, 0.1, 0.1}});
 }
 

--- a/test/orange/orangeinp/PolySolid.test.cc
+++ b/test/orange/orangeinp/PolySolid.test.cc
@@ -182,7 +182,7 @@ TEST_F(PolyconeTest, sliced)
 {
     this->build_volume(PolyCone{"pc",
                                 PolySegments{{2, 1, 3}, {-2, 0, 2}},
-                                SolidEnclosedAngle{Turn{0.125}, Turn{0.75}}});
+                                EnclosedAzi{Turn{0.125}, Turn{0.75}}});
 
     static char const* const expected_surface_strings[] = {
         "Plane: z=-2",
@@ -265,7 +265,7 @@ TEST_F(PolyconeTest, or_solid)
 {
     {
         auto s = PolyCone::or_solid(
-            "cone", PolySegments{{1, 2}, {-2, 2}}, SolidEnclosedAngle{});
+            "cone", PolySegments{{1, 2}, {-2, 2}}, EnclosedAzi{});
         EXPECT_TRUE(s);
         EXPECT_TRUE(dynamic_cast<ConeShape const*>(s.get()));
         this->build_volume(*s);
@@ -273,14 +273,14 @@ TEST_F(PolyconeTest, or_solid)
     {
         auto s = PolyCone::or_solid("hollowcone",
                                     PolySegments{{0.5, 0.75}, {1, 2}, {-2, 2}},
-                                    SolidEnclosedAngle{});
+                                    EnclosedAzi{});
         EXPECT_TRUE(s);
         EXPECT_TRUE(dynamic_cast<ConeSolid const*>(s.get()));
         this->build_volume(*s);
     }
     {
         auto s = PolyCone::or_solid(
-            "transcyl", PolySegments{{2, 2}, {0, 4}}, SolidEnclosedAngle{});
+            "transcyl", PolySegments{{2, 2}, {0, 4}}, EnclosedAzi{});
         EXPECT_TRUE(s);
         EXPECT_TRUE(dynamic_cast<Transformed const*>(s.get()));
         this->build_volume(*s);

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -20,41 +20,41 @@ namespace orangeinp
 namespace test
 {
 //---------------------------------------------------------------------------//
-TEST(SolidEnclosedAngleTest, errors)
+TEST(EnclosedAziTest, errors)
 {
-    EXPECT_THROW(SolidEnclosedAngle(Turn{0}, Turn{-0.5}), RuntimeError);
-    EXPECT_THROW(SolidEnclosedAngle(Turn{0}, Turn{0}), RuntimeError);
-    EXPECT_THROW(SolidEnclosedAngle(Turn{0}, Turn{1.5}), RuntimeError);
+    EXPECT_THROW(EnclosedAzi(Turn{0}, Turn{-0.5}), RuntimeError);
+    EXPECT_THROW(EnclosedAzi(Turn{0}, Turn{0}), RuntimeError);
+    EXPECT_THROW(EnclosedAzi(Turn{0}, Turn{1.5}), RuntimeError);
 }
 
-TEST(SolidEnclosedAngleTest, null)
+TEST(EnclosedAziTest, null)
 {
-    SolidEnclosedAngle sea;
-    EXPECT_FALSE(sea);
+    EnclosedAzi azi;
+    EXPECT_FALSE(azi);
 }
 
-TEST(SolidEnclosedAngleTest, make_wedge)
+TEST(EnclosedAziTest, make_wedge)
 {
     {
         SCOPED_TRACE("concave");
-        SolidEnclosedAngle sea(Turn{-0.25}, Turn{0.1});
-        auto&& [sense, wedge] = sea.make_wedge();
+        EnclosedAzi azi(Turn{-0.25}, Turn{0.1});
+        auto&& [sense, wedge] = azi.make_wedge();
         EXPECT_EQ(Sense::inside, sense);
         EXPECT_SOFT_EQ(0.75, wedge.start().value());
         EXPECT_SOFT_EQ(0.1, wedge.interior().value());
     }
     {
         SCOPED_TRACE("convex");
-        SolidEnclosedAngle sea(Turn{0.25}, Turn{0.8});
-        auto&& [sense, wedge] = sea.make_wedge();
+        EnclosedAzi azi(Turn{0.25}, Turn{0.8});
+        auto&& [sense, wedge] = azi.make_wedge();
         EXPECT_EQ(Sense::outside, sense);
         EXPECT_SOFT_EQ(0.05, wedge.start().value());
         EXPECT_SOFT_EQ(0.2, wedge.interior().value());
     }
     {
         SCOPED_TRACE("half");
-        SolidEnclosedAngle sea(Turn{0.1}, Turn{0.5});
-        auto&& [sense, wedge] = sea.make_wedge();
+        EnclosedAzi azi(Turn{0.1}, Turn{0.5});
+        auto&& [sense, wedge] = azi.make_wedge();
         EXPECT_EQ(Sense::inside, sense);
         EXPECT_SOFT_EQ(0.1, wedge.start().value());
         EXPECT_SOFT_EQ(0.5, wedge.interior().value());
@@ -97,11 +97,10 @@ TEST_F(SolidTest, errors)
     EXPECT_THROW(ConeSolid("cone", Cone{{1, 2}, 10.0}, Cone{{1.1, 1.9}, 10.0}),
                  RuntimeError);
     // No exclusion, no wedge
-    EXPECT_THROW(ConeSolid("cone", Cone{{1, 2}, 10.0}, SolidEnclosedAngle{}),
+    EXPECT_THROW(ConeSolid("cone", Cone{{1, 2}, 10.0}, EnclosedAzi{}),
                  RuntimeError);
     EXPECT_THROW(
-        ConeSolid(
-            "cone", Cone{{1, 2}, 10.0}, std::nullopt, SolidEnclosedAngle{}),
+        ConeSolid("cone", Cone{{1, 2}, 10.0}, std::nullopt, EnclosedAzi{}),
         RuntimeError);
 }
 
@@ -153,9 +152,8 @@ TEST_F(SolidTest, inner)
 
 TEST_F(SolidTest, wedge)
 {
-    ConeSolid cone("cone",
-                   Cone{{1, 2}, 10.0},
-                   SolidEnclosedAngle{Turn{-0.125}, Turn{0.25}});
+    ConeSolid cone(
+        "cone", Cone{{1, 2}, 10.0}, EnclosedAzi{Turn{-0.125}, Turn{0.25}});
     this->build_volume(cone);
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -198,9 +196,8 @@ TEST_F(SolidTest, wedge)
 
 TEST_F(SolidTest, antiwedge)
 {
-    ConeSolid cone("cone",
-                   Cone{{1, 2}, 10.0},
-                   SolidEnclosedAngle{Turn{0.125}, Turn{0.75}});
+    ConeSolid cone(
+        "cone", Cone{{1, 2}, 10.0}, EnclosedAzi{Turn{0.125}, Turn{0.75}});
     this->build_volume(cone);
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -248,7 +245,7 @@ TEST_F(SolidTest, both)
     ConeSolid cone("cone",
                    Cone{{1, 2}, 10.0},
                    Cone{{0.9, 1.9}, 10.0},
-                   SolidEnclosedAngle{Turn{-0.125}, Turn{0.25}});
+                   EnclosedAzi{Turn{-0.125}, Turn{0.25}});
     this->build_volume(cone);
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -299,11 +296,10 @@ TEST_F(SolidTest, both)
 
 TEST_F(SolidTest, cyl)
 {
-    this->build_volume(
-        CylinderSolid("cyl",
-                      Cylinder{1, 10.0},
-                      Cylinder{0.9, 10.0},
-                      SolidEnclosedAngle{Turn{-0.125}, Turn{0.25}}));
+    this->build_volume(CylinderSolid("cyl",
+                                     Cylinder{1, 10.0},
+                                     Cylinder{0.9, 10.0},
+                                     EnclosedAzi{Turn{-0.125}, Turn{0.25}}));
 
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -327,16 +323,14 @@ TEST_F(SolidTest, or_shape)
     TypeDemangler<ObjectInterface> demangle_shape;
     {
         auto shape = ConeSolid::or_shape(
-            "cone", Cone{{1, 2}, 10.0}, std::nullopt, SolidEnclosedAngle{});
+            "cone", Cone{{1, 2}, 10.0}, std::nullopt, EnclosedAzi{});
         EXPECT_TRUE(shape);
         EXPECT_TRUE(dynamic_cast<ConeShape const*>(shape.get()))
             << "actual shape: " << demangle_shape(*shape);
     }
     {
-        auto solid = ConeSolid::or_shape("cone",
-                                         Cone{{1.1, 2}, 10.0},
-                                         Cone{{0.9, 1.9}, 10.0},
-                                         SolidEnclosedAngle{});
+        auto solid = ConeSolid::or_shape(
+            "cone", Cone{{1.1, 2}, 10.0}, Cone{{0.9, 1.9}, 10.0}, EnclosedAzi{});
         EXPECT_TRUE(solid);
         EXPECT_TRUE(dynamic_cast<ConeSolid const*>(solid.get()))
             << demangle_shape(*solid);

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -33,12 +33,12 @@ TEST(EnclosedAziTest, null)
     EXPECT_FALSE(azi);
 }
 
-TEST(EnclosedAziTest, make_wedge)
+TEST(EnclosedAziTest, make_sense_region)
 {
     {
         SCOPED_TRACE("concave");
         EnclosedAzi azi(Turn{-0.25}, Turn{0.1});
-        auto&& [sense, wedge] = azi.make_wedge();
+        auto&& [sense, wedge] = azi.make_sense_region();
         EXPECT_EQ(Sense::inside, sense);
         EXPECT_SOFT_EQ(0.75, wedge.start().value());
         EXPECT_SOFT_EQ(0.1, wedge.interior().value());
@@ -46,7 +46,7 @@ TEST(EnclosedAziTest, make_wedge)
     {
         SCOPED_TRACE("convex");
         EnclosedAzi azi(Turn{0.25}, Turn{0.8});
-        auto&& [sense, wedge] = azi.make_wedge();
+        auto&& [sense, wedge] = azi.make_sense_region();
         EXPECT_EQ(Sense::outside, sense);
         EXPECT_SOFT_EQ(0.05, wedge.start().value());
         EXPECT_SOFT_EQ(0.2, wedge.interior().value());
@@ -54,7 +54,7 @@ TEST(EnclosedAziTest, make_wedge)
     {
         SCOPED_TRACE("half");
         EnclosedAzi azi(Turn{0.1}, Turn{0.5});
-        auto&& [sense, wedge] = azi.make_wedge();
+        auto&& [sense, wedge] = azi.make_sense_region();
         EXPECT_EQ(Sense::inside, sense);
         EXPECT_SOFT_EQ(0.1, wedge.start().value());
         EXPECT_SOFT_EQ(0.5, wedge.interior().value());
@@ -75,7 +75,7 @@ TEST(SolidZSlabTest, infinite)
     EXPECT_FALSE(szs);
 }
 
-TEST(SolidZSlabTest, make_wedge)
+TEST(SolidZSlabTest, make_sense_region)
 {
     SolidZSlab szs(5, 10);
     auto inf_slab = szs.make_inf_slab();


### PR DESCRIPTION
LHCb's RICH detector requires the polar truncation of a sphere. This will need to create a cone rather than a wedge, and it will have different extents. Therefore I'll be adding a new class that's also a solid angle.

This is strictly renaming, no other changes.