### PR TITLE
Add surface properties to core and optical params

### DIFF
--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -106,6 +106,9 @@ inp = {
 }
 
 if "lar" in geometry_filename:
+    # Volume and surface properties are currently only loaded if Geant4 import
+    # is enabled
+    physics_filename = None
     num_optical_tracks = 4096
     inp['max_steps'] = 2
     inp['optical'] = {

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -33,6 +33,7 @@
 #include "corecel/sys/MpiCommunicator.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "geocel/GeoParamsOutput.hh"
+#include "geocel/SurfaceParams.hh"
 #include "celeritas/alongstep/AlongStepNeutralAction.hh"
 #include "celeritas/em/params/WentzelOKVIParams.hh"  // IWYU pragma: keep
 #include "celeritas/geo/GeoMaterialParams.hh"  // IWYU pragma: keep
@@ -90,6 +91,7 @@ build_params_refs(CoreParams::Input const& p, CoreScalars const& scalars)
     ref.physics = get_ref<M>(*p.physics);
     ref.rng = get_ref<M>(*p.rng);
     ref.sim = get_ref<M>(*p.sim);
+    ref.surface = get_ref<M>(*p.surface);
     ref.init = get_ref<M>(*p.init);
     if (p.wentzel)
     {

--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -30,6 +30,7 @@ class OutputRegistry;
 class ParticleParams;
 class PhysicsParams;
 class SimParams;
+class SurfaceParams;
 class TrackInitParams;
 class AuxParamsRegistry;
 class WentzelOKVIParams;
@@ -54,6 +55,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
     using SPConstPhysics = std::shared_ptr<PhysicsParams const>;
     using SPConstRng = std::shared_ptr<RngParams const>;
     using SPConstSim = std::shared_ptr<SimParams const>;
+    using SPConstSurface = std::shared_ptr<SurfaceParams const>;
     using SPConstTrackInit = std::shared_ptr<TrackInitParams const>;
     using SPConstWentzelOKVI = std::shared_ptr<WentzelOKVIParams const>;
     using SPConstMpiCommunicator = std::shared_ptr<MpiCommunicator const>;
@@ -77,6 +79,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
         SPConstPhysics physics;
         SPConstRng rng;
         SPConstSim sim;
+        SPConstSurface surface;
         SPConstTrackInit init;
         SPConstWentzelOKVI wentzel;  //!< Optional (TODO: aux data?)
 
@@ -95,8 +98,8 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
         explicit operator bool() const
         {
             return geometry && material && geomaterial && particle && cutoff
-                   && physics && rng && sim && init && action_reg && output_reg
-                   && max_streams;
+                   && physics && rng && sim && surface && init && action_reg
+                   && output_reg && max_streams;
         }
     };
 
@@ -117,6 +120,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
     SPConstPhysics const& physics() const { return input_.physics; }
     SPConstRng const& rng() const { return input_.rng; }
     SPConstSim const& sim() const { return input_.sim; }
+    SPConstSurface const& surface() const { return input_.surface; }
     SPConstTrackInit const& init() const { return input_.init; }
     SPConstWentzelOKVI const& wentzel() const { return input_.wentzel; }
     SPActionRegistry const& action_reg() const { return input_.action_reg; }

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -10,6 +10,7 @@
 #include "corecel/data/Collection.hh"
 #include "corecel/data/ObserverPtr.hh"
 #include "corecel/random/data/RngData.hh"
+#include "geocel/SurfaceData.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/em/data/WentzelOKVIData.hh"
 #include "celeritas/geo/GeoData.hh"
@@ -72,6 +73,7 @@ struct CoreParamsData
     PhysicsParamsData<W, M> physics;
     RngParamsData<W, M> rng;
     SimParamsData<W, M> sim;
+    SurfaceParamsData<W, M> surface;
     TrackInitParamsData<W, M> init;
     WentzelOKVIData<W, M> wentzel;
 
@@ -97,6 +99,7 @@ struct CoreParamsData
         physics = other.physics;
         rng = other.rng;
         sim = other.sim;
+        surface = other.surface;
         init = other.init;
         wentzel = other.wentzel;
         scalars = other.scalars;

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -10,6 +10,7 @@
 #include "corecel/random/params/RngParams.hh"
 #include "corecel/sys/ActionRegistry.hh"
 #include "corecel/sys/ScopedMem.hh"
+#include "geocel/SurfaceParams.hh"
 #include "celeritas/geo/GeoParams.hh"
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/track/SimParams.hh"
@@ -48,6 +49,7 @@ build_params_refs(CoreParams::Input const& p, CoreScalars const& scalars)
     ref.geometry = get_ref<M>(*p.geometry);
     ref.material = get_ref<M>(*p.material);
     ref.physics = get_ref<M>(*p.physics);
+    ref.surface = get_ref<M>(*p.surface);
     ref.rng = get_ref<M>(*p.rng);
     ref.init = get_ref<M>(*p.init);
 
@@ -115,6 +117,7 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     CP_VALIDATE_INPUT(material);
     CP_VALIDATE_INPUT(physics);
     CP_VALIDATE_INPUT(rng);
+    CP_VALIDATE_INPUT(surface);
     CP_VALIDATE_INPUT(init);
     CP_VALIDATE_INPUT(action_reg);
     CP_VALIDATE_INPUT(max_streams);

--- a/src/celeritas/optical/CoreParams.hh
+++ b/src/celeritas/optical/CoreParams.hh
@@ -22,6 +22,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 class ActionRegistry;
+class SurfaceParams;
 
 namespace optical
 {
@@ -42,6 +43,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
     using SPConstMaterial = std::shared_ptr<MaterialParams const>;
     using SPConstPhysics = std::shared_ptr<PhysicsParams const>;
     using SPConstRng = std::shared_ptr<RngParams const>;
+    using SPConstSurface = std::shared_ptr<SurfaceParams const>;
     using SPConstTrackInit = std::shared_ptr<TrackInitParams const>;
     using SPActionRegistry = std::shared_ptr<ActionRegistry>;
     using SPConstDetectors = std::shared_ptr<SDParams const>;
@@ -59,6 +61,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
         SPConstMaterial material;
         SPConstPhysics physics;
         SPConstRng rng;
+        SPConstSurface surface;
         SPConstTrackInit init;
 
         std::optional<VecLabel> detector_labels;
@@ -71,7 +74,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
         //! True if all params are assigned and valid
         explicit operator bool() const
         {
-            return geometry && material && rng && init && action_reg
+            return geometry && material && rng && surface && init && action_reg
                    && max_streams;
         }
     };
@@ -95,6 +98,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
     SPConstMaterial const& material() const { return input_.material; }
     SPConstPhysics const& physics() const { return input_.physics; }
     SPConstRng const& rng() const { return input_.rng; }
+    SPConstSurface const& surface() const { return input_.surface; }
     SPConstTrackInit const& init() const { return input_.init; }
     SPActionRegistry const& action_reg() const { return input_.action_reg; }
     SPConstDetectors const& detectors() const { return detectors_; }

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -9,6 +9,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/random/data/RngData.hh"
+#include "geocel/SurfaceData.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/geo/GeoData.hh"
 
@@ -55,6 +56,7 @@ struct CoreParamsData
     MaterialParamsData<W, M> material;
     PhysicsParamsData<W, M> physics;
     RngParamsData<W, M> rng;
+    SurfaceParamsData<W, M> surface;
     TrackInitParamsData<W, M> init;
 
     CoreScalars scalars;
@@ -74,6 +76,7 @@ struct CoreParamsData
         material = other.material;
         physics = other.physics;
         rng = other.rng;
+        surface = other.surface;
         init = other.init;
         scalars = other.scalars;
         return *this;

--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "corecel/random/engine/RngEngine.hh"
+#include "geocel/VolumeSurfaceView.hh"
 #include "celeritas/geo/GeoTrackView.hh"
 
 #include "CoreTrackData.hh"
@@ -63,6 +64,9 @@ class CoreTrackView
 
     // Return a physics view
     inline CELER_FUNCTION PhysicsTrackView physics() const;
+
+    // Return a view to surface properties attached to a volume
+    inline CELER_FUNCTION VolumeSurfaceView volume_surface(VolumeId vid) const;
 
     // Return an RNG engine
     inline CELER_FUNCTION RngEngine rng() const;
@@ -186,6 +190,16 @@ CELER_FUNCTION auto CoreTrackView::physics() const -> PhysicsTrackView
     CELER_ASSERT(mat_id);
     return PhysicsTrackView{
         params_.physics, states_.physics, mat_id, this->track_slot_id()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a view to surface properties attached to a volume.
+ */
+CELER_FUNCTION auto CoreTrackView::volume_surface(VolumeId vid) const
+    -> VolumeSurfaceView
+{
+    return VolumeSurfaceView{params_.surface, vid};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -85,6 +85,7 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
         op_inp.rng = core.rng();
         op_inp.init = std::make_shared<optical::TrackInitParams>(
             inp.initializer_capacity);
+        op_inp.surface = core.surface();
         op_inp.action_reg = std::make_shared<ActionRegistry>();
         op_inp.max_streams = core.max_streams();
         {

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -26,6 +26,8 @@
 #include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedProfiling.hh"
 #include "geocel/GeantGdmlLoader.hh"
+#include "geocel/SurfaceParams.hh"
+#include "geocel/VolumeParams.hh"
 #include "geocel/inp/Model.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Types.hh"
@@ -417,6 +419,16 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
                "safety algorithm: multiple scattering may "
                "result in arbitrarily small steps without displacement";
     }
+
+    // Construct optical surfaces, if present
+    params.surface = [&] {
+        if (p.model.surfaces)
+        {
+            auto volume = std::make_shared<VolumeParams>(p.model.volumes);
+            return std::make_shared<SurfaceParams>(p.model.surfaces, *volume);
+        }
+        return std::make_shared<SurfaceParams>();
+    }();
 
     // Load materials
     params.material = MaterialParams::from_import(imported);

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -420,9 +420,9 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
                "result in arbitrarily small steps without displacement";
     }
 
-    // Construct optical surfaces, if present
+    // Construct optical surfaces if optical physics is enabled
     params.surface = [&] {
-        if (p.model.surfaces)
+        if (p.control.optical_capacity)
         {
             auto volume = std::make_shared<VolumeParams>(p.model.volumes);
             return std::make_shared<SurfaceParams>(p.model.surfaces, *volume);

--- a/src/geocel/SurfaceData.hh
+++ b/src/geocel/SurfaceData.hh
@@ -92,7 +92,10 @@ struct SurfaceParamsData
     //// METHODS ////
 
     //! True if surfaces are present
-    explicit CELER_FUNCTION operator bool() const { return num_surfaces != 0; }
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return !volume_surfaces.empty();
+    }
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>

--- a/src/geocel/SurfaceParams.cc
+++ b/src/geocel/SurfaceParams.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include "corecel/data/CollectionMirror.hh"
+#include "corecel/io/Logger.hh"
 
 #include "SurfaceData.hh"
 #include "VolumeParams.hh"
@@ -22,7 +23,10 @@ namespace celeritas
 SurfaceParams::SurfaceParams(inp::Surfaces const& input,
                              VolumeParams const& volumes)
 {
-    CELER_EXPECT(input);
+    if (!input)
+    {
+        CELER_LOG(warning) << "No optical surfaces are defined";
+    }
 
     // Set up temporary storage
     std::vector<detail::VolumeSurfaceData> temp_volume_surfaces;

--- a/src/geocel/SurfaceParams.cc
+++ b/src/geocel/SurfaceParams.cc
@@ -22,7 +22,7 @@ namespace celeritas
 SurfaceParams::SurfaceParams(inp::Surfaces const& input,
                              VolumeParams const& volumes)
 {
-    CELER_EXPECT(!input.surfaces.empty());
+    CELER_EXPECT(input);
 
     // Set up temporary storage
     std::vector<detail::VolumeSurfaceData> temp_volume_surfaces;

--- a/src/geocel/VolumeSurfaceView.hh
+++ b/src/geocel/VolumeSurfaceView.hh
@@ -72,7 +72,7 @@ VolumeSurfaceView::VolumeSurfaceView(SurfaceParamsRef const& params,
                                      VolumeId id)
     : params_(params), volume_(id)
 {
-    CELER_EXPECT(id < params.volume_surfaces.size());
+    CELER_EXPECT(id < params.volume_surfaces.size() || !params_);
 }
 
 //---------------------------------------------------------------------------//
@@ -92,6 +92,11 @@ CELER_FUNCTION auto VolumeSurfaceView::volume_id() const -> VolumeId
  */
 CELER_FUNCTION SurfaceId VolumeSurfaceView::boundary_id() const
 {
+    if (!params_)
+    {
+        // No surfaces are present
+        return {};
+    }
     return this->volume_record().boundary;
 }
 
@@ -101,6 +106,11 @@ CELER_FUNCTION SurfaceId VolumeSurfaceView::boundary_id() const
  */
 CELER_FUNCTION bool VolumeSurfaceView::has_interface() const
 {
+    if (!params_)
+    {
+        // No surfaces are present
+        return false;
+    }
     return !this->volume_record().surface.empty();
 }
 
@@ -175,6 +185,7 @@ CELER_FUNCTION SurfaceId VolumeSurfaceView::find_interface(
 CELER_FUNCTION VolumeSurfaceRecord const&
 VolumeSurfaceView::volume_record() const
 {
+    CELER_EXPECT(params_);
     return params_.volume_surfaces[volume_];
 }
 

--- a/src/geocel/VolumeSurfaceView.hh
+++ b/src/geocel/VolumeSurfaceView.hh
@@ -72,7 +72,7 @@ VolumeSurfaceView::VolumeSurfaceView(SurfaceParamsRef const& params,
                                      VolumeId id)
     : params_(params), volume_(id)
 {
-    CELER_EXPECT(id < params.volume_surfaces.size() || !params_);
+    CELER_EXPECT(id < params.volume_surfaces.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -92,11 +92,6 @@ CELER_FUNCTION auto VolumeSurfaceView::volume_id() const -> VolumeId
  */
 CELER_FUNCTION SurfaceId VolumeSurfaceView::boundary_id() const
 {
-    if (!params_)
-    {
-        // No surfaces are present
-        return {};
-    }
     return this->volume_record().boundary;
 }
 
@@ -106,11 +101,6 @@ CELER_FUNCTION SurfaceId VolumeSurfaceView::boundary_id() const
  */
 CELER_FUNCTION bool VolumeSurfaceView::has_interface() const
 {
-    if (!params_)
-    {
-        // No surfaces are present
-        return false;
-    }
     return !this->volume_record().surface.empty();
 }
 
@@ -185,7 +175,6 @@ CELER_FUNCTION SurfaceId VolumeSurfaceView::find_interface(
 CELER_FUNCTION VolumeSurfaceRecord const&
 VolumeSurfaceView::volume_record() const
 {
-    CELER_EXPECT(params_);
     return params_.volume_surfaces[volume_];
 }
 

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -125,6 +125,7 @@ auto GlobalTestBase::build_core() -> SPConstCore
     inp.physics = this->physics();
     inp.rng = this->rng();
     inp.sim = this->sim();
+    inp.surface = this->surface();
     inp.init = this->init();
     inp.wentzel = this->wentzel();
     inp.action_reg = this->action_reg();

--- a/test/celeritas/GlobalTestBase.hh
+++ b/test/celeritas/GlobalTestBase.hh
@@ -33,6 +33,7 @@ class ParticleParams;
 class PhysicsParams;
 class ScintillationParams;
 class SimParams;
+class SurfaceParams;
 class TrackInitParams;
 class AuxParamsRegistry;
 class WentzelOKVIParams;
@@ -79,6 +80,7 @@ class GlobalTestBase : public Test
     using SPConstAction = SP<CoreStepActionInterface const>;
     using SPConstRng = SP<RngParams const>;
     using SPConstSim = SP<SimParams const>;
+    using SPConstSurface = SP<SurfaceParams const>;
     using SPConstTrackInit = SP<TrackInitParams const>;
     using SPConstWentzelOKVI = SP<WentzelOKVIParams const>;
     using SPConstCore = SP<CoreParams const>;
@@ -115,6 +117,7 @@ class GlobalTestBase : public Test
     inline SPConstAction const& along_step();
     inline SPConstRng const& rng();
     inline SPConstSim const& sim();
+    inline SPConstSurface const& surface();
     inline SPConstTrackInit const& init();
     inline SPConstWentzelOKVI const& wentzel();
     inline SPActionRegistry const& action_reg();
@@ -134,6 +137,7 @@ class GlobalTestBase : public Test
     inline SPConstAction const& along_step() const;
     inline SPConstRng const& rng() const;
     inline SPConstSim const& sim() const;
+    inline SPConstSurface const& surface() const;
     inline SPConstTrackInit const& init() const;
     inline SPConstWentzelOKVI const& wentzel() const;
     inline SPActionRegistry const& action_reg() const;
@@ -164,6 +168,7 @@ class GlobalTestBase : public Test
     [[nodiscard]] virtual SPConstCutoff build_cutoff() = 0;
     [[nodiscard]] virtual SPConstPhysics build_physics() = 0;
     [[nodiscard]] virtual SPConstSim build_sim() = 0;
+    [[nodiscard]] virtual SPConstSurface build_surface() = 0;
     [[nodiscard]] virtual SPConstTrackInit build_init() = 0;
     [[nodiscard]] virtual SPConstWentzelOKVI build_wentzel() = 0;
     [[nodiscard]] virtual SPConstAction build_along_step() = 0;
@@ -193,6 +198,7 @@ class GlobalTestBase : public Test
     SPConstAction along_step_;
     SPConstRng rng_;
     SPConstSim sim_;
+    SPConstSurface surface_;
     SPConstTrackInit init_;
     SPConstWentzelOKVI wentzel_;
     SPConstCore core_;
@@ -235,6 +241,7 @@ DEF_GTB_ACCESSORS(SPConstPhysics, physics)
 DEF_GTB_ACCESSORS(SPConstAction, along_step)
 DEF_GTB_ACCESSORS(SPConstRng, rng)
 DEF_GTB_ACCESSORS(SPConstSim, sim)
+DEF_GTB_ACCESSORS(SPConstSurface, surface)
 DEF_GTB_ACCESSORS(SPConstTrackInit, init)
 DEF_GTB_ACCESSORS(SPActionRegistry, action_reg)
 DEF_GTB_ACCESSORS(SPUserRegistry, aux_reg)

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -79,7 +79,7 @@ auto ImportedDataTestBase::build_surface() -> SPConstSurface
     if (auto const* geo = geant_geo())
     {
         auto model = geo->make_model_input();
-        if (model.surfaces)
+        if (!this->imported_data().optical_materials.empty())
         {
             auto volume = std::make_shared<VolumeParams>(model.volumes);
             return std::make_shared<SurfaceParams>(model.surfaces, *volume);

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -6,6 +6,10 @@
 //---------------------------------------------------------------------------//
 #include "ImportedDataTestBase.hh"
 
+#include "geocel/GeantGeoParams.hh"
+#include "geocel/SurfaceParams.hh"
+#include "geocel/VolumeParams.hh"
+#include "geocel/inp/Model.hh"
 #include "celeritas/em/params/WentzelOKVIParams.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"
 #include "celeritas/io/ImportData.hh"
@@ -67,6 +71,21 @@ auto ImportedDataTestBase::build_sim() -> SPConstSim
         return SimParams::Input::from_import(this->imported_data(),
                                              this->particle());
     }());
+}
+
+//---------------------------------------------------------------------------//
+auto ImportedDataTestBase::build_surface() -> SPConstSurface
+{
+    if (auto const* geo = geant_geo())
+    {
+        auto model = geo->make_model_input();
+        if (model.surfaces)
+        {
+            auto volume = std::make_shared<VolumeParams>(model.volumes);
+            return std::make_shared<SurfaceParams>(model.surfaces, *volume);
+        }
+    }
+    return std::make_shared<SurfaceParams>();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ImportedDataTestBase.hh
+++ b/test/celeritas/ImportedDataTestBase.hh
@@ -39,6 +39,7 @@ class ImportedDataTestBase : virtual public GlobalGeoTestBase
     SPConstCutoff build_cutoff() override;
     SPConstPhysics build_physics() override;
     SPConstSim build_sim() override;
+    SPConstSurface build_surface() override;
     SPConstWentzelOKVI build_wentzel() override;
     SPConstCherenkov build_cherenkov() override;
     SPConstOpticalMaterial build_optical_material() override;

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -8,6 +8,7 @@
 
 #include "corecel/math/Algorithms.hh"
 #include "corecel/sys/ActionRegistry.hh"
+#include "geocel/SurfaceParams.hh"
 #include "celeritas/alongstep/AlongStepGeneralLinearAction.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"
 #include "celeritas/mat/MaterialParams.hh"
@@ -257,6 +258,12 @@ auto MockTestBase::build_sim() -> SPConstSim
     SimParams::Input input;
     input.particles = this->particle();
     return std::make_shared<SimParams>(input);
+}
+
+//---------------------------------------------------------------------------//
+auto MockTestBase::build_surface() -> SPConstSurface
+{
+    return std::make_shared<SurfaceParams>();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/MockTestBase.hh
+++ b/test/celeritas/MockTestBase.hh
@@ -78,6 +78,7 @@ class MockTestBase : virtual public GlobalGeoTestBase, public OnlyCoreTestBase
     SPConstPhysics build_physics() override;
     SPConstAction build_along_step() override;
     SPConstSim build_sim() override;
+    SPConstSurface build_surface() override;
     SPConstTrackInit build_init() override;
     SPConstWentzelOKVI build_wentzel() override { return nullptr; }
 

--- a/test/celeritas/OnlyGeoTestBase.hh
+++ b/test/celeritas/OnlyGeoTestBase.hh
@@ -25,6 +25,7 @@ class OnlyGeoTestBase : virtual public GlobalTestBase
     SPConstCutoff build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstPhysics build_physics() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstSim build_sim() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstSurface build_surface() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstMaterial build_material() override { CELER_ASSERT_UNREACHABLE(); }

--- a/test/celeritas/SimpleTestBase.cc
+++ b/test/celeritas/SimpleTestBase.cc
@@ -7,6 +7,7 @@
 #include "SimpleTestBase.hh"
 
 #include "corecel/sys/ActionRegistry.hh"
+#include "geocel/SurfaceParams.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/alongstep/AlongStepNeutralAction.hh"
 #include "celeritas/em/params/WentzelOKVIParams.hh"
@@ -167,6 +168,12 @@ auto SimpleTestBase::build_sim() -> SPConstSim
     SimParams::Input input;
     input.particles = this->particle();
     return std::make_shared<SimParams>(input);
+}
+
+//---------------------------------------------------------------------------//
+auto SimpleTestBase::build_surface() -> SPConstSurface
+{
+    return std::make_shared<SurfaceParams>();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/SimpleTestBase.hh
+++ b/test/celeritas/SimpleTestBase.hh
@@ -32,6 +32,7 @@ class SimpleTestBase : virtual public GlobalGeoTestBase, public OnlyCoreTestBase
     SPConstCutoff build_cutoff() override;
     SPConstPhysics build_physics() override;
     SPConstSim build_sim() override;
+    SPConstSurface build_surface() override;
     SPConstTrackInit build_init() override;
     SPConstAction build_along_step() override;
     SPConstWentzelOKVI build_wentzel() override;

--- a/test/celeritas/optical/OpticalMockTestBase.hh
+++ b/test/celeritas/optical/OpticalMockTestBase.hh
@@ -54,6 +54,7 @@ class OpticalMockTestBase : public GlobalTestBase
     SPConstCutoff build_cutoff() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstPhysics build_physics() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstSim build_sim() override { CELER_ASSERT_UNREACHABLE(); }
+    SPConstSurface build_surface() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstTrackInit build_init() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstWentzelOKVI build_wentzel() override { CELER_ASSERT_UNREACHABLE(); }
     SPConstAction build_along_step() override { CELER_ASSERT_UNREACHABLE(); }

--- a/test/geocel/Surface.test.cc
+++ b/test/geocel/Surface.test.cc
@@ -110,10 +110,10 @@ TEST_F(SurfacesTest, none)
     EXPECT_EQ(0, sp.num_surfaces());
     EXPECT_EQ(0, sp.labels().size());
 
-    VolumeSurfaceView vsv(sp.host_ref(), VolumeId{0});
-    EXPECT_EQ(VolumeId{0}, vsv.volume_id());
-    EXPECT_EQ(SurfaceId{}, vsv.boundary_id());
-    EXPECT_FALSE(vsv.has_interface());
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(VolumeSurfaceView(sp.host_ref(), VolumeId{0}), DebugError);
+    }
 }
 
 TEST_F(SurfacesTest, errors)

--- a/test/geocel/Surface.test.cc
+++ b/test/geocel/Surface.test.cc
@@ -110,10 +110,10 @@ TEST_F(SurfacesTest, none)
     EXPECT_EQ(0, sp.num_surfaces());
     EXPECT_EQ(0, sp.labels().size());
 
-    if (CELERITAS_DEBUG)
-    {
-        EXPECT_THROW(VolumeSurfaceView(sp.host_ref(), VolumeId{0}), DebugError);
-    }
+    VolumeSurfaceView vsv(sp.host_ref(), VolumeId{0});
+    EXPECT_EQ(VolumeId{0}, vsv.volume_id());
+    EXPECT_EQ(SurfaceId{}, vsv.boundary_id());
+    EXPECT_FALSE(vsv.has_interface());
 }
 
 TEST_F(SurfacesTest, errors)


### PR DESCRIPTION
I haven't added the `VolumeParams` as it's currently only used to construct the surfaces, but I can if needed.