### PR TITLE
Reconstruct additional data in G4Track

### DIFF
--- a/src/celeritas/ext/detail/HitProcessor.cc
+++ b/src/celeritas/ext/detail/HitProcessor.cc
@@ -178,7 +178,7 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         p->SetLocalTime(std::numeric_limits<double>::infinity());
         // Time in rest frame since track was created
         p->SetProperTime(std::numeric_limits<double>::infinity());
-        // Speed
+        // Speed (TODO: use ParticleView)
         p->SetVelocity(std::numeric_limits<double>::infinity());
         // Safety distance
         p->SetSafety(std::numeric_limits<double>::infinity());
@@ -190,10 +190,13 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
     for (G4ParticleDefinition const* pd : particles)
     {
         CELER_ASSERT(pd);
-        tracks_.emplace_back(new G4Track(
-            new G4DynamicParticle(pd, G4ThreeVector()), 0.0, G4ThreeVector()));
-        tracks_.back()->SetTrackID(-1);
-        tracks_.back()->SetParentID(-1);
+        auto track = std::make_unique<G4Track>(
+            new G4DynamicParticle(pd, G4ThreeVector()), 0.0, G4ThreeVector());
+        track->SetTrackID(-1);
+        track->SetParentID(-1);
+        track->SetStep(step_.get());
+
+        tracks_.emplace_back(std::move(track));
     }
 
     // Convert logical volumes (global) to sensitive detectors (thread local)
@@ -386,6 +389,9 @@ void HitProcessor::update_track(ParticleId id) const
     G4Track& track = *tracks_[id.unchecked_get()];
     step_->SetTrack(&track);
 
+    // Copy data from step to track
+    track.SetStepLength(step_->GetStepLength());
+
     G4ParticleDefinition const& pd = *track.GetParticleDefinition();
 
     for (G4StepPoint* p : step_points_)
@@ -407,6 +413,9 @@ void HitProcessor::update_track(ParticleId id) const
         track.SetKineticEnergy(post_step->GetKineticEnergy());
         track.SetMomentumDirection(post_step->GetMomentumDirection());
         track.SetWeight(post_step->GetWeight());
+
+        track.SetNextTouchableHandle(post_step->GetTouchableHandle());
+        track.SetVelocity(post_step->GetVelocity());
     }
 }
 

--- a/src/celeritas/ext/detail/HitProcessor.cc
+++ b/src/celeritas/ext/detail/HitProcessor.cc
@@ -192,8 +192,8 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         CELER_ASSERT(pd);
         auto track = std::make_unique<G4Track>(
             new G4DynamicParticle(pd, G4ThreeVector()), 0.0, G4ThreeVector());
-        track->SetTrackID(-1);
-        track->SetParentID(-1);
+        track->SetTrackID(0);
+        track->SetParentID(0);
         track->SetStep(step_.get());
 
         tracks_.emplace_back(std::move(track));

--- a/src/celeritas/ext/detail/HitProcessor.cc
+++ b/src/celeritas/ext/detail/HitProcessor.cc
@@ -405,6 +405,13 @@ void HitProcessor::update_track(ParticleId id) const
         p->SetMass(pd.GetPDGMass());
         p->SetCharge(pd.GetPDGCharge());
     }
+
+    if (G4StepPoint* pre_step = step_points_[StepPoint::pre])
+    {
+        // Copy data from post-step to track
+        track.SetTouchableHandle(pre_step->GetTouchableHandle());
+    }
+
     if (G4StepPoint* post_step = step_points_[StepPoint::post])
     {
         // Copy data from post-step to track


### PR DESCRIPTION
#1756 is crashing due to a null pointer: @rahmans1 and I tracked it down to `G4Track::GetMaterialCutsCouple` which actually points to the *step*: `fpStep->GetPreStepPoint()->GetMaterialCutsCouple();`. There are circular dependencies between Step and Track and a lot of duplicate data between the three.

This should fix the crash by setting the track's step pointer during construction.