### PR TITLE
Optimize cosine for turn

### DIFF
--- a/src/corecel/math/Turn.hh
+++ b/src/corecel/math/Turn.hh
@@ -95,8 +95,16 @@ CELER_FORCEINLINE_FUNCTION void sincos(Turn_t<T> r, T* sinv, T* cosv)
 
 CELER_CONSTEXPR_FUNCTION int cos(IntQuarterTurn r)
 {
-    constexpr int cosval[] = {1, 0, -1, 0};
-    return cosval[(r.value() > 0 ? r.value() : -r.value()) % 4];
+    // Get the last two bits
+    auto i = std::abs(r.value()) & 0x3;
+    // Map to {1, 0, -1, 0}[i] by encoding the 2-bit values into an int
+    // offset by one: {2, 1, 0, 1}. Since ints are written big endian,
+    // the bits below are:   { 1,0,1,2}
+    constexpr int valbits = 0b01000110;
+
+    // Select the two bits we care about
+    auto result_plus_one = (valbits >> (i << 1)) & 0b11;
+    return result_plus_one - 1;
 }
 
 CELER_CONSTEXPR_FUNCTION int sin(IntQuarterTurn r)

--- a/src/corecel/math/Turn.hh
+++ b/src/corecel/math/Turn.hh
@@ -95,8 +95,8 @@ CELER_FORCEINLINE_FUNCTION void sincos(Turn_t<T> r, T* sinv, T* cosv)
 
 CELER_CONSTEXPR_FUNCTION int cos(IntQuarterTurn r)
 {
-    // Get the last two bits
-    auto i = std::abs(r.value()) & 0x3;
+    // Cosine is symmetric and periodic: modulo with 4
+    auto i = std::abs(r.value()) % 4;
     // Map to {1, 0, -1, 0}[i] by encoding the 2-bit values into an int
     // offset by one: {2, 1, 0, 1}. Since ints are written big endian,
     // the bits below are:   { 1,0,1,2}

--- a/src/corecel/math/Turn.hh
+++ b/src/corecel/math/Turn.hh
@@ -96,7 +96,8 @@ CELER_FORCEINLINE_FUNCTION void sincos(Turn_t<T> r, T* sinv, T* cosv)
 CELER_CONSTEXPR_FUNCTION int cos(IntQuarterTurn r)
 {
     // Cosine is symmetric and periodic: modulo with 4
-    auto i = std::abs(r.value()) % 4;
+    // (note: avoid std::abs which isn't constexpr till C++23)
+    auto i = (r.value() > 0 ? r.value() : -r.value()) % 4;
     // Map to {1, 0, -1, 0}[i] by encoding the 2-bit values into an int
     // offset by one: {2, 1, 0, 1}. Since ints are written big endian,
     // the bits below are:   { 1,0,1,2}

--- a/src/corecel/math/Turn.hh
+++ b/src/corecel/math/Turn.hh
@@ -109,8 +109,8 @@ CELER_CONSTEXPR_FUNCTION int cos(IntQuarterTurn r)
 
 CELER_CONSTEXPR_FUNCTION int sin(IntQuarterTurn r)
 {
-    // Define in terms of the symmetric "cos"
-    return cos(IntQuarterTurn{r.value() - 1});
+    // Define in terms of the symmetric "cos": sin(x) = cos(x - pi/2)
+    return cos(r - IntQuarterTurn{1});
 }
 
 CELER_CONSTEXPR_FUNCTION void sincos(IntQuarterTurn r, int* sinv, int* cosv)

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -307,25 +307,23 @@ TEST(QuarterTurnTest, basic)
 
 TEST(QuarterTurnTest, sincos)
 {
-    std::vector<int> result;
+    std::vector<int> actual;
+    std::vector<int> expected;
+    auto push_expected_int = [&expected](double v) {
+        expected.push_back(static_cast<int>(std::round(v)));
+    };
+
     for (auto i : range(-4, 5))
     {
-        result.push_back(sin(IntQuarterTurn{i}));
-        result.push_back(cos(IntQuarterTurn{i}));
+        IntQuarterTurn theta{i};
+        actual.push_back(sin(theta));
+        actual.push_back(cos(theta));
+
+        auto theta_dbl = static_cast<double>(native_value_from(theta));
+        push_expected_int(std::sin(theta_dbl));
+        push_expected_int(std::cos(theta_dbl));
     }
-    // clang-format off
-    static int const expected_result[]
-        = {  0,  1, // -1 turn
-             1,  0, // -3/4 turn
-             0, -1, // -1/2 turn
-            -1,  0, // -1/4 turn
-             0,  1, // 0 turn
-             1,  0, // 1/4
-             0, -1, // 1/2
-            -1,  0, // 3/4
-             0,  1}; // 1
-    // clang-format on
-    EXPECT_VEC_EQ(expected_result, result);
+    EXPECT_VEC_EQ(expected, actual);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This is a stupid minor change while I was diddling with some other Turn related stuff; as a diversion I tried to improve the integer sin/cos theta to use simple instructions rather than a static array lookup.

https://github.com/sethrj/testsnippets/commit/87d733274d90fe83c0c106ca5d766e1a2d6eba0e