### PR TITLE
Convert to using counterclockwise order for polygons

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -519,10 +519,9 @@ auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
     // ordering.
     std::vector<G4TwoVector> g4polygon = solid.GetPolygon();
     VecReal2 polygon;
-    size_type n = g4polygon.size();
-    for (auto i : range(n))
+    for (auto i : range<int>(g4polygon.size()).step(-1))
     {
-        auto point = g4polygon[n - 1 - i];
+        auto point = g4polygon[i];
         polygon.push_back(Real2{scale_(point[0]), scale_(point[1])});
     }
 

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -514,7 +514,7 @@ auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
 
     auto const& solid = dynamic_cast<G4ExtrudedSolid const&>(solid_base);
 
-    // Get the polygon and reverse is order; ORANGE uses standard
+    // Get the polygon and reverse its order; ORANGE uses standard
     // counterclockwise ordering for polygons where GEANT4 uses clockwise
     // ordering.
     std::vector<G4TwoVector> g4polygon = solid.GetPolygon();

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -514,12 +514,15 @@ auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
 
     auto const& solid = dynamic_cast<G4ExtrudedSolid const&>(solid_base);
 
-    // Get the polygon
+    // Get the polygon and reverse is order; ORANGE uses standard
+    // counterclockwise ordering for polygons where GEANT4 uses clockwise
+    // ordering.
     std::vector<G4TwoVector> g4polygon = solid.GetPolygon();
     VecReal2 polygon;
-    for (auto i : range(g4polygon.size()))
+    size_type n = g4polygon.size();
+    for (auto i : range(n))
     {
-        auto point = g4polygon[i];
+        auto point = g4polygon[n - 1 - i];
         polygon.push_back(Real2{scale_(point[0]), scale_(point[1])});
     }
 

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -515,7 +515,7 @@ auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
     auto const& solid = dynamic_cast<G4ExtrudedSolid const&>(solid_base);
 
     // Get the polygon and reverse its order; ORANGE uses standard
-    // counterclockwise ordering for polygons where GEANT4 uses clockwise
+    // counterclockwise ordering for polygons whereas GEANT4 uses clockwise
     // ordering.
     std::vector<G4TwoVector> g4polygon = solid.GetPolygon();
     VecReal2 polygon;

--- a/src/orange/orangeinp/CsgTypes.cc
+++ b/src/orange/orangeinp/CsgTypes.cc
@@ -128,10 +128,7 @@ SpecialTrapezoid::SpecialTrapezoid(ZSegment&& bot, ZSegment&& top)
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the unique points in clockwise order, starting with the bottom right.
- *
- * TODO: use counterclockwise order, which is standard in the computational
- * geometry field.
+ *Get the unique points in counterclockwise order, from the upper right.
  */
 auto SpecialTrapezoid::unique_points() const -> VecReal2
 {
@@ -140,18 +137,18 @@ auto SpecialTrapezoid::unique_points() const -> VecReal2
 
     VecReal2 points;
 
-    // Add bottom points
-    points.push_back({bot_.r[right], bot_.z});
-    if (variety_ != Variety::pointy_bot)
-    {
-        points.push_back({bot_.r[left], bot_.z});
-    }
-
     // Add top points
-    points.push_back({top_.r[left], top_.z});
+    points.push_back({top_.r[right], top_.z});
     if (variety_ != Variety::pointy_top)
     {
-        points.push_back({top_.r[right], top_.z});
+        points.push_back({top_.r[left], top_.z});
+    }
+
+    // Add bottom points
+    points.push_back({bot_.r[left], bot_.z});
+    if (variety_ != Variety::pointy_bot)
+    {
+        points.push_back({bot_.r[right], bot_.z});
     }
 
     return points;

--- a/src/orange/orangeinp/CsgTypes.cc
+++ b/src/orange/orangeinp/CsgTypes.cc
@@ -128,7 +128,7 @@ SpecialTrapezoid::SpecialTrapezoid(ZSegment&& bot, ZSegment&& top)
 
 //---------------------------------------------------------------------------//
 /*!
- *Get the unique points in counterclockwise order, from the upper right.
+ * Get the unique points in counterclockwise order, from the upper right.
  */
 auto SpecialTrapezoid::unique_points() const -> VecReal2
 {

--- a/src/orange/orangeinp/CsgTypes.hh
+++ b/src/orange/orangeinp/CsgTypes.hh
@@ -198,7 +198,7 @@ class SpecialTrapezoid
     //! Get the absolute tolerance for soft equality
     real_type abs_tol() const { return abs_tol_; }
 
-    // Get the unique points in clockwise order, starting with the bottom right
+    // Get the unique points in counterclockwise order, from the upper right
     VecReal2 unique_points() const;
 
   private:

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -547,7 +547,6 @@ ExtrudedPolygon::ExtrudedPolygon(ExtrudedPolygon::VecReal2 const& polygon,
                                  ExtrudedPolygon::PolygonFace const& top_face)
     : line_segment_{bot_face.line_segment_point, top_face.line_segment_point}
     , scaling_factors_{bot_face.scaling_factor, top_face.scaling_factor}
-
 {
     constexpr auto bot = Bound::lo;
     constexpr auto top = Bound::hi;

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -578,10 +578,11 @@ ExtrudedPolygon::ExtrudedPolygon(ExtrudedPolygon::VecReal2 const& polygon,
                    << "polygon must consist of at least 3 points");
 
     // After removing collinear points, the polygon should have a *strictly*
-    // clockwise orientation, which also guarantees it is convex.
-    CELER_VALIDATE(
-        has_orientation(make_span(polygon_), detail::Orientation::clockwise),
-        << "polygon must be specified in strictly clockwise order");
+    // counterclockwise orientation, which also guarantees it is convex.
+    CELER_VALIDATE(has_orientation(make_span(polygon_),
+                                   detail::Orientation::counterclockwise),
+                   << "polygon must be specified in strictly counterclockwise "
+                      "order");
 }
 
 //---------------------------------------------------------------------------//
@@ -606,13 +607,13 @@ void ExtrudedPolygon::build(IntersectSurfaceBuilder& insert_surface) const
 
         // Specify points in an order such that the normal is outward-facing
         // (via the right-hand rule), given that the polygon is provided in
-        // clockwise order
+        // counterclockwise order
         auto p0 = scaling_factors_[bot] * Real3{p_a[X], p_a[Y], 0}
                   + line_segment_[bot];
-        auto p1 = scaling_factors_[top] * Real3{p_a[X], p_a[Y], 0}
-                  + line_segment_[top];
-        auto p2 = scaling_factors_[bot] * Real3{p_b[X], p_b[Y], 0}
+        auto p1 = scaling_factors_[bot] * Real3{p_b[X], p_b[Y], 0}
                   + line_segment_[bot];
+        auto p2 = scaling_factors_[top] * Real3{p_a[X], p_a[Y], 0}
+                  + line_segment_[top];
 
         insert_surface(Sense::inside, Plane{p0, p1, p2});
     }

--- a/src/orange/orangeinp/IntersectRegion.hh
+++ b/src/orange/orangeinp/IntersectRegion.hh
@@ -327,8 +327,8 @@ class EllipticalCone final : public IntersectRegionInterface
  * Region formed by extruding + scaling a convex polygon along a line segment.
  *
  * The convex polygon is supplied as a set of points on the XY plane in
- * clockwise order. The line segment and scaling factors are specified by
- * providing a line segment point and scaling factor for the top and bottom
+ * counterclockwise order. The line segment and scaling factors are specified
+ * by providing a line segment point and scaling factor for the top and bottom
  * polygon faces of the region. The line segment point of the top face must
  * have a z value greater than that of the bottom face. Along the line segment,
  * the size of the polygon is linearly scaled in accordance with scaling

--- a/src/orange/orangeinp/StackedExtrudedPolygon.hh
+++ b/src/orange/orangeinp/StackedExtrudedPolygon.hh
@@ -18,10 +18,9 @@ namespace orangeinp
 /*! A convex/concave polygon extruded along a polyline, with scaling.
  *
  * The polygon must be specified in counterclockwise order. The polyline must
- be
- * strictly monotonically increasing in z. Scaling factors can be any positive
- * value. Scaling is assumed to occur with respect to the polygon's original
- * coordinate system.
+ * be strictly monotonically increasing in z. Scaling factors can be any
+ * positive value. Scaling is assumed to occur with respect to the polygon's
+ * original coordinate system.
  *
  * Construction is performed using a convex decomposition approach
  * \citep{tor-convexdecomp-1984, https://doi.org/10.1145/357346.357348}. The

--- a/src/orange/orangeinp/StackedExtrudedPolygon.hh
+++ b/src/orange/orangeinp/StackedExtrudedPolygon.hh
@@ -17,7 +17,8 @@ namespace orangeinp
 //---------------------------------------------------------------------------//
 /*! A convex/concave polygon extruded along a polyline, with scaling.
  *
- * The polygon must be specified in clockwise order. The polyline must be
+ * The polygon must be specified in counterclockwise order. The polyline must
+ be
  * strictly monotonically increasing in z. Scaling factors can be any positive
  * value. Scaling is assumed to occur with respect to the polygon's original
  * coordinate system.

--- a/src/orange/orangeinp/detail/ConvexHullFinder.hh
+++ b/src/orange/orangeinp/detail/ConvexHullFinder.hh
@@ -99,8 +99,8 @@ class ConvexHullFinder
  * and associated concave regions. Note that this function does not enforce
  * ordering.
  *
- * \todo Check that points form a non-self-intersecting polygon with clockwise
- * ordering.
+ * \todo Check that points form a non-self-intersecting polygon with
+ * counterclockwise ordering.
  */
 template<class T>
 ConvexHullFinder<T>::ConvexHullFinder(ConvexHullFinder::VecReal2 const& points,
@@ -186,7 +186,7 @@ auto ConvexHullFinder<T>::calc_concave_regions() const -> VecVecReal2
 
     // Since the original shape was supplied in counterclockwise order, we must
     // traverse the points backwards in order to obtain the concave regions in
-    // clockwise order.
+    // counterclockwise order.
     size_type i = this->calc_previous(start_index_);
     while (i != start_index_)
     {

--- a/src/orange/orangeinp/detail/ConvexHullFinder.hh
+++ b/src/orange/orangeinp/detail/ConvexHullFinder.hh
@@ -29,12 +29,12 @@ namespace detail
  *
  * This helper class does not take ownership of the supplied points and
  * tolerance, so the lifetime of objects of this class should be shorter than
- * the lifetime of these arguments. Points must be supplied in clockwise-order
- * such that segments between adjacent points, including the last and first
- * points, comprise a non-self-intersecting polygon. Exploiting this ordering,
- * the Graham Scan algorithm \citet{graham-convexhull-1972,
- * https://doi.org/10.1016/0020-0190(72)90045-2} finds the convex hull with
- * O(N) time complexity.
+ * the lifetime of these arguments. Points must be supplied in
+ * counterclockwise-order such that segments between adjacent points, including
+ * the last and first points, comprise a non-self-intersecting polygon.
+ * Exploiting this ordering, the Graham Scan algorithm
+ * \citet{graham-convexhull-1972, https://doi.org/10.1016/0020-0190(72)90045-2}
+ * finds the convex hull with O(N) time complexity.
  */
 template<class T>
 class ConvexHullFinder
@@ -55,7 +55,7 @@ class ConvexHullFinder
     // Make the convex hull
     VecReal2 make_convex_hull() const;
 
-    // Calculate the concave regions, each supplied in clockwise order
+    // Calculate the concave regions, each supplied in counterclockwise order
     VecVecReal2 calc_concave_regions() const;
 
   private:
@@ -80,8 +80,9 @@ class ConvexHullFinder
     // Find the index of the element with the minimum y value
     size_type min_element_idx() const;
 
-    // Determine if three points, traversed in order, form a clockwise turn
-    bool is_clockwise(size_type i_prev, size_type i, size_type i_next) const;
+    // Determine if three points, traversed in order, are counterclockwise
+    bool
+    is_counterclockwise(size_type i_prev, size_type i, size_type i_next) const;
 
     // Determine the next index, with modular indexing
     size_type calc_next(size_type i) const;
@@ -162,20 +163,20 @@ auto ConvexHullFinder<T>::make_convex_hull() const -> VecReal2
 
 //---------------------------------------------------------------------------//
 /*!
- * Calculate the concave regions, each supplied in clockwise order.
+ * Calculate the concave regions, each supplied in counterclockwise order.
  *
  * Here, a "concave region" is a region that lies entirely within the convex
  * hull, that is concavity within the *original* shape. Note that a concave
  * region itself may be convex or concave. For example, consider the shape:
  *
- *   0 _______ 1
+ *   4 _______ 3
  *    |       |
- *    |     2 |____ 3
+ *    |     2 |____ 1
  *    |            |
- *  5 |____________| 4
+ *  5 |____________| 0
  *
  * The convex hull is (0, 1, 3, 4, 5). There is one concave region: the
- * triangle formed by (1, 2, 3).
+ * triangle formed by (1, 3, 2).
  */
 template<class T>
 auto ConvexHullFinder<T>::calc_concave_regions() const -> VecVecReal2
@@ -183,7 +184,7 @@ auto ConvexHullFinder<T>::calc_concave_regions() const -> VecVecReal2
     CELER_EXPECT(convex_mask_.size() > 2);
     VecVecReal2 concave_regions;
 
-    // Since the original shape was supplied in clockwise order, we must
+    // Since the original shape was supplied in counterclockwise order, we must
     // traverse the points backwards in order to obtain the concave regions in
     // clockwise order.
     size_type i = this->calc_previous(start_index_);
@@ -232,17 +233,17 @@ auto ConvexHullFinder<T>::calc_convex_mask() const -> ConvexMask
     {
         size_type i_next = this->calc_next(i);
 
-        if (this->is_clockwise(hull.back(), i, i_next))
+        if (this->is_counterclockwise(hull.back(), i, i_next))
         {
-            // Clockwise point is part of the hull
+            // Counterclockwise point is part of the hull
             hull.push_back(i);
         }
         else
         {
             // Pop points off the hull until we can reach the next point by
-            // turning clockwise.
+            // turning counterclockwise.
             while (hull.size() >= 2
-                   && !this->is_clockwise(
+                   && !this->is_counterclockwise(
                        hull[hull.size() - 2], hull.back(), i_next))
             {
                 hull.pop_back();
@@ -283,14 +284,14 @@ size_type ConvexHullFinder<T>::min_element_idx() const
  * Here, collinear points are considered clockwise.
  */
 template<class T>
-auto ConvexHullFinder<T>::is_clockwise(size_type i_prev,
-                                       size_type i,
-                                       size_type i_next) const -> bool
+auto ConvexHullFinder<T>::is_counterclockwise(size_type i_prev,
+                                              size_type i,
+                                              size_type i_next) const -> bool
 {
     auto const& a = points_[i_prev];
     auto const& b = points_[i];
     auto const& c = points_[i_next];
-    return soft_ori_(a, b, c) != detail::Orientation::counterclockwise;
+    return soft_ori_(a, b, c) != detail::Orientation::clockwise;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -313,18 +313,20 @@ TEST_F(SolidConverterTest, extrudedsolid_concave)
     using ZSection = G4ExtrudedSolid::ZSection;
 
     // Setup G4Extruded solid construction commands
-    std::vector<G4TwoVector> polygon = {{0, 0},
-                                        {-0.3, 1},
-                                        {0.15, 0.5},
-                                        {0.4, 0.7},
-                                        {0.45, 0.6},
-                                        {0.5, 0.7},
-                                        {0.8, 0.4},
-                                        {0.9, 1.2},
-                                        {1.2, 0.5},
-                                        {1, 0},
-                                        {0.1, 0},
-                                        {0.05, 0.01}};
+    std::vector<G4TwoVector> polygon = {
+        {0.05, 0.01},
+        {0.1, 0},
+        {1, 0},
+        {1.2, 0.5},
+        {0.9, 1.2},
+        {0.8, 0.4},
+        {0.5, 0.7},
+        {0.45, 0.6},
+        {0.4, 0.7},
+        {0.15, 0.5},
+        {-0.3, 1},
+        {0, 0},
+    };
 
     ZSection bot(0, {0, 0}, 1);
     ZSection mid(1, {10, 5}, 0.5);
@@ -334,7 +336,7 @@ TEST_F(SolidConverterTest, extrudedsolid_concave)
     // Build and test, with 5 points near tricky corners explicitly tested
     this->build_and_test(
         G4ExtrudedSolid("testExtrudedSolid", polygon, z_sections),
-        R"json({"_type":"stackedextrudedpolygon","polygon":[[0.0,0.0],[-0.03,0.1],[0.015,0.05],[0.04000000000000001,0.06999999999999999],[0.045000000000000005,0.06],[0.05,0.06999999999999999],[0.08000000000000002,0.04000000000000001],[0.09000000000000001,0.12],[0.12,0.05],[0.1,0.0],[0.010000000000000002,0.0],[0.005000000000000001,0.001]],"polyline":[[0.0,0.0,0.0],[1.0,0.5,0.1],[0.1,0.2,0.2]],"scaling":[1.0,0.5,1.5]})json",
+        R"json({"_type":"stackedextrudedpolygon","polygon":[[0.005000000000000001,0.001],[0.010000000000000002,0.0],[0.1,0.0],[0.12,0.05],[0.09000000000000001,0.12],[0.08000000000000002,0.04000000000000001],[0.05,0.06999999999999999],[0.045000000000000005,0.06],[0.04000000000000001,0.06999999999999999],[0.015,0.05],[-0.03,0.1],[0.0,0.0]],"polyline":[[0.0,0.0,0.0],[1.0,0.5,0.1],[0.1,0.2,0.2]],"scaling":[1.0,0.5,1.5]})json",
         {{0.01, 0.011, 0.3},
          {0.39, 0.79, 1.5},
          {0.79, 0.39, 1.1},
@@ -359,7 +361,7 @@ TEST_F(SolidConverterTest, extrudedsolid_simple)
     // Test 4 points near tricky corners
     this->build_and_test(
         G4ExtrudedSolid("testExtrudedSolid", polygon, z_sections),
-        R"json({"_type":"shape","interior":{"_type":"extrudedpolygon","bot_line_segment_point":[0.0,0.0,0.0],"bot_scaling_factor":1.0,"polygon":[[0.0,0.0],[0.0,0.1],[0.1,0.1],[0.1,0.0]],"top_line_segment_point":[0.1,0.2,0.1],"top_scaling_factor":1.5},"label":"testExtrudedSolid"})json",
+        R"json({"_type":"shape","interior":{"_type":"extrudedpolygon","bot_line_segment_point":[0.0,0.0,0.0],"bot_scaling_factor":1.0,"polygon":[[0.1,0.0],[0.1,0.1],[0.0,0.1],[0.0,0.0]],"top_line_segment_point":[0.1,0.2,0.1],"top_scaling_factor":1.5},"label":"testExtrudedSolid"})json",
         {{0.5, 0.5, 0.5}, {-1, 0.5, 0.5}});
 }
 

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -313,20 +313,18 @@ TEST_F(SolidConverterTest, extrudedsolid_concave)
     using ZSection = G4ExtrudedSolid::ZSection;
 
     // Setup G4Extruded solid construction commands
-    std::vector<G4TwoVector> polygon = {
-        {0.05, 0.01},
-        {0.1, 0},
-        {1, 0},
-        {1.2, 0.5},
-        {0.9, 1.2},
-        {0.8, 0.4},
-        {0.5, 0.7},
-        {0.45, 0.6},
-        {0.4, 0.7},
-        {0.15, 0.5},
-        {-0.3, 1},
-        {0, 0},
-    };
+    std::vector<G4TwoVector> polygon = {{0.05, 0.01},
+                                        {0.1, 0},
+                                        {1, 0},
+                                        {1.2, 0.5},
+                                        {0.9, 1.2},
+                                        {0.8, 0.4},
+                                        {0.5, 0.7},
+                                        {0.45, 0.6},
+                                        {0.4, 0.7},
+                                        {0.15, 0.5},
+                                        {-0.3, 1},
+                                        {0, 0}};
 
     ZSection bot(0, {0, 0}, 1);
     ZSection mid(1, {10, 5}, 0.5);

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -534,19 +534,23 @@ TEST_F(ExtrudedPolygonTest, simple_cube)
 {
     // Test a simple unit cube
     ExtrudedPolygon::VecReal2 polygon{
-        Real2{0, 0}, Real2{0, 1}, Real2{1, 1}, Real2{1, 0}};
+        Real2{1, 0},
+        Real2{1, 1},
+        Real2{0, 1},
+        Real2{0, 0},
+    };
 
     ExtrudedPolygon::PolygonFace bot{Real3{0, 0, 0}, 1};
     ExtrudedPolygon::PolygonFace top{Real3{0, 0, 1}, 1};
 
     auto result = this->test(ExtrudedPolygon(polygon, bot, top));
 
-    static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
+    static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5)";
     static char const* const expected_surfaces[] = {"Plane: z=0",
                                                     "Plane: z=1",
-                                                    "Plane: x=0",
-                                                    "Plane: y=1",
                                                     "Plane: x=1",
+                                                    "Plane: y=1",
+                                                    "Plane: x=0",
                                                     "Plane: y=0"};
 
     EXPECT_EQ(expected_node, result.node);
@@ -559,27 +563,29 @@ TEST_F(ExtrudedPolygonTest, simple_cube)
 TEST_F(ExtrudedPolygonTest, collinear)
 {
     // Same test as simple_cube, but with collinear points
-    ExtrudedPolygon::VecReal2 polygon{Real2{0, 0},
-                                      Real2{0, 0.5},
-                                      Real2{0, 1},
-                                      Real2{0.5, 1},
-                                      Real2{1, 1},
-                                      Real2{1, 0.5},
-                                      Real2{1, 0},
-                                      Real2{0.7, 0},
-                                      Real2{0.3, 0}};
+    ExtrudedPolygon::VecReal2 polygon{
+        Real2{0.3, 0},
+        Real2{0.7, 0},
+        Real2{1, 0},
+        Real2{1, 0.5},
+        Real2{1, 1},
+        Real2{0.5, 1},
+        Real2{0, 1},
+        Real2{0, 0.5},
+        Real2{0, 0},
+    };
 
     ExtrudedPolygon::PolygonFace bot{Real3{0, 0, 0}, 1};
     ExtrudedPolygon::PolygonFace top{Real3{0, 0, 1}, 1};
 
     auto result = this->test(ExtrudedPolygon(polygon, bot, top));
 
-    static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
+    static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5)";
     static char const* const expected_surfaces[] = {"Plane: z=0",
                                                     "Plane: z=1",
-                                                    "Plane: x=0",
-                                                    "Plane: y=1",
                                                     "Plane: x=1",
+                                                    "Plane: y=1",
+                                                    "Plane: x=0",
                                                     "Plane: y=0"};
 
     EXPECT_EQ(expected_node, result.node);
@@ -592,21 +598,26 @@ TEST_F(ExtrudedPolygonTest, collinear)
 TEST_F(ExtrudedPolygonTest, flat_top_pyramid)
 {
     ExtrudedPolygon::VecReal2 polygon{
-        Real2{0, 0}, Real2{0, 1}, Real2{1, 1}, Real2{1, 0}};
+        Real2{1, 0},
+        Real2{1, 1},
+        Real2{0, 1},
+        Real2{0, 0},
+
+    };
 
     ExtrudedPolygon::PolygonFace bot{Real3{0, 0, 0}, 1};
     ExtrudedPolygon::PolygonFace top{Real3{0, 0, 0.5}, 0.5};
 
     auto result = this->test(ExtrudedPolygon(polygon, bot, top));
 
-    static char const expected_node[] = "all(+0, -1, +2, -3, -4, +5)";
+    static char const expected_node[] = "all(+0, -1, -2, -3, +4, +5)";
     // Planes have x- and y-slopes equal to +/- sqrt(2)/2, as expected
     static char const* const expected_surfaces[]
         = {"Plane: z=0",
            "Plane: z=0.5",
+           "Plane: n={0.70711,-0,0.70711}, d=0.70711",
+           "Plane: n={0,0.70711,0.70711}, d=0.70711",
            "Plane: x=0",
-           "Plane: n={-0,0.70711,0.70711}, d=0.70711",
-           "Plane: n={0.70711,0,0.70711}, d=0.70711",
            "Plane: y=0"};
 
     EXPECT_EQ(expected_node, result.node);
@@ -619,13 +630,15 @@ TEST_F(ExtrudedPolygonTest, flat_top_pyramid)
 TEST_F(ExtrudedPolygonTest, skewed)
 {
     // Irregular hexagon with a single collinear point at (0, 0)
-    ExtrudedPolygon::VecReal2 polygon{Real2{0, 0},
-                                      Real2{-1, 0},
-                                      Real2{-2, 1},
-                                      Real2{-1, 3},
-                                      Real2{1, 4},
-                                      Real2{2, 2},
-                                      Real2{1, 0}};
+    ExtrudedPolygon::VecReal2 polygon{
+        Real2{1, 0},
+        Real2{2, 2},
+        Real2{1, 4},
+        Real2{-1, 3},
+        Real2{-2, 1},
+        Real2{-1, 0},
+        Real2{0, 0},
+    };
 
     ExtrudedPolygon::PolygonFace bot{Real3{4, 3, 10}, 0.7};
     ExtrudedPolygon::PolygonFace top{Real3{10, 11, 15}, 0.5};
@@ -636,11 +649,11 @@ TEST_F(ExtrudedPolygonTest, skewed)
     static char const* const expected_surfaces[]
         = {"Plane: z=10",
            "Plane: z=15",
-           "Plane: n={0.3152,0.3152,-0.89516}, d=-6.9658",
-           "Plane: n={-0.8165,0.40825,0.40825}, d=3.4701",
-           "Plane: n={0.35448,-0.70895,0.6097}, d=3.6511",
-           "Plane: n={0.45718,0.22859,-0.8595}, d=-5.1204",
            "Plane: n={-0.85138,0.42569,0.3065}, d=0.34055",
+           "Plane: n={0.45718,0.22859,-0.8595}, d=-5.1204",
+           "Plane: n={0.35448,-0.70895,0.6097}, d=3.6511",
+           "Plane: n={-0.8165,0.40825,0.40825}, d=3.4701",
+           "Plane: n={0.3152,0.3152,-0.89516}, d=-6.9658",
            "Plane: n={0,0.53,-0.848}, d=-6.89"};
 
     EXPECT_EQ(expected_node, result.node);

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -534,11 +534,7 @@ TEST_F(ExtrudedPolygonTest, simple_cube)
 {
     // Test a simple unit cube
     ExtrudedPolygon::VecReal2 polygon{
-        Real2{1, 0},
-        Real2{1, 1},
-        Real2{0, 1},
-        Real2{0, 0},
-    };
+        Real2{1, 0}, Real2{1, 1}, Real2{0, 1}, Real2{0, 0}};
 
     ExtrudedPolygon::PolygonFace bot{Real3{0, 0, 0}, 1};
     ExtrudedPolygon::PolygonFace top{Real3{0, 0, 1}, 1};
@@ -598,12 +594,7 @@ TEST_F(ExtrudedPolygonTest, collinear)
 TEST_F(ExtrudedPolygonTest, flat_top_pyramid)
 {
     ExtrudedPolygon::VecReal2 polygon{
-        Real2{1, 0},
-        Real2{1, 1},
-        Real2{0, 1},
-        Real2{0, 0},
-
-    };
+        Real2{1, 0}, Real2{1, 1}, Real2{0, 1}, Real2{0, 0}};
 
     ExtrudedPolygon::PolygonFace bot{Real3{0, 0, 0}, 1};
     ExtrudedPolygon::PolygonFace top{Real3{0, 0, 0.5}, 0.5};
@@ -630,15 +621,13 @@ TEST_F(ExtrudedPolygonTest, flat_top_pyramid)
 TEST_F(ExtrudedPolygonTest, skewed)
 {
     // Irregular hexagon with a single collinear point at (0, 0)
-    ExtrudedPolygon::VecReal2 polygon{
-        Real2{1, 0},
-        Real2{2, 2},
-        Real2{1, 4},
-        Real2{-1, 3},
-        Real2{-2, 1},
-        Real2{-1, 0},
-        Real2{0, 0},
-    };
+    ExtrudedPolygon::VecReal2 polygon{Real2{1, 0},
+                                      Real2{2, 2},
+                                      Real2{1, 4},
+                                      Real2{-1, 3},
+                                      Real2{-2, 1},
+                                      Real2{-1, 0},
+                                      Real2{0, 0}};
 
     ExtrudedPolygon::PolygonFace bot{Real3{4, 3, 10}, 0.7};
     ExtrudedPolygon::PolygonFace top{Real3{10, 11, 15}, 0.5};

--- a/test/orange/orangeinp/StackedExtrudedPolygon.test.cc
+++ b/test/orange/orangeinp/StackedExtrudedPolygon.test.cc
@@ -39,12 +39,7 @@ class StackedExtrudedPolygonTest : public ObjectTestBase
  */
 TEST_F(StackedExtrudedPolygonTest, scaled_convex_stack)
 {
-    VecReal2 polygon{
-        {1, -1},
-        {1, 1},
-        {-1, 1},
-        {-1, -1},
-    };
+    VecReal2 polygon{{1, -1}, {1, 1}, {-1, 1}, {-1, -1}};
 
     VecReal3 polyline{{0, 0, 0}, {0, 0, 1}, {0, 0, 1.5}};
     VecReal scaling{1, 1, 0.5};
@@ -105,12 +100,7 @@ TEST_F(StackedExtrudedPolygonTest, scaled_convex_stack)
  */
 TEST_F(StackedExtrudedPolygonTest, skewed_convex_stack)
 {
-    VecReal2 polygon{
-        {1, -1},
-        {1, 1},
-        {-1, 1},
-        {-1, -1},
-    };
+    VecReal2 polygon{{1, -1}, {1, 1}, {-1, 1}, {-1, -1}};
 
     VecReal3 polyline{{0, 0, 0}, {0, 0, 1}, {1, 1, 2}};
     VecReal scaling{1, 1, 1};
@@ -182,40 +172,36 @@ TEST_F(StackedExtrudedPolygonTest, skewed_convex_stack)
  */
 TEST_F(StackedExtrudedPolygonTest, concave_stack)
 {
-    VecReal2 polygon{
-        {5, 0},
-        {5, 3},
-        {4, 3},
-        {4, 1},
-        {3, 1},
-        {3, 2},
-        {2, 2},
-        {2, 1},
-        {1, 1},
-        {1, 3},
-        {0, 3},
-        {0, 0},
-    };
+    VecReal2 polygon{{5, 0},
+                     {5, 3},
+                     {4, 3},
+                     {4, 1},
+                     {3, 1},
+                     {3, 2},
+                     {2, 2},
+                     {2, 1},
+                     {1, 1},
+                     {1, 3},
+                     {0, 3},
+                     {0, 0}};
     VecReal3 polyline{{0, 0, 0}, {0, 0, 1}};
     VecReal scaling{1, 1};
 
     this->build_volume(StackedExtrudedPolygon{
         "pc", std::move(polygon), std::move(polyline), std::move(scaling)});
 
-    static char const* const expected_surface_strings[] = {
-        "Plane: z=0",
-        "Plane: z=1",
-        "Plane: x=5",
-        "Plane: y=3",
-        "Plane: x=0",
-        "Plane: y=0",
-        "Plane: x=1",
-        "Plane: y=1",
-        "Plane: x=4",
-        "Plane: x=3",
-        "Plane: y=2",
-        "Plane: x=2",
-    };
+    static char const* const expected_surface_strings[] = {"Plane: z=0",
+                                                           "Plane: z=1",
+                                                           "Plane: x=5",
+                                                           "Plane: y=3",
+                                                           "Plane: x=0",
+                                                           "Plane: y=0",
+                                                           "Plane: x=1",
+                                                           "Plane: y=1",
+                                                           "Plane: x=4",
+                                                           "Plane: x=3",
+                                                           "Plane: y=2",
+                                                           "Plane: x=2"};
 
     static char const* const expected_volume_strings[] = {
         R"(all(+0, -1, -2, -3, +4, +5, !all(+0, -1, -3, +6, +7, -8, !all(+0, -1, +7, -9, -10, +11))))"};

--- a/test/orange/orangeinp/StackedExtrudedPolygon.test.cc
+++ b/test/orange/orangeinp/StackedExtrudedPolygon.test.cc
@@ -39,51 +39,58 @@ class StackedExtrudedPolygonTest : public ObjectTestBase
  */
 TEST_F(StackedExtrudedPolygonTest, scaled_convex_stack)
 {
-    VecReal2 polygon{{-1, -1}, {-1, 1}, {1, 1}, {1, -1}};
+    VecReal2 polygon{
+        {1, -1},
+        {1, 1},
+        {-1, 1},
+        {-1, -1},
+    };
+
     VecReal3 polyline{{0, 0, 0}, {0, 0, 1}, {0, 0, 1.5}};
     VecReal scaling{1, 1, 0.5};
 
     this->build_volume(StackedExtrudedPolygon{
         "pc", std::move(polygon), std::move(polyline), std::move(scaling)});
 
-    static char const* const expected_surface_strings[]
-        = {"Plane: z=0",
-           "Plane: z=1",
-           "Plane: x=-1",
-           "Plane: y=1",
-           "Plane: x=1",
-           "Plane: y=-1",
-           "Plane: z=1.5",
-           "Plane: n={0.70711,0,-0.70711}, d=-1.4142",
-           "Plane: n={-0,0.70711,0.70711}, d=1.4142",
-           "Plane: n={0.70711,0,0.70711}, d=1.4142",
-           "Plane: n={0,0.70711,-0.70711}, d=-1.4142"};
-
+    static char const* const expected_surface_strings[] = {
+        "Plane: z=0",
+        "Plane: z=1",
+        "Plane: x=1",
+        "Plane: y=1",
+        "Plane: x=-1",
+        "Plane: y=-1",
+        "Plane: z=1.5",
+        "Plane: n={0.70711,-0,0.70711}, d=1.4142",
+        "Plane: n={0,0.70711,0.70711}, d=1.4142",
+        "Plane: n={0.70711,0,-0.70711}, d=-1.4142",
+        "Plane: n={0,0.70711,-0.70711}, d=-1.4142",
+    };
     static char const* const expected_volume_strings[]
-        = {"any(all(+0, -1, +2, -3, -4, +5), all(+1, -6, +7, -8, -9, +10))"};
-    static char const* const expected_md_strings[] = {"",
-                                                      "",
-                                                      "pc@0.0.0.mz",
-                                                      ("pc@0.0.0.pz,pc@0.0.1."
-                                                       "mz"),
-                                                      "",
-                                                      "pc@0.0.0.p0",
-                                                      "pc@0.0.0.p1",
-                                                      "",
-                                                      "pc@0.0.0.p2",
-                                                      "",
-                                                      "pc@0.0.0.p3",
-                                                      "pc@0.0.0",
-                                                      "pc@0.0.1.pz",
-                                                      "",
-                                                      "pc@0.0.1.p0",
-                                                      "pc@0.0.1.p1",
-                                                      "",
-                                                      "pc@0.0.1.p2",
-                                                      "",
-                                                      "pc@0.0.1.p3",
-                                                      "pc@0.0.1",
-                                                      "pc@0.0"};
+        = {"any(all(+0, -1, -2, -3, +4, +5), all(+1, -6, -7, -8, +9, +10))"};
+    static char const* const expected_md_strings[] = {
+        "",
+        "",
+        "pc@0.0.0.mz",
+        "pc@0.0.0.pz,pc@0.0.1.mz",
+        "",
+        "pc@0.0.0.p0",
+        "",
+        "pc@0.0.0.p1",
+        "",
+        "pc@0.0.0.p2",
+        "pc@0.0.0.p3",
+        "pc@0.0.0",
+        "pc@0.0.1.pz",
+        "",
+        "pc@0.0.1.p0",
+        "",
+        "pc@0.0.1.p1",
+        "",
+        "pc@0.0.1.p2",
+        "pc@0.0.1.p3",
+        "pc@0.0.1",
+        "pc@0.0",
+    };
 
     auto const& u = this->unit();
     EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
@@ -98,51 +105,59 @@ TEST_F(StackedExtrudedPolygonTest, scaled_convex_stack)
  */
 TEST_F(StackedExtrudedPolygonTest, skewed_convex_stack)
 {
-    VecReal2 polygon{{-1, -1}, {-1, 1}, {1, 1}, {1, -1}};
+    VecReal2 polygon{
+        {1, -1},
+        {1, 1},
+        {-1, 1},
+        {-1, -1},
+    };
+
     VecReal3 polyline{{0, 0, 0}, {0, 0, 1}, {1, 1, 2}};
     VecReal scaling{1, 1, 1};
 
     this->build_volume(StackedExtrudedPolygon{
         "pc", std::move(polygon), std::move(polyline), std::move(scaling)});
 
-    static char const* const expected_surface_strings[]
-        = {"Plane: z=0",
-           "Plane: z=1",
-           "Plane: x=-1",
-           "Plane: y=1",
-           "Plane: x=1",
-           "Plane: y=-1",
-           "Plane: z=2",
-           "Plane: n={0.70711,0,-0.70711}, d=-1.4142",
-           "Plane: n={0,0.70711,-0.70711}, d=0",
-           "Plane: n={0.70711,0,-0.70711}, d=0",
-           "Plane: n={0,0.70711,-0.70711}, d=-1.4142"};
+    static char const* const expected_surface_strings[] = {
+        "Plane: z=0",
+        "Plane: z=1",
+        "Plane: x=1",
+        "Plane: y=1",
+        "Plane: x=-1",
+        "Plane: y=-1",
+        "Plane: z=2",
+        "Plane: n={0.70711,0,-0.70711}, d=0",
+        "Plane: n={0,0.70711,-0.70711}, d=0",
+        "Plane: n={0.70711,0,-0.70711}, d=-1.4142",
+        "Plane: n={0,0.70711,-0.70711}, d=-1.4142",
+    };
 
     static char const* const expected_volume_strings[]
-        = {"any(all(+0, -1, +2, -3, -4, +5), all(+1, -6, +7, -8, -9, +10))"};
-    static char const* const expected_md_strings[] = {"",
-                                                      "",
-                                                      "pc@0.0.0.mz",
-                                                      ("pc@0.0.0.pz,pc@0.0.1."
-                                                       "mz"),
-                                                      "",
-                                                      "pc@0.0.0.p0",
-                                                      "pc@0.0.0.p1",
-                                                      "",
-                                                      "pc@0.0.0.p2",
-                                                      "",
-                                                      "pc@0.0.0.p3",
-                                                      "pc@0.0.0",
-                                                      "pc@0.0.1.pz",
-                                                      "",
-                                                      "pc@0.0.1.p0",
-                                                      "pc@0.0.1.p1",
-                                                      "",
-                                                      "pc@0.0.1.p2",
-                                                      "",
-                                                      "pc@0.0.1.p3",
-                                                      "pc@0.0.1",
-                                                      "pc@0.0"};
+        = {"any(all(+0, -1, -2, -3, +4, +5), all(+1, -6, -7, -8, +9, +10))"};
+    static char const* const expected_md_strings[] = {
+        "",
+        "",
+        "pc@0.0.0.mz",
+        "pc@0.0.0.pz,pc@0.0.1.mz",
+        "",
+        "pc@0.0.0.p0",
+        "",
+        "pc@0.0.0.p1",
+        "",
+        "pc@0.0.0.p2",
+        "pc@0.0.0.p3",
+        "pc@0.0.0",
+        "pc@0.0.1.pz",
+        "",
+        "pc@0.0.1.p0",
+        "",
+        "pc@0.0.1.p1",
+        "",
+        "pc@0.0.1.p2",
+        "pc@0.0.1.p3",
+        "pc@0.0.1",
+        "pc@0.0",
+    };
 
     auto const& u = this->unit();
     EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
@@ -167,18 +182,20 @@ TEST_F(StackedExtrudedPolygonTest, skewed_convex_stack)
  */
 TEST_F(StackedExtrudedPolygonTest, concave_stack)
 {
-    VecReal2 polygon{{0, 0},
-                     {0, 3},
-                     {1, 3},
-                     {1, 1},
-                     {2, 1},
-                     {2, 2},
-                     {3, 2},
-                     {3, 1},
-                     {4, 1},
-                     {4, 3},
-                     {5, 3},
-                     {5, 0}};
+    VecReal2 polygon{
+        {5, 0},
+        {5, 3},
+        {4, 3},
+        {4, 1},
+        {3, 1},
+        {3, 2},
+        {2, 2},
+        {2, 1},
+        {1, 1},
+        {1, 3},
+        {0, 3},
+        {0, 0},
+    };
     VecReal3 polyline{{0, 0, 0}, {0, 0, 1}};
     VecReal scaling{1, 1};
 
@@ -188,49 +205,50 @@ TEST_F(StackedExtrudedPolygonTest, concave_stack)
     static char const* const expected_surface_strings[] = {
         "Plane: z=0",
         "Plane: z=1",
-        "Plane: x=0",
-        "Plane: y=3",
         "Plane: x=5",
+        "Plane: y=3",
+        "Plane: x=0",
         "Plane: y=0",
-        "Plane: x=4",
-        "Plane: y=1",
         "Plane: x=1",
-        "Plane: x=2",
-        "Plane: y=2",
+        "Plane: y=1",
+        "Plane: x=4",
         "Plane: x=3",
+        "Plane: y=2",
+        "Plane: x=2",
     };
 
     static char const* const expected_volume_strings[] = {
-        R"(all(+0, -1, +2, -3, -4, +5, !all(+0, -1, -3, -6, +7, +8, !all(+0, -1, +7, +9, -10, -11))))"};
+        R"(all(+0, -1, -2, -3, +4, +5, !all(+0, -1, -3, +6, +7, -8, !all(+0, -1, +7, -9, -10, +11))))"};
 
-    static char const* const expected_md_strings[]
-        = {"",
-           "",
-           "pc@0.0.0.mz,pc@1.0.0.mz,pc@2.0.0.mz",
-           "pc@0.0.0.pz,pc@1.0.0.pz,pc@2.0.0.pz",
-           "",
-           "pc@0.0.0.p0",
-           "pc@0.0.0.p1,pc@1.0.0.p3",
-           "",
-           "pc@0.0.0.p2",
-           "",
-           "pc@0.0.0.p3",
-           "pc@0.0,pc@0.0.0",
-           "pc@1.0.0.p0",
-           "",
-           "pc@1.0.0.p1,pc@2.0.0.p3",
-           "pc@1.0.0.p2",
-           "pc@1.0,pc@1.0.0",
-           "pc@2.0.0.p0",
-           "pc@2.0.0.p1",
-           "",
-           "pc@2.0.0.p2",
-           "",
-           "pc@1.cu,pc@2.0,pc@2.0.0",
-           "pc@1.ncu",
-           "pc@0.cu,pc@1.d",
-           "pc@0.ncu",
-           "pc@0.d"};
+    static char const* const expected_md_strings[] = {
+        "",
+        "",
+        "pc@0.0.0.mz,pc@1.0.0.mz,pc@2.0.0.mz",
+        "pc@0.0.0.pz,pc@1.0.0.pz,pc@2.0.0.pz",
+        "",
+        "pc@0.0.0.p0",
+        "",
+        "pc@0.0.0.p1,pc@1.0.0.p3",
+        "",
+        "pc@0.0.0.p2",
+        "pc@0.0.0.p3",
+        "pc@0.0,pc@0.0.0",
+        "pc@1.0.0.p0",
+        "pc@1.0.0.p1,pc@2.0.0.p3",
+        "pc@1.0.0.p2",
+        "",
+        "pc@1.0,pc@1.0.0",
+        "pc@2.0.0.p0",
+        "",
+        "pc@2.0.0.p1",
+        "",
+        "pc@2.0.0.p2",
+        "pc@1.cu,pc@2.0,pc@2.0.0",
+        "pc@1.ncu",
+        "pc@0.cu,pc@1.d",
+        "pc@0.ncu",
+        "pc@0.d",
+    };
 
     auto const& u = this->unit();
     EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));

--- a/test/orange/orangeinp/detail/ConvexHullFinder.test.cc
+++ b/test/orange/orangeinp/detail/ConvexHullFinder.test.cc
@@ -69,21 +69,23 @@ class ConvexHullFinderTest : public ::celeritas::test::Test
  *
  * The starting point is point 5.
  *
- *    1 _______________________ 2
- *     |                      /
- *     |                    /
- *     |                  /
- *     |                /
- *     |              3 \
- *     |                  \
- *     |                    \
- *     |                      \ 4
- *     |                      /
- *   0 |_____________________/ 5
+ * \verbatim
+   2 _______________________ 1
+     \                      |
+       \                    |
+         \                  |
+           \                |
+           / 3              |
+         /                  |
+       /                    |
+   4 /                      |
+     \                      |
+    5 \_____________________| 0
+   \endverbatim
  */
 TEST_F(ConvexHullFinderTest, basic)
 {
-    VecReal2 p{{0, 0}, {0, 1}, {1, 1}, {0.8, 0.5}, {0.95, 0.2}, {0.9, 0}};
+    VecReal2 p{{0, 0}, {0, 1}, {-1, 1}, {-0.8, 0.5}, {-0.95, 0.2}, {-0.9, 0}};
 
     // Compare convex hulls using 1--6 points
     expect_eq(VecReal2({p[0], p[1], p[2]}),
@@ -105,18 +107,19 @@ TEST_F(ConvexHullFinderTest, basic)
  * hull.
  *
  * The starting point is point 2.
- *
- *  0 _______________ 1
- *    \              |
- *      \       3    |
- *        \    /\    |
- *          \/    \  |
- *           4      \|
- *                   2
+ * \verbatim
+   1 _______________ 0
+    |              /
+    |    3       /
+    |    /\    /
+    |  /    \/
+    |/      4
+    2
+    \endverbatim
  */
 TEST_F(ConvexHullFinderTest, first_concavity)
 {
-    VecReal2 p{{-0.3, 1}, {0.9, 1}, {0.8, 0.4}, {0.5, 0.7}, {0.15, 0.5}};
+    VecReal2 p{{0.3, 1}, {-0.9, 1}, {-0.8, 0.4}, {-0.5, 0.7}, {-0.15, 0.5}};
     CHF chf(p, t);
     expect_eq(VecReal2({p[0], p[1], p[2], p[4]}), chf.make_convex_hull());
     expect_eq(VecVecReal2({{p[4], p[3], p[2]}}), chf.calc_concave_regions());
@@ -127,17 +130,18 @@ TEST_F(ConvexHullFinderTest, first_concavity)
  * Test case where the last point encountered is *not* part of the convex hull.
  *
  * The starting point is point 4.
- *
- *  0 _______________ 1
- *    \              |
- *      \      3 ____|
- *        \    /     2
- *          \/
- *           4
+ * \verbatim
+   1 _______________ 0
+    |              /
+    |____ 3      /
+    2     \    /
+            \/
+            4
+   \endverbatim
  */
 TEST_F(ConvexHullFinderTest, last_concavity)
 {
-    VecReal2 p{{0, 0}, {1, 0}, {1, -0.5}, {0.6, -0.5}, {0.4, -0.8}};
+    VecReal2 p{{0, 0}, {-1, 0}, {-1, -0.5}, {-0.6, -0.5}, {-0.4, -0.8}};
     CHF chf(p, t);
     expect_eq(VecReal2({p[0], p[1], p[2], p[4]}), chf.make_convex_hull());
     expect_eq(VecVecReal2({{p[4], p[3], p[2]}}), chf.calc_concave_regions());
@@ -149,26 +153,27 @@ TEST_F(ConvexHullFinderTest, last_concavity)
  * encountered.
  *
  * The starting point is point 7.
- *
- *  0 _______1_______ 2
- *    \              |_3
- *      \     5 _____|
- *     8  \   /_6    4
- *          \/
- *           7
+ * \verbatim
+    2 _______1_______ 0
+   3_|              /
+     |_____ 5     /
+     4    6_\   /  8
+             \/
+             7
+   \endverbatim
  *
  */
 TEST_F(ConvexHullFinderTest, collinear)
 {
     VecReal2 p{{0, 0},
-               {0.5, 0},
-               {1, 0},
-               {1, -0.2},
-               {1, -0.5},
-               {0.6, -0.5},
-               {0.5, -0.65},
-               {0.4, -0.8},
-               {0.2, -0.4}};
+               {-0.5, 0},
+               {-1, 0},
+               {-1, -0.2},
+               {-1, -0.5},
+               {-0.6, -0.5},
+               {-0.5, -0.65},
+               {-0.4, -0.8},
+               {-0.2, -0.4}};
     CHF chf(p, t);
     expect_eq(VecReal2({p[0], p[1], p[2], p[3], p[4], p[7], p[8]}),
               chf.make_convex_hull());
@@ -180,33 +185,34 @@ TEST_F(ConvexHullFinderTest, collinear)
  * Test case with a quadruply nested concavity.
  *
  * The starting point is point 9.
- *
- *                     7
- *   1                 |\
- *   \\                | \
- *    \ \      3  5    |  \
- *     \  \    /\/\    |   \
- *      \   \/   4  \  |    \ 8
- *       \   2        \|    /
- *        \            6   /
- *         \ 11           /
- *          \/\__________/
- *          0  10        9
+ * \verbatim
+          7
+         /|                 1
+        / |                //
+       /  |    5  3      / /
+      /   |    /\/\    /  /
+   8 /    |  /  4   \/   /
+     \    |/        2   /
+      \   6            /
+       \           11 /
+        \__________/\/
+        9        01  0
+   \endverbatim
  */
 TEST_F(ConvexHullFinderTest, nested_concavity)
 {
-    VecReal2 p{{0.001, 0.001},
-               {-0.3, 1},
-               {0.15, 0.5},
-               {0.4, 0.7},
-               {0.45, 0.6},
-               {0.5, 0.7},
-               {0.8, 0.4},
-               {0.9, 1.2},
-               {1.2, 0.5},
-               {1, 0},
-               {0.1, 0},
-               {0.05, 0.01}};
+    VecReal2 p{{-0.001, 0.001},
+               {0.3, 1},
+               {-0.15, 0.5},
+               {-0.4, 0.7},
+               {-0.45, 0.6},
+               {-0.5, 0.7},
+               {-0.8, 0.4},
+               {-0.9, 1.2},
+               {-1.2, 0.5},
+               {-1, 0},
+               {-0.1, 0},
+               {-0.05, 0.01}};
 
     // Test level 0
     CHF chf0(p, t);


### PR DESCRIPTION
This MR changes recent additions to ORANGE to use polygons specified in Geant4's clockwise order to instead use counterclockwise order, which is standard within in the computational geometry community. Polygons arriving from Geant 4 have their points reversed accoringly.