### PR TITLE
Add volume params visitor

### DIFF
--- a/src/celeritas/user/detail/StepParams.cc
+++ b/src/celeritas/user/detail/StepParams.cc
@@ -113,6 +113,8 @@ StepParams::StepParams(AuxId aux_id,
         if (selection.points[StepPoint::pre].volume_instance_ids
             || selection.points[StepPoint::post].volume_instance_ids)
         {
+            // TODO: replace with volume params, so we can use touchable
+            // representation
             host_data.volume_instance_depth = geo.max_depth();
             CELER_VALIDATE(host_data.volume_instance_depth > 0,
                            << "geometry type does not support volume "

--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND SOURCES
   GeoVolumeFinder.cc
   SurfaceParams.cc
   VolumeParams.cc
+  VolumeToString.cc
   detail/SurfaceParamsBuilder.cc
   rasterize/Color.cc
   rasterize/Image.cc

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -598,6 +598,7 @@ inp::Model GeantGeoParams::make_model_input() const
         // Get volumes from Geant4 geometry
         result.volumes = make_inp_volumes(*this);
         result.volume_instances = make_inp_volume_instances(*this);
+        result.world = this->geant_to_id(*(this->world()->GetLogicalVolume()));
 
         return result;
     }();

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -52,21 +52,6 @@ namespace celeritas
 {
 namespace
 {
-
-//---------------------------------------------------------------------------//
-LevelId::size_type get_max_depth(G4VPhysicalVolume const& world)
-{
-    LevelId::size_type result{0};
-    visit_volume_instances(
-        [&result](G4VPhysicalVolume const*, int level) {
-            result = max(level, static_cast<int>(result));
-            return true;
-        },
-        &world);
-    // Maximum "depth" is one greater than "highest level"
-    return result + 1;
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Get a reproducible vector of LV instance ID -> label from the given world.
@@ -812,7 +797,6 @@ void GeantGeoParams::build_metadata()
         "volume instance",
         make_physical_vol_labels(*this->world(), this->pv_offset())};
     surfaces_ = make_surface_vec(*this);
-    max_depth_ = get_max_depth(*this->world());
 
     auto clhep_bbox = this->get_clhep_bbox();
     bbox_ = {convert_from_geant(clhep_bbox.lower().data(), clhep_length),

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -52,6 +52,21 @@ namespace celeritas
 {
 namespace
 {
+
+//---------------------------------------------------------------------------//
+LevelId::size_type get_max_depth(G4VPhysicalVolume const& world)
+{
+    LevelId::size_type result{0};
+    visit_volume_instances(
+        [&result](G4VPhysicalVolume const*, int level) {
+            result = max(level, static_cast<int>(result));
+            return true;
+        },
+        &world);
+    // Maximum "depth" is one greater than "highest level"
+    return result + 1;
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Get a reproducible vector of LV instance ID -> label from the given world.
@@ -797,6 +812,7 @@ void GeantGeoParams::build_metadata()
         "volume instance",
         make_physical_vol_labels(*this->world(), this->pv_offset())};
     surfaces_ = make_surface_vec(*this);
+    max_depth_ = get_max_depth(*this->world());
 
     auto clhep_bbox = this->get_clhep_bbox();
     bbox_ = {convert_from_geant(clhep_bbox.lower().data(), clhep_length),

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -58,11 +58,11 @@ LevelId::size_type get_max_depth(G4VPhysicalVolume const& world)
 {
     LevelId::size_type result{0};
     visit_volume_instances(
-        [&result](G4VPhysicalVolume const&, int level) {
+        [&result](G4VPhysicalVolume const*, int level) {
             result = max(level, static_cast<int>(result));
             return true;
         },
-        world);
+        &world);
     // Maximum "depth" is one greater than "highest level"
     return result + 1;
 }
@@ -77,18 +77,19 @@ std::vector<Label> make_logical_vol_labels(G4VPhysicalVolume const& world,
     std::unordered_map<std::string, std::vector<G4LogicalVolume const*>> names;
 
     visit_volumes(
-        [&](G4LogicalVolume const& lv) {
-            std::string name = lv.GetName();
+        [&](G4LogicalVolume const* lv) {
+            CELER_EXPECT(lv);
+            std::string name = lv->GetName();
             if (name.empty())
             {
-                CELER_LOG(debug)
-                    << "Empty name for reachable LV id=" << lv.GetInstanceID();
+                CELER_LOG(debug) << "Empty name for reachable LV id="
+                                 << lv->GetInstanceID();
                 name = "[UNTITLED]";
             }
             // Add to name map
-            names[std::move(name)].push_back(&lv);
+            names[std::move(name)].push_back(lv);
         },
-        world);
+        &world);
 
     return detail::make_label_vector<G4LogicalVolume const*>(
         std::move(names), [offset](G4LogicalVolume const* lv) {
@@ -109,8 +110,9 @@ std::vector<Label> make_physical_vol_labels(G4VPhysicalVolume const& world,
     // Visit PVs, mapping names to instances, skipping those that have already
     // been visited at a deeper level
     visit_volume_instances(
-        [&](G4VPhysicalVolume const& pv, int depth) {
-            auto&& [iter, inserted] = max_depth.insert({&pv, depth});
+        [&](G4VPhysicalVolume const* pv, int depth) {
+            CELER_EXPECT(pv);
+            auto&& [iter, inserted] = max_depth.insert({pv, depth});
             if (!inserted)
             {
                 if (iter->second >= depth)
@@ -123,11 +125,11 @@ std::vector<Label> make_physical_vol_labels(G4VPhysicalVolume const& world,
             }
 
             // Add to name map
-            names[pv.GetName()].push_back(&pv);
+            names[pv->GetName()].push_back(pv);
             // Visit daughters
             return true;
         },
-        world);
+        &world);
 
     return detail::make_label_vector<G4VPhysicalVolume const*>(
         std::move(names), [offset](G4VPhysicalVolume const* pv) {

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -92,9 +92,6 @@ class GeantGeoParams final : public GeoParamsInterface,
     //! Outer bounding box of geometry
     BBox const& bbox() const final { return bbox_; }
 
-    // Maximum nested scene/volume depth
-    LevelId::size_type max_depth() const final { return max_depth_; }
-
     // Create model parameters corresponding to our internal representation
     inp::Model make_model_input() const final;
 
@@ -183,7 +180,6 @@ class GeantGeoParams final : public GeoParamsInterface,
     VolInstanceMap vol_instances_;
     std::vector<G4LogicalSurface const*> surfaces_;
     BBox bbox_;
-    LevelId::size_type max_depth_{0};
 
     // Storage
     HostRef data_;

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -92,6 +92,9 @@ class GeantGeoParams final : public GeoParamsInterface,
     //! Outer bounding box of geometry
     BBox const& bbox() const final { return bbox_; }
 
+    // Maximum nested scene/volume depth
+    LevelId::size_type max_depth() const { return max_depth_; }
+
     // Create model parameters corresponding to our internal representation
     inp::Model make_model_input() const final;
 
@@ -180,6 +183,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     VolInstanceMap vol_instances_;
     std::vector<G4LogicalSurface const*> surfaces_;
     BBox bbox_;
+    LevelId::size_type max_depth_{0};
 
     // Storage
     HostRef data_;

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -78,10 +78,6 @@ class GeoParamsInterface
     //! Outer bounding box of geometry
     virtual BBox const& bbox() const = 0;
 
-    //! Maximum nested volume instance depth
-    //! \todo move to VolumeParams
-    virtual LevelId::size_type max_depth() const = 0;
-
     // Create model parameters corresponding to our internal representation
     virtual inp::Model make_model_input() const = 0;
 

--- a/src/geocel/GeoParamsOutput.cc
+++ b/src/geocel/GeoParamsOutput.cc
@@ -42,9 +42,9 @@ void GeoParamsOutput::output(JsonPimpl* j) const
 
     obj["supports_safety"] = geo_->supports_safety();
     obj["bbox"] = geo_->bbox();
-    obj["max_depth"] = geo_->max_depth();
 
     // Save volume names
+    // TODO: move to volume params output?
     {
         auto label = json::array();
 

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -65,6 +65,12 @@ class VolumeParams
     //! Empty if no volumes are present (e.g., ORANGE debugging)
     bool empty() const { return v_labels_.empty(); }
 
+    //! World volume
+    VolumeId world() const { return world_; }
+
+    //! Depth of the volume DAG (a world without children is depth zero)
+    LevelId::size_type depth() const { return depth_; }
+
     //! Number of volumes
     VolumeId::size_type num_volumes() const { return v_labels_.size(); }
 
@@ -95,6 +101,9 @@ class VolumeParams
   private:
     VolumeMap v_labels_;
     VolInstMap vi_labels_;
+
+    VolumeId world_;
+    size_type depth_{};
 
     std::vector<std::vector<VolumeInstanceId>> parents_;
     std::vector<std::vector<VolumeInstanceId>> children_;

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -46,6 +46,13 @@ class VolumeParams
     //! \name Type aliases
     using VolumeMap = LabelIdMultiMap<VolumeId>;
     using VolInstMap = LabelIdMultiMap<VolumeInstanceId>;
+    using SpanVolInst = Span<VolumeInstanceId const>;
+    //!@}
+
+    //!@{
+    //! \name VolumeVisitor template interface
+    using VolumeRef = VolumeId;
+    using VolumeInstanceRef = VolumeInstanceId;
     //!@}
 
   public:
@@ -74,10 +81,10 @@ class VolumeParams
     VolInstMap const& volume_instance_labels() const { return vi_labels_; }
 
     // Find all instances of a volume (incoming edges)
-    inline Span<VolumeInstanceId const> parents(VolumeId v_id) const;
+    inline SpanVolInst parents(VolumeId v_id) const;
 
     // Get the list of daughter volumes (outgoing edges)
-    inline Span<VolumeInstanceId const> children(VolumeId v_id) const;
+    inline SpanVolInst children(VolumeId v_id) const;
 
     // Get the geometry material of a volume
     inline GeoMatId material(VolumeId v_id) const;
@@ -101,7 +108,7 @@ class VolumeParams
 /*!
  * Find all instances of a volume (incoming edges).
  */
-Span<VolumeInstanceId const> VolumeParams::parents(VolumeId v_id) const
+auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
 {
     CELER_EXPECT(v_id < parents_.size());
     return make_span(parents_[v_id.unchecked_get()]);
@@ -111,7 +118,7 @@ Span<VolumeInstanceId const> VolumeParams::parents(VolumeId v_id) const
 /*!
  * Get the list of daughter volumes (outgoing edges).
  */
-Span<VolumeInstanceId const> VolumeParams::children(VolumeId v_id) const
+auto VolumeParams::children(VolumeId v_id) const -> SpanVolInst
 {
     CELER_EXPECT(v_id < children_.size());
     return make_span(children_[v_id.unchecked_get()]);

--- a/src/geocel/VolumeToString.cc
+++ b/src/geocel/VolumeToString.cc
@@ -1,0 +1,53 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/VolumeToString.cc
+//---------------------------------------------------------------------------//
+#include "VolumeToString.hh"
+
+#include "VolumeParams.hh"
+
+namespace celeritas
+{
+/*!
+ * Convert Label to string.
+ */
+std::string VolumeToString::operator()(Label const& label) const
+{
+    return to_string(label);
+}
+
+/*!
+ * Convert VolumeId to string.
+ */
+std::string VolumeToString::operator()(VolumeId const& id) const
+{
+    if (!id)
+        return "<null>";
+
+    if (params_)
+    {
+        return to_string(params_->volume_labels().at(id));
+    }
+
+    return "v " + std::to_string(id.get());
+}
+
+/*!
+ * Convert VolumeInstanceId to string.
+ */
+std::string VolumeToString::operator()(VolumeInstanceId const& id) const
+{
+    if (!id)
+        return "<null>";
+
+    if (params_)
+    {
+        return to_string(params_->volume_instance_labels().at(id));
+    }
+
+    return "vi " + std::to_string(id.get());
+}
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/VolumeToString.hh
+++ b/src/geocel/VolumeToString.hh
@@ -1,0 +1,63 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/VolumeToString.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include "corecel/io/Label.hh"
+
+#include "Types.hh"
+
+namespace celeritas
+{
+class VolumeParams;
+//---------------------------------------------------------------------------//
+/*!
+ * Visitor class that converts volume-related types to string representations.
+ *
+ * This class can be used with std::visit to convert variant types to strings.
+ * When constructed with VolumeParams reference, it will look up labels for
+ * IDs; otherwise it will print just the ID value or a null indicator.
+ */
+class VolumeToString
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VariantLabel
+        = std::variant<Label, VolumeId, VolumeInstanceId, std::string>;
+    //!@}
+
+  public:
+    // Construct without any labels
+    VolumeToString() = default;
+
+    // Construct with volume params reference
+    inline explicit VolumeToString(VolumeParams const& params);
+
+    // Overloaded operators for different types
+    std::string operator()(Label const& label) const;
+    std::string operator()(VolumeId const& id) const;
+    std::string operator()(VolumeInstanceId const& id) const;
+
+  private:
+    VolumeParams const* params_{nullptr};
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with volume params reference.
+ */
+VolumeToString::VolumeToString(VolumeParams const& params) : params_(&params)
+{
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/VolumeVisitor.hh
+++ b/src/geocel/VolumeVisitor.hh
@@ -47,7 +47,8 @@ class VolumeAccessorInterface
 
 //---------------------------------------------------------------------------//
 /*!
- * Recursively walk through all unique volume instances.
+ * Recursively walk through all unique volumes/instances.
+ *
  * \tparam VA Helper class with the same signature as VolumeAccessor above.
  *
  * This class can be used for both Geant4 and VecGeom to give the same visiting
@@ -55,10 +56,11 @@ class VolumeAccessorInterface
  * as \c VolumeAccessor above.
  *
  * The visitor function must have the signature
- * <code>bool(*)(VolumeInstanceRef, int)</code>
+ * <code>bool(*)(Ref, int)</code>
  * where the return value indicates whether the volume's children should be
- * visited, and the integer is the depth of the volume being visited (world has
- * depth zero).
+ * visited, \c Ref is either VolumeRef or \c VolumeInstanceRef , and the
+ * integer is the depth of the volume being visited (the top element has depth
+ * zero).
  *
  * By default this will visit all unique instances, i.e. every path in the
  * graph (the entire "touchable" hierarchy): this may be
@@ -67,118 +69,172 @@ class VolumeAccessorInterface
  * from the visitor to terminate the search path.
  */
 template<class VA>
-class VolumeInstanceVisitor
-{
-  public:
-    using VolumeInstanceRef = typename VA::VolumeInstanceRef;
-
-    //! Construct from accessor for obtaining volumes
-    explicit VolumeInstanceVisitor(VA va) : accessor_(std::forward<VA>(va)) {}
-
-    // Visit and return whether to continue visiting
-    template<class F>
-    inline void operator()(F&& visit, VolumeInstanceRef world);
-
-  private:
-    VA accessor_;
-
-    struct QueuedVolume
-    {
-        VolumeInstanceRef vi{};
-        int depth{0};
-    };
-};
-
-//---------------------------------------------------------------------------//
-/*!
- * Recursively visit volume instances.
- */
-template<class VA>
 class VolumeVisitor
 {
   public:
     using VolumeRef = typename VA::VolumeRef;
     using VolumeInstanceRef = typename VA::VolumeInstanceRef;
 
-    //! Construct from accessor for obtaining children
+    //! Construct from accessor for obtaining volumes
     explicit VolumeVisitor(VA va) : accessor_(std::forward<VA>(va)) {}
 
-    // Apply this visitor
+    // Visit a volume
+    template<class F>
+    inline void operator()(F&& visit, VolumeRef top);
+
+    // Visit a volume instance
     template<class F>
     inline void operator()(F&& visit, VolumeInstanceRef top);
 
   private:
+    //// TYPES ////
+
+    struct QueuedVolume
+    {
+        VolumeInstanceRef vi;
+        int depth;
+    };
+
+    //// DATA ////
+
     VA accessor_;
+    std::vector<QueuedVolume> queue_;
+
+    //// HELPERS ////
+
+    inline void add_children(VolumeInstanceRef vol, int depth);
+    inline void add_children(VolumeRef vol, int depth);
 };
+
+//---------------------------------------------------------------------------//
+/*!
+ * Visit the first volume/instance encountered, once, depth-first.
+ *
+ * \tparam T VolumeRef or VolumeInstanceRef
+ * \tparam F Visitor function \c void(*)(Vol)
+ */
+template<class T, class F>
+class VisitVolumeOnce
+{
+  public:
+    //! Construct with volume/depth visitor
+    VisitVolumeOnce(F&& visit) : visit_impl_(std::forward<F>(visit)) {}
+
+    //! Visit a single volume
+    bool operator()(T v, int)
+    {
+        if (!visited_.insert(v).second)
+        {
+            // Already visited
+            return false;
+        }
+        visit_impl_(v);
+        return true;
+    }
+
+  private:
+    F visit_impl_;
+    std::unordered_set<T> visited_;
+};
+
+//! Return a wrapper for a visitor function to make the visit unique
+template<class T, class F>
+auto make_visit_volume_once(F&& visit)
+{
+    return VisitVolumeOnce<T, F>{std::forward<F>(visit)};
+}
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Apply the given visitor to the volume instance.
+ * Visit all volume instance paths, depth-first.
  *
- * Future work: we could keep full paths instead of just the depth if we
- * wanted.
+ * Future work: we could keep and return full paths instead of just the depth
+ * if we wanted.
  */
 template<class VA>
 template<class F>
-void VolumeInstanceVisitor<VA>::operator()(F&& visit, VolumeInstanceRef world)
+void VolumeVisitor<VA>::operator()(F&& visit, VolumeInstanceRef top)
 {
-    std::vector<QueuedVolume> queue;
-    std::vector<VolumeInstanceRef> temp_children;
-    auto visit_impl = [&](VolumeInstanceRef vi, int depth) {
-        if (visit(vi, depth))
-        {
-            auto&& children = accessor_.children(accessor_.volume(vi));
-            // Append children in *reverse* order since we pop back
-            auto const rend = std::reverse_iterator(children.begin());
-            for (auto iter = std::reverse_iterator(children.end());
-                 iter != rend;
-                 ++iter)
-            {
-                queue.push_back({*iter, depth + 1});
-            }
-        }
-    };
+    // Add the top volume to the queue
+    queue_ = {{top, 0}};
 
-    // Visit the top-level physical volume
-    visit_impl(world, 0);
-
-    while (!queue.empty())
+    // Visit remaining children instances
+    while (!queue_.empty())
     {
-        QueuedVolume qv = queue.back();
-        queue.pop_back();
+        // Pop volume off the queue
+        QueuedVolume qv = queue_.back();
+        queue_.pop_back();
 
-        // Visit popped daughter
-        visit_impl(qv.vi, qv.depth);
+        if (visit(qv.vi, qv.depth))
+        {
+            this->add_children(qv.vi, qv.depth);
+        }
     }
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Visit all logical volumes, once, depth-first.
+ * Visit all volume instance paths, depth-first.
+ *
+ * Future work: we could keep and return full paths instead of just the depth
+ * if we wanted.
  */
 template<class VA>
 template<class F>
-void VolumeVisitor<VA>::operator()(F&& visit_vol, VolumeInstanceRef world)
+void VolumeVisitor<VA>::operator()(F&& visit, VolumeRef top)
 {
-    // Keep track of visited volumes
-    std::unordered_set<VolumeRef> visited;
-    // Convert volume instances to volumes, and
-    auto visitor = [&](VolumeInstanceRef vi, int) -> bool {
-        auto vol = accessor_.volume(vi);
-        if (!visited.insert(vol).second)
+    auto visit_impl = [this, &visit](VolumeRef v, int depth) {
+        if (visit(v, depth))
         {
-            // Already visited
-            return false;
+            this->add_children(v, depth);
         }
-        // Call user-supplied function and continue visiting children
-        visit_vol(vol);
-        return true;
     };
 
-    VolumeInstanceVisitor visit_vol_inst{accessor_};
-    visit_vol_inst(visitor, world);
+    // Visit top and add children
+    visit_impl(top, 0);
+
+    // Visit remaining children instances
+    while (!queue_.empty())
+    {
+        // Pop volume off the queue
+        QueuedVolume qv = queue_.back();
+        queue_.pop_back();
+
+        visit_impl(accessor_.volume(qv.vi), qv.depth);
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add child instances from the current volume to the queue.
+ *
+ * \arg depth Depth of the given volume
+ */
+template<class VA>
+void VolumeVisitor<VA>::add_children(VolumeInstanceRef vi, int depth)
+{
+    return this->add_children(accessor_.volume(vi), depth);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Add child instances from the current to the queue.
+ *
+ * \arg depth Depth of the given volume
+ */
+template<class VA>
+void VolumeVisitor<VA>::add_children(VolumeRef vol, int depth)
+{
+    auto&& children = accessor_.children(vol);
+    // Append children in *reverse* order since we pop back
+    auto const rend = std::reverse_iterator(children.begin());
+    for (auto iter = std::reverse_iterator(children.end()); iter != rend;
+         ++iter)
+    {
+        queue_.push_back({*iter, depth + 1});
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/VolumeVisitor.hh
+++ b/src/geocel/VolumeVisitor.hh
@@ -12,84 +12,119 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-//! Traits class to access children and associated logical volume
-template<class PV>
-struct VolumeVisitorTraits
+/*!
+ * Interface for accessing the volume graph.
+ * \tparam V Lightweight volume reference
+ * \tparam VI Lightweight volume instance reference
+ */
+template<class V, class VI>
+class VolumeAccessorInterface
 {
-    using LV = void;
+  public:
+    //! A lightweight identifier for a volume: OpaqueId or pointer
+    using VolumeRef = V;
+    //! A lightweight identifier for a volume instance
+    using VolumeInstanceRef = VI;
+    //! Result vector
+    using VecVolInstRef = std::vector<VolumeInstanceRef>;
 
-    static void get_children(PV const& parent, std::vector<PV const*>& dst);
-    static LV get_lv(PV const& pv);
+  public:
+    //! Outgoing volume node from an instance
+    virtual VolumeRef volume(VolumeInstanceRef parent) = 0;
+    //! Outgoing instance nodes from a volume
+    virtual VecVolInstRef children(VolumeRef parent) = 0;
+
+  protected:
+    ~VolumeAccessorInterface() = default;
 };
 
 //---------------------------------------------------------------------------//
 /*!
- * Recursively visit volumes.
- * \tparam T Volume type
+ * Recursively walk through all unique volume instances.
+ * \tparam VA Helper class with the same signature as VolumeAccessor above.
  *
  * This class can be used for both Geant4 and VecGeom to give the same visiting
- * behavior across the two.
+ * behavior across the two. The volume accessor should have the same signature
+ * as \c VolumeAccessor above.
  *
- * The function must have the signature
- * <code>bool(*)(T const&, int)</code>
+ * The visitor function must have the signature
+ * <code>bool(*)(VolumeInstanceRef, int)</code>
  * where the return value indicates whether the volume's children should be
  * visited, and the integer is the depth of the volume being visited.
  *
- * By default this will visit the entire "touchable" hierarchy: this may be
+ * By default this will visit all unique instances, i.e. every path in the
+ * graph (the entire "touchable" hierarchy): this may be
  * very expensive! If it's desired to only visit single physical volumes, mark
- * them as visited using a set (see unit test for example).
+ * them as visited using a set (see unit test for example) and return \c false
+ * from the visitor to terminate the search path.
  */
-template<class T>
-class VolumeVisitor
+template<class VA>
+class VolumeInstanceVisitor
 {
   public:
-    //! Construct from top-level volume
-    explicit VolumeVisitor(T const& world) : world_{world} {}
+    using VolumeInstanceRef = typename VA::VolumeInstanceRef;
 
-    // Apply this visitor
+    //! Construct from accessor for obtaining volumes
+    explicit VolumeInstanceVisitor(VA va) : accessor_(std::forward<VA>(va)) {}
+
+    // Visit and return whether to continue visiting
     template<class F>
-    inline void operator()(F&& visit);
+    inline void operator()(F&& visit, VolumeInstanceRef world);
 
   private:
-    T const& world_;
+    VA accessor_;
 
     struct QueuedVolume
     {
-        T const* pv{nullptr};
+        VolumeInstanceRef vi{};
         int depth{0};
     };
 };
 
 //---------------------------------------------------------------------------//
+/*!
+ * Recursively visit volume instances.
+ */
+template<class VA>
+class VolumeVisitor
+{
+  public:
+    using VolumeRef = typename VA::VolumeRef;
+    using VolumeInstanceRef = typename VA::VolumeInstanceRef;
 
-// Visit all logical volumes
-template<class F, class T>
-inline void visit_logical_volumes(F&& vis, T const& parent_vol);
+    //! Construct from accessor for obtaining children
+    explicit VolumeVisitor(VA va) : accessor_(std::forward<VA>(va)) {}
+
+    // Apply this visitor
+    template<class F>
+    inline void operator()(F&& visit, VolumeInstanceRef top);
+
+  private:
+    VA accessor_;
+};
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Apply this visitor.
+ * Apply the given visitor to the volume instance.
+ *
+ * Future work: we could keep full paths instead of just the depth if we
+ * wanted.
  */
-template<class T>
+template<class VA>
 template<class F>
-void VolumeVisitor<T>::operator()(F&& visit)
+void VolumeInstanceVisitor<VA>::operator()(F&& visit, VolumeInstanceRef world)
 {
-    using TraitsT = VolumeVisitorTraits<T>;
-
     std::vector<QueuedVolume> queue;
-    std::vector<T const*> temp_children;
-    auto visit_impl = [&](T const& pv, int depth) {
-        if (visit(pv, depth))
+    std::vector<VolumeInstanceRef> temp_children;
+    auto visit_impl = [&](VolumeInstanceRef vi, int depth) {
+        if (visit(vi, depth))
         {
-            temp_children.clear();
-            TraitsT::get_children(pv, temp_children);
-
-            // Append children in reverse order since we pop back
-            for (auto iter = temp_children.rbegin();
-                 iter != temp_children.rend();
-                 ++iter)
+            auto vol = accessor_.volume(vi);
+            auto&& children = accessor_.children(vol);
+            // Append children in *reverse* order since we pop back
+            for (auto iter = children.rbegin(); iter != children.rend(); ++iter)
             {
                 queue.push_back({*iter, depth + 1});
             }
@@ -97,7 +132,7 @@ void VolumeVisitor<T>::operator()(F&& visit)
     };
 
     // Visit the top-level physical volume
-    visit_impl(world_, 0);
+    visit_impl(world, 0);
 
     while (!queue.empty())
     {
@@ -105,7 +140,7 @@ void VolumeVisitor<T>::operator()(F&& visit)
         queue.pop_back();
 
         // Visit popped daughter
-        visit_impl(*qv.pv, qv.depth);
+        visit_impl(qv.vi, qv.depth);
     }
 }
 
@@ -113,25 +148,27 @@ void VolumeVisitor<T>::operator()(F&& visit)
 /*!
  * Visit all logical volumes, once, depth-first.
  */
-template<class F, class T>
-inline void visit_logical_volumes(F&& vis, T const& parent_vol)
+template<class VA>
+template<class F>
+void VolumeVisitor<VA>::operator()(F&& visit_vol, VolumeInstanceRef world)
 {
-    using TraitsT = VolumeVisitorTraits<T>;
-    using LV = typename TraitsT::LV;
-
-    VolumeVisitor visit_impl{parent_vol};
-
-    std::unordered_set<LV const*> visited;
-    visit_impl([&vis, &visited](T const& pv, int) -> bool {
-        auto const& lv = TraitsT::get_lv(pv);
-        if (!visited.insert(&lv).second)
+    // Keep track of visited volumes
+    std::unordered_set<VolumeRef> visited;
+    // Convert volume instances to volumes, and
+    auto visitor = [&](VolumeInstanceRef vi, int) -> bool {
+        auto vol = accessor_.volume(vi);
+        if (!visited.insert(vol).second)
         {
             // Already visited
             return false;
         }
-        vis(lv);
+        // Call user-supplied function and continue visiting children
+        visit_vol(vol);
         return true;
-    });
+    };
+
+    VolumeInstanceVisitor visit_vol_inst{accessor_};
+    visit_vol_inst(visitor, world);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/VolumeVisitor.hh
+++ b/src/geocel/VolumeVisitor.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <iterator>
 #include <unordered_set>
 #include <vector>
 
@@ -14,10 +15,16 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Interface for accessing the volume graph.
+ *
  * \tparam V Lightweight volume reference
  * \tparam VI Lightweight volume instance reference
+ * \tparam CVI Container of volume instance references
+ *
+ * Note that this helper class is a template interface specification, not a
+ * required base class. Providing the type aliases and member functions is all
+ * that's needed.
  */
-template<class V, class VI>
+template<class V, class VI, class CVI = std::vector<VI>>
 class VolumeAccessorInterface
 {
   public:
@@ -25,14 +32,14 @@ class VolumeAccessorInterface
     using VolumeRef = V;
     //! A lightweight identifier for a volume instance
     using VolumeInstanceRef = VI;
-    //! Result vector
-    using VecVolInstRef = std::vector<VolumeInstanceRef>;
+    //! Container of child volume instances
+    using ContainerVolInstRef = CVI;
 
   public:
     //! Outgoing volume node from an instance
     virtual VolumeRef volume(VolumeInstanceRef parent) = 0;
     //! Outgoing instance nodes from a volume
-    virtual VecVolInstRef children(VolumeRef parent) = 0;
+    virtual ContainerVolInstRef children(VolumeRef parent) = 0;
 
   protected:
     ~VolumeAccessorInterface() = default;
@@ -50,7 +57,8 @@ class VolumeAccessorInterface
  * The visitor function must have the signature
  * <code>bool(*)(VolumeInstanceRef, int)</code>
  * where the return value indicates whether the volume's children should be
- * visited, and the integer is the depth of the volume being visited.
+ * visited, and the integer is the depth of the volume being visited (world has
+ * depth zero).
  *
  * By default this will visit all unique instances, i.e. every path in the
  * graph (the entire "touchable" hierarchy): this may be
@@ -121,10 +129,12 @@ void VolumeInstanceVisitor<VA>::operator()(F&& visit, VolumeInstanceRef world)
     auto visit_impl = [&](VolumeInstanceRef vi, int depth) {
         if (visit(vi, depth))
         {
-            auto vol = accessor_.volume(vi);
-            auto&& children = accessor_.children(vol);
+            auto&& children = accessor_.children(accessor_.volume(vi));
             // Append children in *reverse* order since we pop back
-            for (auto iter = children.rbegin(); iter != children.rend(); ++iter)
+            auto const rend = std::reverse_iterator(children.begin());
+            for (auto iter = std::reverse_iterator(children.end());
+                 iter != rend;
+                 ++iter)
             {
                 queue.push_back({*iter, depth + 1});
             }

--- a/src/geocel/g4/VisitVolumes.hh
+++ b/src/geocel/g4/VisitVolumes.hh
@@ -31,7 +31,7 @@ class GeantVolumeAccessor final
         return result;
     }
 
-    //! Outgoing instance nodes from a volume
+    //! Outgoing instance edges from a volume
     ContainerVolInstRef children(VolumeRef parent) final
     {
         CELER_EXPECT(parent);

--- a/src/geocel/g4/VisitVolumes.hh
+++ b/src/geocel/g4/VisitVolumes.hh
@@ -32,10 +32,10 @@ class GeantVolumeAccessor final
     }
 
     //! Outgoing instance nodes from a volume
-    VecVolInstRef children(VolumeRef parent) final
+    ContainerVolInstRef children(VolumeRef parent) final
     {
         CELER_EXPECT(parent);
-        VecVolInstRef result;
+        ContainerVolInstRef result;
         for (auto i : range(parent->GetNoDaughters()))
         {
             result.push_back(parent->GetDaughter(i));

--- a/src/geocel/g4/VisitVolumes.hh
+++ b/src/geocel/g4/VisitVolumes.hh
@@ -17,22 +17,30 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-template<>
-struct VolumeVisitorTraits<G4VPhysicalVolume>
+class GeantVolumeAccessor final
+    : public VolumeAccessorInterface<G4LogicalVolume const*,
+                                     G4VPhysicalVolume const*>
 {
-    using PV = G4VPhysicalVolume;
-    using LV = G4LogicalVolume;
-
-    static LV const& get_lv(PV const& pv) { return *pv.GetLogicalVolume(); }
-
-    static void get_children(PV const& parent, std::vector<PV const*>& dst)
+  public:
+    //! Outgoing volume node from an instance
+    VolumeRef volume(VolumeInstanceRef parent) final
     {
-        LV const& lv = get_lv(parent);
-        auto num_children = lv.GetNoDaughters();
-        for (auto i : range(num_children))
+        CELER_EXPECT(parent);
+        auto result = parent->GetLogicalVolume();
+        CELER_ENSURE(result);
+        return result;
+    }
+
+    //! Outgoing instance nodes from a volume
+    VecVolInstRef children(VolumeRef parent) final
+    {
+        CELER_EXPECT(parent);
+        VecVolInstRef result;
+        for (auto i : range(parent->GetNoDaughters()))
         {
-            dst.push_back(lv.GetDaughter(i));
+            result.push_back(parent->GetDaughter(i));
         }
+        return result;
     }
 };
 
@@ -41,7 +49,7 @@ struct VolumeVisitorTraits<G4VPhysicalVolume>
  * Perform a depth-first traversal of physical volumes.
  *
  * The function must have the signature
- * <code>bool(*)(G4VPhysicalVolume const&, int)</code>
+ * <code>bool(*)(G4VPhysicalVolume const*, int)</code>
  * where the return value indicates whether the volume's children should be
  * visited, and the integer is the depth of the volume being visited.
  *
@@ -50,26 +58,30 @@ struct VolumeVisitorTraits<G4VPhysicalVolume>
  * them as visited using a set.
  */
 template<class F>
-void visit_volume_instances(F&& visit, G4VPhysicalVolume const& world)
+void visit_volume_instances(F&& vis, G4VPhysicalVolume const* world)
 {
+    CELER_EXPECT(world);
     ScopedProfiling profile_this{"visit-geant-volume-instance"};
-    VolumeVisitor{world}(std::forward<F>(visit));
+    VolumeInstanceVisitor visit_vol{GeantVolumeAccessor{}};
+    visit_vol(std::forward<F>(vis), world);
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Perform a depth-first listing of Geant4 logical volumes.
+ * Perform a depth-first traversal of Geant4 logical volumes.
  *
  * This will visit each volume exactly once based on when it's encountered in
  * the hierarchy. The visitor function F should have the signature
- * \code void(*)(G4LogicalVolume const&) \endcode .
+ * \code void(*)(G4LogicalVolume const*) \endcode .
  */
 template<class F>
-void visit_volumes(F&& vis, G4VPhysicalVolume const& parent_vol)
+void visit_volumes(F&& vis, G4VPhysicalVolume const* world)
 {
+    CELER_EXPECT(world);
     ScopedProfiling profile_this{"visit-geant-volume"};
 
-    visit_logical_volumes(std::forward<F>(vis), parent_vol);
+    VolumeVisitor visit_vol{GeantVolumeAccessor{}};
+    visit_vol(std::forward<F>(vis), world);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/g4/VisitVolumes.hh
+++ b/src/geocel/g4/VisitVolumes.hh
@@ -57,13 +57,13 @@ class GeantVolumeAccessor final
  * very expensive! If it's desired to only visit single physical volumes, mark
  * them as visited using a set.
  */
-template<class F>
-void visit_volume_instances(F&& vis, G4VPhysicalVolume const* world)
+template<class Visitor>
+void visit_volume_instances(Visitor&& vis, G4VPhysicalVolume const* world)
 {
     CELER_EXPECT(world);
     ScopedProfiling profile_this{"visit-geant-volume-instance"};
-    VolumeInstanceVisitor visit_vol{GeantVolumeAccessor{}};
-    visit_vol(std::forward<F>(vis), world);
+    VolumeVisitor visit_vol{GeantVolumeAccessor{}};
+    visit_vol(std::forward<Visitor>(vis), world);
 }
 
 //---------------------------------------------------------------------------//
@@ -71,17 +71,19 @@ void visit_volume_instances(F&& vis, G4VPhysicalVolume const* world)
  * Perform a depth-first traversal of Geant4 logical volumes.
  *
  * This will visit each volume exactly once based on when it's encountered in
- * the hierarchy. The visitor function F should have the signature
+ * the hierarchy. The visitor function Visitor should have the signature
  * \code void(*)(G4LogicalVolume const*) \endcode .
  */
-template<class F>
-void visit_volumes(F&& vis, G4VPhysicalVolume const* world)
+template<class Visitor>
+void visit_volumes(Visitor&& vis, G4VPhysicalVolume const* world)
 {
     CELER_EXPECT(world);
     ScopedProfiling profile_this{"visit-geant-volume"};
 
     VolumeVisitor visit_vol{GeantVolumeAccessor{}};
-    visit_vol(std::forward<F>(vis), world);
+    visit_vol(make_visit_volume_once<G4LogicalVolume const*>(
+                  std::forward<Visitor>(vis)),
+              world->GetLogicalVolume());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/inp/Model.hh
+++ b/src/geocel/inp/Model.hh
@@ -72,9 +72,11 @@ struct Volumes
     std::vector<Volume> volumes;
     //! Properties of edges in the graph (physical volumes)
     std::vector<VolumeInstance> volume_instances;
+    //! Root volume of the geometry graph
+    VolumeId world;
 
     //! True if at least one node is defined
-    explicit operator bool() const { return !volumes.empty(); }
+    explicit operator bool() const { return !volumes.empty() && world; }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -117,8 +117,9 @@ std::vector<Label> make_logical_vol_labels(vecgeom::VPlacedVolume const& world)
     using VolT = vecgeom::LogicalVolume;
     std::unordered_map<std::string, std::vector<VolT const*>> names;
     visit_volumes(
-        [&](VolT const& lv) {
-            std::string name{lv.GetLabel()};
+        [&](VolT const* lv) {
+            CELER_EXPECT(lv);
+            std::string name{lv->GetLabel()};
             if (starts_with(name, "[TEMP]"))
             {
                 // Temporary volume not directly used in transport, generated
@@ -134,9 +135,9 @@ std::vector<Label> make_logical_vol_labels(vecgeom::VPlacedVolume const& world)
             }
 
             // Add to name map
-            names[name].push_back(&lv);
+            names[name].push_back(lv);
         },
-        world);
+        &world);
 
     return detail::make_label_vector<VolT const*>(
         std::move(names), [](VolT const* vol) { return vol->id(); });
@@ -155,8 +156,8 @@ std::vector<Label> make_physical_vol_labels(vecgeom::VPlacedVolume const& world)
     // Visit PVs, mapping names to instances, skipping those that have already
     // been visited at a deeper level
     visit_volume_instances(
-        [&](VolT const& pv, int depth) {
-            auto&& [iter, inserted] = max_depth.insert({&pv, depth});
+        [&](VolT const* pv, int depth) {
+            auto&& [iter, inserted] = max_depth.insert({pv, depth});
             if (!inserted)
             {
                 if (iter->second >= depth)
@@ -168,7 +169,7 @@ std::vector<Label> make_physical_vol_labels(vecgeom::VPlacedVolume const& world)
                 iter->second = depth;
             }
 
-            std::string name = pv.GetLabel();
+            std::string name = pv->GetLabel();
             if (starts_with(name, "[TEMP]"))
             {
                 // Temporary volume not directly used in tracking
@@ -177,18 +178,18 @@ std::vector<Label> make_physical_vol_labels(vecgeom::VPlacedVolume const& world)
 
             if (ends_with(name, "_refl")
                 && vecgeom::ReflFactory::Instance().IsReflected(
-                    pv.GetLogicalVolume()))
+                    pv->GetLogicalVolume()))
             {
                 // Strip suffix for consistency with Geant4
                 name.erase(name.end() - 5, name.end());
             }
 
             // Add to name map
-            names[std::move(name)].push_back(&pv);
+            names[std::move(name)].push_back(pv);
             // Visit daughters
             return true;
         },
-        world);
+        &world);
 
     return detail::make_label_vector<VolT const*>(
         std::move(names), [](VolT const* vol) { return vol->id(); });

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -219,7 +219,7 @@ auto make_lv_map(std::vector<G4LogicalVolume const*> const& all_lv)
             // This shouldn't happen...
             CELER_LOG(warning)
                 << "Geant4 logical volume " << PrintableLV{iter->first}
-                << " maps to multiple volume IDs";
+                << " maps to multiple VecGeom volume IDs";
         }
     }
     return result;

--- a/src/geocel/vg/VecgeomParams.hh
+++ b/src/geocel/vg/VecgeomParams.hh
@@ -108,7 +108,7 @@ class VecgeomParams final : public GeoParamsInterface,
 
     //! Maximum nested geometry depth
     //! \todo move to VolumeParams
-    LevelId::size_type max_depth() const final { return host_ref_.max_depth; }
+    LevelId::size_type max_depth() const { return host_ref_.max_depth; }
 
     // Create model parameters corresponding to our internal representation
     inp::Model make_model_input() const final;

--- a/src/geocel/vg/VisitVolumes.hh
+++ b/src/geocel/vg/VisitVolumes.hh
@@ -32,10 +32,10 @@ class VecgeomVolumeAccessor final
     }
 
     //! Outgoing instance nodes from a volume
-    VecVolInstRef children(VolumeRef parent) final
+    ContainerVolInstRef children(VolumeRef parent) final
     {
         auto&& daughters = parent->GetDaughters();
-        return VecVolInstRef(daughters.begin(), daughters.end());
+        return ContainerVolInstRef(daughters.begin(), daughters.end());
     }
 };
 

--- a/src/geocel/vg/VisitVolumes.hh
+++ b/src/geocel/vg/VisitVolumes.hh
@@ -17,19 +17,26 @@
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-template<>
-struct VolumeVisitorTraits<vecgeom::VPlacedVolume>
+class VecgeomVolumeAccessor final
+    : public VolumeAccessorInterface<vecgeom::LogicalVolume const*,
+                                     vecgeom::VPlacedVolume const*>
 {
-    using PV = vecgeom::VPlacedVolume;
-    using LV = vecgeom::LogicalVolume;
-
-    static void get_children(PV const& parent, std::vector<PV const*>& dst)
+  public:
+    //! Outgoing volume node from an instance
+    VolumeRef volume(VolumeInstanceRef parent) final
     {
-        auto const& daughters = parent.GetDaughters();
-        dst.assign(daughters.begin(), daughters.end());
+        CELER_EXPECT(parent);
+        auto result = parent->GetLogicalVolume();
+        CELER_ENSURE(result);
+        return result;
     }
 
-    static LV const& get_lv(PV const& pv) { return *pv.GetLogicalVolume(); }
+    //! Outgoing instance nodes from a volume
+    VecVolInstRef children(VolumeRef parent) final
+    {
+        auto&& daughters = parent->GetDaughters();
+        return VecVolInstRef(daughters.begin(), daughters.end());
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -46,10 +53,11 @@ struct VolumeVisitorTraits<vecgeom::VPlacedVolume>
  * them as visited using a set.
  */
 template<class F>
-void visit_volume_instances(F&& visit, vecgeom::VPlacedVolume const& world)
+void visit_volume_instances(F&& vis, vecgeom::VPlacedVolume const* world)
 {
     ScopedProfiling profile_this{"visit-vecgeom-volume-instance"};
-    VolumeVisitor{world}(std::forward<F>(visit));
+    VolumeInstanceVisitor visit_vol{VecgeomVolumeAccessor{}};
+    visit_vol(std::forward<F>(vis), world);
 }
 
 //---------------------------------------------------------------------------//
@@ -61,11 +69,12 @@ void visit_volume_instances(F&& visit, vecgeom::VPlacedVolume const& world)
  * \code void(*)(G4LogicalVolume const&) \endcode .
  */
 template<class F>
-void visit_volumes(F&& vis, vecgeom::VPlacedVolume const& parent_vol)
+void visit_volumes(F&& vis, vecgeom::VPlacedVolume const* world)
 {
     ScopedProfiling profile_this{"visit-vecgeom-volume"};
 
-    visit_logical_volumes(std::forward<F>(vis), parent_vol);
+    VolumeVisitor visit_vol{VecgeomVolumeAccessor{}};
+    visit_vol(std::forward<F>(vis), world);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VisitVolumes.hh
+++ b/src/geocel/vg/VisitVolumes.hh
@@ -44,7 +44,7 @@ class VecgeomVolumeAccessor final
  * Perform a depth-first traversal of physical volumes.
  *
  * The function must have the signature
- * <code>bool(*)(G4VPhysicalVolume const&, int)</code>
+ * <code>bool(*)(vecgeom::VPlacedVolume const*, int)</code>
  * where the return value indicates whether the volume's children should be
  * visited, and the integer is the depth of the volume being visited.
  *
@@ -52,12 +52,12 @@ class VecgeomVolumeAccessor final
  * very expensive! If it's desired to only visit single physical volumes, mark
  * them as visited using a set.
  */
-template<class F>
-void visit_volume_instances(F&& vis, vecgeom::VPlacedVolume const* world)
+template<class Visitor>
+void visit_volume_instances(Visitor&& v, vecgeom::VPlacedVolume const* world)
 {
     ScopedProfiling profile_this{"visit-vecgeom-volume-instance"};
-    VolumeInstanceVisitor visit_vol{VecgeomVolumeAccessor{}};
-    visit_vol(std::forward<F>(vis), world);
+    VolumeVisitor visit_vol{VecgeomVolumeAccessor{}};
+    visit_vol(std::forward<Visitor>(v), world);
 }
 
 //---------------------------------------------------------------------------//
@@ -65,16 +65,19 @@ void visit_volume_instances(F&& vis, vecgeom::VPlacedVolume const* world)
  * Perform a depth-first listing of Geant4 logical volumes.
  *
  * This will visit each volume exactly once based on when it's encountered in
- * the hierarchy. The visitor function F should have the signature
- * \code void(*)(G4LogicalVolume const&) \endcode .
+ * the hierarchy. The visitor function Visitor should have the signature
+ * \code void(*)(vecgeom::LogicalVolume const&) \endcode .
  */
-template<class F>
-void visit_volumes(F&& vis, vecgeom::VPlacedVolume const* world)
+template<class Visitor>
+void visit_volumes(Visitor&& v, vecgeom::VPlacedVolume const* world)
 {
+    CELER_EXPECT(world);
     ScopedProfiling profile_this{"visit-vecgeom-volume"};
 
     VolumeVisitor visit_vol{VecgeomVolumeAccessor{}};
-    visit_vol(std::forward<F>(vis), world);
+    visit_vol(make_visit_volume_once<vecgeom::LogicalVolume const*>(
+                  std::forward<Visitor>(v)),
+              world->GetLogicalVolume());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -79,8 +79,8 @@ class OrangeParams final : public GeoParamsInterface,
     //! Outer bounding box of geometry
     BBox const& bbox() const final { return bbox_; }
 
-    // Maximum universe depth
-    inline size_type max_depth() const final;
+    // Maximum universe depth (not geometry volume depth!)
+    inline size_type max_depth() const;
 
     // Create model parameters corresponding to our internal representation
     inp::Model make_model_input() const final;

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -316,7 +316,7 @@ TEST_F(SimpleCmsTest, output)
     if (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE && CELERITAS_USE_GEANT4)
     {
         EXPECT_JSON_EQ(
-            R"json({"_category":"internal","_label":"geometry","bbox":[[-1000.0,-1000.0,-2000.0],[1000.0,1000.0,2000.0]],"max_depth":2,"supports_safety":true,"volumes":{"label":["vacuum_tube","si_tracker","em_calorimeter","had_calorimeter","sc_solenoid","fe_muon_chambers","world"]}})json",
+            R"json({"_category":"internal","_label":"geometry","bbox":[[-1e3,-1e3,-2e3],[1e3,1e3,2e3]],"supports_safety":true,"volumes":{"label":["vacuum_tube","si_tracker","em_calorimeter","had_calorimeter","sc_solenoid","fe_muon_chambers","world"]}})json",
             s);
     }
 }

--- a/test/geocel/GenericGeoResults.cc
+++ b/test/geocel/GenericGeoResults.cc
@@ -202,6 +202,15 @@ GenericGeoModelInp GenericGeoModelInp::from_model_input(inp::Model const& in)
         result.volume_instance.volumes.push_back(id_to_int(vol_inst.volume));
     }
 
+    if (in.volumes.world < result.volume_instance.labels.size())
+    {
+        result.world = result.volume_instance.labels[in.volumes.world.get()];
+    }
+    else
+    {
+        result.world = "<invalid>";
+    }
+
     // Extract surface data
     result.surface.labels.reserve(in.surfaces.surfaces.size());
     result.surface.volumes.reserve(in.surfaces.surfaces.size());
@@ -232,7 +241,7 @@ void GenericGeoModelInp::print_expected() const
          << CELER_REF_ATTR(volume.labels) << CELER_REF_ATTR(volume.materials)
          << CELER_REF_ATTR(volume.daughters)
          << CELER_REF_ATTR(volume_instance.labels)
-         << CELER_REF_ATTR(volume_instance.volumes);
+         << CELER_REF_ATTR(volume_instance.volumes) << CELER_REF_ATTR(world);
 
     if (!surface.labels.empty())
     {
@@ -264,6 +273,7 @@ void GenericGeoModelInp::print_expected() const
     IRE_COMPARE(volume.daughters);
     IRE_COMPARE(volume_instance.labels);
     IRE_COMPARE(volume_instance.volumes);
+    IRE_COMPARE(world);
     IRE_COMPARE(surface.labels);
     IRE_COMPARE(surface.volumes);
 

--- a/test/geocel/GenericGeoResults.hh
+++ b/test/geocel/GenericGeoResults.hh
@@ -114,6 +114,8 @@ struct GenericGeoModelInp
         std::vector<std::string> labels;
         std::vector<int> volumes;
     } volume_instance;
+    std::string world;
+
     struct
     {
         std::vector<std::string> labels;

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -83,31 +83,35 @@ void CmsEeBackDeeGeoTest::test_model() const
 {
     auto result = test_->model_inp();
     GenericGeoModelInp ref;
-    ref.volume.labels = {"EEBackPlate",
-                         "EESRing",
-                         "EEBackQuad",
-                         "EEBackDee",
-                         "EEBackQuad_refl",
-                         "EEBackPlate_refl",
-                         "EESRing_refl"};
+    ref.volume.labels = {
+        "EEBackPlate",
+        "EESRing",
+        "EEBackQuad",
+        "EEBackDee",
+        "EEBackQuad_refl",
+        "EEBackPlate_refl",
+        "EESRing_refl",
+    };
     ref.volume.materials = {0, 0, 1, 1, 1, 0, 0};
     ref.volume.daughters = {{}, {}, {0, 1}, {2, 5}, {3, 4}, {}, {}};
-    ref.volume_instance.labels = {"EEBackPlate@0",
-                                  "EESRing@0",
-                                  "EEBackQuad@0",
-                                  "EEBackPlate@1",
-                                  "EESRing@1",
-                                  "EEBackQuad@1",
-                                  "EEBackDee_PV"};
+    ref.volume_instance.labels = {
+        "EEBackPlate@0",
+        "EESRing@0",
+        "EEBackQuad@0",
+        "EEBackPlate@1",
+        "EESRing@1",
+        "EEBackQuad@1",
+        "EEBackDee_PV",
+    };
     ref.volume_instance.volumes = {0, 1, 2, 5, 6, 4, 3};
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "EEBackPlate@1";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //! Test geometry accessors
 void CmsEeBackDeeGeoTest::test_accessors() const
 {
     auto const& geo = *test_->geometry_interface();
-    EXPECT_EQ(3, geo.max_depth());
 
     auto expected_bbox = calc_expected_bbox(
         test_->geometry_type(), {0., -177.5, 359.5}, {177.5, 177.5, 399.6});
@@ -263,7 +267,8 @@ void CmseGeoTest::test_model() const
         0,  0,  1,  1,  2,  3,  4,  5,  5,  6,  6,  7,  7,  8,  8,  9,  9,
         10, 10, 11, 11, 12, 12, 13, 14, 15, 15, 16, 16, 17, 17, 18, 19,
     };
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "TotemT1@0";
+    EXPECT_REF_EQ(ref, result);
 }
 
 void CmseGeoTest::test_trace() const
@@ -390,14 +395,14 @@ void FourLevelsGeoTest::test_model() const
         2,
         3,
     };
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "env2";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //! Test geometry accessors
 void FourLevelsGeoTest::test_accessors() const
 {
     auto const& geo = *test_->geometry_interface();
-    EXPECT_EQ(4, geo.max_depth());
 
     auto expected_bbox = calc_expected_bbox(
         test_->geometry_type(), {-24., -24., -24.}, {24., 24., 24.});
@@ -562,7 +567,8 @@ void MultiLevelGeoTest::test_model() const
         4,
         3,
     };
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "topbox1";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //---------------------------------------------------------------------------//
@@ -743,7 +749,8 @@ void OpticalSurfacesGeoTest::test_model() const
         "mid_to_above",
     };
     ref.surface.volumes = {"0", "2", "1->2", "2->1", "2->3"};
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "tube2_above_pv";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //---------------------------------------------------------------------------//
@@ -893,7 +900,8 @@ void PolyhedraGeoTest::test_model() const
         15,
         16,
     };
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "world_PV";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //---------------------------------------------------------------------------//
@@ -950,7 +958,7 @@ void PolyhedraGeoTest::test_trace() const
         ref.bumps = {};
         fixup_orange(*test_, ref, result);
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
     {
         SCOPED_TRACE("quad");
@@ -1003,7 +1011,7 @@ void PolyhedraGeoTest::test_trace() const
         ref.bumps = {};
         fixup_orange(*test_, ref, result);
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
     {
         SCOPED_TRACE("penta");
@@ -1056,7 +1064,7 @@ void PolyhedraGeoTest::test_trace() const
         ref.bumps = {};
         fixup_orange(*test_, ref, result);
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
     {
         SCOPED_TRACE("hex");
@@ -1109,7 +1117,7 @@ void PolyhedraGeoTest::test_trace() const
         ref.bumps = {};
         fixup_orange(*test_, ref, result);
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
 }
 
@@ -1126,8 +1134,9 @@ void ReplicaGeoTest::test_model() const
     ref.volume.daughters = {{}, {}, {}, {0}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,}, {}, {}, {21}, {}, {22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22,}, {}, {23}, {24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,}, {25, 25}, {26, 26, 26, 26, 26, 26, 26, 26, 26, 26,}, {27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58,}, {59, 60, 61},};
     ref.volume_instance.labels = {"wirePlane1", "hodoscope1@0", "hodoscope1@1", "hodoscope1@2", "hodoscope1@3", "hodoscope1@4", "hodoscope1@5", "hodoscope1@6", "hodoscope1@7", "hodoscope1@8", "hodoscope1@9", "hodoscope1@10", "hodoscope1@11", "hodoscope1@12", "hodoscope1@13", "hodoscope1@14", "chamber1@0", "chamber1@1", "chamber1@2", "chamber1@3", "chamber1@4", "wirePlane2", "cell_param", "HadCalScinti", "HadCalLayer_PV", "HadCalCell_PV", "HadCalColumn_PV", "hodoscope2@0", "hodoscope2@1", "hodoscope2@2", "hodoscope2@3", "hodoscope2@4", "hodoscope2@5", "hodoscope2@6", "hodoscope2@7", "hodoscope2@8", "hodoscope2@9", "hodoscope2@10", "hodoscope2@11", "hodoscope2@12", "hodoscope2@13", "hodoscope2@14", "hodoscope2@15", "hodoscope2@16", "hodoscope2@17", "hodoscope2@18", "hodoscope2@19", "hodoscope2@20", "hodoscope2@21", "hodoscope2@22", "hodoscope2@23", "hodoscope2@24", "chamber2@0", "chamber2@1", "chamber2@2", "chamber2@3", "chamber2@4", "EMcalorimeter", "HadCalorimeter", "magnetic", "firstArm", "fSecondArmPhys", "world_PV",};
     ref.volume_instance.volumes = {2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 6, 8, 10, 11, 12, 13, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 7, 7, 7, 7, 7, 9, 14, 0, 4, 15, 16,};
+    ref.world = "chamber1@0";
     // clang-format on
-    EXPECT_RESULT_EQ(ref, result);
+    EXPECT_REF_EQ(ref, result);
 }
 
 //---------------------------------------------------------------------------//
@@ -1235,7 +1244,7 @@ void ReplicaGeoTest::test_trace() const
         delete_orange_safety(*test_, ref, result);
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
         tol.distance *= 10;  // 2e-12 diff between g4, vg
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
     {
         SCOPED_TRACE("Second arm");
@@ -1433,7 +1442,7 @@ void ReplicaGeoTest::test_trace() const
         delete_orange_safety(*test_, ref, result);
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
         tol.distance *= 10;  // 2e-12 diff between g4, vg
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
 }
 
@@ -1452,7 +1461,7 @@ void ReplicaGeoTest::test_volume_stack() const
             "HadCalLayer_PV",
         };
         ref.replicas = {-1, -1, -1, 4, 1, 2};
-        EXPECT_RESULT_EQ(ref, result);
+        EXPECT_REF_EQ(ref, result);
     }
     {
         // Geant4 gets stuck here (it's close to a boundary)
@@ -1471,7 +1480,7 @@ void ReplicaGeoTest::test_volume_stack() const
                                         {"EMcalorimeter", "cell_param"});
             ref.replicas.insert(ref.replicas.end(), {-1, 42});
         }
-        EXPECT_RESULT_EQ(ref, result);
+        EXPECT_REF_EQ(ref, result);
     }
     {
         // A bit further along from the stuck point
@@ -1484,7 +1493,7 @@ void ReplicaGeoTest::test_volume_stack() const
             "cell_param",
         };
         ref.replicas = {-1, -1, -1, 42};
-        EXPECT_RESULT_EQ(ref, result);
+        EXPECT_REF_EQ(ref, result);
     }
 }
 
@@ -1495,7 +1504,6 @@ void ReplicaGeoTest::test_volume_stack() const
 void SolidsGeoTest::test_accessors() const
 {
     auto const& geo = *test_->geometry_interface();
-    EXPECT_EQ(2, geo.max_depth());
 
     auto expected_bbox = calc_expected_bbox(
         test_->geometry_type(), {-600., -300., -75.}, {600., 300., 75.});
@@ -1843,24 +1851,29 @@ void SimpleCmsGeoTest::test_model() const
 {
     auto result = test_->model_inp();
     GenericGeoModelInp ref;
-    ref.volume.labels = {"vacuum_tube",
-                         "si_tracker",
-                         "em_calorimeter",
-                         "had_calorimeter",
-                         "sc_solenoid",
-                         "fe_muon_chambers",
-                         "world"};
+    ref.volume.labels = {
+        "vacuum_tube",
+        "si_tracker",
+        "em_calorimeter",
+        "had_calorimeter",
+        "sc_solenoid",
+        "fe_muon_chambers",
+        "world",
+    };
     ref.volume.materials = {0, 1, 2, 3, 4, 5, 0};
     ref.volume.daughters = {{}, {}, {}, {}, {}, {}, {0, 1, 2, 3, 4, 5}};
-    ref.volume_instance.labels = {"vacuum_tube_pv",
-                                  "si_tracker_pv",
-                                  "em_calorimeter_pv",
-                                  "had_calorimeter_pv",
-                                  "sc_solenoid_pv",
-                                  "iron_muon_chambers_pv",
-                                  "world_PV"};
+    ref.volume_instance.labels = {
+        "vacuum_tube_pv",
+        "si_tracker_pv",
+        "em_calorimeter_pv",
+        "had_calorimeter_pv",
+        "sc_solenoid_pv",
+        "iron_muon_chambers_pv",
+        "world_PV",
+    };
     ref.volume_instance.volumes = {0, 1, 2, 3, 4, 5, 6};
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "world_PV";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //---------------------------------------------------------------------------//
@@ -1901,7 +1914,7 @@ void SimpleCmsGeoTest::test_trace() const
             ref.halfway_safeties[1] = 700;
         }
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
     {
         auto result = test_->track({25, 0, 701}, {0, 0, -1});
@@ -1919,7 +1932,7 @@ void SimpleCmsGeoTest::test_trace() const
         }
 
         auto tol = GenericGeoTrackingTolerance::from_test(*test_);
-        EXPECT_RESULT_NEAR(ref, result, tol);
+        EXPECT_REF_NEAR(ref, result, tol);
     }
 }
 
@@ -2068,17 +2081,14 @@ void TransformedBoxGeoTest::test_model() const
     ref.volume_instance.labels
         = {"rot", "transrot", "default", "trans", "world_PV"};
     ref.volume_instance.volumes = {1, 0, 2, 0, 3};
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "trans";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //! Test geometry accessors
 void TransformedBoxGeoTest::test_accessors() const
 {
     auto const& geo = *test_->geometry_interface();
-    if (test_->geometry_type() != "ORANGE")
-    {
-        EXPECT_EQ(3, geo.max_depth());
-    }
 
     auto expected_bbox = calc_expected_bbox(
         test_->geometry_type(), {-50., -50., -50.}, {50., 50., 50.});
@@ -2253,21 +2263,14 @@ void TwoBoxesGeoTest::test_model() const
     ref.volume.daughters = {{}, {0}};
     ref.volume_instance.labels = {"inner_PV", "world_PV"};
     ref.volume_instance.volumes = {0, 1};
-    EXPECT_RESULT_EQ(ref, result);
+    ref.world = "world_PV";
+    EXPECT_REF_EQ(ref, result);
 }
 
 //! Test geometry accessors
 void TwoBoxesGeoTest::test_accessors() const
 {
     auto const& geo = *test_->geometry_interface();
-    if (test_->geometry_type() != "ORANGE")
-    {
-        EXPECT_EQ(2, geo.max_depth());
-    }
-    else
-    {
-        EXPECT_EQ(3, geo.volumes().size());
-    }
 
     auto expected_bbox = calc_expected_bbox(
         test_->geometry_type(), {-500., -500., -500.}, {500., 500., 500.});
@@ -2336,32 +2339,8 @@ void ZnenvGeoTest::test_model() const
         {},
         {3},
         {4, 5, 6, 7},
-        {
-            8,
-            8,
-            8,
-            8,
-            8,
-            8,
-            8,
-            8,
-            8,
-            8,
-            8,
-        },
-        {
-            9,
-            9,
-            9,
-            9,
-            9,
-            9,
-            9,
-            9,
-            9,
-            9,
-            9,
-        },
+        {8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8},
+        {9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9},
         {10, 10},
         {11, 11},
         {12},
@@ -2384,24 +2363,10 @@ void ZnenvGeoTest::test_model() const
         "WorldBoxPV",
         "World_PV",
     };
-    ref.volume_instance.volumes = {
-        0,
-        2,
-        4,
-        6,
-        1,
-        3,
-        5,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-    };
-    EXPECT_RESULT_EQ(ref, result);
+    ref.volume_instance.volumes
+        = {0, 2, 4, 6, 1, 3, 5, 7, 8, 9, 10, 11, 12, 13, 14};
+    ref.world = "World_PV";
+    EXPECT_REF_EQ(ref, result);
 }
 
 void ZnenvGeoTest::test_trace() const

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -72,6 +72,8 @@ struct MaxVisitor
             os << depth << ':' << labels.at(id).name;
             names.push_back(std::move(os).str());
         }
+        // Make reproducible across unordered map implementation
+        std::sort(names.begin(), names.end());
         return names;
     }
 };
@@ -338,6 +340,9 @@ TEST_F(ComplexVolumeTest, visit)
     {
         MaxVisitor mpv{volumes_.volume_labels(), {}};
         visit(mpv, VolumeId{0});
+        static std::string const expected_names[]
+            = {"0:A", "1:B", "2:C", "3:D", "3:E"};
+        EXPECT_VEC_EQ(expected_names, mpv.get_names());
     }
 }
 

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -8,6 +8,7 @@
 #include "corecel/cont/LabelIdMultiMapUtils.hh"
 #include "geocel/Types.hh"
 #include "geocel/VolumeParams.hh"
+#include "geocel/VolumeToString.hh"
 #include "geocel/inp/Model.hh"
 
 #include "TestMacros.hh"
@@ -23,33 +24,61 @@ namespace test
  * - volumes are alphabetical (A, B, C...)
  * - volume instances are numeric (0, 1, 2...)
  */
-using VolumeTest = ::celeritas::test::Test;
+class VolumeTest : public ::celeritas::test::Test
+{
+  protected:
+    VolumeParams volumes_;
+};
+
+//---------------------------------------------------------------------------//
+class NoVolumeTest : public VolumeTest
+{
+};
 
 /*!
  * No volumes, for unit testing
  */
-TEST_F(VolumeTest, no_volumes)
+TEST_F(NoVolumeTest, params)
 {
-    VolumeParams const params;
+    VolumeParams const& params = volumes_;
     EXPECT_TRUE(params.empty());
     EXPECT_EQ(0, params.num_volumes());
 }
 
+TEST_F(NoVolumeTest, volume_to_string)
+{
+    VolumeToString to_string;
+    EXPECT_EQ("<null>", to_string(VolumeId{}));
+    EXPECT_EQ("<null>", to_string(VolumeInstanceId{}));
+    EXPECT_EQ("v 1", to_string(VolumeId{1}));
+    EXPECT_EQ("vi 2", to_string(VolumeInstanceId{2}));
+}
+
+//---------------------------------------------------------------------------//
 /*!
  * Graph:
  *    A
  */
-TEST_F(VolumeTest, single_volume)
+class SingleVolumeTest : public VolumeTest
 {
-    VolumeParams const params([] {
-        using namespace inp;
-        Volumes in;
-        Volume v;
-        v.label = "A";
-        v.material = GeoMatId{0};
-        in.volumes.push_back(v);
-        return in;
-    }());
+  public:
+    void SetUp()
+    {
+        volumes_ = VolumeParams([] {
+            using namespace inp;
+            Volumes in;
+            Volume v;
+            v.label = "A";
+            v.material = GeoMatId{0};
+            in.volumes.push_back(v);
+            return in;
+        }());
+    }
+};
+
+TEST_F(SingleVolumeTest, params)
+{
+    VolumeParams const& params = volumes_;
 
     EXPECT_FALSE(params.empty());
     EXPECT_EQ(1, params.num_volumes());
@@ -78,6 +107,20 @@ TEST_F(VolumeTest, single_volume)
     }
 }
 
+TEST_F(SingleVolumeTest, volume_to_string)
+{
+    VolumeToString to_string{volumes_};
+    EXPECT_EQ("<null>", to_string(VolumeId{}));
+    EXPECT_EQ("<null>", to_string(VolumeInstanceId{}));
+    EXPECT_EQ("A", to_string(VolumeId{0}));
+
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(to_string(VolumeId{1}), DebugError);
+    }
+}
+
+//---------------------------------------------------------------------------//
 /*!
  * Graph:
  * A -> B [0]
@@ -89,47 +132,56 @@ TEST_F(VolumeTest, single_volume)
  *
  * Where bracketed values are volume instance IDs.
  */
-TEST_F(VolumeTest, complex_hierarchy)
+class ComplexVolumeTest : public VolumeTest
 {
-    VolumeParams const params([] {
-        using namespace inp;
-        Volumes in;
+  public:
+    void SetUp()
+    {
+        volumes_ = VolumeParams([] {
+            using namespace inp;
+            Volumes in;
 
-        // Helper to create volumes
-        auto add_volume = [&in](std::string label,
-                                std::vector<VolumeInstanceId> children) {
-            Volume v;
-            v.label = std::move(label);
-            v.material = id_cast<GeoMatId>(in.volumes.size());
-            v.children = std::move(children);
-            in.volumes.push_back(v);
-        };
-        auto add_instance = [&in](VolumeId vol_id) {
-            VolumeInstance vi;
-            vi.label = std::to_string(in.volume_instances.size());
-            vi.volume = vol_id;
-            in.volume_instances.push_back(vi);
-        };
+            // Helper to create volumes
+            auto add_volume = [&in](std::string label,
+                                    std::vector<VolumeInstanceId> children) {
+                Volume v;
+                v.label = std::move(label);
+                v.material = id_cast<GeoMatId>(in.volumes.size());
+                v.children = std::move(children);
+                in.volumes.push_back(v);
+            };
+            auto add_instance = [&in](VolumeId vol_id) {
+                VolumeInstance vi;
+                vi.label = std::to_string(in.volume_instances.size());
+                vi.volume = vol_id;
+                in.volume_instances.push_back(vi);
+            };
 
-        // Create volumes A, B, C, D, E
-        add_volume("A", {VolumeInstanceId{0}, VolumeInstanceId{1}});
-        add_volume("B", {VolumeInstanceId{2}, VolumeInstanceId{3}});
-        add_volume("C", {VolumeInstanceId{4}, VolumeInstanceId{6}});
-        add_volume("D", {});
-        add_volume("E", {});
+            // Create volumes A, B, C, D, E
+            add_volume("A", {VolumeInstanceId{0}, VolumeInstanceId{1}});
+            add_volume("B", {VolumeInstanceId{2}, VolumeInstanceId{3}});
+            add_volume("C", {VolumeInstanceId{4}, VolumeInstanceId{6}});
+            add_volume("D", {});
+            add_volume("E", {});
 
-        // Create volume instances
-        add_instance(VolumeId{1});  // 0 -> B
-        add_instance(VolumeId{2});  // 1 -> C
-        add_instance(VolumeId{2});  // 2 -> C
-        add_instance(VolumeId{2});  // 3 -> C
-        add_instance(VolumeId{3});  // 4 -> D
-        // Add 'null' instance
-        in.volume_instances.push_back(VolumeInstance{});
-        add_instance(VolumeId{4});  // 6 -> E
+            // Create volume instances
+            add_instance(VolumeId{1});  // 0 -> B
+            add_instance(VolumeId{2});  // 1 -> C
+            add_instance(VolumeId{2});  // 2 -> C
+            add_instance(VolumeId{2});  // 3 -> C
+            add_instance(VolumeId{3});  // 4 -> D
+            // Add 'null' instance
+            in.volume_instances.push_back(VolumeInstance{});
+            add_instance(VolumeId{4});  // 6 -> E
 
-        return in;
-    }());
+            return in;
+        }());
+    }
+};
+
+TEST_F(ComplexVolumeTest, params)
+{
+    VolumeParams const& params = volumes_;
 
     static std::string const expected_volume_labels[]
         = {"A", "B", "C", "D", "E"};
@@ -172,6 +224,13 @@ TEST_F(VolumeTest, complex_hierarchy)
 
     static int const expected_volume_mapping[] = {1, 2, 2, 2, 3, -1, 4};
     EXPECT_VEC_EQ(expected_volume_mapping, volume_mapping);
+}
+
+TEST_F(ComplexVolumeTest, volume_to_string)
+{
+    VolumeToString to_string{volumes_};
+    EXPECT_EQ("A", to_string(VolumeId{0}));
+    EXPECT_EQ("1", to_string(VolumeInstanceId{1}));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -321,19 +321,8 @@ TEST_F(ComplexVolumeTest, visit)
         NameVisitor nv{volumes_, {}};
         visit(nv, VolumeId{0});
 
-        static std::string const expected_names[] = {
-            "A",
-            "B",
-            "C",
-            "D",
-            "E",
-            "C",
-            "D",
-            "E",
-            "C",
-            "D",
-            "E",
-        };
+        static std::string const expected_names[]
+            = {"A", "B", "C", "D", "E", "C", "D", "E", "C", "D", "E"};
         EXPECT_VEC_EQ(expected_names, nv.names);
     }
 

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file geocel/Volume.test.cc
+//! Test VolumeParams and related utilities
 //---------------------------------------------------------------------------//
 #include "corecel/OpaqueIdUtils.hh"
 #include "corecel/cont/LabelIdMultiMapUtils.hh"
 #include "geocel/Types.hh"
 #include "geocel/VolumeParams.hh"
 #include "geocel/VolumeToString.hh"
+#include "geocel/VolumeVisitor.hh"
 #include "geocel/inp/Model.hh"
 
 #include "TestMacros.hh"
@@ -18,6 +20,62 @@ namespace celeritas
 {
 namespace test
 {
+//---------------------------------------------------------------------------//
+struct NameVisitor
+{
+    VolumeParams const& vols;
+    std::vector<std::string> names;
+
+    bool operator()(VolumeId id, int)
+    {
+        names.push_back(vols.volume_labels().at(id).name);
+        return true;
+    }
+
+    bool operator()(VolumeInstanceId id, int depth)
+    {
+        auto const& vlabels = vols.volume_instance_labels();
+        std::ostringstream os;
+        os << depth << ':' << vlabels.at(id).name;
+        names.push_back(std::move(os).str());
+        return true;
+    }
+};
+
+struct MaxVisitor
+{
+    VolumeParams::VolumeMap const& labels;
+    std::unordered_map<VolumeId, int> max_depth;
+
+    bool operator()(VolumeId id, int depth)
+    {
+        auto&& [iter, inserted] = max_depth.insert({id, depth});
+        if (!inserted)
+        {
+            if (iter->second >= depth)
+            {
+                // Already visited PV at this depth or more
+                return false;
+            }
+            // Update the max depth
+            iter->second = depth;
+        }
+        return true;
+    }
+
+    auto get_names() const
+    {
+        std::vector<std::string> names;
+        for (auto&& [id, depth] : max_depth)
+        {
+            std::ostringstream os;
+            os << depth << ':' << labels.at(id).name;
+            names.push_back(std::move(os).str());
+        }
+        return names;
+    }
+};
+
 //---------------------------------------------------------------------------//
 /*!
  * Note in the following tests:
@@ -43,6 +101,8 @@ TEST_F(NoVolumeTest, params)
     VolumeParams const& params = volumes_;
     EXPECT_TRUE(params.empty());
     EXPECT_EQ(0, params.num_volumes());
+    EXPECT_EQ(VolumeId{}, params.world());
+    EXPECT_EQ(0, params.depth());
 }
 
 TEST_F(NoVolumeTest, volume_to_string)
@@ -67,10 +127,13 @@ class SingleVolumeTest : public VolumeTest
         volumes_ = VolumeParams([] {
             using namespace inp;
             Volumes in;
-            Volume v;
-            v.label = "A";
-            v.material = GeoMatId{0};
-            in.volumes.push_back(v);
+            in.volumes.push_back([] {
+                Volume v;
+                v.label = "A";
+                v.material = GeoMatId{0};
+                return v;
+            }());
+            in.world = VolumeId{0};
             return in;
         }());
     }
@@ -83,6 +146,8 @@ TEST_F(SingleVolumeTest, params)
     EXPECT_FALSE(params.empty());
     EXPECT_EQ(1, params.num_volumes());
     EXPECT_EQ(0, params.num_volume_instances());
+    EXPECT_EQ(VolumeId{0}, params.world());
+    EXPECT_EQ(0, params.depth());
     EXPECT_EQ(1, params.volume_labels().size());
     EXPECT_EQ(0, params.volume_instance_labels().size());
 
@@ -117,6 +182,18 @@ TEST_F(SingleVolumeTest, volume_to_string)
     if (CELERITAS_DEBUG)
     {
         EXPECT_THROW(to_string(VolumeId{1}), DebugError);
+    }
+}
+
+TEST_F(SingleVolumeTest, visit)
+{
+    VolumeVisitor visit(volumes_);
+    {
+        NameVisitor nv{volumes_, {}};
+        visit(nv, VolumeId{0});
+
+        static std::string const expected_names[] = {"A"};
+        EXPECT_VEC_EQ(expected_names, nv.names);
     }
 }
 
@@ -170,9 +247,12 @@ class ComplexVolumeTest : public VolumeTest
             add_instance(VolumeId{2});  // 2 -> C
             add_instance(VolumeId{2});  // 3 -> C
             add_instance(VolumeId{3});  // 4 -> D
-            // Add 'null' instance
+            // Add 'null' (unused) instance
             in.volume_instances.push_back(VolumeInstance{});
             add_instance(VolumeId{4});  // 6 -> E
+
+            // Top-level volume is zero
+            in.world = VolumeId{0};
 
             return in;
         }());
@@ -231,6 +311,45 @@ TEST_F(ComplexVolumeTest, volume_to_string)
     VolumeToString to_string{volumes_};
     EXPECT_EQ("A", to_string(VolumeId{0}));
     EXPECT_EQ("1", to_string(VolumeInstanceId{1}));
+}
+
+TEST_F(ComplexVolumeTest, visit)
+{
+    VolumeVisitor visit(volumes_);
+
+    {
+        NameVisitor nv{volumes_, {}};
+        visit(nv, VolumeId{0});
+
+        static std::string const expected_names[] = {
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "C",
+            "D",
+            "E",
+            "C",
+            "D",
+            "E",
+        };
+        EXPECT_VEC_EQ(expected_names, nv.names);
+    }
+
+    {
+        NameVisitor nv{volumes_, {}};
+        visit(nv, VolumeInstanceId{0});
+
+        static std::string const expected_names[]
+            = {"0:0", "1:2", "2:4", "2:6", "1:3", "2:4", "2:6"};
+        EXPECT_VEC_EQ(expected_names, nv.names);
+    }
+
+    {
+        MaxVisitor mpv{volumes_.volume_labels(), {}};
+        visit(mpv, VolumeId{0});
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -603,7 +603,7 @@ TEST_F(SolidsTest, output)
         std::regex pattern(R"("",)");
         actual = std::regex_replace(actual, pattern, "");
         EXPECT_JSON_EQ(
-            R"json({"_category":"internal","_label":"geometry","bbox":[[-600.0,-300.0,-75.0],[600.0,300.0,75.0]],"max_depth":2,"supports_safety":true,"volumes":{"label":["box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3_refl@1","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","trd3_refl@0"]}})json",
+            R"json({"_category":"internal","_label":"geometry","bbox":[[-600.0,-300.0,-75.0],[600.0,300.0,75.0]],"supports_safety":true,"volumes":{"label":["box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3_refl@1","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","trd3_refl@0"]}})json",
             actual);
     }
 }

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -451,7 +451,7 @@ TEST_F(SolidsVgdmlTest, output)
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         EXPECT_JSON_EQ(
-            R"json({"_category":"internal","_label":"geometry","bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"max_depth":2,"supports_safety":true,"volumes":{"label":["","","","","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","","trd3_refl@1","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl@0"]}})json",
+            R"json({"_category":"internal","_label":"geometry","bbox":[[-600.001,-300.001,-75.001],[600.001,300.001,75.001]],"supports_safety":true,"volumes":{"label":["","","","","box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","","trd3_refl@1","tube100","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl@0"]}})json",
             to_string(out));
     }
 }
@@ -670,7 +670,7 @@ TEST_F(SolidsTest, output)
         auto out_str = StringSimplifier{1}(to_string(out));
 
         EXPECT_JSON_EQ(
-            R"json({"_category":"internal","_label":"geometry","bbox":[[-6e2,-3e2,-8e1],[6e2,3e2,8e1]],"max_depth":2,"supports_safety":true,"volumes":{"label":["box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3_refl@1","tube100","","","","","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl@0"]}})json",
+            R"json({"_category":"internal","_label":"geometry","bbox":[[-6e2,-3e2,-8e1],[6e2,3e2,8e1]],"supports_safety":true,"volumes":{"label":["box500","cone1","para1","sphere1","parabol1","trap1","trd1","trd2","trd3_refl@1","tube100","","","","","boolean1","polycone1","genPocone1","ellipsoid1","tetrah1","orb1","polyhedr1","hype1","elltube1","ellcone1","arb8b","arb8a","xtru1","World","","trd3_refl@0"]}})json",
             out_str);
     }
 }


### PR DESCRIPTION
This refactors the volume visitor to support VolumeParams as a type to visit, allowing us to unfold and manipulate the geometry structure outside geant4/vecgeom. Since the `max_depth` in the geometry interface had different meanings between the geometry types, it is now removed from the geo params interface.

It also adds `VolumeToString`, a `std::visit`-oriented visitor class for the upcoming use of volume instance IDs in place of labels for ORANGE input.

These changes are both to implement #1749 .