### PR TITLE
Add polar truncation for sphere shape

### DIFF
--- a/src/corecel/math/Turn.hh
+++ b/src/corecel/math/Turn.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstdlib>
 #include <type_traits>
 
 #include "corecel/Constants.hh"
@@ -88,6 +89,12 @@ CELER_FORCEINLINE_FUNCTION T cos(Turn_t<T> r)
 }
 
 template<class T>
+CELER_FORCEINLINE_FUNCTION T tan(Turn_t<T> r)
+{
+    return std::tan(native_value_from(r));
+}
+
+template<class T>
 CELER_FORCEINLINE_FUNCTION void sincos(Turn_t<T> r, T* sinv, T* cosv)
 {
     return sincospi(r.value() * 2, sinv, cosv);
@@ -125,7 +132,7 @@ CELER_CONSTEXPR_FUNCTION void sincos(IntQuarterTurn r, int* sinv, int* cosv)
 template<class T>
 CELER_FORCEINLINE_FUNCTION Turn_t<T> atan2turn(T y, T x)
 {
-    // TODO: some OS/lib has this natively; use that instad
+    // TODO: some hardware/libraries have this natively; use that instad
     return native_value_to<Turn_t<T>>(std::atan2(y, x));
 }
 

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -85,7 +85,11 @@ auto enclosed_azi_radians(double start_rad, double stop_rad)
 {
     auto start = native_value_to<RealTurn>(start_rad);
     auto stop = native_value_to<RealTurn>(stop_rad);
-    if (soft_equal(stop.value() - start.value(), real_type{1}))
+    auto delta_turn = value_as<RealTurn>(stop - start);
+    CELER_VALIDATE(delta_turn <= 1 || soft_equal(delta_turn, real_type{1}),
+                   << "azimuthal restriction [" << start.value() << ", "
+                   << stop.value() << "] [turn] exceeds 1 turn");
+    if (delta_turn >= real_type{1})
     {
         // Avoid roundoff error: return full region, *but* keep orientation,
         // needed for polyhedra
@@ -107,11 +111,14 @@ auto enclosed_polar_radians(double start_rad, double stop_rad)
 {
     auto start = native_value_to<RealTurn>(start_rad);
     auto stop = native_value_to<RealTurn>(stop_rad);
-    if (stop > RealTurn{0.5})
-    {
-        // Avoid roundoff error: clip to +pi
-        stop = RealTurn{0.5};
-    }
+    CELER_VALIDATE(start.value() >= 0 || soft_zero(start.value()),
+                   << "polar start angle " << start.value()
+                   << " [turn] exceeds half a turn");
+    start = min(RealTurn{0.5}, start);
+    CELER_VALIDATE(stop.value() <= 0.5 || soft_equal(stop.value(), 0.5),
+                   << "polar end angle " << stop.value()
+                   << " [turn] exceeds half a turn");
+    stop = min(RealTurn{0.5}, stop);
     return EnclosedPolar{start, stop};
 }
 

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -89,10 +89,9 @@ auto enclosed_azi_radians(double start_rad, double stop_rad)
     CELER_VALIDATE(delta_turn <= 1 || soft_equal(delta_turn, real_type{1}),
                    << "azimuthal restriction [" << start.value() << ", "
                    << stop.value() << "] [turn] exceeds 1 turn");
-    if (delta_turn >= real_type{1})
+    if (delta_turn >= real_type{1} || soft_equal(delta_turn, real_type{1}))
     {
-        // Avoid roundoff error: return full region, *but* keep orientation,
-        // needed for polyhedra
+        // Avoid roundoff error: return full region
         return EnclosedAzi{};
     }
     return EnclosedAzi{start, stop};

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -96,6 +96,27 @@ auto enclosed_azi_radians(double start_rad, double stop_rad)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get an EnclosedPolar, avoiding values slightly beyond a half turn.
+ *
+ * This constructs from native Geant4 radians and truncates to \c real_type,
+ * ensuring that roundoff doesn't push the turn beyond a full one. The
+ * G4Sphere::CheckThetaAngles implementation prevents the endpoint being
+ * greater than 180 degrees, so we do the same here.
+ */
+auto enclosed_polar_radians(double start_rad, double stop_rad)
+{
+    auto start = native_value_to<RealTurn>(start_rad);
+    auto stop = native_value_to<RealTurn>(stop_rad);
+    if (stop > RealTurn{0.5})
+    {
+        // Avoid roundoff error: clip to +pi
+        stop = RealTurn{0.5};
+    }
+    return EnclosedPolar{start, stop};
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the enclosed azimuthal angle by a solid.
  *
  * This internally converts from native Geant4 radians.
@@ -140,11 +161,11 @@ EnclosedAzi enclosed_azi_from_poly(S const& solid)
  * Get the enclosed polar angle by a solid.
  */
 template<class S>
-EnclosedAzi enclosed_pol_from(S const& solid)
+EnclosedPolar enclosed_pol_from(S const& solid)
 {
-    // FIXME: polar angle will be a different class
-    return enclosed_azi_radians(solid.GetStartThetaAngle(),
-                                solid.GetDeltaThetaAngle());
+    auto start = solid.GetStartThetaAngle();
+    auto delta = solid.GetDeltaThetaAngle();
+    return enclosed_polar_radians(start, start + delta);
 }
 
 //---------------------------------------------------------------------------//
@@ -709,15 +730,12 @@ auto SolidConverter::sphere(arg_type solid_base) -> result_type
     }
 
     auto polar_cone = enclosed_pol_from(solid);
-    if (!soft_equal(value_as<Turn>(polar_cone.stop() - polar_cone.start()), 0.5))
-    {
-        CELER_NOT_IMPLEMENTED("sphere with polar limits");
-    }
 
     return make_solid(solid,
                       Sphere{scale_(solid.GetOuterRadius())},
                       std::move(inner),
-                      enclosed_azi_from(solid));
+                      enclosed_azi_from(solid),
+                      std::move(polar_cone));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -139,8 +139,7 @@ bool Cone::encloses(Cone const& other) const
  */
 void Cone::build(IntersectSurfaceBuilder& insert_surface) const
 {
-    if (CELER_UNLIKELY(
-            SoftEqual{insert_surface.tol().rel}(radii_[0], radii_[1])))
+    if (CELER_UNLIKELY(make_soft_equal(insert_surface)(radii_[0], radii_[1])))
     {
         // Degenerate cone: build a cylinder instead
         Cylinder cyl{real_type{0.5} * (radii_[0] + radii_[1]), hh_};
@@ -711,7 +710,7 @@ GenPrism GenPrism::from_trap(
     auto [dxdz_hz, dydz_hz] = [&]() -> std::pair<real_type, real_type> {
         real_type cos_phi{}, sin_phi{};
         sincos(phi, &sin_phi, &cos_phi);
-        real_type const tan_theta = std::tan(native_value_from(theta));
+        real_type const tan_theta = tan(theta);
         return {hz * tan_theta * cos_phi, hz * tan_theta * sin_phi};
     }();
 
@@ -733,8 +732,7 @@ GenPrism GenPrism::from_trap(
 
         real_type const xoff = (i == 0 ? -dxdz_hz : dxdz_hz);
         real_type const yoff = (i == 0 ? -dydz_hz : dydz_hz);
-        real_type const shear = std::tan(native_value_from(face.alpha))
-                                * face.hy;
+        real_type const shear = tan(face.alpha) * face.hy;
 
         // Construct points counterclockwise from lower right
         points[i] = {{xoff - shear + face.hx_lo, yoff - face.hy},

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -1018,15 +1018,20 @@ InfAziWedge::InfAziWedge(Turn start, Turn stop) : start_{start}, stop_{stop}
  *
  * Both planes should point "outward" to the wedge. In the degenerate case of
  * stop = 0.5 + start, we rely on CSG object deduplication.
+ *
+ * Names are 'azimuthal wedge' with plus/minus
  */
 void InfAziWedge::build(IntersectSurfaceBuilder& insert_surface) const
 {
-    for (auto [sense, angle] :
-         {std::pair{Sense::inside, start_}, std::pair{Sense::outside, stop_}})
+    for (auto&& [sense, angle, namechar] :
+         {std::tuple{Sense::outside, stop_, 'm'},
+          std::tuple{Sense::inside, start_, 'p'}})
     {
         real_type s, c;
         sincos(angle, &s, &c);
-        insert_surface(sense, Plane{Real3{s, -c, 0}, 0});
+        std::string facename("aw*");
+        facename[2] = namechar;
+        insert_surface(sense, Plane{Real3{s, -c, 0}, 0}, std::move(facename));
     }
 
     //! \todo Restrict bounding boxes, at least eliminating two quadrants...
@@ -1050,7 +1055,7 @@ void InfAziWedge::output(JsonPimpl* j) const
 InfPolarWedge::InfPolarWedge(Turn start, Turn stop)
     : start_{start}, stop_{stop}
 {
-    CELER_VALIDATE(start_ >= zero_quantity() && start_ < Turn{0.5},
+    CELER_VALIDATE(start_ >= north_pole && start_ < south_pole,
                    << "invalid start angle " << start_.value()
                    << " [turns]: must be in the range [0, 0.5)");
 
@@ -1067,6 +1072,11 @@ InfPolarWedge::InfPolarWedge(Turn start, Turn stop)
 //---------------------------------------------------------------------------//
 /*!
  * Build surfaces.
+ *
+ * Names use 'pw' for polar wedge, 'z' for plane:
+ *  - pwm: middle plane
+ *  - pwt: top cone
+ *  - pwb: bottom cone
  */
 void InfPolarWedge::build(IntersectSurfaceBuilder& insert_surface) const
 {
@@ -1074,22 +1084,23 @@ void InfPolarWedge::build(IntersectSurfaceBuilder& insert_surface) const
 
     // Greater-than-equator start means below z (southern hemisphere)
     auto sense = start_ >= equator ? Sense::inside : Sense::outside;
-    insert_surface(sense, PlaneZ{0});
+    insert_surface(sense, PlaneZ{0}, "pwm");
 
     if (!soft_equal(start_.value(), north_pole.value())
         && !soft_equal(start_.value(), equator.value()))
     {
         // Start point is not a degenerate cone: we're "outside" if top
-        // hemisphere, "inside" if bottom
-        insert_surface(sense, ConeZ{Real3{0, 0, 0}, tan(start_)});
+        // hemisphere, "inside" if bottom. "kt" means "cone top"
+        insert_surface(sense, ConeZ{Real3{0, 0, 0}, tan(start_)}, "pwt");
     }
 
     if (!soft_equal(stop_.value(), south_pole.value())
         && !soft_equal(stop_.value(), equator.value()))
     {
         // End point is not a degenerate cone: we're "inside" if top
-        // hemisphere, "outside" if bottom
-        insert_surface(flip_sense(sense), ConeZ{Real3{0, 0, 0}, tan(stop_)});
+        // hemisphere, "outside" if bottom. "kb" is "cone bottom".
+        insert_surface(
+            flip_sense(sense), ConeZ{Real3{0, 0, 0}, tan(stop_)}, "pwb");
     }
 }
 

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -39,6 +39,16 @@ namespace
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Create a SoftEqual instance using the surface builder tolerance.
+ */
+auto make_soft_equal(IntersectSurfaceBuilder const& sb)
+{
+    auto tol = sb.tol();
+    return SoftEqual{tol.rel, tol.abs};
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Create a z-aligned bounding box infinite along z and symmetric in r.
  */
 BBox make_xyradial_bbox(real_type r)
@@ -1027,6 +1037,64 @@ void InfAziWedge::build(IntersectSurfaceBuilder& insert_surface) const
  * Write output to the given JSON object.
  */
 void InfAziWedge::output(JsonPimpl* j) const
+{
+    to_json_pimpl(j, *this);
+}
+
+//---------------------------------------------------------------------------//
+// INFPOLARWEDGE
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a starting angle and stop angle.
+ */
+InfPolarWedge::InfPolarWedge(Turn start, Turn stop)
+    : start_{start}, stop_{stop}
+{
+    CELER_VALIDATE(start_ >= zero_quantity() && start_ < Turn{0.5},
+                   << "invalid start angle " << start_.value()
+                   << " [turns]: must be in the range [0, 0.5)");
+
+    // Stay only on a single side of z=0
+    auto max_endpoint = Turn{start_ < equator ? equator : south_pole};
+    CELER_VALIDATE(stop_ > start_ && stop_ <= max_endpoint
+                       || soft_equal(stop_.value(), max_endpoint.value()),
+                   << "invalid stop wedge angle " << stop.value()
+                   << " [turns]: must be in [0, "
+                   << (max_endpoint - start_).value() << ")");
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build surfaces.
+ */
+void InfPolarWedge::build(IntersectSurfaceBuilder& insert_surface) const
+{
+    auto soft_equal = make_soft_equal(insert_surface);
+
+    // Greater-than-equator start means below z (southern hemisphere)
+    auto sense = start_ >= equator ? Sense::inside : Sense::outside;
+    insert_surface(sense, PlaneZ{0});
+
+    if (!soft_equal(start_.value(), north_pole.value())
+        && !soft_equal(start_.value(), equator.value()))
+    {
+        // If wedge is in the top hemisphere, we're outside the start
+        insert_surface(sense, ConeZ{Real3{0, 0, 0}, tan(start_)});
+    }
+
+    if (!soft_equal(stop_.value(), south_pole.value())
+        && !soft_equal(stop_.value(), equator.value()))
+    {
+        // If wedge is in the top hemisphere, we're inside the end
+        insert_surface(flip_sense(sense), ConeZ{Real3{0, 0, 0}, tan(stop_)});
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void InfPolarWedge::output(JsonPimpl* j) const
 {
     to_json_pimpl(j, *this);
 }

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -1055,12 +1055,13 @@ InfPolarWedge::InfPolarWedge(Turn start, Turn stop)
                    << " [turns]: must be in the range [0, 0.5)");
 
     // Stay only on a single side of z=0
-    auto max_endpoint = Turn{start_ < equator ? equator : south_pole};
-    CELER_VALIDATE(stop_ > start_ && stop_ <= max_endpoint
-                       || soft_equal(stop_.value(), max_endpoint.value()),
+    auto max_stop = Turn{start_ < equator ? equator : south_pole};
+    CELER_VALIDATE(stop_ > start_
+                       && (stop_ <= max_stop
+                           || soft_equal(stop_.value(), max_stop.value())),
                    << "invalid stop wedge angle " << stop.value()
                    << " [turns]: must be in [0, "
-                   << (max_endpoint - start_).value() << ")");
+                   << (max_stop - start_).value() << ")");
 }
 
 //---------------------------------------------------------------------------//
@@ -1078,14 +1079,16 @@ void InfPolarWedge::build(IntersectSurfaceBuilder& insert_surface) const
     if (!soft_equal(start_.value(), north_pole.value())
         && !soft_equal(start_.value(), equator.value()))
     {
-        // If wedge is in the top hemisphere, we're outside the start
+        // Start point is not a degenerate cone: we're "outside" if top
+        // hemisphere, "inside" if bottom
         insert_surface(sense, ConeZ{Real3{0, 0, 0}, tan(start_)});
     }
 
     if (!soft_equal(stop_.value(), south_pole.value())
         && !soft_equal(stop_.value(), equator.value()))
     {
-        // If wedge is in the top hemisphere, we're inside the end
+        // End point is not a degenerate cone: we're "inside" if top
+        // hemisphere, "outside" if bottom
         insert_surface(flip_sense(sense), ConeZ{Real3{0, 0, 0}, tan(stop_)});
     }
 }

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -574,6 +574,43 @@ class InfAziWedge final : public IntersectRegionInterface
 
 //---------------------------------------------------------------------------//
 /*!
+ * Use a cone and plane to select a polar (latitudinal) region.
+ *
+ * A polar wedge always defines a region in a single hemisphere: either
+ * \f$ z >= 0 \f$ or \f$ z <= 0 \f$, corresponding to an stop range of
+ * [0, .25] turns or [0.25, 0.5] turns.
+ */
+class InfPolarWedge final : public IntersectRegionInterface
+{
+  public:
+    // Construct from a starting angle and stop angle
+    InfPolarWedge(Turn start, Turn stop);
+
+    // Build surfaces
+    void build(IntersectSurfaceBuilder&) const final;
+
+    // Output to JSON
+    void output(JsonPimpl*) const final;
+
+    //// ACCESSORS ////
+
+    //! Starting angle
+    Turn start() const { return start_; }
+
+    //! stop angle
+    Turn stop() const { return stop_; }
+
+  private:
+    Turn start_;
+    Turn stop_;
+
+    static constexpr Turn north_pole{0};
+    static constexpr Turn equator{0.25};
+    static constexpr Turn south_pole{0.5};
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * An involute "blade" centered on the origin.
  *
  * This is the intersection of two parallel involutes with a cylindrical shell.

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -574,11 +574,12 @@ class InfAziWedge final : public IntersectRegionInterface
 
 //---------------------------------------------------------------------------//
 /*!
- * Use a cone and plane to select a polar (latitudinal) region.
+ * Select a polar (latitudinal) region.
  *
- * A polar wedge always defines a region in a single hemisphere: either
- * \f$ z >= 0 \f$ or \f$ z <= 0 \f$, corresponding to an stop range of
- * [0, .25] turns or [0.25, 0.5] turns.
+ * This uses an equatorial plane and up to two cones to slice a
+ * polar-coordinate region from the origin.  A polar wedge always defines a
+ * region in a single hemisphere: either \f$ z >= 0 \f$ or \f$ z <= 0 \f$,
+ * corresponding to an stop range of [0, .25] turns or [0.25, 0.5] turns.
  */
 class InfPolarWedge final : public IntersectRegionInterface
 {

--- a/src/orange/orangeinp/ObjectIO.json.cc
+++ b/src/orange/orangeinp/ObjectIO.json.cc
@@ -119,6 +119,10 @@ void to_json(nlohmann::json& j, SolidBase const& obj)
     {
         j["enclosed_azi"] = azi;
     }
+    if (auto polar = obj.enclosed_polar())
+    {
+        j["enclosed_polar"] = polar;
+    }
 }
 
 void to_json(nlohmann::json& j, StackedExtrudedPolygon const& cr)
@@ -162,6 +166,11 @@ void to_json(nlohmann::json& j, PolySegments const& ps)
 void to_json(nlohmann::json& j, EnclosedAzi const& azi)
 {
     j = {{"start", azi.start().value()}, {"stop", azi.stop().value()}};
+}
+
+void to_json(nlohmann::json& j, EnclosedPolar const& pol)
+{
+    j = {{"start", pol.start().value()}, {"stop", pol.stop().value()}};
 }
 
 //---------------------------------------------------------------------------//
@@ -241,6 +250,13 @@ void to_json(nlohmann::json& j, InfPlane const& pa)
 void to_json(nlohmann::json& j, InfAziWedge const& cr)
 {
     j = {{"_type", "infaziwedge"},
+         {"start", cr.start().value()},
+         {"stop", cr.stop().value()}};
+}
+
+void to_json(nlohmann::json& j, InfPolarWedge const& cr)
+{
+    j = {{"_type", "infpolarwedge"},
          {"start", cr.start().value()},
          {"stop", cr.stop().value()}};
 }

--- a/src/orange/orangeinp/ObjectIO.json.hh
+++ b/src/orange/orangeinp/ObjectIO.json.hh
@@ -33,6 +33,7 @@ class Truncated;
 
 class PolySegments;
 class EnclosedAzi;
+class EnclosedPolar;
 
 class IntersectRegionInterface;
 class Box;
@@ -43,8 +44,9 @@ class EllipticalCone;
 class EllipticalCylinder;
 class ExtrudedPolygon;
 class GenPrism;
-class InfAziWedge;
 class InfPlane;
+class InfAziWedge;
+class InfPolarWedge;
 class Involute;
 class Parallelepiped;
 class Prism;
@@ -70,6 +72,7 @@ void to_json(nlohmann::json& j, Truncated const& tr);
 // Write helper classes to JSON
 void to_json(nlohmann::json& j, PolySegments const&);
 void to_json(nlohmann::json& j, EnclosedAzi const&);
+void to_json(nlohmann::json& j, EnclosedPolar const&);
 
 // Write intersect regions to JSON
 void to_json(nlohmann::json& j, IntersectRegionInterface const& cr);
@@ -83,6 +86,7 @@ void to_json(nlohmann::json& j, ExtrudedPolygon const& cr);
 void to_json(nlohmann::json& j, GenPrism const& cr);
 void to_json(nlohmann::json& j, InfPlane const& pa);
 void to_json(nlohmann::json& j, InfAziWedge const& cr);
+void to_json(nlohmann::json& j, InfPolarWedge const& cr);
 void to_json(nlohmann::json& j, Involute const& cr);
 void to_json(nlohmann::json& j, Parallelepiped const& cr);
 void to_json(nlohmann::json& j, Prism const& cr);

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -151,8 +151,8 @@ NodeId SolidBase::build(VolumeBuilder& vb) const
         // The user is truncating the shape azimuthally: construct a wedge to
         // be added or deleted
         auto&& [sense, wedge] = azi.make_sense_region();
-        NodeId wedge_id
-            = build_intersect_region(vb, this->label(), "azi", wedge);
+        char const* ext = (sense == Sense::outside ? "~azi" : "azi");
+        NodeId wedge_id = build_intersect_region(vb, this->label(), ext, wedge);
         if (sense == Sense::outside)
         {
             wedge_id = vb.insert_region({}, Negated{wedge_id});

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -164,7 +164,7 @@ NodeId SolidBase::build(VolumeBuilder& vb) const
     {
         // Union the polar wedge components
         std::vector<NodeId> wedge_nodes;
-        for (auto wedge : pol.make_regions())
+        for (auto const& wedge : pol.make_regions())
         {
             wedge_nodes.push_back(
                 build_intersect_region(vb, this->label(), "pol", wedge));

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -32,7 +32,6 @@ constexpr auto eumod(RealTurn numer, RealTurn denom)
 }
 
 }  // namespace
-
 //---------------------------------------------------------------------------//
 /*!
  * Construct from a starting angle and stop angle.
@@ -76,6 +75,56 @@ auto EnclosedAzi::make_sense_region() const -> SenseWedge
 
 //---------------------------------------------------------------------------//
 /*!
+ * Construct from a starting angle and stop angle.
+ *
+ * The beginning starts at the north pole/top point and the end is at the south
+ * pole/bottom point.
+ *
+ * \internal Note that since the azimuthal region is periodic and can start
+ * anywhere from zero to 1 turn, we have to make decisions about its shape
+ * based on the stop angle rather than end angle, else we'd have to
+ * restrict the input start value to `+/- pi` or something. In contrast, the
+ * \em polar region is on a non-periodic range `[0, 0.5]` and we have to...
+ */
+EnclosedPolar::EnclosedPolar(Turn start, Turn stop)
+    : start_{start}, stop_{stop}
+{
+    CELER_VALIDATE(start_ >= zero_quantity() && start_ < Turn{0.5},
+                   << "invalid start angle " << start_.value()
+                   << " [turns]: must be in [0, 0.5)");
+    CELER_VALIDATE(stop_ > start_ && stop_ <= Turn{0.5},
+                   << "invalid stop angle " << stop.value()
+                   << " [turns]: must be in (" << start_.value() << ", 0.5]");
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct one or two wedges to union.
+ *
+ * The result will be intersected the solid: these wedges are the parts to
+ * \em keep.
+ */
+auto EnclosedPolar::make_regions() const -> VecPolarWedge
+{
+    CELER_EXPECT(*this);
+
+    VecPolarWedge result;
+
+    static constexpr Turn equator{0.25};
+
+    if (start_ < equator)
+    {
+        result.emplace_back(start_, std::min(equator, stop_));
+    }
+    if (stop_ > equator)
+    {
+        result.emplace_back(std::max(equator, start_), stop_);
+    }
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct a volume from this shape.
  */
 NodeId SolidBase::build(VolumeBuilder& vb) const
@@ -109,7 +158,23 @@ NodeId SolidBase::build(VolumeBuilder& vb) const
         nodes.push_back(wedge_id);
     }
 
-    // Intersect the given surfaces to create a new CSG node
+    if (auto const& pol = this->enclosed_polar())
+    {
+        // Union the polar wedge components
+        std::vector<NodeId> wedge_nodes;
+        for (auto wedge : pol.make_regions())
+        {
+            wedge_nodes.push_back(
+                build_intersect_region(vb, this->label(), "pol", wedge));
+        }
+        auto union_id
+            = vb.insert_region({}, Joined{op_or, std::move(wedge_nodes)});
+
+        // Intersect the union with the result
+        nodes.push_back(union_id);
+    }
+
+    // Intersect the given surfaces+regions to create a new CSG node
     return vb.insert_region(Label{std::string{this->label()}},
                             Joined{op_and, std::move(nodes)});
 }
@@ -125,15 +190,16 @@ void SolidBase::output(JsonPimpl* j) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Return a solid or shape given an optional interior or azi angle.
+ * Return a solid or shape given an optional interior or enclosed angle.
  */
 template<class T>
 auto Solid<T>::or_shape(std::string&& label,
                         T&& interior,
                         OptionalRegion&& excluded,
-                        EnclosedAzi&& azi) -> SPConstObject
+                        EnclosedAzi&& azi,
+                        EnclosedPolar&& polar) -> SPConstObject
 {
-    if (!excluded && !azi)
+    if (!excluded && !azi && !polar)
     {
         // Just a shape
         return std::make_shared<Shape<T>>(std::move(label),
@@ -143,56 +209,33 @@ auto Solid<T>::or_shape(std::string&& label,
     return std::make_shared<Solid<T>>(std::move(label),
                                       std::move(interior),
                                       std::move(excluded),
-                                      std::move(azi));
+                                      std::move(azi),
+                                      std::move(polar));
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with optional optional excluded region and azi angle.
+ * Construct with optional excluded region and enclosed angle.
  */
 template<class T>
 Solid<T>::Solid(std::string&& label,
                 T&& interior,
                 OptionalRegion&& excluded,
-                EnclosedAzi&& azi)
+                EnclosedAzi&& azi,
+                EnclosedPolar&& polar)
     : label_{std::move(label)}
     , interior_{std::move(interior)}
     , exclusion_{std::move(excluded)}
     , azi_{std::move(azi)}
+    , polar_{std::move(polar)}
 {
-    CELER_VALIDATE(exclusion_ || azi_,
-                   << "solid requires either an excluded region or a shape");
+    CELER_VALIDATE(exclusion_ || azi_ || polar_,
+                   << "solid requires an excluded slice or region: use a "
+                      "Shape instead");
     CELER_VALIDATE(!exclusion_ || interior_.encloses(*exclusion_),
                    << "solid '" << this->label()
-                   << "' was given an interior region that is not azi by "
+                   << "' was given an interior region that is not enclosed by "
                       "its exterior");
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct with an excluded interior.
- */
-template<class T>
-Solid<T>::Solid(std::string&& label, T&& interior, T&& excluded)
-    : Solid{std::move(label),
-            std::move(interior),
-            std::move(excluded),
-            EnclosedAzi{}}
-{
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct with an azi angle.
- */
-template<class T>
-Solid<T>::Solid(std::string&& label, T&& interior, EnclosedAzi&& azi)
-    : Solid{std::move(label), std::move(interior), std::nullopt, std::move(azi)}
-{
-    CELER_VALIDATE(azi_,
-                   << "solid '" << this->label()
-                   << "' did not exclude an interior or a wedge (use a Shape "
-                      "instead)");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/Solid.cc
+++ b/src/orange/orangeinp/Solid.cc
@@ -120,6 +120,8 @@ auto EnclosedPolar::make_regions() const -> VecPolarWedge
     {
         result.emplace_back(std::max(equator, start_), stop_);
     }
+
+    CELER_ENSURE(!result.empty());
     return result;
 }
 

--- a/src/orange/orangeinp/Solid.hh
+++ b/src/orange/orangeinp/Solid.hh
@@ -9,6 +9,7 @@
 #include <optional>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "corecel/math/Turn.hh"
 
@@ -72,6 +73,54 @@ class EnclosedAzi
 
 //---------------------------------------------------------------------------//
 /*!
+ * Define the polar trunction of a solid.
+ *
+ * This subtracts up to two infinite cones centered along the z axis from the
+ * origin.
+ *
+ * A start angle of zero corresponding to the \em +z axis. An interior angle of
+ * 0.5 results in no exclusion from the resulting solid.
+ * \code
+  // Truncates a solid to the top hemisphere
+  EnclosedPolar{Turn{0}, Turn{0.25}};
+  // Truncates a solid to the equatorial region (18 degrees N/S)
+  EnclosedPolar{Turn{0.2}, Turn{0.3}};
+  \endcode
+ */
+class EnclosedPolar
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecPolarWedge = std::vector<InfPolarWedge>;
+    //!@}
+
+  public:
+    //! Default to "all angles"
+    EnclosedPolar() = default;
+
+    // Construct from a starting angle and stop angle
+    EnclosedPolar(Turn start, Turn stop);
+
+    // Construct one or two wedges to union then intersect with the solid
+    VecPolarWedge make_regions() const;
+
+    // Whether the enclosed angle is not a full circle
+    constexpr explicit inline operator bool() const;
+
+    //! Starting angle
+    Turn start() const { return start_; }
+
+    //! stop angle
+    Turn stop() const { return stop_; }
+
+  private:
+    Turn start_{0};
+    Turn stop_{0.5};
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * A hollow shape with an optional start and end angle.
  *
  * Solids are a shape with (optionally) the same *kind* of shape subtracted
@@ -94,6 +143,9 @@ class SolidBase : public ObjectInterface
 
     //! Optional azimuthal angular restriction
     virtual EnclosedAzi const& enclosed_azi() const = 0;
+
+    //! Optional polar angular restriction
+    virtual EnclosedPolar const& enclosed_polar() const = 0;
 
     ~SolidBase() override = default;
 
@@ -140,20 +192,16 @@ class Solid final : public SolidBase
     // Return a solid *or* shape given an optional interior or enclosed angle
     static SPConstObject or_shape(std::string&& label,
                                   T&& interior,
-                                  OptionalRegion&& excluded,
-                                  EnclosedAzi&& enclosed);
+                                  OptionalRegion&& excluded = {},
+                                  EnclosedAzi&& enclosed = {},
+                                  EnclosedPolar&& polar = {});
 
-    // Construct with an excluded interior *and/or* enclosed angle
+    // Construct with everything
     Solid(std::string&& label,
           T&& interior,
           OptionalRegion&& excluded,
-          EnclosedAzi&& enclosed);
-
-    // Construct with only an enclosed angle
-    Solid(std::string&& label, T&& interior, EnclosedAzi&& enclosed);
-
-    // Construct with only an excluded interior
-    Solid(std::string&& label, T&& interior, T&& excluded);
+          EnclosedAzi&& enclosed,
+          EnclosedPolar&& polar);
 
     //! Get the user-provided label
     std::string_view label() const final { return label_; }
@@ -170,11 +218,15 @@ class Solid final : public SolidBase
     //! Optional azimuthal restriction
     EnclosedAzi const& enclosed_azi() const final { return azi_; }
 
+    //! Optional polar restriction
+    EnclosedPolar const& enclosed_polar() const final { return polar_; }
+
   private:
     std::string label_;
     T interior_;
     OptionalRegion exclusion_;
     EnclosedAzi azi_;
+    EnclosedPolar polar_;
 };
 
 //---------------------------------------------------------------------------//
@@ -216,6 +268,15 @@ extern template class Solid<Sphere>;
 constexpr EnclosedAzi::operator bool() const
 {
     return !(start_ == Turn{0} && stop_ == Turn{1});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether the enclosed angle is less than the whole polar range.
+ */
+constexpr EnclosedPolar::operator bool() const
+{
+    return !(start_ == Turn{0} && stop_ == Turn{0.5});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/Solid.hh
+++ b/src/orange/orangeinp/Solid.hh
@@ -81,10 +81,13 @@ class EnclosedAzi
  * A start angle of zero corresponding to the \em +z axis. An interior angle of
  * 0.5 results in no exclusion from the resulting solid.
  * \code
-  // Truncates a solid to the top hemisphere
+  // Truncates a solid to the top hemisphere (no cones, just equatorial plane)
   EnclosedPolar{Turn{0}, Turn{0.25}};
-  // Truncates a solid to the equatorial region (18 degrees N/S)
-  EnclosedPolar{Turn{0.2}, Turn{0.3}};
+  // Truncates a solid to northern latitudes (intersect two cones and a plane)
+  EnclosedPolar{Turn{0.15}, Turn{0.2}};
+  // Truncates a solid to an equatorial region (18 degrees N to 36 S: the union
+  // of two polar wedge cones)
+  EnclosedPolar{Turn{0.2}, Turn{0.35}};
   \endcode
  */
 class EnclosedPolar

--- a/src/orange/surf/ConeAligned.cc
+++ b/src/orange/surf/ConeAligned.cc
@@ -10,6 +10,17 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Construct from origin and tangent of the angle of its opening.
+ */
+template<Axis T>
+ConeAligned<T>::ConeAligned(Real3 const& origin, real_type tangent)
+    : origin_{origin}, tsq_{ipow<2>(tangent)}
+{
+    CELER_EXPECT(tsq_ > 0);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct with square of tangent for simplification.
  */
 template<Axis T>

--- a/src/orange/surf/ConeAligned.hh
+++ b/src/orange/surf/ConeAligned.hh
@@ -27,7 +27,22 @@ namespace celeritas
    \f]
 
  * where \em t is the tangent of the opening angle (\f$r/h\f$ for a finite cone
- * with radius \em r and height \em h).
+ * with radius \em r and height \em h). In the cone below, the tangent of the
+ * inner angle is \f$ t = \tan(\theta) = r/h \f$. Negative values of \em t are
+ * equivalent and valid, representing the four points on a slice of the
+ * double-sheet cone.
+ * \verbatim
+  \        |   r    /
+   o- - - -+- - - -o
+    '--_   :   _--'
+ h      --.:.--
+ ---       O
+       _--':'--_
+    .--    :    --.
+   o-------+-------o
+  /        |        \
+   \endverbatim
+ *
  */
 template<Axis T>
 class ConeAligned
@@ -66,7 +81,7 @@ class ConeAligned
     static ConeAligned from_tangent_sq(Real3 const& origin, real_type tsq);
 
     // Construct from origin and tangent of the angle of its opening
-    inline CELER_FUNCTION ConeAligned(Real3 const& origin, real_type tangent);
+    ConeAligned(Real3 const& origin, real_type tangent);
 
     // Construct from raw data
     template<class R>
@@ -127,31 +142,6 @@ CELER_CONSTEXPR_FUNCTION SurfaceType ConeAligned<T>::surface_type()
            : T == Axis::y ? SurfaceType::ky
            : T == Axis::z ? SurfaceType::kz
                           : SurfaceType::size_;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Construct from origin and tangent of the angle of its opening.
- *
- * Given a finite cone, the tangent is the ratio of its base radius to its
- * height.
- *
- * In the cone, below, the tangent of the inner angle
- * \f$ \tan(\theta) = r/h \f$ is the second argument.
- * \verbatim
-     r
-   +-------*
-   |   _--^
- h |_--
-   O
-   \endverbatim
- */
-template<Axis T>
-CELER_FUNCTION
-ConeAligned<T>::ConeAligned(Real3 const& origin, real_type tangent)
-    : origin_{origin}, tsq_{ipow<2>(tangent)}
-{
-    CELER_EXPECT(tangent > 0);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -267,6 +267,7 @@ TEST(TurnTest, basic)
 
 TEST(TurnTest, math)
 {
+    // Fractional powers of two should yield exact results
     EXPECT_EQ(double(1), sin(make_turn(0.25)));
     EXPECT_EQ(double(-1), cos(make_turn(0.5)));
     {
@@ -293,6 +294,15 @@ TEST(TurnTest, math)
         EXPECT_DOUBLE_EQ(-0.5, ta.value());
         ta = atan2turn(-1.0, 0.0);
         EXPECT_DOUBLE_EQ(-0.25, ta.value());
+    }
+    {
+        auto t = make_turn(1.0 / 6);
+
+        double s, c;
+        sincos(t, &s, &c);
+        EXPECT_DOUBLE_EQ(0.8660254037844386, s);
+        EXPECT_DOUBLE_EQ(0.5, c);
+        EXPECT_DOUBLE_EQ(1.7320508075688767, tan(t));
     }
 }
 

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -604,26 +604,25 @@ TEST_F(SolidConverterTest, sphere)
         G4Sphere("sn1", 0, 50, halfpi, 3. * halfpi, 0, pi),
         R"json({"_type":"solid","enclosed_azi":{"stop":1.0,"start":0.25},"interior":{"_type":"sphere","radius":5.0},"label":"sn1"})json",
         {{-3, 0.05, 0}, {3, 0.5, 0}, {0, -0.01, 4.9}});
-    EXPECT_THROW(
-        this->build_and_test(G4Sphere("sn12", 0, 50, 0, twopi, 0., 0.25 * pi)),
-        RuntimeError);
+    this->build_and_test(
+        G4Sphere("sn12", 0, 50, 0, twopi, 0., 0.25 * pi),
+        R"json({"_type":"solid","enclosed_polar":{"start":0.0,"stop":0.125},"interior":{"_type":"sphere","radius":5.0},"label":"sn12"})json");
 
     this->build_and_test(
         G4Sphere("Spherical Shell", 45, 50, 0, twopi, 0, pi),
         R"json({"_type":"solid","excluded":{"_type":"sphere","radius":4.5},"interior":{"_type":"sphere","radius":5.0},"label":"Spherical Shell"})json",
         {{0, 0, 4.4}, {0, 0, 4.6}, {0, 0, 5.1}});
-    EXPECT_THROW(
-        this->build_and_test(G4Sphere(
-            "Band (theta segment1)", 45, 50, 0, twopi, pi * 3 / 4, pi / 4)),
-        RuntimeError);
+    this->build_and_test(
+        G4Sphere("Band (theta segment1)", 45, 50, 0, twopi, pi * 3 / 4, pi / 4),
+        R"json({"_type":"solid","enclosed_polar":{"start":0.375,"stop":0.5},"excluded":{"_type":"sphere","radius":4.5},"interior":{"_type":"sphere","radius":5.0},"label":"Band (theta segment1)"})json");
 
     this->build_and_test(
         G4Sphere("Band (phi segment)", 5, 50, -pi, 3. * pi / 2., 0, twopi),
-        R"json({"_type":"solid","enclosed_azi":{"stop":1.25,"start":0.5},"excluded":{"_type":"sphere","radius":0.5},"interior":{"_type":"sphere","radius":5.0},"label":"Band (phi segment)"})json");
-    EXPECT_THROW(
-        this->build_and_test(G4Sphere(
-            "Patch (phi/theta seg)", 45, 50, -pi / 4, halfpi, pi / 4, halfpi)),
-        RuntimeError);
+        R"json({"_type":"solid","enclosed_azi":{"start":0.5,"stop":1.25},"excluded":{"_type":"sphere","radius":0.5},"interior":{"_type":"sphere","radius":5.0},"label":"Band (phi segment)"})json");
+    this->build_and_test(
+        G4Sphere(
+            "Patch (phi/theta seg)", 45, 50, -pi / 4, halfpi, pi / 4, halfpi),
+        R"json({"_type":"solid","enclosed_azi":{"start":0.875,"stop":1.125},"enclosed_polar":{"start":0.125,"stop":0.375},"excluded":{"_type":"sphere","radius":4.5},"interior":{"_type":"sphere","radius":5.0},"label":"Patch (phi/theta seg)"})json");
 
     this->build_and_test(
         G4Sphere("John example", 300, 500, 0, 5.76, 0, pi),

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -603,7 +603,7 @@ TEST_F(SolidConverterTest, sphere)
     this->build_and_test(
         G4Sphere("sn1", 0, 50, halfpi, 3. * halfpi, 0, pi),
         R"json({"_type":"solid","enclosed_azi":{"stop":1.0,"start":0.25},"interior":{"_type":"sphere","radius":5.0},"label":"sn1"})json",
-        {{-3, 0.05, 0}, {3, 0.5, 0}, {0, -0.01, 4.9}});
+        {{-3, 0.05, 0}, {3, 0.5, 0}, {-0.01, -0.01, 4.9}});
     this->build_and_test(
         G4Sphere("sn12", 0, 50, 0, twopi, 0., 0.25 * pi),
         R"json({"_type":"solid","enclosed_polar":{"start":0.0,"stop":0.125},"interior":{"_type":"sphere","radius":5.0},"label":"sn12"})json");

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -1536,6 +1536,89 @@ TEST_F(InfAziWedgeTest, half_turn)
         EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
     }
 }
+//---------------------------------------------------------------------------//
+// INFPOLARWEDGE
+//---------------------------------------------------------------------------//
+using InfPolarWedgeTest = IntersectRegionTest;
+
+TEST_F(InfPolarWedgeTest, errors)
+{
+    EXPECT_THROW(InfPolarWedge(Turn{-0.2}, Turn{-0.001}), RuntimeError);
+    EXPECT_THROW(InfPolarWedge(Turn{-0.1}, Turn{0.1}), RuntimeError);
+    EXPECT_THROW(InfPolarWedge(Turn{0}, Turn{-0.1}), RuntimeError);
+    EXPECT_THROW(InfPolarWedge(Turn{0}, Turn{0.26}), RuntimeError);
+    EXPECT_THROW(InfPolarWedge(Turn{0.1}, Turn{0.1}), RuntimeError);
+    EXPECT_THROW(InfPolarWedge(Turn{0.24}, Turn{0.26}), RuntimeError);
+    EXPECT_THROW(InfPolarWedge(Turn{0.26}, Turn{0.52}), RuntimeError);
+}
+
+TEST_F(InfPolarWedgeTest, quarter_turn)
+{
+    {
+        SCOPED_TRACE("top half");
+        auto result = this->test(InfPolarWedge(Turn{0}, Turn{0.25}));
+        IntersectTestResult ref;
+        ref.node = "+0";
+        ref.surfaces = {"Plane: z=0"};
+        ref.interior = {{-inf, -inf, 0}, {inf, inf, inf}};
+        ref.exterior = {{-inf, -inf, 0}, {inf, inf, inf}};
+        EXPECT_REF_EQ(ref, result);
+    }
+    {
+        SCOPED_TRACE("bottom half");
+        auto result = this->test(InfPolarWedge(Turn{0.25}, Turn{0.5}));
+        IntersectTestResult ref;
+        ref.node = "-0";
+        ref.surfaces = {"Plane: z=0"};
+        ref.interior = {{-inf, -inf, -inf}, {inf, inf, 0}};
+        ref.exterior = {{-inf, -inf, -inf}, {inf, inf, 0}};
+        EXPECT_REF_EQ(ref, result);
+    }
+}
+
+TEST_F(InfPolarWedgeTest, eighth_turn)
+{
+    {
+        SCOPED_TRACE("north pole");
+        auto result = this->test(InfPolarWedge(Turn{0}, Turn{0.125}));
+        IntersectTestResult ref;
+        ref.node = "all(+0, -1)";
+        ref.surfaces = {"Plane: z=0", "Cone z: t=1 at {0,0,0}"};
+        ref.interior = {};
+        ref.exterior = {{-inf, -inf, 0}, {inf, inf, inf}};
+        EXPECT_REF_EQ(ref, result);
+    }
+    {
+        SCOPED_TRACE("north tropic");
+        auto result = this->test(InfPolarWedge(Turn{0.125}, Turn{0.25}));
+        IntersectTestResult ref;
+        ref.node = "all(+0, +1)";
+        ref.surfaces = {"Plane: z=0", "Cone z: t=1 at {0,0,0}"};
+        ref.interior = {};
+        ref.exterior = {{-inf, -inf, 0}, {inf, inf, inf}};
+        EXPECT_REF_EQ(ref, result);
+    }
+    {
+        SCOPED_TRACE("south tropic");
+        auto result = this->test(InfPolarWedge(Turn{0.25}, Turn{0.375}));
+        IntersectTestResult ref;
+        ref.node = "all(+1, -0)";
+        ref.surfaces = {"Plane: z=0", "Cone z: t=1 at {0,0,0}"};
+        ref.interior = {};
+        ref.exterior = {{-inf, -inf, -inf}, {inf, inf, 0}};
+        EXPECT_REF_EQ(ref, result);
+    }
+    {
+        SCOPED_TRACE("south pole");
+        auto result = this->test(InfPolarWedge(Turn{0.375}, Turn{0.5}));
+        IntersectTestResult ref;
+        ref.node = "all(-1, -0)";
+        ref.surfaces = {"Plane: z=0", "Cone z: t=1 at {0,0,0}"};
+        ref.interior = {};
+        ref.exterior = {{-inf, -inf, -inf}, {inf, inf, 0}};
+        EXPECT_REF_EQ(ref, result);
+    }
+}
 
 //---------------------------------------------------------------------------//
 // INVOLUTE

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -1620,6 +1620,38 @@ TEST_F(InfPolarWedgeTest, eighth_turn)
     }
 }
 
+TEST_F(InfPolarWedgeTest, sliver)
+{
+    {
+        SCOPED_TRACE("north");
+        auto result = this->test(InfPolarWedge(Turn{0.0625}, Turn{0.125}));
+        IntersectTestResult ref;
+        ref.node = "all(+0, +1, -2)";
+        ref.surfaces = {
+            "Plane: z=0",
+            "Cone z: t=0.41421 at {0,0,0}",
+            "Cone z: t=1 at {0,0,0}",
+        };
+        ref.interior = {};
+        ref.exterior = {{-inf, -inf, 0}, {inf, inf, inf}};
+        EXPECT_REF_EQ(ref, result);
+    }
+    {
+        SCOPED_TRACE("south");
+        auto result = this->test(InfPolarWedge(Turn{0.375}, Turn{0.4375}));
+        IntersectTestResult ref;
+        ref.node = "all(+1, -2, -0)";
+        ref.surfaces = {
+            "Plane: z=0",
+            "Cone z: t=0.41421 at {0,0,0}",
+            "Cone z: t=1 at {0,0,0}",
+        };
+        ref.interior = {};
+        ref.exterior = {{-inf, -inf, -inf}, {inf, inf, 0}};
+        EXPECT_REF_EQ(ref, result);
+    }
+}
+
 //---------------------------------------------------------------------------//
 // INVOLUTE
 //---------------------------------------------------------------------------//

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -1457,7 +1457,7 @@ TEST_F(InfAziWedgeTest, quarter_turn)
         auto result = this->test(InfAziWedge(Turn{0}, Turn{0.25}));
         static char const expected_node[] = "all(+0, +1)";
         static char const* const expected_surfaces[]
-            = {"Plane: y=0", "Plane: x=0"};
+            = {"Plane: x=0", "Plane: y=0"};
 
         EXPECT_EQ(expected_node, result.node);
         EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -1469,19 +1469,19 @@ TEST_F(InfAziWedgeTest, quarter_turn)
     {
         SCOPED_TRACE("second quadrant");
         auto result = this->test(InfAziWedge(Turn{.25}, Turn{0.5}));
-        EXPECT_EQ("all(+0, -1)", result.node);
+        EXPECT_EQ("all(+1, -0)", result.node);
     }
     {
         SCOPED_TRACE("fourth quadrant");
         InfAziWedge wedge(Turn{0.75}, Turn{1.0});
         EXPECT_SOFT_EQ(0.75, wedge.start().value());
         auto result = this->test(wedge);
-        EXPECT_EQ("all(+1, -0)", result.node);
+        EXPECT_EQ("all(+0, -1)", result.node);
     }
     {
         SCOPED_TRACE("north quadrant");
         auto result = this->test(InfAziWedge(Turn{0.125}, Turn{0.375}));
-        EXPECT_EQ("all(-2, +3)", result.node);
+        EXPECT_EQ("all(+2, -3)", result.node);
     }
     {
         SCOPED_TRACE("east quadrant");
@@ -1495,12 +1495,12 @@ TEST_F(InfAziWedgeTest, quarter_turn)
     {
         SCOPED_TRACE("west quadrant");
         auto result = this->test(InfAziWedge(Turn{0.375}, Turn{0.625}));
-        static char const expected_node[] = "all(-2, -3)";
+        static char const expected_node[] = "all(-3, -2)";
         static char const* const expected_surfaces[] = {
-            "Plane: y=0",
             "Plane: x=0",
-            "Plane: n={0.70711,-0.70711,0}, d=0",
+            "Plane: y=0",
             "Plane: n={0.70711,0.70711,0}, d=0",
+            "Plane: n={0.70711,-0.70711,0}, d=0",
         };
 
         EXPECT_EQ(expected_node, result.node);

--- a/test/orange/orangeinp/PolySolid.test.cc
+++ b/test/orange/orangeinp/PolySolid.test.cc
@@ -190,8 +190,8 @@ TEST_F(PolyconeTest, sliced)
         "Cone z: t=0.5 at {0,0,2}",
         "Plane: z=2",
         "Cone z: t=1 at {0,0,-1}",
-        "Plane: n={0.70711,0.70711,0}, d=0",
         "Plane: n={0.70711,-0.70711,0}, d=0",
+        "Plane: n={0.70711,0.70711,0}, d=0",
     };
     static char const* const expected_volume_strings[] = {
         "all(any(all(+0, -1, -2), all(+1, -3, -4)), !all(+5, +6))",
@@ -211,8 +211,8 @@ TEST_F(PolyconeTest, sliced)
         "",
         "pc@1.interior",
         "pc@segments",
-        "pc@angle.p0",
-        "pc@angle.p1",
+        "pc@awm",
+        "pc@awp",
         "pc@angle",
         "",
         "pc@restricted",

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -100,15 +100,16 @@ TEST_F(SolidTest, errors)
 {
     // Inner region is outside outer
     EXPECT_THROW(
-        ConeSolid("cone", Cone{{1, 2}, 10.0}, Cone{{1.1, 1.9}, 10.0}, {}),
+        ConeSolid("cone", Cone{{1, 2}, 10.0}, Cone{{1.1, 1.9}, 10.0}, {}, {}),
         RuntimeError);
     // No exclusion, no wedge
-    EXPECT_THROW(ConeSolid("cone", Cone{{1, 2}, 10.0}, {}, {}), RuntimeError);
+    EXPECT_THROW(ConeSolid("cone", Cone{{1, 2}, 10.0}, {}, {}, {}),
+                 RuntimeError);
 }
 
 TEST_F(SolidTest, inner)
 {
-    ConeSolid cone("cone", Cone{{1, 2}, 10.0}, Cone{{0.9, 1.9}, 10.0}, {});
+    ConeSolid cone("cone", Cone{{1, 2}, 10.0}, Cone{{0.9, 1.9}, 10.0}, {}, {});
     this->build_volume(cone);
 
     static char const* const expected_surface_strings[] = {
@@ -154,8 +155,11 @@ TEST_F(SolidTest, inner)
 
 TEST_F(SolidTest, wedge)
 {
-    ConeSolid cone(
-        "cone", Cone{{1, 2}, 10.0}, {}, EnclosedAzi{Turn{-0.125}, Turn{0.125}});
+    ConeSolid cone("cone",
+                   Cone{{1, 2}, 10.0},
+                   {},
+                   EnclosedAzi{Turn{-0.125}, Turn{0.125}},
+                   {});
     this->build_volume(cone);
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -198,8 +202,11 @@ TEST_F(SolidTest, wedge)
 
 TEST_F(SolidTest, antiwedge)
 {
-    ConeSolid cone(
-        "cone", Cone{{1, 2}, 10.0}, {}, EnclosedAzi{Turn{0.125}, Turn{0.875}});
+    ConeSolid cone("cone",
+                   Cone{{1, 2}, 10.0},
+                   {},
+                   EnclosedAzi{Turn{0.125}, Turn{0.875}},
+                   {});
     this->build_volume(cone);
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -247,7 +254,8 @@ TEST_F(SolidTest, both)
     ConeSolid cone("cone",
                    Cone{{1, 2}, 10.0},
                    Cone{{0.9, 1.9}, 10.0},
-                   EnclosedAzi{Turn{-0.125}, Turn{0.125}});
+                   EnclosedAzi{Turn{-0.125}, Turn{0.125}},
+                   {});
     this->build_volume(cone);
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -301,7 +309,8 @@ TEST_F(SolidTest, cyl)
     this->build_volume(CylinderSolid("cyl",
                                      Cylinder{1, 10.0},
                                      Cylinder{0.9, 10.0},
-                                     EnclosedAzi{Turn{-0.125}, Turn{0.125}}));
+                                     EnclosedAzi{Turn{-0.125}, Turn{0.125}},
+                                     {}));
 
     static char const* const expected_surface_strings[] = {
         "Plane: z=-10",
@@ -318,6 +327,74 @@ TEST_F(SolidTest, cyl)
     auto const& u = this->unit();
     EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
     EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
+}
+
+TEST_F(SolidTest, sphere_polar)
+{
+    using SS = SphereSolid;
+    using EP = EnclosedPolar;
+    {
+        this->build_volume(
+            SS("top", Sphere{10.0}, {}, {}, EP{Turn{0.0}, Turn{0.125}}));
+    }
+    {
+        this->build_volume(
+            SS("mid", Sphere{10.0}, {}, {}, EP{Turn{0.125}, Turn{0.5}}));
+    }
+    {
+        this->build_volume(
+            SS("bot", Sphere{10.0}, {}, {}, EP{Turn{0.375}, Turn{0.5}}));
+    }
+    {
+        // --+ octant
+        this->build_volume(SS("oct",
+                              Sphere{10.0},
+                              {},
+                              EnclosedAzi{Turn{0.5}, Turn{1.25}},
+                              EP{Turn{0.0}, Turn{0.25}}));
+    }
+
+    auto const& u = this->unit();
+    static char const* const expected_surface_strings[] = {
+        "Sphere: r=10",
+        "Plane: z=0",
+        "Cone z: t=1 at {0,0,0}",
+        "Plane: x=0",
+        "Plane: y=0",
+    };
+    static char const* const expected_volume_strings[] = {
+        "all(-0, +1, -2)",
+        "all(-0, any(all(+1, +2), -1))",
+        "all(-0, -2, -1)",
+        "all(-0, +1, !all(-4, +5))",
+    };
+    static char const* const expected_md_strings[] = {
+        "",
+        "",
+        "bot@int.s,mid@int.s,oct@int.s,top@int.s",
+        "bot@int,mid@int,oct@int,top@int",
+        R"(,bot@pol.pz,mid@pol.mz,mid@pol.pz,oct@pol,oct@pol.mz,top@pol.mz)",
+        "bot@pol.kz,mid@pol.kz,top@pol.kz",
+        "",
+        ",top@pol",
+        "top",
+        "mid@pol",
+        "mid@pol",
+        "",
+        "mid",
+        ",bot@pol",
+        "bot",
+        "oct@azi.p0",
+        "",
+        "oct@azi.p1",
+        "oct@azi",
+        "",
+        "oct",
+    };
+
+    EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
+    EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
+    EXPECT_VEC_EQ(expected_md_strings, md_strings(u));
 }
 
 TEST_F(SolidTest, or_shape)

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -483,11 +483,19 @@ TEST_F(SolidTest, sphere_polar)
         "~27: {{{-inf,-inf,-inf}, {0,0,inf}}, {{-inf,-inf,-inf}, {0,0,inf}}}",
         "28: {null, {{-inf,-inf,-inf}, {inf,inf,0}}}",
     };
+    static char const expected_tree_string[]
+        = R"json(["t",["~",0],["S",0],["~",2],["S",1],["S",2],["~",5],["&",[4,6]],["&",[3,4,6]],["&",[4,5]],["~",4],["&",[5,10]],["|",[9,11]],["&",[3,12]],["S",4],["&",[10,14]],["|",[9,15]],["&",[3,16]],["~",14],["&",[10,18]],["&",[3,10,18]],["S",5],["~",21],["S",6],["~",23],["&",[22,24]],["&",[3,4,22,24]],["~",25],["&",[3,10,27]]])json";
 
     EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
-    EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
     EXPECT_VEC_EQ(expected_md_strings, md_strings(u));
     EXPECT_VEC_EQ(expected_bound_strings, bound_strings(u));
+
+    if constexpr (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+    {
+        // Surface deduplication removes one of the cones a bit later
+        EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
+        EXPECT_JSON_EQ(expected_tree_string, tree_string(u));
+    }
 }
 
 TEST_F(SolidTest, or_shape)

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -213,8 +213,8 @@ TEST_F(SolidTest, wedge)
         "Plane: z=-10",
         "Plane: z=10",
         "Cone z: t=0.05 at {0,0,-30}",
-        "Plane: n={0.70711,0.70711,0}, d=0",
         "Plane: n={0.70711,-0.70711,0}, d=0",
+        "Plane: n={0.70711,0.70711,0}, d=0",
     };
     static char const* const expected_volume_strings[] = {
         "all(+0, -1, -2, +3, +4)",
@@ -228,8 +228,8 @@ TEST_F(SolidTest, wedge)
         "cone@int.kz",
         "",
         "cone@int",
-        "cone@azi.p0",
-        "cone@azi.p1",
+        "cone@awm",
+        "cone@awp",
         "cone@azi",
         "cone",
     };
@@ -260,8 +260,8 @@ TEST_F(SolidTest, antiwedge)
         "Plane: z=-10",
         "Plane: z=10",
         "Cone z: t=0.05 at {0,0,-30}",
-        "Plane: n={0.70711,0.70711,0}, d=0",
         "Plane: n={0.70711,-0.70711,0}, d=0",
+        "Plane: n={0.70711,0.70711,0}, d=0",
     };
     static char const* const expected_volume_strings[] = {
         "all(+0, -1, -2, !all(+3, +4))",
@@ -275,9 +275,9 @@ TEST_F(SolidTest, antiwedge)
         "cone@int.kz",
         "",
         "cone@int",
-        "cone@azi.p0",
-        "cone@azi.p1",
-        "cone@azi",
+        "cone@awm",
+        "cone@awp",
+        "cone@~azi",
         "",
         "cone",
     };
@@ -310,8 +310,8 @@ TEST_F(SolidTest, both)
         "Plane: z=10",
         "Cone z: t=0.05 at {0,0,-30}",
         "Cone z: t=0.05 at {0,0,-28}",
-        "Plane: n={0.70711,0.70711,0}, d=0",
         "Plane: n={0.70711,-0.70711,0}, d=0",
+        "Plane: n={0.70711,0.70711,0}, d=0",
     };
     static char const* const expected_volume_strings[] = {
         "all(+0, -1, -2, !all(+0, -1, -3), +4, +5)",
@@ -329,8 +329,8 @@ TEST_F(SolidTest, both)
         "",
         "cone@exc",
         "",
-        "cone@azi.p0",
-        "cone@azi.p1",
+        "cone@awm",
+        "cone@awp",
         "cone@azi",
         "cone",
     };
@@ -365,8 +365,8 @@ TEST_F(SolidTest, cyl)
         "Plane: z=10",
         "Cyl z: r=1",
         "Cyl z: r=0.9",
-        "Plane: n={0.70711,0.70711,0}, d=0",
         "Plane: n={0.70711,-0.70711,0}, d=0",
+        "Plane: n={0.70711,0.70711,0}, d=0",
     };
     static char const* const expected_volume_strings[] = {
         "all(+0, -1, -2, !all(+0, -1, -3), +4, +5)",
@@ -421,8 +421,8 @@ TEST_F(SolidTest, sphere_polar)
         "Plane: z=0",
         "Cone z: t=1 at {0,0,0}",
         "Cone z: t=1.7321 at {0,0,0}",
-        "Plane: y=0",
         "Plane: x=0",
+        "Plane: y=0",
     };
     static char const* const expected_volume_strings[] = {
         "all(-0, +1, -2)",
@@ -437,8 +437,8 @@ TEST_F(SolidTest, sphere_polar)
         "",
         "bot@int.s,mid@int.s,midsym@int.s,negoct@int.s,oct@int.s,top@int.s",
         "bot@int,mid@int,midsym@int,negoct@int,oct@int,top@int",
-        R"(,bot@pol.pz,mid@pol.mz,mid@pol.pz,midsym@pol.mz,midsym@pol.pz,negoct@pol.pz,oct@pol,oct@pol.mz,top@pol.mz)",
-        "mid@pol.kz,midsym@pol.kz,top@pol.kz",
+        R"(,bot@pwm,mid@pwm,midsym@pwm,negoct@pwm,oct@pol,oct@pwm,top@pwm)",
+        "mid@pwt,midsym@pwb,midsym@pwt,top@pwb",
         "",
         ",top@pol",
         "top",
@@ -447,18 +447,18 @@ TEST_F(SolidTest, sphere_polar)
         "midsym@pol",
         "",
         "midsym",
-        "bot@pol.kz,mid@pol.kz",
+        "bot@pwt,mid@pwb",
         "mid@pol",
         "",
         "mid",
         "",
         ",bot@pol",
         "bot",
-        "negoct@azi.p0,oct@azi.p0",
+        "negoct@awm,oct@awm",
         "",
-        "negoct@azi.p1,oct@azi.p1",
+        "negoct@awp,oct@awp",
         "",
-        "negoct@azi,oct@azi",
+        "negoct@~azi,oct@azi",
         "oct",
         "",
         "negoct",

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -89,6 +89,54 @@ TEST(EnclosedAziTest, make_sense_region)
 }
 
 //---------------------------------------------------------------------------//
+TEST(EnclosedPolar, errors)
+{
+    EXPECT_THROW(EnclosedPolar(Turn{0.1}, Turn{0.05}), RuntimeError);
+    EXPECT_THROW(EnclosedPolar(Turn{-0.1}, Turn{0.1}), RuntimeError);
+    EXPECT_THROW(EnclosedPolar(Turn{0}, Turn{0}), RuntimeError);
+    EXPECT_THROW(EnclosedPolar(Turn{0}, Turn{0.75}), RuntimeError);
+}
+
+//---------------------------------------------------------------------------//
+TEST(EnclosedPolar, regions)
+{
+    {
+        SCOPED_TRACE("pole");
+        EnclosedPolar pol(Turn{0}, Turn{0.1});
+        auto regions = pol.make_regions();
+        ASSERT_EQ(1, regions.size());
+        EXPECT_REAL_EQ(0.0, regions[0].start().value());
+        EXPECT_REAL_EQ(0.1, regions[0].stop().value());
+    }
+    {
+        SCOPED_TRACE("north");
+        EnclosedPolar pol(Turn{0.0}, Turn{0.25});
+        auto regions = pol.make_regions();
+        ASSERT_EQ(1, regions.size());
+        EXPECT_REAL_EQ(0.0, regions[0].start().value());
+        EXPECT_REAL_EQ(0.25, regions[0].stop().value());
+    }
+    {
+        SCOPED_TRACE("south");
+        EnclosedPolar pol(Turn{0.25}, Turn{0.5});
+        auto regions = pol.make_regions();
+        ASSERT_EQ(1, regions.size());
+        EXPECT_REAL_EQ(0.25, regions[0].start().value());
+        EXPECT_REAL_EQ(0.5, regions[0].stop().value());
+    }
+    {
+        SCOPED_TRACE("tropics");
+        EnclosedPolar pol(Turn{0.2}, Turn{0.3});
+        auto regions = pol.make_regions();
+        ASSERT_EQ(2, regions.size());
+        EXPECT_REAL_EQ(0.2, regions[0].start().value());
+        EXPECT_REAL_EQ(0.25, regions[0].stop().value());
+        EXPECT_REAL_EQ(0.25, regions[1].start().value());
+        EXPECT_REAL_EQ(0.3, regions[1].stop().value());
+    }
+}
+
+//---------------------------------------------------------------------------//
 class SolidTest : public ObjectTestBase
 {
   protected:
@@ -333,25 +381,38 @@ TEST_F(SolidTest, sphere_polar)
 {
     using SS = SphereSolid;
     using EP = EnclosedPolar;
+    constexpr real_type one_third = 1 / real_type{3};
     {
         this->build_volume(
             SS("top", Sphere{10.0}, {}, {}, EP{Turn{0.0}, Turn{0.125}}));
     }
     {
         this->build_volume(
-            SS("mid", Sphere{10.0}, {}, {}, EP{Turn{0.125}, Turn{0.5}}));
+            SS("midsym", Sphere{10.0}, {}, {}, EP{Turn{0.125}, Turn{0.375}}));
     }
     {
         this->build_volume(
-            SS("bot", Sphere{10.0}, {}, {}, EP{Turn{0.375}, Turn{0.5}}));
+            SS("mid", Sphere{10.0}, {}, {}, EP{Turn{0.125}, Turn{one_third}}));
+    }
+    {
+        this->build_volume(
+            SS("bot", Sphere{10.0}, {}, {}, EP{Turn{one_third}, Turn{0.5}}));
     }
     {
         // --+ octant
         this->build_volume(SS("oct",
                               Sphere{10.0},
                               {},
-                              EnclosedAzi{Turn{0.5}, Turn{1.25}},
+                              EnclosedAzi{Turn{0.5}, Turn{0.75}},
                               EP{Turn{0.0}, Turn{0.25}}));
+    }
+    {
+        // Bottom half, not quadrant III
+        this->build_volume(SS("negoct",
+                              Sphere{10.0},
+                              {},
+                              EnclosedAzi{Turn{0.75}, Turn{1.5}},
+                              EP{Turn{0.25}, Turn{0.5}}));
     }
 
     auto const& u = this->unit();
@@ -359,42 +420,74 @@ TEST_F(SolidTest, sphere_polar)
         "Sphere: r=10",
         "Plane: z=0",
         "Cone z: t=1 at {0,0,0}",
-        "Plane: x=0",
+        "Cone z: t=1.7321 at {0,0,0}",
         "Plane: y=0",
+        "Plane: x=0",
     };
     static char const* const expected_volume_strings[] = {
         "all(-0, +1, -2)",
-        "all(-0, any(all(+1, +2), -1))",
-        "all(-0, -2, -1)",
-        "all(-0, +1, !all(-4, +5))",
+        "all(-0, any(all(+1, +2), all(+2, -1)))",
+        "all(-0, any(all(+1, +2), all(-1, +4)))",
+        "all(-0, -1, -4)",
+        "all(-0, +1, -5, -6)",
+        "all(-0, -1, !all(-5, -6))",
     };
     static char const* const expected_md_strings[] = {
         "",
         "",
-        "bot@int.s,mid@int.s,oct@int.s,top@int.s",
-        "bot@int,mid@int,oct@int,top@int",
-        R"(,bot@pol.pz,mid@pol.mz,mid@pol.pz,oct@pol,oct@pol.mz,top@pol.mz)",
-        "bot@pol.kz,mid@pol.kz,top@pol.kz",
+        "bot@int.s,mid@int.s,midsym@int.s,negoct@int.s,oct@int.s,top@int.s",
+        "bot@int,mid@int,midsym@int,negoct@int,oct@int,top@int",
+        R"(,bot@pol.pz,mid@pol.mz,mid@pol.pz,midsym@pol.mz,midsym@pol.pz,negoct@pol.pz,oct@pol,oct@pol.mz,top@pol.mz)",
+        "mid@pol.kz,midsym@pol.kz,top@pol.kz",
         "",
         ",top@pol",
         "top",
-        "mid@pol",
+        "mid@pol,midsym@pol",
+        ",negoct@pol",
+        "midsym@pol",
+        "",
+        "midsym",
+        "bot@pol.kz,mid@pol.kz",
         "mid@pol",
         "",
         "mid",
+        "",
         ",bot@pol",
         "bot",
-        "oct@azi.p0",
+        "negoct@azi.p0,oct@azi.p0",
         "",
-        "oct@azi.p1",
-        "oct@azi",
+        "negoct@azi.p1,oct@azi.p1",
         "",
+        "negoct@azi,oct@azi",
         "oct",
+        "",
+        "negoct",
+    };
+    static char const* const expected_bound_strings[] = {
+        R"(3: {{{-8.66,-8.66,-8.66}, {8.66,8.66,8.66}}, {{-10,-10,-10}, {10,10,10}}})",
+        "4: {{{-inf,-inf,0}, {inf,inf,inf}}, {{-inf,-inf,0}, {inf,inf,inf}}}",
+        "7: {null, {{-inf,-inf,0}, {inf,inf,inf}}}",
+        "8: {null, {{-10,-10,0}, {10,10,10}}}",
+        "9: {null, {{-inf,-inf,0}, {inf,inf,inf}}}",
+        R"(10: {{{-inf,-inf,-inf}, {inf,inf,0}}, {{-inf,-inf,-inf}, {inf,inf,0}}})",
+        "11: {null, {{-inf,-inf,-inf}, {inf,inf,0}}}",
+        "12: {null, inf}",
+        "13: {null, {{-10,-10,-10}, {10,10,10}}}",
+        "15: {null, {{-inf,-inf,-inf}, {inf,inf,0}}}",
+        "16: {null, inf}",
+        "17: {null, {{-10,-10,-10}, {10,10,10}}}",
+        "19: {null, {{-inf,-inf,-inf}, {inf,inf,0}}}",
+        "20: {null, {{-10,-10,-10}, {10,10,0}}}",
+        "25: {{{-inf,-inf,-inf}, {0,0,inf}}, {{-inf,-inf,-inf}, {0,0,inf}}}",
+        "26: {{{-8.66,-8.66,0}, {0,0,8.66}}, {{-10,-10,0}, {0,0,10}}}",
+        "~27: {{{-inf,-inf,-inf}, {0,0,inf}}, {{-inf,-inf,-inf}, {0,0,inf}}}",
+        "28: {null, {{-inf,-inf,-inf}, {inf,inf,0}}}",
     };
 
     EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
     EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
     EXPECT_VEC_EQ(expected_md_strings, md_strings(u));
+    EXPECT_VEC_EQ(expected_bound_strings, bound_strings(u));
 }
 
 TEST_F(SolidTest, or_shape)


### PR DESCRIPTION
Chained on #1831.

This adds the ability to truncate a sphere's polar region to a particular set of latitudes. This is used by LHCb's RICH detector (#1473 )