### PR TITLE
Fix volume params construction in model setup

### DIFF
--- a/src/celeritas/setup/Model.cc
+++ b/src/celeritas/setup/Model.cc
@@ -107,7 +107,7 @@ ModelLoaded model(inp::Model const& m)
     {
         CELER_LOG(debug) << "Volume structure data is unavailable";
     }
-    result.volume = std::make_shared<VolumeParams>();
+    result.volume = std::make_shared<VolumeParams>(m.volumes);
 
     // Construct surfaces
     if (!m.surfaces)

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -383,13 +383,15 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
                    "result in arbitrarily small steps without displacement";
         }
         params.volume = std::move(loaded_model.volume);
+        CELER_ASSERT(loaded_model.surface);
         if (p.control.optical_capacity)
         {
+            CELER_VALIDATE(!loaded_model.surface->disabled(),
+                           << "surfaces are required for optical physics");
             params.surface = std::move(loaded_model.surface);
         }
         else
         {
-            CELER_ASSERT(loaded_model.surface);
             if (!loaded_model.surface->empty())
             {
                 CELER_LOG(debug) << "Ignoring surfaces for non-optical "


### PR DESCRIPTION
@hhollenb pointed out in #1876 that the surface params aren't always valid when optical physics is enabled: I confirmed this was the case in our celer-sim tests. It looks like this is because we weren't properly constructing the volume params in the model setup.