### PR TITLE
Fix counters in optical generator action

### DIFF
--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -102,7 +102,6 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
     {
         // Create action to generate Cherenkov primaries
         GeneratorAction<GT::cherenkov>::Input ga_inp;
-        ga_inp.optical_id = optical_aux_id;
         ga_inp.material = inp.material;
         ga_inp.shared = inp.cherenkov;
         ga_inp.capacity = inp.buffer_capacity;
@@ -113,7 +112,6 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
     {
         // Create action to generate scintillation primaries
         GeneratorAction<GT::scintillation>::Input ga_inp;
-        ga_inp.optical_id = optical_aux_id;
         ga_inp.material = inp.material;
         ga_inp.shared = inp.scintillation;
         ga_inp.capacity = inp.buffer_capacity;

--- a/src/celeritas/optical/gen/detail/GeneratorAction.hh
+++ b/src/celeritas/optical/gen/detail/GeneratorAction.hh
@@ -55,14 +55,13 @@ class GeneratorAction final : public optical::OpticalStepActionInterface,
     //! Generator input data
     struct Input
     {
-        AuxId optical_id;
         SPConstMaterial material;
         SPConstParams shared;
         size_type capacity{};
 
         explicit operator bool() const
         {
-            return optical_id && material && shared && capacity > 0;
+            return material && shared && capacity > 0;
         }
     };
 

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -501,7 +501,7 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        EXPECT_EQ(1804, result.accum.steps);
+        EXPECT_EQ(1711, result.accum.steps);
         EXPECT_EQ(57, result.accum.step_iters);
         EXPECT_EQ(1, result.accum.flushes);
         ASSERT_EQ(2, result.accum.generators.size());
@@ -532,8 +532,7 @@ TEST_F(LArSphereOffloadTest, host_generate)
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        EXPECT_SOFT_NEAR(
-            4593666, static_cast<double>(result.accum.steps), 1e-4);
+        EXPECT_SOFT_NEAR(462229, static_cast<double>(result.accum.steps), 1e-4);
         EXPECT_EQ(49, result.accum.step_iters);
         EXPECT_EQ(3, result.accum.flushes);
         ASSERT_EQ(2, result.accum.generators.size());


### PR DESCRIPTION
In the optical generator action we weren't updating the number of active tracks in the case that the generating process had no pending photons. This is fixed here and explains the change in https://github.com/celeritas-project/celeritas/pull/1844#discussion_r2186078020.
