### PR TITLE
Use variant set for uniform field input

### DIFF
--- a/src/accel/AlongStepFactory.cc
+++ b/src/accel/AlongStepFactory.cc
@@ -21,7 +21,6 @@
 #include "celeritas/em/params/UrbanMscParams.hh"
 #include "celeritas/ext/GeantUnits.hh"
 #include "celeritas/ext/GeantVolumeMapper.hh"
-#include "celeritas/field/CartMapFieldInput.hh"
 #include "celeritas/field/CylMapFieldInput.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
 #include "celeritas/field/UniformFieldData.hh"
@@ -77,27 +76,15 @@ auto UniformAlongStepFactory::operator()(AlongStepFactoryInput const& input) con
         // Get the IDs of the volumes with field
         if (!volumes.empty())
         {
-            field.volumes.reserve(volumes.size());
-            GeantVolumeMapper find_volume(*input.geometry);
-            for (auto const* lv : volumes)
-            {
-                CELER_ASSERT(lv);
-                auto vol = find_volume(*lv);
-                CELER_VALIDATE(
-                    vol,
-                    << "failed to find volume corresponding to Geant4 volume "
-                    << lv->GetName() << " while setting up uniform field");
-                CELER_LOG(debug) << "Found volume " << lv->GetName()
-                                 << " that will be assigned a uniform field";
-                field.volumes.push_back(vol);
-            }
+            field.volumes
+                = inp::UniformField::SetVolume{volumes.begin(), volumes.end()};
         }
 
         // Create a uniform field
         CELER_LOG(info)
             << "Creating along-step action with field strength " << magnitude
             << " T in "
-            << (field.volumes.empty() ? "all" : std::to_string(volumes.size()))
+            << (volumes.empty() ? "all" : std::to_string(volumes.size()))
             << " volumes";
 
         return celeritas::AlongStepUniformMscAction::from_params(

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -140,15 +140,18 @@ void ProblemSetup::operator()(inp::Problem& p) const
         auto field_val = norm(field.strength);
         if (field_val > 0)
         {
+            auto volumes = u->get_volumes();
             auto msg = CELER_LOG(info);
             msg << "Using a uniform field: " << field_val << " [T] in ";
-            if (field.volumes.empty())
+            if (volumes.empty())
             {
                 msg << "all";
             }
             else
             {
-                msg << field.volumes.size();
+                msg << volumes.size();
+                field.volumes = inp::UniformField::SetVolume{volumes.begin(),
+                                                             volumes.end()};
             }
             msg << " volumes";
             p.field = std::move(field);

--- a/src/celeritas/inp/Field.hh
+++ b/src/celeritas/inp/Field.hh
@@ -6,8 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <unordered_set>
 #include <variant>
-#include <vector>
 
 #include "geocel/Types.hh"
 #include "celeritas/UnitTypes.hh"
@@ -15,6 +15,8 @@
 #include "celeritas/field/CylMapFieldInput.hh"
 #include "celeritas/field/FieldDriverOptions.hh"
 #include "celeritas/field/RZMapFieldInput.hh"
+
+class G4LogicalVolume;
 
 namespace celeritas
 {
@@ -42,6 +44,10 @@ struct NoField
  */
 struct UniformField
 {
+    using SetVolume = std::unordered_set<G4LogicalVolume const*>;
+    using SetString = std::unordered_set<std::string>;
+    using VariantSetVolume = std::variant<std::monostate, SetVolume, SetString>;
+
     //! Default field units are tesla
     UnitSystem units{UnitSystem::si};
 
@@ -52,7 +58,7 @@ struct UniformField
     FieldDriverOptions driver_options;
 
     //! Volumes where the field is present (optional)
-    std::vector<VolumeId> volumes;
+    VariantSetVolume volumes;
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -132,21 +132,17 @@ class SimpleCmsFieldVolAlongStepTest : public SimpleCmsAlongStepTest
   public:
     SPConstAction build_along_step() override
     {
-        auto find = [&](std::string name) {
-            return this->geometry()->volumes().find_unique(name);
-        };
-
         auto& action_reg = *this->action_reg();
         UniformFieldParams::Input field_inp;
         field_inp.strength = {0, 0, 1};
 
         // No field in muon chambers or world volume
-        field_inp.volumes = {
-            find("vacuum_tube"),
-            find("si_tracker"),
-            find("em_calorimeter"),
-            find("had_calorimeter"),
-            find("sc_solenoid"),
+        field_inp.volumes = inp::UniformField::SetString{
+            "vacuum_tube",
+            "si_tracker",
+            "em_calorimeter",
+            "had_calorimeter",
+            "sc_solenoid",
         };
 
         auto msc = UrbanMscParams::from_import(


### PR DESCRIPTION
This is a little update to the volume-specific field input (see https://github.com/celeritas-project/celeritas/pull/1659#discussion_r1987915912) I'd forgotten about.