### PR TITLE
Output optical actions

### DIFF
--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -11,6 +11,7 @@
 #include "corecel/io/OutputInterfaceAdapter.hh"
 #include "corecel/io/OutputRegistry.hh"
 #include "corecel/sys/ActionRegistry.hh"
+#include "corecel/sys/ActionRegistryOutput.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/track/TrackInitParams.hh"
 
@@ -121,6 +122,10 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
         scint_generate_ = GeneratorAction<GT::scintillation>::make_and_insert(
             core, *optical_params, std::move(ga_inp));
     }
+
+    // Save optical diagnostic information
+    core.output_reg()->insert(std::make_shared<ActionRegistryOutput>(
+        optical_params->action_reg(), "optical-actions"));
 
     // Create launch action with optical params+state and access to gen data
     detail::OpticalLaunchAction::Input la_inp;

--- a/src/corecel/sys/ActionRegistryOutput.cc
+++ b/src/corecel/sys/ActionRegistryOutput.cc
@@ -25,7 +25,17 @@ namespace celeritas
  * Construct from a shared action manager.
  */
 ActionRegistryOutput::ActionRegistryOutput(SPConstActionRegistry actions)
-    : actions_(std::move(actions))
+    : ActionRegistryOutput(actions, "actions")
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a shared action manager and label.
+ */
+ActionRegistryOutput::ActionRegistryOutput(SPConstActionRegistry actions,
+                                           std::string label)
+    : actions_(std::move(actions)), label_(std::move(label))
 {
     CELER_EXPECT(actions_);
 }

--- a/src/corecel/sys/ActionRegistryOutput.hh
+++ b/src/corecel/sys/ActionRegistryOutput.hh
@@ -29,17 +29,21 @@ class ActionRegistryOutput final : public OutputInterface
     // Construct from a shared action manager
     explicit ActionRegistryOutput(SPConstActionRegistry actions);
 
+    // Construct from a shared action manager and label
+    explicit ActionRegistryOutput(SPConstActionRegistry, std::string);
+
     //! Category of data to write
     Category category() const final { return Category::internal; }
 
     //! Name of the entry inside the category.
-    std::string_view label() const final { return "actions"; }
+    std::string_view label() const final { return label_; }
 
     // Write output to the given JSON object
     void output(JsonPimpl*) const final;
 
   private:
     SPConstActionRegistry actions_;
+    std::string label_;
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This tiny update lets us write the optical actions (and processes) that are enabled to the output.