### PR TITLE
Hotfix: revert accidental changes from #1839

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -368,12 +368,6 @@ struct OrangeParamsData
     Items<RectArrayRecord> rect_arrays;
     Items<TransformRecord> transforms;
 
-    // Map of ORANGE internal volume ID -> Celeritas volume ID
-    ImplVolumeItems<VolumeId> volume_ids;
-    ImplVolumeItems<VolumeInstanceId> volume_instance_ids;
-    // TODO: for reconstructing hierarchy:
-    // ImplVolumeItems<ImplVolumeId> parent_impl_volumes;
-
     // BIH tree storage
     BIHTreeData<W, M> bih_tree_data;
 

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -462,13 +462,6 @@ CELER_FUNCTION Real3 const& OrangeTrackView::dir() const
 CELER_FUNCTION VolumeId OrangeTrackView::volume_id() const
 {
     ImplVolumeId impl_id = this->impl_volume_id();
-    if (!params_.volume_ids.empty())
-    {
-        // Return structural volume mapping
-        CELER_ASSERT(impl_id);
-        return params_.volume_ids[impl_id];
-    }
-    // No volume mapping specified (unit test or SCALE embedding)
     return impl_id;
 }
 
@@ -481,14 +474,6 @@ CELER_FUNCTION VolumeId OrangeTrackView::volume_id() const
  */
 CELER_FUNCTION VolumeInstanceId OrangeTrackView::volume_instance_id() const
 {
-    if (!params_.volume_instance_ids.empty())
-    {
-        // Return structural volume mapping
-        ImplVolumeId impl_id = this->impl_volume_id();
-        CELER_ASSERT(impl_id);
-        return params_.volume_instance_ids[impl_id];
-    }
-    // No volume mapping specified (unit test or SCALE embedding)
     return {};
 }
 


### PR DESCRIPTION
I accidentally committed some partially implemented changes to the ORANGE volume code in a refactor PR. This reverts those bits, to be restored in an upcoming PR.