### PR TITLE
Flush optical tracks at the end of core stepping loop

### DIFF
--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -166,7 +166,8 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
     append_track_counts(track_counts);
     record_step_time();
 
-    while (track_counts)
+    OpticalOffloadCounters optical_counts;
+    while (track_counts || !optical_counts.empty())
     {
         if (CELER_UNLIKELY(--remaining_steps == 0))
         {
@@ -185,6 +186,12 @@ auto Transporter<M>::operator()(SpanConstPrimary primaries)
         track_counts = step();
         append_track_counts(track_counts);
         record_step_time();
+
+        if (optical_)
+        {
+            auto& aux = stepper_->sp_state()->aux();
+            optical_counts = optical_->buffer_counts(aux);
+        }
     }
 
     auto counters = copy_to_host(stepper_->state_ref().init.track_counters);

--- a/src/celeritas/optical/ModelImporter.cc
+++ b/src/celeritas/optical/ModelImporter.cc
@@ -43,7 +43,6 @@ ModelImporter::ModelImporter(ImportData const& data,
     input_.import_material = ImportedMaterials::from_import(data);
 
     CELER_ENSURE(input_.imported);
-    CELER_ENSURE(input_.import_material);
 }
 
 //---------------------------------------------------------------------------//
@@ -106,6 +105,8 @@ auto ModelImporter::build_absorption() const -> ModelBuilder
  */
 auto ModelImporter::build_rayleigh() const -> ModelBuilder
 {
+    CELER_EXPECT(input_.import_material);
+
     return RayleighModel::make_builder(
         this->imported(),
         RayleighModel::Input{
@@ -118,6 +119,8 @@ auto ModelImporter::build_rayleigh() const -> ModelBuilder
  */
 auto ModelImporter::build_wls() const -> ModelBuilder
 {
+    CELER_EXPECT(input_.import_material);
+
     WavelengthShiftModel::Input input;
     input.model = ImportModelClass::wls;
     input.time_profile = params_.wls_time_profile;
@@ -135,6 +138,8 @@ auto ModelImporter::build_wls() const -> ModelBuilder
  */
 auto ModelImporter::build_wls2() const -> ModelBuilder
 {
+    CELER_EXPECT(input_.import_material);
+
     WavelengthShiftModel::Input input;
     input.model = ImportModelClass::wls2;
     input.time_profile = params_.wls2_time_profile;

--- a/src/celeritas/optical/OpticalCollector.hh
+++ b/src/celeritas/optical/OpticalCollector.hh
@@ -105,7 +105,7 @@ class OpticalCollector
             return material && (scintillation || cherenkov)
                    && num_track_slots > 0 && buffer_capacity > 0
                    && initializer_capacity > 0 && auto_flush > 0
-                   && max_step_iters > 0 && !model_builders.empty();
+                   && !model_builders.empty();
         }
     };
 

--- a/src/celeritas/optical/detail/OpticalLaunchAction.hh
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.hh
@@ -57,8 +57,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
         //! True if all input is assigned and valid
         explicit operator bool() const
         {
-            return optical_params && num_track_slots > 0 && max_step_iters > 0
-                   && auto_flush > 0;
+            return optical_params && num_track_slots > 0 && auto_flush > 0;
         }
     };
 
@@ -94,7 +93,7 @@ class OpticalLaunchAction : public AuxParamsInterface,
     //! ID of the model
     ActionId action_id() const final { return action_id_; }
     //! Dependency ordering of the action
-    StepActionOrder order() const final { return StepActionOrder::user_post; }
+    StepActionOrder order() const final { return StepActionOrder::end; }
     // Launch kernel with host data
     void step(CoreParams const&, CoreStateHost&) const final;
     // Launch kernel with device data

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -95,6 +95,7 @@ class LArSphereOffloadTest : public LArSphereBase
     size_type buffer_capacity_{256};
     size_type initializer_capacity_{8192};
     size_type auto_flush_{4096};
+    size_type max_step_iters_{static_cast<size_type>(-1)};
     units::MevEnergy primary_energy_{10.0};
 
     std::shared_ptr<OpticalCollector> collector_;
@@ -206,6 +207,7 @@ void LArSphereOffloadTest::build_optical_collector()
     inp.buffer_capacity = buffer_capacity_;
     inp.initializer_capacity = initializer_capacity_;
     inp.auto_flush = auto_flush_;
+    inp.max_step_iters = max_step_iters_;
 
     using IMC = celeritas::optical::ImportModelClass;
 
@@ -343,7 +345,7 @@ template LArSphereOffloadTest::RunResult
 
 TEST_F(LArSphereOffloadTest, host_distributions)
 {
-    auto_flush_ = size_type(-1);
+    max_step_iters_ = 0;
     num_track_slots_ = 4;
     this->build_optical_collector();
 
@@ -412,7 +414,7 @@ TEST_F(LArSphereOffloadTest, host_distributions)
 
 TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_distributions))
 {
-    auto_flush_ = size_type(-1);
+    max_step_iters_ = 0;
     num_track_slots_ = 8;
     this->build_optical_collector();
 
@@ -491,7 +493,7 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_distributions))
 TEST_F(LArSphereOffloadTest, cherenkov_distributiona)
 {
     use_scintillation_ = false;
-    auto_flush_ = size_type(-1);
+    max_step_iters_ = 0;
     num_track_slots_ = 4;
     this->build_optical_collector();
 
@@ -515,7 +517,7 @@ TEST_F(LArSphereOffloadTest, cherenkov_distributiona)
 TEST_F(LArSphereOffloadTest, scintillation_distributions)
 {
     use_cherenkov_ = false;
-    auto_flush_ = size_type(-1);
+    max_step_iters_ = 0;
     num_track_slots_ = 4;
     this->build_optical_collector();
 
@@ -619,10 +621,12 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        EXPECT_EQ(218314, result.scintillation.total_num_photons);
-        EXPECT_EQ(2236, result.cherenkov.total_num_photons);
+        EXPECT_EQ(5338, result.accum.cherenkov.photons);
+        EXPECT_EQ(500472, result.accum.scintillation.photons);
     }
     EXPECT_EQ(7, result.optical_launch_step);
+    EXPECT_EQ(0, result.scintillation.total_num_photons);
+    EXPECT_EQ(0, result.cherenkov.total_num_photons);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
While [updating the LAr sphere optical benchmark](https://github.com/celeritas-project/benchmarks/commit/8fb39e0b92aa08083d35c9fb76e046c76f6f31af) to account for some recent optical physics changes, I realized we don't flush the remaining optical tracks at the end of the core stepping loop: this fixes that.