### PR TITLE
Begin exposing Cherenkov/optical loop outside of the optical collector 

### DIFF
--- a/app/celer-sim/Runner.hh
+++ b/app/celer-sim/Runner.hh
@@ -15,7 +15,6 @@
 #include "corecel/Types.hh"
 #include "corecel/sys/ThreadId.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/io/ImportData.hh"
 #include "celeritas/phys/Primary.hh"
 
 #include "Transporter.hh"
@@ -25,7 +24,6 @@ class G4VPhysicalVolume;  // IWYU pragma: keep
 namespace celeritas
 {
 class CoreParams;
-class OpticalCollector;
 class ParticleParams;
 class RootFileManager;
 class StepCollector;

--- a/app/celer-sim/Transporter.cc
+++ b/app/celer-sim/Transporter.cc
@@ -15,17 +15,16 @@
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
-#include "corecel/data/Ref.hh"
-#include "corecel/grid/VectorUtils.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/ScopedTimeLog.hh"
 #include "corecel/sys/ScopedSignalHandler.hh"
 #include "corecel/sys/TraceCounter.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/global/ActionSequence.hh"
-#include "celeritas/global/CoreParams.hh"
+#include "celeritas/global/CoreParams.hh"  // IWYU pragma: keep
 #include "celeritas/global/Stepper.hh"
-#include "celeritas/optical/OpticalCollector.hh"
+#include "celeritas/optical/OpticalCollector.hh"  // IWYU pragma: keep
+#include "celeritas/phys/GeneratorCounters.hh"
 #include "celeritas/phys/Model.hh"
 
 #include "StepTimer.hh"

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -262,6 +262,7 @@ SharedParams::SharedParams(SetupOptions const& options)
     auto framework_inp = to_inp(options);
     auto loaded = setup::framework_input(framework_inp);
     params_ = std::move(loaded.problem.core_params);
+    optical_ = std::move(loaded.problem.optical_collector);
     output_filename_ = loaded.problem.output_file;
     CELER_ASSERT(params_);
 

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -28,13 +28,14 @@ class OffloadWriter;
 
 class CoreParams;
 class CoreStateInterface;
+class GeantGeoParams;
+class GeantSd;
+class OpticalCollector;
+class OutputRegistry;
+class StepCollector;
+class TimeOutput;
 struct Primary;
 struct SetupOptions;
-class StepCollector;
-class GeantGeoParams;
-class OutputRegistry;
-class TimeOutput;
-class GeantSd;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -128,11 +129,15 @@ class SharedParams
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
     using SPTimeOutput = std::shared_ptr<TimeOutput>;
     using SPState = std::shared_ptr<CoreStateInterface>;
+    using SPOptical = std::shared_ptr<OpticalCollector>;
     using SPConstGeantGeoParams = std::shared_ptr<GeantGeoParams const>;
     using BBox = BoundingBox<double>;
 
     //! Initialization status and integration mode
     Mode mode() const { return mode_; }
+
+    // Optical properties (only if using optical physics)
+    inline SPOptical const& optical() const;
 
     // Hit manager, to be used only by LocalTransporter
     inline SPGeantSd const& hit_manager() const;
@@ -163,6 +168,7 @@ class SharedParams
     Mode mode_{Mode::uninitialized};
     SPConstGeantGeoParams geant_geo_;
     std::shared_ptr<CoreParams> params_;
+    std::shared_ptr<OpticalCollector> optical_;
     std::shared_ptr<GeantSd> geant_sd_;
     std::shared_ptr<StepCollector> step_collector_;
     VecG4ParticleDef particles_;
@@ -222,6 +228,16 @@ auto SharedParams::OffloadParticles() const -> VecG4ParticleDef const&
 {
     CELER_EXPECT(*this);
     return particles_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Optical data: null if Celeritas optical physics is disabled.
+ */
+auto SharedParams::optical() const -> SPOptical const&
+{
+    CELER_EXPECT(*this);
+    return optical_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -174,6 +174,17 @@ auto OpticalCollector::cherenkov() const -> SPConstCherenkov
 
 //---------------------------------------------------------------------------//
 /*!
+ * Access scintillation params (may be null).
+ */
+auto OpticalCollector::scintillation() const -> SPConstScintillation
+{
+    if (!scint_offload_)
+        return nullptr;
+    return scint_offload_->params();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the generator registry.
  */
 GeneratorRegistry const& OpticalCollector::gen_reg() const

--- a/src/celeritas/optical/OpticalCollector.cc
+++ b/src/celeritas/optical/OpticalCollector.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "OpticalCollector.hh"
 
+#include "corecel/Assert.hh"
 #include "corecel/data/AuxParamsRegistry.hh"
 #include "corecel/data/AuxStateVec.hh"
 #include "corecel/io/OutputInterfaceAdapter.hh"
@@ -128,7 +129,7 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
     la_inp.num_track_slots = inp.num_track_slots;
     la_inp.max_step_iters = inp.max_step_iters;
     la_inp.auto_flush = inp.auto_flush;
-    la_inp.optical_params = std::move(optical_params);
+    la_inp.optical_params = optical_params;
     launch_ = detail::OpticalLaunchAction::make_and_insert(core,
                                                            std::move(la_inp));
 
@@ -144,6 +145,9 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
             "optical-sizes",
             std::move(sizes)));
 
+    // Save core params
+    optical_params_ = optical_params;
+
     // Launch action must be *after* offload and generator actions
     CELER_ENSURE(!cherenkov_offload_
                  || launch_->action_id() > cherenkov_offload_->action_id());
@@ -154,6 +158,18 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
     CELER_ENSURE(!scint_generate_
                  || launch_->action_id() > scint_generate_->action_id());
     CELER_ENSURE(launch_->aux_id() == optical_aux_id);
+    CELER_ENSURE(optical_params_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access Cherenkov params (may be null).
+ */
+auto OpticalCollector::cherenkov() const -> SPConstCherenkov
+{
+    if (!cherenkov_offload_)
+        return nullptr;
+    return cherenkov_offload_->params();
 }
 
 //---------------------------------------------------------------------------//
@@ -162,7 +178,7 @@ OpticalCollector::OpticalCollector(CoreParams const& core, Input&& inp)
  */
 GeneratorRegistry const& OpticalCollector::gen_reg() const
 {
-    return *launch_->optical_params().gen_reg();
+    return *optical_params_->gen_reg();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/OpticalCollector.hh
+++ b/src/celeritas/optical/OpticalCollector.hh
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 
-#include "corecel/data/AuxInterface.hh"
 #include "corecel/io/Label.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/phys/GeneratorCounters.hh"
@@ -72,6 +71,7 @@ class OpticalCollector
     using SPConstMaterial = std::shared_ptr<optical::MaterialParams const>;
     using SPConstScintillation = std::shared_ptr<ScintillationParams const>;
     using OpticalBufferSize = GeneratorCounters<size_type>;
+    using SPConstOpticalParams = std::shared_ptr<optical::CoreParams const>;
     //!@}
 
     struct Input
@@ -111,6 +111,22 @@ class OpticalCollector
     // Construct with core data and optical params
     OpticalCollector(CoreParams const&, Input&&);
 
+    //// ACCESSORS ////
+
+    //! Access optical params
+    SPConstOpticalParams const& optical_params() const
+    {
+        return optical_params_;
+    }
+
+    // Access Cherenkov params (may be null)
+    SPConstCherenkov cherenkov() const;
+
+    // Access scintillation params (may be null)
+    SPConstScintillation scintillation() const;
+
+    //// GENERATOR MANAGEMENT ////
+
     // Get the generator registry
     GeneratorRegistry const& gen_reg() const;
 
@@ -137,6 +153,7 @@ class OpticalCollector
 
     //// DATA ////
 
+    SPConstOpticalParams optical_params_;
     SPGatherAction gather_;
     SPCherenkovOffload cherenkov_offload_;
     SPScintOffload scint_offload_;

--- a/src/celeritas/optical/gen/CherenkovGenerator.hh
+++ b/src/celeritas/optical/gen/CherenkovGenerator.hh
@@ -112,9 +112,10 @@ CherenkovGenerator::CherenkovGenerator(optical::MaterialView const& material,
     sample_energy_ = UniformRealDist(energy_grid.front(), energy_grid.back());
 
     // Calculate 1 / beta and the max sin^2 theta
+    // note that with single precision, 10 GeV e- rounds to c=1
     inv_beta_
         = 2 / (value_as<LS>(pre_step.speed) + value_as<LS>(post_step.speed));
-    CELER_ASSERT(inv_beta_ > 1);
+    CELER_ASSERT(inv_beta_ >= 1);
     real_type cos_max = inv_beta_ / calc_refractive_index_(energy_grid.back());
     sin_max_sq_ = 1 - ipow<2>(cos_max);
 

--- a/src/celeritas/optical/gen/detail/CherenkovOffloadExecutor.hh
+++ b/src/celeritas/optical/gen/detail/CherenkovOffloadExecutor.hh
@@ -73,12 +73,17 @@ CherenkovOffloadExecutor::operator()(CoreTrackView const& track)
     // Get the distribution data used to generate Cherenkov optical photons
     if (particle.charge() != zero_quantity())
     {
-        Real3 const& pos = track.geometry().pos();
-        optical::MaterialView opt_mat{material, step.material};
+        CherenkovOffload sample_dist(
+            // Pre-step:
+            step,
+            optical::MaterialView{material, step.material},
+            // Post-step:
+            particle,
+            sim,
+            track.geometry().pos(),
+            cherenkov);
         auto rng = track.rng();
-
-        dist = CherenkovOffload(
-            particle, sim, opt_mat, pos, cherenkov, step)(rng);
+        dist = sample_dist(rng);
     }
 }
 

--- a/src/celeritas/optical/gen/detail/OffloadAction.hh
+++ b/src/celeritas/optical/gen/detail/OffloadAction.hh
@@ -85,6 +85,11 @@ class OffloadAction final : public CoreStepActionInterface
     void step(CoreParams const&, CoreStateDevice&) const final;
     //!@}
 
+    //// ACCESSORS ////
+
+    //! Access shared data used by this offload physics
+    SPConstParams const& params() const { return data_.shared; }
+
   private:
     //// TYPES ////
 

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -239,7 +239,7 @@ TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
         Real3 pos = {sim.step_length(), 0, 0};
 
         CherenkovOffload pre_generate(
-            particle, sim, mat_view, pos, params->host_ref(), pre_step);
+            pre_step, mat_view, particle, sim, pos, params->host_ref());
 
         size_type num_samples = 10;
         std::vector<size_type> sampled_num_photons;
@@ -284,7 +284,7 @@ TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
         Real3 pos = {sim.step_length(), 0, 0};
 
         CherenkovOffload pre_generate(
-            particle, sim, mat_view, pos, params->host_ref(), pre_step);
+            pre_step, mat_view, particle, sim, pos, params->host_ref());
         auto const result = pre_generate(rng);
 
         EXPECT_FALSE(result);
@@ -336,7 +336,7 @@ TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
 
         // Calculate the average number of photons produced per unit length
         CherenkovOffload pre_generate(
-            particle, sim, mat_view, pos, params->host_ref(), pre_step);
+            pre_step, mat_view, particle, sim, pos, params->host_ref());
 
         Real3 inc_dir = make_unit_vector(pos - pre_step.pos);
         for (size_type i = 0; i < num_samples; ++i)

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "corecel/Config.hh"
+
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/CollectionStateStore.hh"
@@ -218,7 +220,7 @@ TEST_F(CherenkovTest, dndx)
 
 //---------------------------------------------------------------------------//
 
-TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
+TEST_F(CherenkovTest, pre_generator)
 {
     Rng rng;
     optical::MaterialView const mat_view{material->host_ref(), material_id};
@@ -262,10 +264,13 @@ TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
             EXPECT_VEC_EQ(pos, result.points[StepPoint::post].pos);
         }
 
-        // Only number of photons is sampled
-        static size_type const expected_num_photons[]
-            = {15, 17, 11, 15, 14, 19, 23, 13, 10, 12};
-        EXPECT_VEC_EQ(expected_num_photons, sampled_num_photons);
+        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+        {
+            // Only number of photons is sampled
+            static size_type const expected_num_photons[]
+                = {15, 17, 11, 15, 14, 19, 23, 13, 10, 12};
+            EXPECT_VEC_EQ(expected_num_photons, sampled_num_photons);
+        }
     }
 
     // Below Cherenkov threshold
@@ -294,7 +299,7 @@ TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(pre_generator))
 
 //---------------------------------------------------------------------------//
 
-TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
+TEST_F(CherenkovTest, generator)
 {
     Rng rng;
     optical::MaterialView mat_view{material->host_ref(), material_id};
@@ -426,14 +431,17 @@ TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
 
         sample(pre_step, particle, sim, pos, num_samples);
 
-        EXPECT_VEC_EQ(expected_costheta_dist, costheta_dist);
-        EXPECT_VEC_EQ(expected_energy_dist, energy_dist);
-        EXPECT_VEC_EQ(expected_displacement_dist, displacement_dist);
-        EXPECT_SOFT_EQ(0.73055857883146702, avg_costheta);
-        EXPECT_SOFT_EQ(4.0497726102182314e-06, avg_energy);
-        EXPECT_SOFT_EQ(0.50020101984474064, avg_displacement);
-        EXPECT_SOFT_EQ(983.734375, total_num_photons / num_samples);
-        EXPECT_SOFT_EQ(10.609603075017075, avg_engine_samples);
+        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+        {
+            EXPECT_VEC_EQ(expected_costheta_dist, costheta_dist);
+            EXPECT_VEC_EQ(expected_energy_dist, energy_dist);
+            EXPECT_VEC_EQ(expected_displacement_dist, displacement_dist);
+            EXPECT_SOFT_EQ(0.73055857883146702, avg_costheta);
+            EXPECT_SOFT_EQ(4.0497726102182314e-06, avg_energy);
+            EXPECT_SOFT_EQ(0.50020101984474064, avg_displacement);
+            EXPECT_SOFT_EQ(983.734375, total_num_photons / num_samples);
+            EXPECT_SOFT_EQ(10.609603075017075, avg_engine_samples);
+        }
     }
 
     // 500 keV e-: 1/beta_avg ~ 1.336
@@ -462,14 +470,17 @@ TEST_F(CherenkovTest, TEST_IF_CELERITAS_DOUBLE(generator))
 
         sample(pre_step, particle, sim, pos, num_samples);
 
-        EXPECT_VEC_EQ(expected_costheta_dist, costheta_dist);
-        EXPECT_VEC_EQ(expected_energy_dist, energy_dist);
-        EXPECT_VEC_EQ(expected_displacement_dist, displacement_dist);
-        EXPECT_SOFT_EQ(0.95045221539598979, avg_costheta);
-        EXPECT_SOFT_EQ(5.5902203966702514e-06, avg_energy);
-        EXPECT_SOFT_EQ(0.049715603846029896, avg_displacement);
-        EXPECT_SOFT_EQ(15.484375, total_num_photons / num_samples);
-        EXPECT_SOFT_EQ(25.077699293642784, avg_engine_samples);
+        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+        {
+            EXPECT_VEC_EQ(expected_costheta_dist, costheta_dist);
+            EXPECT_VEC_EQ(expected_energy_dist, energy_dist);
+            EXPECT_VEC_EQ(expected_displacement_dist, displacement_dist);
+            EXPECT_SOFT_EQ(0.95045221539598979, avg_costheta);
+            EXPECT_SOFT_EQ(5.5902203966702514e-06, avg_energy);
+            EXPECT_SOFT_EQ(0.049715603846029896, avg_displacement);
+            EXPECT_SOFT_EQ(15.484375, total_num_photons / num_samples);
+            EXPECT_SOFT_EQ(25.077699293642784, avg_engine_samples);
+        }
     }
 }
 

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -152,6 +152,12 @@ void LArSphereOffloadTest::build_optical_collector()
 
     collector_
         = std::make_shared<OpticalCollector>(*this->core(), std::move(inp));
+
+    // Check accessors
+    EXPECT_TRUE(collector_->optical_params());
+    EXPECT_EQ(use_cherenkov_, static_cast<bool>(collector_->cherenkov()));
+    EXPECT_EQ(use_scintillation_,
+              static_cast<bool>(collector_->scintillation()));
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Maybe I should break these into a few micro-PRs:
- Enable running (but not testing results) for cherenkov; it exposes the minor oddness that 10 GeV electrons have beta=1.0f in single precision
- Allow construction of ~~optical collector~~ offload distribution builder from low-level data, to be used in #1860
- Allow access to the optical collector from accel SharedParams, and allow access to the cherenkov/scintillation params from inside that