### PR TITLE
Revert one unintentional typo change from #1867

### DIFF
--- a/doc/licenses/additional.rst
+++ b/doc/licenses/additional.rst
@@ -43,7 +43,7 @@ from implementations in Geant4::
       software itself.
 
    3. The names "Geant4" and "The Geant4 toolkit" may not be used to endorse or
-      promote software,or products derived there from, except with prior written
+      promote software,or products derived therefrom, except with prior written
       permission  by  license@geant4.org.  If this software is redistributed in
       modified form,  the name  and  reference of  the modified version must be
       clearly distinguishable from that of this software.

--- a/scripts/dev/codespell-ignore.txt
+++ b/scripts/dev/codespell-ignore.txt
@@ -2,3 +2,4 @@ AssertIO
 nax
 nd
 VarT
+therefrom


### PR DESCRIPTION
This is small partial revert of commit 2b343e9f925c4650991bdf938bcd406d51c11480

