### PR TITLE
Delete IPAContextException

### DIFF
--- a/src/celeritas/phys/ImportedProcessAdapter.cc
+++ b/src/celeritas/phys/ImportedProcessAdapter.cc
@@ -50,17 +50,6 @@ bool is_contiguous_increasing(inp::UniformGrid const& lower,
 }  // namespace
 
 //---------------------------------------------------------------------------//
-IPAContextException::IPAContextException(ParticleId id,
-                                         ImportProcessClass ipc,
-                                         PhysMatId mid)
-{
-    std::stringstream os;
-    os << "Particle ID=" << id.unchecked_get() << ", process '" << ipc
-       << ", material ID=" << mid.unchecked_get();
-    what_ = os.str();
-}
-
-//---------------------------------------------------------------------------//
 /*!
  * Construct with imported data.
  */

--- a/src/celeritas/phys/ImportedProcessAdapter.hh
+++ b/src/celeritas/phys/ImportedProcessAdapter.hh
@@ -29,25 +29,6 @@ namespace celeritas
 {
 class ParticleParams;
 struct ImportData;
-//---------------------------------------------------------------------------//
-//! Small helper class to hopefully help a little with debugging errors
-class IPAContextException : public RichContextException
-{
-  public:
-    IPAContextException(ParticleId id, ImportProcessClass ipc, PhysMatId mid);
-
-    //! This class type
-    char const* type() const final { return "ImportProcessAdapterContext"; }
-
-    // Save context to a JSON object
-    void output(JsonPimpl*) const final {}
-
-    //! Get an explanatory message
-    char const* what() const noexcept final { return what_.c_str(); }
-
-  private:
-    std::string what_;
-};
 
 //---------------------------------------------------------------------------//
 /*!


### PR DESCRIPTION
This context class is unused after #1739 and #1766 .