### PR TITLE
Add `begin_run` to optical launch action

### DIFF
--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -131,7 +131,7 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
     else
     {
         CELER_LOG(status) << "Transporting " << run_stream.num_events()
-                          << " on " << num_streams << " threads";
+                          << " events on " << num_streams << " threads";
         MultiExceptionHandler capture_exception;
         size_type const num_events = run_stream.num_events();
 #if CELERITAS_OPENMP == CELERITAS_OPENMP_EVENT

--- a/src/celeritas/optical/detail/OpticalLaunchAction.hh
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.hh
@@ -41,7 +41,8 @@ namespace detail
  * the beginning of the run, and stores the optical core state as "aux" data.
  */
 class OpticalLaunchAction : public AuxParamsInterface,
-                            public CoreStepActionInterface
+                            public CoreStepActionInterface,
+                            public CoreBeginRunActionInterface
 {
   public:
     //!@{
@@ -90,6 +91,15 @@ class OpticalLaunchAction : public AuxParamsInterface,
     //!@}
 
     //!@{
+    //! \name BeginRunAction interface
+
+    // Greate the action groups and get a pointer to the aux data
+    void begin_run(CoreParams const&, CoreStateHost&) final;
+    // Greate the action groups and get a pointer to the aux data
+    void begin_run(CoreParams const&, CoreStateDevice&) final;
+    //!@}
+
+    //!@{
     //! \name Action interface
 
     //! ID of the model
@@ -131,6 +141,8 @@ class OpticalLaunchAction : public AuxParamsInterface,
 
     template<MemSpace M>
     void execute_impl(CoreParams const&, CoreState<M>&) const;
+    template<MemSpace M>
+    void begin_run_impl(CoreState<M>&);
 };
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/OpticalLaunchAction.test.cc
+++ b/test/celeritas/optical/OpticalLaunchAction.test.cc
@@ -137,10 +137,12 @@ OpticalAccumStats LArSphereLaunchTest::counters() const
 
 TEST_F(LArSphereLaunchTest, primary_generator)
 {
-    // Get the optical state and pointer to the auxiliary state vector
+    // Set actions and pointer to aux data during \c begin_run
+    launch_->begin_run(*this->core(), *core_state_);
+
+    // Get the optical state
     auto& state = get<optical::CoreState<MemSpace::host>>(core_state_->aux(),
                                                           launch_->aux_id());
-    state.aux() = core_state_->aux_ptr();
 
     // Queue primaries for one event
     generate_->queue_primaries(state);


### PR DESCRIPTION
This adds a `begin_run` to the optical launch action which sets the aux state pointer and constructs the action groups so that additional actions can be added after the launch action's construction. Combined with the previous refactoring of the generators, this means there’s no longer any restriction on the order in which we construct the actions in the optical collector.