### PR TITLE
Provide canonical volume and instance IDs from ORANGE

### DIFF
--- a/src/celeritas/geo/GeoMaterialParams.cc
+++ b/src/celeritas/geo/GeoMaterialParams.cc
@@ -322,7 +322,7 @@ GeoMaterialParams::from_import(ImportData const& data,
             if (!inp_vol)
                 continue;
 
-            vol_to_mat[vol_idx] = PhysMatId(inp_vol.phys_material_id);
+            vol_to_mat[vol_idx] = id_cast<PhysMatId>(inp_vol.phys_material_id);
         }
         input.volume_to_mat = std::move(vol_to_mat);
     }
@@ -344,7 +344,8 @@ GeoMaterialParams::from_import(ImportData const& data,
 
             CELER_EXPECT(!inp_vol.name.empty());
             auto&& [iter, inserted] = label_to_mat.emplace(
-                Label::from_separator(inp_vol.name), inp_vol.phys_material_id);
+                Label::from_separator(inp_vol.name),
+                id_cast<PhysMatId>(inp_vol.phys_material_id));
             if (!inserted)
             {
                 CELER_LOG(error)

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -55,10 +55,10 @@ MaterialParams::from_import(ImportData const& data,
     // Construct volume-to-optical mapping
     inp.volume_to_mat.reserve(geo_mat.num_volumes());
     bool has_opt_mat{false};
-    for (auto vid : range(ImplVolumeId{geo_mat.num_volumes()}))
+    for (auto impl_id : range(ImplVolumeId{geo_mat.num_volumes()}))
     {
         OptMatId optmat;
-        if (auto matid = geo_mat.material_id(vid))
+        if (PhysMatId matid = geo_mat.material_id(impl_id))
         {
             auto mat_view = mat.get(matid);
             optmat = mat_view.optical_material_id();

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -434,17 +434,8 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
     params.material = MaterialParams::from_import(imported);
 
     // Create geometry/material coupling
-    params.geomaterial = [&] {
-        GeoMaterialParams::SPConstVolume volume_params;
-        if constexpr (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
-        {
-            // FIXME: ORANGE doesn't support volume/material conversion
-            volume_params = params.volume;
-        }
-
-        return GeoMaterialParams::from_import(
-            imported, params.geometry, volume_params, params.material);
-    }();
+    params.geomaterial = GeoMaterialParams::from_import(
+        imported, params.geometry, params.volume, params.material);
 
     // Construct particle params
     params.particle = ParticleParams::from_import(imported);

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -275,12 +275,7 @@ inp::Volume inp_from_geant(GeantGeoParams const& geo,
 {
     inp::Volume result;
     result.label = label;
-
-    // Set material ID if available
-    if (auto* mat = g4lv.GetMaterial())
-    {
-        result.material = id_cast<GeoMatId>(mat->GetIndex() - geo.mat_offset());
-    }
+    result.material = geo.geant_to_mat_id(g4lv);
     // Populate volume.children with child volume instances
     auto num_children = g4lv.GetNoDaughters();
     result.children.reserve(num_children);
@@ -700,6 +695,19 @@ GeantGeoParams::geant_to_id(G4VPhysicalVolume const& volume) const
         result = {};
     }
     return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the geometry material ID for a logical volume (may be null).
+ */
+GeoMatId GeantGeoParams::geant_to_mat_id(G4LogicalVolume const& g4lv) const
+{
+    if (auto* mat = g4lv.GetMaterial())
+    {
+        return id_cast<GeoMatId>(mat->GetIndex() - this->mat_offset());
+    }
+    return {};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -275,7 +275,11 @@ inp::Volume inp_from_geant(GeantGeoParams const& geo,
 {
     inp::Volume result;
     result.label = label;
-    result.material = geo.geant_to_mat_id(g4lv);
+    result.material = [&geo, mat = g4lv.GetMaterial()]() -> GeoMatId {
+        if (!mat)
+            return {};
+        return geo.geant_to_id(*mat);
+    }();
     // Populate volume.children with child volume instances
     auto num_children = g4lv.GetNoDaughters();
     result.children.reserve(num_children);
@@ -679,6 +683,15 @@ G4LogicalVolume const* GeantGeoParams::id_to_geant(ImplVolumeId id) const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the geometry material ID for a logical volume (may be null).
+ */
+GeoMatId GeantGeoParams::geant_to_id(G4Material const& g4mat) const
+{
+    return id_cast<GeoMatId>(g4mat.GetIndex() - this->mat_offset());
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the volume ID corresponding to a Geant4 physical volume.
  *
  * \note See id_to_geant: the volume instance ID may be non-unique.
@@ -695,19 +708,6 @@ GeantGeoParams::geant_to_id(G4VPhysicalVolume const& volume) const
         result = {};
     }
     return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the geometry material ID for a logical volume (may be null).
- */
-GeoMatId GeantGeoParams::geant_to_mat_id(G4LogicalVolume const& g4lv) const
-{
-    if (auto* mat = g4lv.GetMaterial())
-    {
-        return id_cast<GeoMatId>(mat->GetIndex() - this->mat_offset());
-    }
-    return {};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -21,8 +21,9 @@
 #    include "inp/Model.hh"
 #endif
 
-class G4VPhysicalVolume;
 class G4LogicalSurface;
+class G4Material;
+class G4VPhysicalVolume;
 
 namespace celeritas
 {
@@ -137,6 +138,9 @@ class GeantGeoParams final : public GeoParamsInterface,
 
     //// G4 ACCESSORS ////
 
+    // Get the geometry material ID for a logical volume (may be null)
+    GeoMatId geant_to_id(G4Material const& mat) const;
+
     //! Get the volume ID corresponding to a Geant4 logical volume
     ImplVolumeId geant_to_id(G4LogicalVolume const& volume) const
     {
@@ -145,9 +149,6 @@ class GeantGeoParams final : public GeoParamsInterface,
 
     // Get the volume ID corresponding to a Geant4 physical volume
     VolumeInstanceId geant_to_id(G4VPhysicalVolume const& volume) const;
-
-    // Get the geometry material ID for a logical volume (may be null)
-    GeoMatId geant_to_mat_id(G4LogicalVolume const& mat) const;
 
     // Get the replica ID corresponding to a Geant4 physical volume
     ReplicaId replica_id(G4VPhysicalVolume const& volume) const;
@@ -302,6 +303,10 @@ inline G4LogicalVolume const* GeantGeoParams::id_to_geant(ImplVolumeId) const
 {
     CELER_ASSERT_UNREACHABLE();
 }
+inline GeoMatId GeantGeoParams::geant_to_id(G4Material const&) const
+{
+    CELER_ASSERT_UNREACHABLE();
+}
 inline VolumeInstanceId
 GeantGeoParams::geant_to_id(G4VPhysicalVolume const&) const
 {
@@ -309,10 +314,6 @@ GeantGeoParams::geant_to_id(G4VPhysicalVolume const&) const
 }
 inline GeantGeoParams::ReplicaId
 GeantGeoParams::replica_id(G4VPhysicalVolume const&) const
-{
-    CELER_ASSERT_UNREACHABLE();
-}
-inline GeoMatId GeantGeoParams::geant_to_mat_id(G4LogicalVolume const&) const
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -146,6 +146,9 @@ class GeantGeoParams final : public GeoParamsInterface,
     // Get the volume ID corresponding to a Geant4 physical volume
     VolumeInstanceId geant_to_id(G4VPhysicalVolume const& volume) const;
 
+    // Get the geometry material ID for a logical volume (may be null)
+    GeoMatId geant_to_mat_id(G4LogicalVolume const& mat) const;
+
     // Get the replica ID corresponding to a Geant4 physical volume
     ReplicaId replica_id(G4VPhysicalVolume const& volume) const;
 
@@ -306,6 +309,10 @@ GeantGeoParams::geant_to_id(G4VPhysicalVolume const&) const
 }
 inline GeantGeoParams::ReplicaId
 GeantGeoParams::replica_id(G4VPhysicalVolume const&) const
+{
+    CELER_ASSERT_UNREACHABLE();
+}
+inline GeoMatId GeantGeoParams::geant_to_mat_id(G4LogicalVolume const&) const
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -267,6 +267,10 @@ struct RectArrayRecord
  *
  * Each collection should be of length num_universes + 1. The first entry is
  * zero and the last item should be the total number of surfaces or volumes.
+ *
+ * \todo These should be indexed into by UniverseId, not the default
+ * OpaqueId<size_type>.
+ * \todo move to detail/UniverseIndexerData
  */
 template<Ownership W, MemSpace M>
 struct UniverseIndexerData
@@ -296,7 +300,7 @@ struct UniverseIndexerData
 /*!
  * Persistent data used by all BIH trees.
  *
- * \todo move to orange/BihTreeData
+ * \todo move to detail/BihTreeData
  */
 template<Ownership W, MemSpace M>
 struct BIHTreeData

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -368,7 +368,7 @@ struct OrangeParamsData
     Items<RectArrayRecord> rect_arrays;
     Items<TransformRecord> transforms;
 
-    // Map of ORANGE internal volume ID -> Celeritas volume ID
+    // Optional map of ORANGE internal volume ID -> Celeritas volume ID
     ImplVolumeItems<VolumeId> volume_ids;
     ImplVolumeItems<VolumeInstanceId> volume_instance_ids;
     // TODO: for reconstructing hierarchy:
@@ -399,6 +399,7 @@ struct OrangeParamsData
     {
         return scalars && !universe_types.empty()
                && universe_indices.size() == universe_types.size()
+               && volume_ids.size() == volume_instance_ids.size()
                && (bih_tree_data || !simple_units.empty())
                && ((!local_volume_ids.empty() && !logic_ints.empty()
                     && !reals.empty())
@@ -417,6 +418,9 @@ struct OrangeParamsData
         simple_units = other.simple_units;
         rect_arrays = other.rect_arrays;
         transforms = other.transforms;
+
+        volume_ids = other.volume_ids;
+        volume_instance_ids = other.volume_instance_ids;
 
         bih_tree_data = other.bih_tree_data;
 

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -368,6 +368,12 @@ struct OrangeParamsData
     Items<RectArrayRecord> rect_arrays;
     Items<TransformRecord> transforms;
 
+    // Map of ORANGE internal volume ID -> Celeritas volume ID
+    ImplVolumeItems<VolumeId> volume_ids;
+    ImplVolumeItems<VolumeInstanceId> volume_instance_ids;
+    // TODO: for reconstructing hierarchy:
+    // ImplVolumeItems<ImplVolumeId> parent_impl_volumes;
+
     // BIH tree storage
     BIHTreeData<W, M> bih_tree_data;
 

--- a/src/orange/OrangeInput.hh
+++ b/src/orange/OrangeInput.hh
@@ -46,9 +46,10 @@ struct OrientedBoundingZoneInput
 struct VolumeInput
 {
     using Flags = VolumeRecord::Flags;
+    using VariantLabel = std::variant<Label, VolumeInstanceId>;
 
-    //! Volume label
-    Label label{};
+    //! Volume label or instance ID
+    VariantLabel label{};
 
     //! Sorted list of surface IDs in this volume
     std::vector<LocalSurfaceId> faces{};

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -20,6 +20,7 @@
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/JsonUtils.json.hh"
 #include "corecel/io/Label.hh"
 #include "corecel/io/LabelIO.json.hh"
@@ -343,7 +344,16 @@ void to_json(nlohmann::json& j, UnitInput const& value)
         auto volume_labels = nlohmann::json::array();
         for (auto const& v : value.volumes)
         {
-            volume_labels.push_back(v.label);
+            // TODO: add JSON IO for OpaqueID
+            volume_labels.push_back(
+                std::visit(return_as<nlohmann::json>(Overload{
+                               [](Label const& label) { return label; },
+                               [](VolumeInstanceId id) -> nlohmann::json {
+                                   if (!id)
+                                       return nullptr;
+                                   return id.unchecked_get();
+                               }}),
+                           v.label));
         }
         return volume_labels;
     }();

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -29,6 +29,7 @@
 #include "corecel/sys/ScopedProfiling.hh"
 #include "geocel/BoundingBox.hh"
 #include "geocel/GeantGeoParams.hh"
+#include "geocel/VolumeParams.hh"
 
 #include "OrangeData.hh"  // IWYU pragma: associated
 #include "OrangeInput.hh"
@@ -82,10 +83,27 @@ OrangeParams::from_gdml(std::string const& filename)
  * Build from a Geant4 world.
  */
 std::shared_ptr<OrangeParams>
+OrangeParams::from_geant(std::shared_ptr<GeantGeoParams const> const& geo,
+                         VolumeParams const& volumes)
+{
+    CELER_EXPECT(geo);
+    auto result = g4org::Converter{}(*geo).input;
+    return std::make_shared<OrangeParams>(std::move(result), volumes);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build from a Geant4 world (no volumes available?).
+ *
+ * \todo Reconstructing the volume params here is going to be redundant; change
+ * interfaces later.
+ */
+std::shared_ptr<OrangeParams>
 OrangeParams::from_geant(std::shared_ptr<GeantGeoParams const> const& geo)
 {
-    auto result = g4org::Converter{}(*geo).input;
-    return std::make_shared<OrangeParams>(std::move(result));
+    CELER_EXPECT(geo);
+    VolumeParams volumes{geo->make_model_input().volumes};
+    return OrangeParams::from_geant(geo, volumes);
 }
 
 //---------------------------------------------------------------------------//
@@ -112,11 +130,17 @@ OrangeParams::from_json(std::string const& filename)
 //---------------------------------------------------------------------------//
 /*!
  * Advanced usage: construct from explicit host data.
- *
- * Volume and surface labels must be unique for the time being.
  */
-// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 OrangeParams::OrangeParams(OrangeInput&& input)
+    : OrangeParams{std::move(input), VolumeParams{}}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Advanced usage: construct from explicit host data and volumes.
+ */
+OrangeParams::OrangeParams(OrangeInput&& input, VolumeParams const& volumes)
 {
     CELER_VALIDATE(input, << "input geometry is incomplete");
 
@@ -144,11 +168,18 @@ OrangeParams::OrangeParams(OrangeInput&& input)
         std::vector<Label> universe_labels;
         std::vector<Label> surface_labels;
         std::vector<Label> volume_labels;
+        // TODO: remove instance labels: will be used only by VolumeParams
+        std::vector<Label> volume_instance_labels;
 
         detail::UniverseInserter insert_universe_base{
             &universe_labels, &surface_labels, &volume_labels, &host_data};
         Overload insert_universe{
-            detail::UnitInserter{&insert_universe_base, &host_data},
+            detail::UnitInserter{volumes,
+                                 &insert_universe_base,
+                                 volumes.empty() ? nullptr
+                                                 : &volume_instance_labels,
+                                 &host_data},
+
             detail::RectArrayInserter{&insert_universe_base, &host_data}};
 
         for (auto&& u : input.universes)
@@ -160,6 +191,7 @@ OrangeParams::OrangeParams(OrangeInput&& input)
         univ_labels_ = UniverseMap{"universe", std::move(universe_labels)};
         vol_labels_ = ImplVolumeMap{"volume", std::move(volume_labels)};
     }
+    std::move(input) = {};
 
     // Simple safety if all SimpleUnits have simple safety and no RectArrays
     // are present
@@ -179,6 +211,11 @@ OrangeParams::OrangeParams(OrangeInput&& input)
                    << " (a volume's CSG tree is too deep); but the logic "
                       "stack is limited to a depth of "
                    << detail::LogicStack::max_stack_depth());
+
+    CELER_ASSERT(host_data.volume_ids.empty()
+                 || host_data.volume_ids.size() == vol_labels_.size());
+    CELER_ASSERT(host_data.volume_instance_ids.empty()
+                 || host_data.volume_ids.size() == vol_labels_.size());
 
     // Construct device values and device/host references
     CELER_ASSERT(host_data);

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -168,18 +168,14 @@ OrangeParams::OrangeParams(OrangeInput&& input, VolumeParams const& volumes)
         std::vector<Label> universe_labels;
         std::vector<Label> surface_labels;
         std::vector<Label> volume_labels;
-        // TODO: remove instance labels: will be used only by VolumeParams
-        std::vector<Label> volume_instance_labels;
 
-        detail::UniverseInserter insert_universe_base{
-            &universe_labels, &surface_labels, &volume_labels, &host_data};
+        detail::UniverseInserter insert_universe_base{volumes,
+                                                      &universe_labels,
+                                                      &surface_labels,
+                                                      &volume_labels,
+                                                      &host_data};
         Overload insert_universe{
-            detail::UnitInserter{volumes,
-                                 &insert_universe_base,
-                                 volumes.empty() ? nullptr
-                                                 : &volume_instance_labels,
-                                 &host_data},
-
+            detail::UnitInserter{&insert_universe_base, &host_data},
             detail::RectArrayInserter{&insert_universe_base, &host_data}};
 
         for (auto&& u : input.universes)

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -166,13 +166,13 @@ OrangeParams::OrangeParams(OrangeInput&& input, VolumeParams const& volumes)
     // Insert all universes
     {
         std::vector<Label> universe_labels;
-        std::vector<Label> surface_labels;
-        std::vector<Label> volume_labels;
+        std::vector<Label> impl_surface_labels;
+        std::vector<Label> impl_volume_labels;
 
         detail::UniverseInserter insert_universe_base{volumes,
                                                       &universe_labels,
-                                                      &surface_labels,
-                                                      &volume_labels,
+                                                      &impl_surface_labels,
+                                                      &impl_volume_labels,
                                                       &host_data};
         Overload insert_universe{
             detail::UnitInserter{&insert_universe_base, &host_data},
@@ -183,9 +183,9 @@ OrangeParams::OrangeParams(OrangeInput&& input, VolumeParams const& volumes)
             std::visit(insert_universe, std::move(u));
         }
 
-        surf_labels_ = SurfaceMap{"surface", std::move(surface_labels)};
+        surf_labels_ = SurfaceMap{"surface", std::move(impl_surface_labels)};
         univ_labels_ = UniverseMap{"universe", std::move(universe_labels)};
-        vol_labels_ = ImplVolumeMap{"volume", std::move(volume_labels)};
+        vol_labels_ = ImplVolumeMap{"volume", std::move(impl_volume_labels)};
     }
     std::move(input) = {};
 

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -217,9 +217,19 @@ GeantPhysicalInstance OrangeParams::id_to_geant(VolumeInstanceId) const
 /*!
  * Get the canonical volume IDs corresponding to an implementation volume.
  */
-VolumeId OrangeParams::volume_id(ImplVolumeId) const
+VolumeId OrangeParams::volume_id(ImplVolumeId iv_id) const
 {
-    return {};
+    auto const& volume_id_map = this->host_ref().volume_ids;
+    CELER_EXPECT(volume_id_map.empty() || iv_id < volume_id_map.size());
+
+    if (CELER_UNLIKELY(volume_id_map.empty()))
+    {
+        // Probably standalone geometry
+        CELER_ASSERT(iv_id);
+        return id_cast<VolumeId>(iv_id.unchecked_get());
+    }
+
+    return volume_id_map[iv_id];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -28,6 +28,7 @@ namespace celeritas
 {
 struct OrangeInput;
 class GeantGeoParams;
+class VolumeParams;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -57,6 +58,11 @@ class OrangeParams final : public GeoParamsInterface,
 
     // Build from a Geant4 geometry
     static std::shared_ptr<OrangeParams>
+    from_geant(std::shared_ptr<GeantGeoParams const> const& geo,
+               VolumeParams const& volumes);
+
+    // Build from a Geant4 geometry (no volumes available?)
+    static std::shared_ptr<OrangeParams>
     from_geant(std::shared_ptr<GeantGeoParams const> const& geo);
 
     // Build from a JSON input
@@ -65,7 +71,10 @@ class OrangeParams final : public GeoParamsInterface,
     //!@}
 
     // ADVANCED usage: construct from explicit host data
-    explicit OrangeParams(OrangeInput&& input);
+    OrangeParams(OrangeInput&& input);
+
+    // ADVANCED usage: construct from explicit host data with volumes
+    OrangeParams(OrangeInput&& input, VolumeParams const& volumes);
 
     // Default destructor to anchor vtable
     ~OrangeParams() final;

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -94,9 +94,9 @@ class OrangeTrackView
     // The current direction
     inline CELER_FUNCTION Real3 const& dir() const;
 
-    // Get the canonical volume ID in the current volume
+    // Get the canonical volume ID in the current impl volume
     inline CELER_FUNCTION VolumeId volume_id() const;
-    // Get the canonical volume instance ID in the current volume
+    // Get the canonical volume instance ID in the current impl volume
     inline CELER_FUNCTION VolumeInstanceId volume_instance_id() const;
     // The current level
     inline CELER_FUNCTION LevelId const& level() const;
@@ -453,7 +453,12 @@ CELER_FUNCTION Real3 const& OrangeTrackView::dir() const
 
 //---------------------------------------------------------------------------//
 /*!
- * The current volume ID.
+ * The current canonical volume ID.
+ *
+ * This is the volume identifier in the user's geometry model, not the ORANGE
+ * implementation of it. For unit tests and certain use cases where the volumes
+ * have not been loaded from Geant4 or a structured geometry model, it may not
+ * be available.
  */
 CELER_FUNCTION VolumeId OrangeTrackView::volume_id() const
 {
@@ -472,15 +477,11 @@ CELER_FUNCTION VolumeId OrangeTrackView::volume_id() const
  */
 CELER_FUNCTION VolumeInstanceId OrangeTrackView::volume_instance_id() const
 {
-    if (!params_.volume_instance_ids.empty())
-    {
-        // Return structural volume mapping
-        ImplVolumeId impl_id = this->impl_volume_id();
-        CELER_ASSERT(impl_id);
-        return params_.volume_instance_ids[impl_id];
-    }
-    // No volume mapping specified (unit test or SCALE embedding)
-    return {};
+    CELER_EXPECT(!params_.volume_instance_ids.empty());
+    // Return canonical volume mapping
+    ImplVolumeId impl_id = this->impl_volume_id();
+    CELER_ASSERT(impl_id);
+    return params_.volume_instance_ids[impl_id];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -94,7 +94,9 @@ class OrangeTrackView
     // The current direction
     inline CELER_FUNCTION Real3 const& dir() const;
 
-    // Get the physical volume ID in the current cell
+    // Get the canonical volume ID in the current volume
+    inline CELER_FUNCTION VolumeId volume_id() const;
+    // Get the canonical volume instance ID in the current volume
     inline CELER_FUNCTION VolumeInstanceId volume_instance_id() const;
     // The current level
     inline CELER_FUNCTION LevelId const& level() const;
@@ -451,6 +453,18 @@ CELER_FUNCTION Real3 const& OrangeTrackView::dir() const
 
 //---------------------------------------------------------------------------//
 /*!
+ * The current volume ID.
+ */
+CELER_FUNCTION VolumeId OrangeTrackView::volume_id() const
+{
+    ImplVolumeId impl_id = this->impl_volume_id();
+    // Return structural volume mapping
+    CELER_ASSERT(impl_id);
+    return params_.volume_ids[impl_id];
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * The current volume instance.
  *
  * \todo not implemented; ImplVolumeId is already halfway between a
@@ -458,6 +472,14 @@ CELER_FUNCTION Real3 const& OrangeTrackView::dir() const
  */
 CELER_FUNCTION VolumeInstanceId OrangeTrackView::volume_instance_id() const
 {
+    if (!params_.volume_instance_ids.empty())
+    {
+        // Return structural volume mapping
+        ImplVolumeId impl_id = this->impl_volume_id();
+        CELER_ASSERT(impl_id);
+        return params_.volume_instance_ids[impl_id];
+    }
+    // No volume mapping specified (unit test or SCALE embedding)
     return {};
 }
 

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -17,12 +17,14 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/cont/VariantUtils.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/sys/Environment.hh"
+#include "geocel/VolumeParams.hh"
 
 #include "UniverseInserter.hh"
 #include "../OrangeInput.hh"
@@ -146,17 +148,29 @@ std::vector<Label> make_surface_labels(UnitInput& inp)
 
 //---------------------------------------------------------------------------//
 //! Construct volume labels from the input volumes
-std::vector<Label> make_volume_labels(UnitInput const& inp)
+std::vector<Label>
+make_volume_labels(UnitInput const& inp, VolumeParams const& volumes)
 {
-    std::vector<Label> result;
-    for (auto const& v : inp.volumes)
-    {
-        Label vl = v.label;
+    auto from_label = [&inp](Label vl) {
         if (vl.ext.empty())
         {
             vl.ext = inp.label.name;
         }
-        result.push_back(std::move(vl));
+        return vl;
+    };
+    auto from_vol_inst = [&volumes](VolumeInstanceId vi_id) -> Label {
+        CELER_EXPECT(!vi_id || vi_id < volumes.num_volume_instances());
+        if (!vi_id)
+            return {};
+        auto vol_id = volumes.volume(vi_id);
+        return volumes.volume_labels().at(vol_id);
+    };
+
+    std::vector<Label> result;
+    for (auto const& v : inp.volumes)
+    {
+        result.push_back(
+            std::visit(Overload{from_label, from_vol_inst}, v.label));
     }
     return result;
 }
@@ -230,15 +244,30 @@ ForceMax const& forced_scalar_max()
     return result;
 }
 
+std::string to_string(VolumeInput::VariantLabel const& vlabel)
+{
+    return std::visit(Overload{[](Label const& lab) { return to_string(lab); },
+                               [](VolumeInstanceId const& id) -> std::string {
+                                   if (!id)
+                                       return "<null>";
+                                   return "vi " + std::to_string(id.get());
+                               }},
+                      vlabel);
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct from full parameter data.
+ * Construct from full parameter data with metadata inserters.
  */
-UnitInserter::UnitInserter(UniverseInserter* insert_universe, Data* orange_data)
-    : orange_data_(orange_data)
+UnitInserter::UnitInserter(VolumeParams const& volumes,
+                           UniverseInserter* insert_universe,
+                           VecLabel* vi_labels,
+                           Data* orange_data)
+    : volumes_{volumes}
+    , orange_data_(orange_data)
     , build_bih_tree_{&orange_data_->bih_tree_data}
     , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
     , build_surfaces_{&orange_data_->surface_types,
@@ -258,6 +287,8 @@ UnitInserter::UnitInserter(UniverseInserter* insert_universe, Data* orange_data)
     , daughters_{&orange_data_->daughters}
     , calc_bumped_(make_bumper(orange_data_->scalars.tol))
 {
+    CELER_EXPECT(insert_universe_);
+    CELER_EXPECT(volumes.empty() == (vi_labels == nullptr));
     CELER_EXPECT(orange_data);
     CELER_EXPECT(orange_data->scalars.tol);
 
@@ -353,7 +384,8 @@ UniverseId UnitInserter::operator()(UnitInput&& inp)
                            invalid.end(),
                            ", ",
                            [&inp, &bboxes](std::ostream& os, size_type i) {
-                               os << i << "='" << inp.volumes[i].label
+                               os << i << "='"
+                                  << to_string(inp.volumes[i].label)
                                   << "': " << bboxes[i];
                            }));
     }
@@ -388,7 +420,7 @@ UniverseId UnitInserter::operator()(UnitInput&& inp)
     CELER_ASSERT(unit);
     simple_units_.push_back(unit);
     auto surf_labels = make_surface_labels(inp);
-    auto vol_labels = make_volume_labels(inp);
+    auto vol_labels = make_volume_labels(inp, volumes_);
     return (*insert_universe_)(UniverseType::simple,
                                std::move(inp.label),
                                std::move(surf_labels),
@@ -456,7 +488,7 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
         CELER_LOG(warning) << "Max intersections (" << output.max_intersections
                            << ") and/or faces (" << output.faces.size()
                            << ") exceed limits of '" << mfi_hack_envname
-                           << " in volume '" << v.label
+                           << " in volume '" << to_string(v.label)
                            << "': replacing with unreachable volume";
 
         output.faces = {};
@@ -478,6 +510,20 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
     inplace_max<size_type>(&scalars.max_intersections,
                            output.max_intersections);
     inplace_max<size_type>(&scalars.max_logic_depth, max_depth);
+
+    // Save volume instance label
+    if (auto* vi_id = std::get_if<VolumeInstanceId>(&v.label))
+    {
+        CELER_ASSERT(*vi_id);
+        vi_labels_->resize(vi_id->get() + 1);
+        auto& label_dst = (*vi_labels_)[vi_id->get()];
+        if (label_dst.empty())
+        {
+            // This is the first 'volume' to instantiate the volume instance
+            (*vi_labels_)[vi_id->get()]
+                = volumes_.volume_instance_labels().at(*vi_id);
+        }
+    }
 
     return output;
 }

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -17,14 +17,12 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/Span.hh"
-#include "corecel/cont/VariantUtils.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/sys/Environment.hh"
-#include "geocel/VolumeParams.hh"
 
 #include "UniverseInserter.hh"
 #include "../OrangeInput.hh"
@@ -148,29 +146,21 @@ std::vector<Label> make_surface_labels(UnitInput& inp)
 
 //---------------------------------------------------------------------------//
 //! Construct volume labels from the input volumes
-std::vector<Label>
-make_volume_labels(UnitInput const& inp, VolumeParams const& volumes)
+auto make_volume_labels(UnitInput const& inp)
 {
-    auto from_label = [&inp](Label vl) {
-        if (vl.ext.empty())
-        {
-            vl.ext = inp.label.name;
-        }
-        return vl;
-    };
-    auto from_vol_inst = [&volumes](VolumeInstanceId vi_id) -> Label {
-        CELER_EXPECT(!vi_id || vi_id < volumes.num_volume_instances());
-        if (!vi_id)
-            return {};
-        auto vol_id = volumes.volume(vi_id);
-        return volumes.volume_labels().at(vol_id);
-    };
-
-    std::vector<Label> result;
+    std::vector<VolumeInput::VariantLabel> result;
     for (auto const& v : inp.volumes)
     {
-        result.push_back(
-            std::visit(Overload{from_label, from_vol_inst}, v.label));
+        auto var_label = v.label;
+        if (auto* label = std::get_if<Label>(&var_label))
+        {
+            // Add the unit's name as an extension if blank
+            if (label->ext.empty())
+            {
+                label->ext = inp.label.name;
+            }
+        }
+        result.push_back(std::move(var_label));
     }
     return result;
 }
@@ -244,6 +234,7 @@ ForceMax const& forced_scalar_max()
     return result;
 }
 
+//---------------------------------------------------------------------------//
 std::string to_string(VolumeInput::VariantLabel const& vlabel)
 {
     return std::visit(Overload{[](Label const& lab) { return to_string(lab); },
@@ -260,14 +251,10 @@ std::string to_string(VolumeInput::VariantLabel const& vlabel)
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct from full parameter data with metadata inserters.
+ * Construct from full parameter data.
  */
-UnitInserter::UnitInserter(VolumeParams const& volumes,
-                           UniverseInserter* insert_universe,
-                           VecLabel* vi_labels,
-                           Data* orange_data)
-    : volumes_{volumes}
-    , orange_data_(orange_data)
+UnitInserter::UnitInserter(UniverseInserter* insert_universe, Data* orange_data)
+    : orange_data_(orange_data)
     , build_bih_tree_{&orange_data_->bih_tree_data}
     , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
     , build_surfaces_{&orange_data_->surface_types,
@@ -287,8 +274,6 @@ UnitInserter::UnitInserter(VolumeParams const& volumes,
     , daughters_{&orange_data_->daughters}
     , calc_bumped_(make_bumper(orange_data_->scalars.tol))
 {
-    CELER_EXPECT(insert_universe_);
-    CELER_EXPECT(volumes.empty() == (vi_labels == nullptr));
     CELER_EXPECT(orange_data);
     CELER_EXPECT(orange_data->scalars.tol);
 
@@ -420,7 +405,7 @@ UniverseId UnitInserter::operator()(UnitInput&& inp)
     CELER_ASSERT(unit);
     simple_units_.push_back(unit);
     auto surf_labels = make_surface_labels(inp);
-    auto vol_labels = make_volume_labels(inp, volumes_);
+    auto vol_labels = make_volume_labels(inp);
     return (*insert_universe_)(UniverseType::simple,
                                std::move(inp.label),
                                std::move(surf_labels),
@@ -510,20 +495,6 @@ VolumeRecord UnitInserter::insert_volume(SurfacesRecord const& surf_record,
     inplace_max<size_type>(&scalars.max_intersections,
                            output.max_intersections);
     inplace_max<size_type>(&scalars.max_logic_depth, max_depth);
-
-    // Save volume instance label
-    if (auto* vi_id = std::get_if<VolumeInstanceId>(&v.label))
-    {
-        CELER_ASSERT(*vi_id);
-        vi_labels_->resize(vi_id->get() + 1);
-        auto& label_dst = (*vi_labels_)[vi_id->get()];
-        if (label_dst.empty())
-        {
-            // This is the first 'volume' to instantiate the volume instance
-            (*vi_labels_)[vi_id->get()]
-                = volumes_.volume_instance_labels().at(*vi_id);
-        }
-    }
 
     return output;
 }

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -20,6 +20,7 @@
 
 namespace celeritas
 {
+class VolumeParams;
 namespace detail
 {
 class UniverseInserter;
@@ -35,21 +36,28 @@ class UnitInserter
     //!@{
     //! \name Type aliases
     using Data = HostVal<OrangeParamsData>;
+    using VecLabel = std::vector<Label>;
     //!@}
 
   public:
     // Construct from full parameter data
-    UnitInserter(UniverseInserter* insert_universe, Data* orange_data);
+    UnitInserter(VolumeParams const& volumes,
+                 UniverseInserter* insert_universe,
+                 VecLabel* vi_labels,
+                 Data* orange_data);
 
     // Create a simple unit and store in in OrangeParamsData
     UniverseId operator()(UnitInput&& inp);
 
   private:
+    VolumeParams const& volumes_;
+
     Data* orange_data_{nullptr};
     BIHBuilder build_bih_tree_;
     TransformRecordInserter insert_transform_;
     SurfacesRecordBuilder build_surfaces_;
     UniverseInserter* insert_universe_;
+    VecLabel* vi_labels_;  //!< NOTE: may be null
 
     CollectionBuilder<SimpleUnitRecord> simple_units_;
 

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -20,7 +20,6 @@
 
 namespace celeritas
 {
-class VolumeParams;
 namespace detail
 {
 class UniverseInserter;
@@ -36,28 +35,21 @@ class UnitInserter
     //!@{
     //! \name Type aliases
     using Data = HostVal<OrangeParamsData>;
-    using VecLabel = std::vector<Label>;
     //!@}
 
   public:
     // Construct from full parameter data
-    UnitInserter(VolumeParams const& volumes,
-                 UniverseInserter* insert_universe,
-                 VecLabel* vi_labels,
-                 Data* orange_data);
+    UnitInserter(UniverseInserter* insert_universe, Data* orange_data);
 
     // Create a simple unit and store in in OrangeParamsData
     UniverseId operator()(UnitInput&& inp);
 
   private:
-    VolumeParams const& volumes_;
-
     Data* orange_data_{nullptr};
     BIHBuilder build_bih_tree_;
     TransformRecordInserter insert_transform_;
     SurfacesRecordBuilder build_surfaces_;
     UniverseInserter* insert_universe_;
-    VecLabel* vi_labels_;  //!< NOTE: may be null
 
     CollectionBuilder<SimpleUnitRecord> simple_units_;
 

--- a/src/orange/detail/UniverseInserter.cc
+++ b/src/orange/detail/UniverseInserter.cc
@@ -19,12 +19,36 @@ namespace detail
 namespace
 {
 //---------------------------------------------------------------------------//
-template<class T>
-void move_back(std::vector<T>& dst, std::vector<T>&& src)
+template<class T, class V>
+T get_or_default(V const& vt, T d = {})
+{
+    if (!std::holds_alternative<T>(vt))
+    {
+        return d;
+    }
+    return std::get<T>(vt);
+}
+
+//---------------------------------------------------------------------------//
+void move_back(std::vector<Label>& dst, std::vector<Label>&& src)
 {
     dst.insert(dst.end(),
                std::make_move_iterator(src.begin()),
                std::make_move_iterator(src.end()));
+    std::move(src).clear();
+}
+
+//---------------------------------------------------------------------------//
+void move_back(std::vector<Label>& dst,
+               std::vector<VolumeInput::VariantLabel>&& src)
+{
+    dst.reserve(dst.size() + src.size());
+    for (auto& label : src)
+    {
+        CELER_ASSUME(std::holds_alternative<Label>(label));
+        dst.push_back(std::move(std::get<Label>(label)));
+    }
+
     std::move(src).clear();
 }
 
@@ -37,17 +61,21 @@ void move_back(std::vector<T>& dst, std::vector<T>&& src)
  *
  * Push back initial zeros on construction.
  */
-UniverseInserter::UniverseInserter(VecLabel* universe_labels,
+UniverseInserter::UniverseInserter(VolumeParams const& volume_params,
+                                   VecLabel* universe_labels,
                                    VecLabel* surface_labels,
                                    VecLabel* volume_labels,
                                    Data* data)
-    : universe_labels_{universe_labels}
+    : volume_params_{volume_params}
+    , universe_labels_{universe_labels}
     , surface_labels_{surface_labels}
     , volume_labels_{volume_labels}
     , types_(&data->universe_types)
     , indices_(&data->universe_indices)
     , surfaces_{&data->universe_indexer_data.surfaces}
     , volumes_{&data->universe_indexer_data.volumes}
+    , volume_ids_{&data->volume_ids}
+    , volume_instance_ids_{&data->volume_instance_ids}
 {
     CELER_EXPECT(universe_labels_ && surface_labels_ && volume_labels_ && data);
     CELER_EXPECT(types_.size() == 0);
@@ -72,6 +100,76 @@ UniverseId UniverseInserter::operator()(UniverseType type,
     CELER_EXPECT(type != UniverseType::size_);
     CELER_EXPECT(!volume_labels.empty());
 
+    UniverseId result = this->update_counters(
+        type, surface_labels.size(), volume_labels.size());
+
+    // Append metadata
+    universe_labels_->push_back(std::move(univ_label));
+    move_back(*surface_labels_, std::move(surface_labels));
+    move_back(*volume_labels_, std::move(volume_labels));
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Accumulate the number of local surfaces and volumes.
+ */
+UniverseId UniverseInserter::operator()(UniverseType type,
+                                        Label univ_label,
+                                        VecLabel surface_labels,
+                                        VecVolLabel volume_labels)
+{
+    CELER_EXPECT(type != UniverseType::size_);
+    CELER_EXPECT(!volume_labels.empty());
+    CELER_EXPECT(
+        !volume_params_.empty()
+        || std::all_of(
+            volume_labels.begin(), volume_labels.end(), [](auto& varlabel) {
+                return std::holds_alternative<Label>(varlabel);
+            }));
+
+    UniverseId result = this->update_counters(
+        type, surface_labels.size(), volume_labels.size());
+
+    if (!volume_params_.empty())
+    {
+        volume_ids_.reserve(volume_ids_.size() + volume_labels.size());
+        volume_instance_ids_.reserve(volume_ids_.size());
+
+        // Add volume IDs and instance IDs
+        for (auto& var_label : volume_labels)
+        {
+            if (auto vi_id = get_or_default<VolumeInstanceId>(var_label))
+            {
+                CELER_ASSERT(vi_id < volume_params_.num_volume_instances());
+                volume_ids_.push_back(volume_params_.volume(vi_id));
+                volume_instance_ids_.push_back(vi_id);
+
+                // Replace with volume instance label corresponding to it
+                var_label = volume_params_.volume_instance_labels().at(vi_id);
+            }
+            else
+            {
+                // No physical volume corresponds to it
+                volume_ids_.push_back(VolumeId{});
+                volume_instance_ids_.push_back(VolumeInstanceId{});
+            }
+        }
+    }
+
+    // Append metadata
+    universe_labels_->push_back(std::move(univ_label));
+    move_back(*surface_labels_, std::move(surface_labels));
+    move_back(*volume_labels_, std::move(volume_labels));
+
+    return result;
+}
+
+UniverseId UniverseInserter::update_counters(UniverseType type,
+                                             size_type num_surfaces,
+                                             size_type num_volumes)
+{
     UniverseId result = types_.size_id();
 
     // Add universe type and index
@@ -79,15 +177,10 @@ UniverseId UniverseInserter::operator()(UniverseType type,
     indices_.push_back(num_universe_types_[type]++);
 
     // Accumulate and append surface/volumes to universe indexer
-    accum_surface_ += surface_labels.size();
-    accum_volume_ += volume_labels.size();
+    accum_surface_ += num_surfaces;
+    accum_volume_ += num_volumes;
     surfaces_.push_back(accum_surface_);
     volumes_.push_back(accum_volume_);
-
-    // Append metadata
-    universe_labels_->push_back(std::move(univ_label));
-    move_back(*surface_labels_, std::move(surface_labels));
-    move_back(*volume_labels_, std::move(volume_labels));
 
     CELER_ENSURE(std::accumulate(num_universe_types_.begin(),
                                  num_universe_types_.end(),

--- a/src/orange/detail/UniverseInserter.cc
+++ b/src/orange/detail/UniverseInserter.cc
@@ -143,11 +143,14 @@ UniverseId UniverseInserter::operator()(UniverseType type,
             if (auto vi_id = get_or_default<VolumeInstanceId>(var_label))
             {
                 CELER_ASSERT(vi_id < volume_params_.num_volume_instances());
-                volume_ids_.push_back(volume_params_.volume(vi_id));
+                auto vol_id = volume_params_.volume(vi_id);
+                volume_ids_.push_back(vol_id);
                 volume_instance_ids_.push_back(vi_id);
 
-                // Replace with volume instance label corresponding to it
-                var_label = volume_params_.volume_instance_labels().at(vi_id);
+                // Replace with volume label corresponding to it
+                // TODO: should be volume instance label or also something else
+                // specific to this implementation
+                var_label = volume_params_.volume_labels().at(vol_id);
             }
             else
             {

--- a/src/orange/detail/UniverseInserter.cc
+++ b/src/orange/detail/UniverseInserter.cc
@@ -10,6 +10,8 @@
 #include <iterator>
 #include <numeric>
 
+#include "geocel/VolumeParams.hh"
+
 namespace celeritas
 {
 namespace detail

--- a/src/orange/detail/UniverseInserter.hh
+++ b/src/orange/detail/UniverseInserter.hh
@@ -12,10 +12,13 @@
 #include "corecel/io/Label.hh"
 
 #include "../OrangeData.hh"
+#include "../OrangeInput.hh"
 #include "../OrangeTypes.hh"
 
 namespace celeritas
 {
+class VolumeParams;
+
 namespace detail
 {
 //---------------------------------------------------------------------------//
@@ -28,12 +31,15 @@ class UniverseInserter
     //!@{
     //! \name Type aliases
     using Data = HostVal<OrangeParamsData>;
+    using VecVolLabel = std::vector<VolumeInput::VariantLabel>;
+    using VecVolInst = std::vector<VolumeInstanceId>;
     using VecLabel = std::vector<Label>;
     //!@}
 
   public:
     // Construct from full parameter data
-    UniverseInserter(VecLabel* universe_labels,
+    UniverseInserter(VolumeParams const& volume_params,
+                     VecLabel* universe_labels,
                      VecLabel* surface_labels,
                      VecLabel* volume_labels,
                      Data* data);
@@ -44,19 +50,39 @@ class UniverseInserter
                           VecLabel surface_labels,
                           VecLabel volume_labels);
 
+    // Append the number of local surfaces and volumes
+    UniverseId operator()(UniverseType type,
+                          Label univ_label,
+                          VecLabel surface_labels,
+                          VecVolLabel volume_labels);
+
   private:
+    // Reference data
+    VolumeParams const& volume_params_;
+
+    // Metadata being constructed
     VecLabel* universe_labels_;
     VecLabel* surface_labels_;
     VecLabel* volume_labels_;
 
+    // Data being constructed
     CollectionBuilder<UniverseType, MemSpace::host, UniverseId> types_;
     CollectionBuilder<size_type, MemSpace::host, UniverseId> indices_;
     CollectionBuilder<size_type> surfaces_;
     CollectionBuilder<size_type> volumes_;
 
+    // Optional data being constructed
+    CollectionBuilder<VolumeId, MemSpace::host, ImplVolumeId> volume_ids_;
+    CollectionBuilder<VolumeInstanceId, MemSpace::host, ImplVolumeId>
+        volume_instance_ids_;
+
     EnumArray<UniverseType, size_type> num_universe_types_{};
     size_type accum_surface_{0};
     size_type accum_volume_{0};
+
+    UniverseId update_counters(UniverseType type,
+                               size_type num_surfaces,
+                               size_type num_volumes);
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/g4org/Converter.cc
+++ b/src/orange/g4org/Converter.cc
@@ -45,7 +45,7 @@ Converter::Converter(Options&& opts) : opts_{std::move(opts)}
 /*!
  * Convert the world.
  */
-auto Converter::operator()(arg_type geo) -> result_type
+auto Converter::operator()(GeantGeoParams const& geo) -> result_type
 {
     using orangeinp::InputBuilder;
 

--- a/src/orange/g4org/Converter.cc
+++ b/src/orange/g4org/Converter.cc
@@ -58,7 +58,7 @@ auto Converter::operator()(GeantGeoParams const& geo) -> result_type
                    << "world volume should not have a transformation");
 
     // Convert logical volumes into protos
-    auto global_proto = ProtoConstructor{geo, opts_.verbose}(*world.lv);
+    auto global_proto = ProtoConstructor{geo, opts_.verbose}(world);
 
     // Build universes from protos
     result_type result;

--- a/src/orange/g4org/Converter.hh
+++ b/src/orange/g4org/Converter.hh
@@ -37,8 +37,8 @@ namespace g4org
 /*!
  * Create an ORANGE geometry model from an in-memory Geant4 model.
  *
- * Return the new world volume and a mapping of Geant4 logical volumes to
- * VecGeom-based volume IDs.
+ * Return a complete geometry input, including a mapping of internal
+ * ORANGE volume IDs to structural volume IDs.
  *
  * The default Geant4 "tolerance" (often used as surface "thickness") is 1e-9
  * mm, and the relative tolerance when specifying a length scale is 1e-11 (so
@@ -53,7 +53,6 @@ class Converter
     //!@{
     //! \name Type aliases
     using arg_type = GeantGeoParams const&;
-    using MapLvVolId = std::unordered_map<G4LogicalVolume const*, ImplVolumeId>;
     //!@}
 
     //! Input options for the conversion
@@ -72,7 +71,6 @@ class Converter
     struct result_type
     {
         OrangeInput input;
-        MapLvVolId volumes;  //! TODO
     };
 
   public:
@@ -83,7 +81,7 @@ class Converter
     Converter() : Converter{Options{}} {}
 
     // Convert the world
-    result_type operator()(arg_type);
+    result_type operator()(GeantGeoParams const&);
 
   private:
     Options opts_;

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -67,7 +67,11 @@ auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> SPLV
 
     // Save Geant4 volume ID
     result->id = geo_.geant_to_id(g4lv);
-    result->material_id = geo_.geant_to_mat_id(g4lv);
+    result->material_id = [this, mat = g4lv.GetMaterial()]() -> GeoMatId {
+        if (!mat)
+            return {};
+        return geo_.geant_to_id(*mat);
+    }();
 
     // Convert solid
     try

--- a/src/orange/g4org/LogicalVolumeConverter.cc
+++ b/src/orange/g4org/LogicalVolumeConverter.cc
@@ -7,7 +7,6 @@
 #include "LogicalVolumeConverter.hh"
 
 #include <G4LogicalVolume.hh>
-#include <G4Material.hh>
 #include <G4VSolid.hh>
 
 #include "corecel/Assert.hh"
@@ -68,19 +67,7 @@ auto LogicalVolumeConverter::construct_impl(arg_type g4lv) -> SPLV
 
     // Save Geant4 volume ID
     result->id = geo_.geant_to_id(g4lv);
-
-    // Save material ID
-    // NOTE: this is *not* the physics material ("cut couple")
-    if (auto* mat = g4lv.GetMaterial())
-    {
-        result->material_id = id_cast<GeoMatId>(mat->GetIndex());
-    }
-    else
-    {
-        CELER_LOG(warning) << "Logical volume '" << PrintableLV{&g4lv}
-                           << "' has no associated material";
-        result->material_id = GeoMatId{0};
-    }
+    result->material_id = geo_.geant_to_mat_id(g4lv);
 
     // Convert solid
     try

--- a/src/orange/g4org/ProtoConstructor.cc
+++ b/src/orange/g4org/ProtoConstructor.cc
@@ -31,6 +31,17 @@ bool is_union(ProtoConstructor::SPConstObject const& obj)
 }
 
 //---------------------------------------------------------------------------//
+// It's possible to have Geant4 geometry with no materials defined:
+// in this case, the background/material will be 'false' unless we use a
+// bogus material ID
+GeoMatId background_fill(GeoMatId mat)
+{
+    if (mat)
+        return mat;
+    return GeoMatId{0};
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -73,7 +84,7 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
         background.interior
             = this->make_explicit_background(lv, NoTransformation{});
         background.label = {};
-        background.fill = lv.material_id;
+        background.fill = background_fill(lv.material_id);
         input.boundary.zorder = ZOrder::media;
         input.materials.push_back(std::move(background));
     }
@@ -84,7 +95,8 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
             std::clog << std::string(depth_, ' ') << " - implicit background"
                       << std::endl;
         }
-        input.background.fill = lv.material_id;
+        input.background.fill = background_fill(lv.material_id);
+        CELER_ASSERT(input.background);
     }
 
     CELER_ENSURE(input);

--- a/src/orange/g4org/ProtoConstructor.cc
+++ b/src/orange/g4org/ProtoConstructor.cc
@@ -39,7 +39,7 @@ bool is_union(ProtoConstructor::SPConstObject const& obj)
  */
 auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
 {
-    auto const& label = this->get_label(lv);
+    auto const& label = geo_.impl_volumes().at(lv.id);
 
     ProtoInput input;
     input.boundary.interior = lv.solid;
@@ -72,7 +72,7 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
         orangeinp::UnitProto::MaterialInput background;
         background.interior
             = this->make_explicit_background(lv, NoTransformation{});
-        background.label = label;
+        background.label = {};
         background.fill = lv.material_id;
         input.boundary.zorder = ZOrder::media;
         input.materials.push_back(std::move(background));
@@ -92,20 +92,6 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
 }
 
 //---------------------------------------------------------------------------//
-Label const& ProtoConstructor::get_label(LogicalVolume const& lv)
-{
-    CELER_EXPECT(lv.id);
-    return geo_.impl_volumes().at(lv.id);
-}
-
-//---------------------------------------------------------------------------//
-Label const& ProtoConstructor::get_label(PhysicalVolume const& pv)
-{
-    CELER_EXPECT(pv.id);
-    return geo_.volume_instances().at(pv.id);
-}
-
-//---------------------------------------------------------------------------//
 /*!
  * Place this physical volume into the proto.
  */
@@ -121,23 +107,22 @@ void ProtoConstructor::place_pv(VariantTransform const& parent_transform,
     // that's subtracted from an inlined LV
     auto transform = apply_transform(parent_transform, pv.transform);
 
-    auto const& label = this->get_label(pv);
-
     if (CELER_UNLIKELY(verbose_))
     {
-        std::clog << std::string(depth_, ' ') << "- Add pv " << label
+        std::clog << std::string(depth_, ' ') << "- Add pv "
+                  << geo_.volume_instances().at(pv.id)
                   << " use_count=" << pv.lv.use_count()
                   << ", num_children=" << pv.lv->children.size() << ", at "
                   << StreamableVariant{transform} << " to " << proto->label
                   << std::endl;
     }
 
-    auto add_material = [this, proto, &lv = *pv.lv](SPConstObject&& obj) {
+    auto add_material = [&](SPConstObject&& obj) {
         CELER_EXPECT(obj);
         UnitProto::MaterialInput mat;
         mat.interior = std::move(obj);
-        mat.fill = lv.material_id;
-        mat.label = this->get_label(lv);
+        mat.fill = pv.lv->material_id;
+        mat.label = pv.id;
         proto->materials.push_back(std::move(mat));
     };
 
@@ -254,13 +239,14 @@ auto ProtoConstructor::make_explicit_background(
     }
     else
     {
-        interior = std::make_shared<AnyObjects>(
-            this->get_label(lv).name + ".children", std::move(children));
+        auto const& name = geo_.impl_volumes().at(lv.id).name;
+        interior = std::make_shared<AnyObjects>(name + ".children",
+                                                std::move(children));
     }
 
+    auto const& name = geo_.impl_volumes().at(lv.id).name;
     return Transformed::or_object(
-        orangeinp::make_subtraction(
-            std::string{this->get_label(lv).name}, lv.solid, interior),
+        orangeinp::make_subtraction(std::string{name}, lv.solid, interior),
         transform);
 }
 

--- a/src/orange/g4org/ProtoConstructor.cc
+++ b/src/orange/g4org/ProtoConstructor.cc
@@ -85,7 +85,6 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
                       << std::endl;
         }
         input.background.fill = lv.material_id;
-        input.background.label = label;
     }
 
     CELER_ENSURE(input);
@@ -210,7 +209,8 @@ void ProtoConstructor::place_pv(VariantTransform const& parent_transform,
             --depth_;
         }
         CELER_ASSERT(iter->second);
-        proto->daughters.push_back({iter->second, transform, ZOrder::media});
+        proto->daughters.push_back(
+            {iter->second, transform, ZOrder::media, pv.id});
 
         if (CELER_UNLIKELY(verbose_))
         {

--- a/src/orange/g4org/ProtoConstructor.cc
+++ b/src/orange/g4org/ProtoConstructor.cc
@@ -46,10 +46,16 @@ GeoMatId background_fill(GeoMatId mat)
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct a proto-universe from a logical volume.
+ * Construct a proto-universe from a physical volume.
+ *
+ * We can use logical volume for the structure, but we need to associate the
+ * world physical volume ID.
  */
-auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
+auto ProtoConstructor::operator()(PhysicalVolume const& pv) -> SPUnitProto
 {
+    LogicalVolume const& lv = *pv.lv;
+
+    // XXX replace with VolumeParams
     auto const& label = geo_.impl_volumes().at(lv.id);
 
     ProtoInput input;
@@ -63,10 +69,10 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
     }
 
     // Add children first
-    for (PhysicalVolume const& pv : lv.children)
+    for (PhysicalVolume const& child_pv : lv.children)
     {
         ++depth_;
-        this->place_pv(NoTransformation{}, pv, &input);
+        this->place_pv(NoTransformation{}, child_pv, &input);
         --depth_;
     }
 
@@ -83,7 +89,7 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
         orangeinp::UnitProto::MaterialInput background;
         background.interior
             = this->make_explicit_background(lv, NoTransformation{});
-        background.label = {};
+        background.label = pv.id;
         background.fill = background_fill(lv.material_id);
         input.boundary.zorder = ZOrder::media;
         input.materials.push_back(std::move(background));
@@ -96,6 +102,7 @@ auto ProtoConstructor::operator()(LogicalVolume const& lv) -> SPUnitProto
                       << std::endl;
         }
         input.background.fill = background_fill(lv.material_id);
+        input.background.label = pv.id;
         CELER_ASSERT(input.background);
     }
 
@@ -202,7 +209,7 @@ void ProtoConstructor::place_pv(VariantTransform const& parent_transform,
         {
             ++depth_;
             // Construct pv proto
-            iter->second = (*this)(*pv.lv);
+            iter->second = (*this)(pv);
             --depth_;
         }
         CELER_ASSERT(iter->second);

--- a/src/orange/g4org/ProtoConstructor.hh
+++ b/src/orange/g4org/ProtoConstructor.hh
@@ -48,8 +48,8 @@ class ProtoConstructor
     {
     }
 
-    // Construct a proto from a logical volume
-    SPUnitProto operator()(LogicalVolume const& lv);
+    // Construct a proto from the world volume
+    SPUnitProto operator()(PhysicalVolume const& pv);
 
   private:
     GeantGeoParams const& geo_;

--- a/src/orange/g4org/ProtoConstructor.hh
+++ b/src/orange/g4org/ProtoConstructor.hh
@@ -57,9 +57,6 @@ class ProtoConstructor
     int depth_{0};
     bool verbose_{false};
 
-    Label const& get_label(LogicalVolume const& lv);
-    Label const& get_label(PhysicalVolume const& lv);
-
     // Place a physical volume into the given unconstructed proto
     void place_pv(VariantTransform const& parent_transform,
                   PhysicalVolume const& pv,

--- a/src/orange/g4org/Volume.hh
+++ b/src/orange/g4org/Volume.hh
@@ -54,6 +54,9 @@ struct PhysicalVolume
  *
  * This holds equivalent information to a Geant4 \c G4LogicalVolume, but with
  * \em only ORANGE data structures.
+ *
+ * \todo Remove the material ID; volume-to-material mapping should be done by
+ * VolumeParams.
  */
 struct LogicalVolume
 {

--- a/src/orange/g4org/Volume.hh
+++ b/src/orange/g4org/Volume.hh
@@ -59,8 +59,8 @@ struct LogicalVolume
 {
     using SPConstObject = std::shared_ptr<orangeinp::ObjectInterface const>;
 
-    //! Corresponding Geant4 logical volume
-    ImplVolumeId id;
+    //! Corresponding Geant4 logical volume, primarily for debug output
+    VolumeId id;
     //! Filled material ID
     GeoMatId material_id;
 

--- a/src/orange/orangeinp/UnitProto.cc
+++ b/src/orange/orangeinp/UnitProto.cc
@@ -242,7 +242,7 @@ void UnitProto::build(ProtoBuilder& input) const
     {
         vol_iter->zorder = input_.boundary.zorder;
     }
-    vol_iter->label = {"[EXTERIOR]", input_.label};
+    vol_iter->label = Label{"[EXTERIOR]", input_.label};
     ++vol_iter;
 
     BoundingBoxBumper<real_type> bump_bbox{input.tol()};
@@ -324,7 +324,10 @@ void UnitProto::build(ProtoBuilder& input) const
         CELER_ASSERT(unit_volumes.size() <= result.volumes.size());
         for (auto vol_idx : range(unit_volumes.size()))
         {
-            jv[vol_idx]["label"] = result.volumes[vol_idx].label;
+            if (auto* label = std::get_if<Label>(&result.volumes[vol_idx].label))
+            {
+                jv[vol_idx]["label"] = *label;
+            }
         }
 
         // Save our universe label

--- a/src/orange/orangeinp/UnitProto.cc
+++ b/src/orange/orangeinp/UnitProto.cc
@@ -300,10 +300,15 @@ void UnitProto::build(ProtoBuilder& input) const
         ++vol_iter;
     }
 
-    if (input_.background)
+    if (auto const& b = input_.background)
     {
         CELER_ASSERT(vol_iter != result.volumes.end());
-        vol_iter->label = Label{input_.label, "bg"};
+        vol_iter->label = b.label;
+        if (vol_iter->label == decltype(b.label){})
+        {
+            // Default: empty label
+            vol_iter->label = Label{input_.label, "bg"};
+        }
         ++vol_iter;
     }
     CELER_EXPECT(vol_iter == result.volumes.end());
@@ -489,6 +494,7 @@ void UnitProto::output(JsonPimpl* j) const
     {
         obj["background"] = {
             {"fill", bg.fill.unchecked_get()},
+            {"label", std::visit(to_string, bg.label)},
         };
     }
 

--- a/src/orange/orangeinp/UnitProto.cc
+++ b/src/orange/orangeinp/UnitProto.cc
@@ -17,6 +17,7 @@
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/io/LabelIO.json.hh"
 #include "corecel/io/Logger.hh"
+#include "geocel/VolumeToString.hh"
 #include "orange/OrangeData.hh"
 #include "orange/OrangeInput.hh"
 #include "orange/transform/VariantTransform.hh"
@@ -251,9 +252,14 @@ void UnitProto::build(ProtoBuilder& input) const
         LocalVolumeId const vol_id{
             static_cast<size_type>(vol_iter - result.volumes.begin())};
 
-        // Save daughter volume attributes
-        vol_iter->label
-            = Label{std::string{d.fill->label()}, std::string{this->label()}};
+        // Save daughter attributes
+        vol_iter->label = d.label;
+        if (vol_iter->label == VariantLabel{})
+        {
+            // Choose default label for the volume
+            vol_iter->label = Label{std::string{d.fill->label()},
+                                    std::string{this->label()}};
+        }
         vol_iter->zorder = d.zorder;
         /* TODO: the "embedded_universe" flag is *also* set by the unit
          * builder. Move that here. */
@@ -284,9 +290,12 @@ void UnitProto::build(ProtoBuilder& input) const
     for (auto const& m : input_.materials)
     {
         CELER_ASSERT(vol_iter != result.volumes.end());
-        vol_iter->label = !m.label.empty()
-                              ? m.label
-                              : Label{std::string(m.interior->label())};
+        vol_iter->label = m.label;
+        if (vol_iter->label == decltype(m.label){})
+        {
+            // Default: empty label
+            vol_iter->label = Label{std::string(m.interior->label())};
+        }
         vol_iter->zorder = ZOrder::media;
         ++vol_iter;
     }
@@ -294,9 +303,7 @@ void UnitProto::build(ProtoBuilder& input) const
     if (input_.background)
     {
         CELER_ASSERT(vol_iter != result.volumes.end());
-        vol_iter->label = !input_.background.label.empty()
-                              ? input_.background.label
-                              : Label{input_.label, "bg"};
+        vol_iter->label = Label{input_.label, "bg"};
         ++vol_iter;
     }
     CELER_EXPECT(vol_iter == result.volumes.end());
@@ -476,29 +483,29 @@ void UnitProto::output(JsonPimpl* j) const
     using json = nlohmann::json;
 
     auto obj = json::object({{"label", input_.label}});
+    VolumeToString to_string;
 
     if (auto& bg = input_.background)
     {
         obj["background"] = {
             {"fill", bg.fill.unchecked_get()},
-            {"label", bg.label},
         };
     }
 
-    obj["materials"] = [&ms = input_.materials] {
+    obj["materials"] = [&ms = input_.materials, to_string] {
         auto result = json::array();
         for (auto const& m : ms)
         {
             result.push_back({
                 {"interior", m.interior},
                 {"fill", m.fill.get()},
-                {"label", m.label},
+                {"label", std::visit(to_string, m.label)},
             });
         }
         return result;
     }();
 
-    obj["daughters"] = [&ds = input_.daughters] {
+    obj["daughters"] = [&ds = input_.daughters, to_string] {
         auto result = json::array();
         for (auto const& d : ds)
         {
@@ -506,6 +513,7 @@ void UnitProto::output(JsonPimpl* j) const
                 {"fill", d.fill->label()},
                 {"transform", d.transform},
                 {"zorder", to_cstring(d.zorder)},
+                {"label", std::visit(to_string, d.label)},
             });
         }
         return result;

--- a/src/orange/orangeinp/UnitProto.hh
+++ b/src/orange/orangeinp/UnitProto.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "geocel/Types.hh"
@@ -76,12 +77,12 @@ class UnitProto : public ProtoInterface
     //! \name Types
     using Unit = detail::CsgUnit;
     using Tol = Tolerance<>;
+    using VariantLabel = std::variant<Label, VolumeInstanceId>;
 
     //! Optional "background" inside of exterior, outside of all mat/daughter
     struct BackgroundInput
     {
         GeoMatId fill{};
-        Label label;
 
         // True if fill or label is specified
         explicit inline operator bool() const;
@@ -92,7 +93,7 @@ class UnitProto : public ProtoInterface
     {
         SPConstObject interior;
         GeoMatId fill;
-        Label label;
+        VariantLabel label;
 
         // True if fully defined
         explicit inline operator bool() const;
@@ -104,6 +105,7 @@ class UnitProto : public ProtoInterface
         SPConstProto fill;  //!< Daughter unit
         VariantTransform transform;  //!< Daughter-to-parent
         ZOrder zorder{ZOrder::media};  //!< Overlap control
+        VariantLabel label;  //!< Placement name
 
         // True if fully defined
         explicit inline operator bool() const;
@@ -173,7 +175,7 @@ class UnitProto : public ProtoInterface
  */
 UnitProto::BackgroundInput::operator bool() const
 {
-    return this->fill || !this->label.empty();
+    return static_cast<bool>(this->fill);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/UnitProto.hh
+++ b/src/orange/orangeinp/UnitProto.hh
@@ -83,6 +83,7 @@ class UnitProto : public ProtoInterface
     struct BackgroundInput
     {
         GeoMatId fill{};
+        VariantLabel label;
 
         // True if fill or label is specified
         explicit inline operator bool() const;

--- a/test/celeritas/GlobalGeoTestBase.cc
+++ b/test/celeritas/GlobalGeoTestBase.cc
@@ -55,10 +55,7 @@ auto GlobalGeoTestBase::build_fresh_geometry(std::string_view basename)
     using namespace std::literals;
 
     constexpr bool use_orange = CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE;
-    constexpr bool use_g4
-        = CELERITAS_USE_GEANT4
-          && (!use_orange
-              || (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE));
+    constexpr bool use_g4 = CELERITAS_USE_GEANT4;
 
     // Construct filename:
     // ${SOURCE}/test/celeritas/data/${basename}${fileext}
@@ -79,8 +76,7 @@ auto GlobalGeoTestBase::build_fresh_geometry(std::string_view basename)
     }
     else if (use_orange)
     {
-        // Using ORANGE, either without Geant4 or without double-precision
-        // arithmetic
+        // Using ORANGE without Geant4 (ultralite CI test harness)
 #if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
         return CoreGeoParams::from_json(filename);
 #endif

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -49,17 +49,11 @@ auto ImportedDataTestBase::build_material() -> SPConstMaterial
 //---------------------------------------------------------------------------//
 auto ImportedDataTestBase::build_geomaterial() -> SPConstGeoMaterial
 {
-    SPConstVolume volume_params;
-    if constexpr (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
-    {
-        // FIXME: ORANGE doesn't support volume/material conversion
-        this->setup_model();
-        volume_params = this->volume();
-    }
+    this->setup_model();
 
     return GeoMaterialParams::from_import(this->imported_data(),
                                           this->geometry(),
-                                          volume_params,
+                                          this->volume(),
                                           this->material());
 }
 

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -302,19 +302,12 @@ TEST_F(SimpleComptonTest, kill_active)
     step.kill_active();
     counters = step();
     EXPECT_EQ(0, counters.alive);
-    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
-        && CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
-        && CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
-        && CELERITAS_USE_GEANT4)
-    {
-        static char const* const expected_log_messages[] = {
-            "Killing 2 active tracks",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@world"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner@world"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
-        };
-        EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages())
-            << scoped_log;
-    }
+    static char const* const expected_log_messages[] = {
+        "Killing 2 active tracks",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
+    };
+    EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages()) << scoped_log;
     static char const* const expected_log_levels[]
         = {"error", "error", "error"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log.levels());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -307,7 +307,12 @@ TEST_F(SimpleComptonTest, kill_active)
         R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
         R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
     };
-    EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages()) << scoped_log;
+    if (CELERITAS_USE_GEANT4)
+    {
+        // Messages match only when importing Geant4 volumes
+        EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages())
+            << scoped_log;
+    }
     static char const* const expected_log_levels[]
         = {"error", "error", "error"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log.levels());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -307,7 +307,7 @@ TEST_F(SimpleComptonTest, kill_active)
         R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
         R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
     };
-    if (CELERITAS_USE_GEANT4)
+    if (CELERITAS_UNITS == CELERITAS_UNITS_CGS && CELERITAS_USE_GEANT4)
     {
         // Messages match only when importing Geant4 volumes
         EXPECT_VEC_EQ(expected_log_messages, scoped_log.messages())

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -101,7 +101,12 @@ std::string GenericGeoTestBase<HP>::volume_name(GeoTrackView const& geo) const
     {
         return "[OUTSIDE]";
     }
-    return this->geometry()->impl_volumes().at(geo.impl_volume_id()).name;
+    auto id = geo.impl_volume_id();
+    if (!id)
+    {
+        return "[INVALID]";
+    }
+    return this->geometry()->impl_volumes().at(id).name;
 }
 
 //---------------------------------------------------------------------------//
@@ -133,7 +138,15 @@ GenericGeoTestBase<HP>::unique_volume_name(GeoTrackView const& geo) const
     os << vol_inst.at(ids[0]);
     for (auto i : range(std::size_t{1}, ids.size()))
     {
-        os << '/' << vol_inst.at(ids[i]);
+        os << '/';
+        if (ids[i])
+        {
+            os << vol_inst.at(ids[i]);
+        }
+        else
+        {
+            os << "[INVALID]";
+        }
     }
     return std::move(os).str();
 }

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -2069,6 +2069,62 @@ void TestEm3FlatGeoTest::test_trace() const
 }
 
 //---------------------------------------------------------------------------//
+// TILECAL PLUG
+//---------------------------------------------------------------------------//
+void TilecalPlugGeoTest::test_model() const
+{
+    auto result = test_->model_inp();
+    GenericGeoModelInp ref;
+    ref.volume.labels = {"Tile_Absorber", "Tile_Plug1Module", "Tile_ITCModule"};
+    ref.volume.materials = {0, 1, 1};
+    ref.volume.daughters = {{}, {0}, {1}};
+    ref.volume_instance.labels
+        = {"Tile_Absorber", "Tile_Plug1Module", "Tile_ITCModule_PV"};
+    ref.volume_instance.volumes = {0, 1, 2};
+    ref.world = "Tile_ITCModule_PV";
+    EXPECT_REF_EQ(ref, result);
+}
+
+void TilecalPlugGeoTest::test_trace() const
+{
+    {
+        SCOPED_TRACE("+z lo");
+        auto result = test_->track({5.75, 0.01, -40}, {0, 0, 1});
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "Tile_ITCModule",
+            "Tile_Plug1Module",
+            "Tile_Absorber",
+            "Tile_Plug1Module",
+        };
+        ref.volume_instances = {
+            "Tile_ITCModule_PV",
+            "Tile_Plug1Module",
+            "Tile_Absorber",
+            "Tile_Plug1Module",
+        };
+        ref.distances = {22.9425, 0.115, 42, 37};
+        ref.halfway_safeties = {9.7, 0.057499999999999, 9.7, 9.7};
+        ref.bumps = {};
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        EXPECT_REF_NEAR(ref, result, tol);
+    }
+    {
+        SCOPED_TRACE("+z hi");
+        auto result = test_->track({6.25, 0.01, -40}, {0, 0, 1});
+        GenericGeoTrackingResult ref;
+        ref.volumes = {"Tile_ITCModule", "Tile_Absorber", "Tile_Plug1Module"};
+        ref.volume_instances
+            = {"Tile_ITCModule_PV", "Tile_Absorber", "Tile_Plug1Module"};
+        ref.distances = {23.0575, 42, 37};
+        ref.halfway_safeties = {9.2, 9.2, 9.2};
+        ref.bumps = {};
+        auto tol = GenericGeoTrackingTolerance::from_test(*test_);
+        EXPECT_REF_NEAR(ref, result, tol);
+    }
+}
+
+//---------------------------------------------------------------------------//
 // TRANSFORMED BOX
 //---------------------------------------------------------------------------//
 void TransformedBoxGeoTest::test_model() const

--- a/test/geocel/GeoTests.hh
+++ b/test/geocel/GeoTests.hh
@@ -241,6 +241,25 @@ class TestEm3FlatGeoTest
 
 //---------------------------------------------------------------------------//
 /*!
+ * Test tilecal plug.
+ */
+class TilecalPlugGeoTest
+{
+  public:
+    static std::string_view geometry_basename() { return "tilecal-plug"; }
+
+    //! Construct with a reference to the GoogleTest
+    TilecalPlugGeoTest(GenericGeoTestInterface* geo_test) : test_{geo_test} {}
+
+    void test_model() const;
+    void test_trace() const;
+
+  private:
+    GenericGeoTestInterface* test_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Test the transformed box geometry.
  */
 class TransformedBoxGeoTest

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -649,33 +649,17 @@ TEST_F(SolidsTest, DISABLED_imager)
 }
 
 //---------------------------------------------------------------------------//
-class TilecalPlugTest : public GeantGeoTest
+using TilecalPlugTest
+    = GenericGeoParameterizedTest<GeantGeoTest, TilecalPlugGeoTest>;
+
+TEST_F(TilecalPlugTest, model)
 {
-    std::string geometry_basename() const final { return "tilecal-plug"; }
-};
+    this->impl().test_model();
+}
 
 TEST_F(TilecalPlugTest, trace)
 {
-    {
-        SCOPED_TRACE("+z");
-        auto result = this->track({5.75, 0.01, -40}, {0, 0, 1});
-        static char const* const expected_volumes[] = {"Tile_ITCModule",
-                                                       "Tile_Plug1Module",
-                                                       "Tile_Absorber",
-                                                       "Tile_Plug1Module"};
-        EXPECT_VEC_EQ(expected_volumes, result.volumes);
-        static real_type const expected_distances[] = {22.9425, 0.115, 42, 37};
-        EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
-    }
-    {
-        SCOPED_TRACE("+z");
-        auto result = this->track({6.25, 0.01, -40}, {0, 0, 1});
-        static char const* const expected_volumes[]
-            = {"Tile_ITCModule", "Tile_Absorber", "Tile_Plug1Module"};
-        EXPECT_VEC_EQ(expected_volumes, result.volumes);
-        static real_type const expected_distances[] = {23.0575, 42, 37};
-        EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
-    }
+    this->impl().test_trace();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeGeoTestBase.cc
+++ b/test/orange/OrangeGeoTestBase.cc
@@ -17,6 +17,7 @@
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "geocel/Types.hh"
+#include "geocel/VolumeParams.hh"
 #include "orange/OrangeInput.hh"
 #include "orange/OrangeParams.hh"
 #include "orange/detail/UniverseIndexer.hh"
@@ -172,7 +173,8 @@ void OrangeGeoTestBase::build_geometry(TwoVolInput inp)
 void OrangeGeoTestBase::build_geometry(UnitInput input)
 {
     CELER_EXPECT(input);
-    params_ = std::make_unique<Params>(to_input(std::move(input)));
+    params_
+        = std::make_unique<Params>(to_input(std::move(input)), VolumeParams{});
     // Base class will construct geometry from this call via build_geometry
     ASSERT_TRUE(this->geometry());
 }

--- a/test/orange/data/inputbuilder-hierarchy.org.json
+++ b/test/orange/data/inputbuilder-hierarchy.org.json
@@ -122,10 +122,10 @@
 ],
 "volume_labels": [
 "[EXTERIOR]@global",
-"d1@global",
-"d2@global",
-"filled_daughter@global",
-"leafy@global",
+"d",
+"e",
+"fd",
+"l",
 "leaf1",
 "interior"
 ],
@@ -428,8 +428,8 @@
 ],
 "volume_labels": [
 "[EXTERIOR]@filled_daughter",
-"d1@filled_daughter",
-"d2@filled_daughter",
+"d",
+"e",
 "leaf1",
 "leaf2",
 "filled_daughter@bg"

--- a/test/orange/data/inputbuilder-universes.org.json
+++ b/test/orange/data/inputbuilder-universes.org.json
@@ -111,8 +111,8 @@
 ],
 "volume_labels": [
 "[EXTERIOR]@outer",
-"inner@outer",
-"inner@outer",
+"i0",
+"i1",
 "bobby",
 "johnny"
 ],
@@ -302,7 +302,7 @@
 ],
 "volume_labels": [
 "[EXTERIOR]@inner",
-"most_inner@inner",
+"p",
 "a",
 "b",
 "c"

--- a/test/orange/g4org/Converter.test.cc
+++ b/test/orange/g4org/Converter.test.cc
@@ -60,6 +60,30 @@ class ConverterTest : public GeantLoadTestBase
     bool verbose_{false};
 };
 
+struct VolumeInstanceAccessor
+{
+    std::vector<VolumeInput> const& volumes;
+
+    std::string operator()(size_type i) const
+    {
+        if (i >= volumes.size())
+        {
+            return "<out of bounds>";
+        }
+        auto const& var_label = volumes[i].label;
+        if (auto* vi_id = std::get_if<VolumeInstanceId>(&var_label))
+        {
+            if (*vi_id)
+            {
+                return std::to_string(vi_id->get());
+            }
+            return "<null>";
+        }
+        CELER_ASSUME(std::holds_alternative<Label>(var_label));
+        return std::get<Label>(var_label).name;
+    }
+};
+
 //---------------------------------------------------------------------------//
 TEST_F(ConverterTest, testem3)
 {
@@ -111,10 +135,12 @@ TEST_F(ConverterTest, tilecal_plug)
     ASSERT_EQ(1, result.universes.size());
     {
         auto const& unit = std::get<UnitInput>(result.universes[0]);
-        ASSERT_EQ(4, unit.volumes.size());
-        EXPECT_EQ("Tile_Plug1Module", unit.volumes[1].label.name);
-        EXPECT_EQ("Tile_Absorber", unit.volumes[2].label.name);
-        EXPECT_EQ("Tile_ITCModule", unit.volumes[3].label.name);
+        EXPECT_EQ(4, unit.volumes.size());
+        VolumeInstanceAccessor get_vi_id{unit.volumes};
+        // See GeoTests
+        EXPECT_EQ("Tile_Plug1Module", get_vi_id(1));
+        EXPECT_EQ("Tile_Absorber", get_vi_id(2));
+        EXPECT_EQ("Tile_ITCModule", get_vi_id(3));
     }
 }
 

--- a/test/orange/g4org/Converter.test.cc
+++ b/test/orange/g4org/Converter.test.cc
@@ -138,8 +138,8 @@ TEST_F(ConverterTest, tilecal_plug)
         EXPECT_EQ(4, unit.volumes.size());
         VolumeInstanceAccessor get_vi_id{unit.volumes};
         // See GeoTests
-        EXPECT_EQ("Tile_Plug1Module", get_vi_id(1));
-        EXPECT_EQ("Tile_Absorber", get_vi_id(2));
+        EXPECT_EQ("1", get_vi_id(1));  // Tile_Plug1Module
+        EXPECT_EQ("0", get_vi_id(2));  // Tile_Absorber
         EXPECT_EQ("Tile_ITCModule", get_vi_id(3));
     }
 }

--- a/test/orange/g4org/Converter.test.cc
+++ b/test/orange/g4org/Converter.test.cc
@@ -80,9 +80,31 @@ struct VolumeInstanceAccessor
             return "<null>";
         }
         CELER_ASSUME(std::holds_alternative<Label>(var_label));
-        return std::get<Label>(var_label).name;
+        return to_string(std::get<Label>(var_label));
     }
 };
+
+//---------------------------------------------------------------------------//
+TEST_F(ConverterTest, simple_cms)
+{
+    verbose_ = true;
+    std::string const basename = "simple-cms";
+    this->load_test_gdml(basename);
+    auto convert = this->make_converter(basename);
+    auto result = convert(this->geo()).input;
+    write_org_json(result, basename);
+
+    ASSERT_EQ(1, result.universes.size());
+    {
+        auto const& unit = std::get<UnitInput>(result.universes[0]);
+        EXPECT_EQ(8, unit.volumes.size());
+        VolumeInstanceAccessor get_vi_id{unit.volumes};
+        EXPECT_EQ("[EXTERIOR]@world", get_vi_id(0));
+        EXPECT_EQ("0", get_vi_id(1));  // vacuum_tube_pv
+        EXPECT_EQ("1", get_vi_id(2));  // si_tracker_pv
+        EXPECT_EQ("6", get_vi_id(7));  // world_PV
+    }
+}
 
 //---------------------------------------------------------------------------//
 TEST_F(ConverterTest, testem3)
@@ -140,7 +162,7 @@ TEST_F(ConverterTest, tilecal_plug)
         // See GeoTests
         EXPECT_EQ("1", get_vi_id(1));  // Tile_Plug1Module
         EXPECT_EQ("0", get_vi_id(2));  // Tile_Absorber
-        EXPECT_EQ("Tile_ITCModule", get_vi_id(3));
+        EXPECT_EQ("2", get_vi_id(3));  // Tile_ITCModule (world volume)
     }
 }
 

--- a/test/orange/g4org/ProtoConstructor.test.cc
+++ b/test/orange/g4org/ProtoConstructor.test.cc
@@ -35,7 +35,7 @@ class ProtoConstructorTest : public GeantLoadTestBase
     using Unit = orangeinp::detail::CsgUnit;
     using Tol = Tolerance<>;
 
-    LogicalVolume load(std::string const& basename)
+    PhysicalVolume load(std::string const& basename)
     {
         this->load_test_gdml(basename);
         PhysicalVolumeConverter::Options opts;
@@ -47,7 +47,7 @@ class ProtoConstructorTest : public GeantLoadTestBase
 
         EXPECT_TRUE(std::holds_alternative<NoTransformation>(world.transform));
         EXPECT_EQ(1, world.lv.use_count());
-        return *world.lv;
+        return world;
     }
 
     auto get_proto_names(ProtoMap const& protos) const
@@ -80,7 +80,7 @@ class ProtoConstructorTest : public GeantLoadTestBase
 //---------------------------------------------------------------------------//
 TEST_F(ProtoConstructorTest, one_box)
 {
-    LogicalVolume world = this->load("one-box");
+    PhysicalVolume world = this->load("one-box");
     auto global_proto
         = ProtoConstructor(this->geo(), /* verbose = */ true)(world);
     ProtoMap protos{*global_proto};
@@ -127,7 +127,7 @@ TEST_F(ProtoConstructorTest, one_box)
 //---------------------------------------------------------------------------//
 TEST_F(ProtoConstructorTest, two_boxes)
 {
-    LogicalVolume world = this->load("two-boxes");
+    PhysicalVolume world = this->load("two-boxes");
     auto global_proto
         = ProtoConstructor(this->geo(), /* verbose = */ false)(world);
     ProtoMap protos{*global_proto};
@@ -163,7 +163,7 @@ TEST_F(ProtoConstructorTest, two_boxes)
 //---------------------------------------------------------------------------//
 TEST_F(ProtoConstructorTest, intersection_boxes)
 {
-    LogicalVolume world = this->load("intersection-boxes");
+    PhysicalVolume world = this->load("intersection-boxes");
     auto global_proto
         = ProtoConstructor(this->geo(), /* verbose = */ false)(world);
     ProtoMap protos{*global_proto};
@@ -255,7 +255,7 @@ TEST_F(ProtoConstructorTest, intersection_boxes)
 TEST_F(ProtoConstructorTest, simple_cms)
 {
     // NOTE: GDML stores widths for box and cylinder Z; Geant4 uses halfwidths
-    LogicalVolume world = this->load("simple-cms");
+    PhysicalVolume world = this->load("simple-cms");
 
     auto global_proto
         = ProtoConstructor(this->geo(), /* verbose = */ false)(world);
@@ -309,7 +309,7 @@ TEST_F(ProtoConstructorTest, simple_cms)
 //---------------------------------------------------------------------------//
 TEST_F(ProtoConstructorTest, testem3)
 {
-    LogicalVolume world = this->load("testem3");
+    PhysicalVolume world = this->load("testem3");
 
     auto global_proto
         = ProtoConstructor(this->geo(), /* verbose = */ false)(world);
@@ -392,7 +392,7 @@ TEST_F(ProtoConstructorTest, testem3)
 // Deduplication slightly changes plane position and CSG node IDs
 TEST_F(ProtoConstructorTest, TEST_IF_CELERITAS_DOUBLE(tilecal_plug))
 {
-    LogicalVolume world = this->load("tilecal-plug");
+    PhysicalVolume world = this->load("tilecal-plug");
 
     auto global_proto
         = ProtoConstructor(this->geo(), /* verbose = */ false)(world);
@@ -438,7 +438,7 @@ TEST_F(ProtoConstructorTest, TEST_IF_CELERITAS_DOUBLE(tilecal_plug))
 //---------------------------------------------------------------------------//
 TEST_F(ProtoConstructorTest, znenv)
 {
-    LogicalVolume world = this->load("znenv");
+    PhysicalVolume world = this->load("znenv");
 
     auto global_proto
         = ProtoConstructor(this->geo(), /* verbose = */ false)(world);

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -110,6 +110,7 @@ void append_daughter(UnitProto::Input& inp,
     UnitProto::DaughterInput di;
     di.fill = std::move(fill);
     di.transform = std::move(transform);
+    di.label = std::move(label);
     inp.daughters.emplace_back(std::move(di));
 }
 

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -102,6 +102,28 @@ SPConstProto make_daughter(std::string label)
     return std::make_shared<UnitProto>(std::move(inp));
 }
 
+void append_daughter(UnitProto::Input& inp,
+                     SPConstProto&& fill,
+                     VariantTransform&& transform,
+                     UnitProto::VariantLabel&& label = {})
+{
+    UnitProto::DaughterInput di;
+    di.fill = std::move(fill);
+    di.transform = std::move(transform);
+    inp.daughters.emplace_back(std::move(di));
+}
+
+void append_material(UnitProto::Input& inp,
+                     SPConstObject&& obj,
+                     GeoMatId::size_type m)
+{
+    CELER_EXPECT(obj);
+    UnitProto::MaterialInput mi;
+    mi.interior = std::move(obj);
+    mi.fill = GeoMatId{m};
+    inp.materials.emplace_back(std::move(mi));
+}
+
 std::string proto_labels(ProtoInterface::VecProto const& vp)
 {
     auto stream_proto_ptr = [](std::ostream& os, ProtoInterface const* p) {
@@ -115,16 +137,6 @@ std::string proto_labels(ProtoInterface::VecProto const& vp)
         }
     };
     return to_string(join_stream(vp.begin(), vp.end(), ",", stream_proto_ptr));
-}
-
-UnitProto::MaterialInput
-make_material(SPConstObject&& obj, GeoMatId::size_type m)
-{
-    CELER_EXPECT(obj);
-    UnitProto::MaterialInput result;
-    result.interior = std::move(obj);
-    result.fill = GeoMatId{m};
-    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -151,8 +163,7 @@ TEST_F(LeafTest, errors)
         inp.boundary.interior = std::make_shared<NegatedObject>(
             "bad-interior", make_cyl("bound", 1.0, 1.0));
         inp.boundary.zorder = ZOrder::media;
-        inp.materials.push_back(
-            make_material(SPConstObject(inp.boundary.interior), 1));
+        append_material(inp, SPConstObject(inp.boundary.interior), 1);
         UnitProto const proto{std::move(inp)};
 
         EXPECT_THROW(proto.build(tol_, BBox{}), RuntimeError);
@@ -166,10 +177,10 @@ TEST_F(LeafTest, explicit_exterior)
     inp.boundary.interior = make_cyl("bound", 1.0, 1.0);
     inp.boundary.zorder = ZOrder::media;
     inp.label = "leaf";
-    inp.materials.push_back(make_material(
-        make_translated(make_cyl("bottom", 1, 0.5), {0, 0, -0.5}), 1));
-    inp.materials.push_back(make_material(
-        make_translated(make_cyl("top", 1, 0.5), {0, 0, 0.5}), 2));
+    append_material(
+        inp, make_translated(make_cyl("bottom", 1, 0.5), {0, 0, -0.5}), 1);
+    append_material(
+        inp, make_translated(make_cyl("top", 1, 0.5), {0, 0, 0.5}), 2);
     UnitProto const proto{std::move(inp)};
 
     EXPECT_EQ("", proto_labels(proto.daughters()));
@@ -221,7 +232,7 @@ TEST_F(LeafTest, implicit_exterior)
     inp.boundary.zorder = ZOrder::exterior;
     inp.background.fill = GeoMatId{0};
     inp.label = "leaf";
-    inp.materials.push_back(make_material(make_cyl("middle", 1, 0.5), 1));
+    append_material(inp, make_cyl("middle", 1, 0.5), 1);
     UnitProto const proto{std::move(inp)};
 
     {
@@ -263,14 +274,14 @@ TEST_F(MotherTest, explicit_exterior)
     inp.boundary.interior = make_sph("bound", 10.0);
     inp.boundary.zorder = ZOrder::media;
     inp.label = "mother";
-    inp.materials.push_back(
-        make_material(make_translated(make_sph("leaf", 1), {0, 0, -5}), 1));
-    inp.materials.push_back(
-        make_material(make_translated(make_sph("leaf2", 1), {0, 0, 5}), 2));
-    inp.daughters.push_back({make_daughter("d1"), Translation{{0, 5, 0}}});
-    inp.daughters.push_back(
-        {make_daughter("d2"),
-         Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}}});
+    append_material(inp, make_translated(make_sph("leaf", 1), {0, 0, -5}), 1);
+    append_material(inp, make_translated(make_sph("leaf2", 1), {0, 0, 5}), 2);
+    append_daughter(inp, make_daughter("d1"), Translation{{0, 5, 0}}, "d");
+    append_daughter(
+        inp,
+        make_daughter("d2"),
+        Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}},
+        "e");
 
     // Construct "inside" cell
     std::vector<std::pair<Sense, SPConstObject>> interior
@@ -283,8 +294,7 @@ TEST_F(MotherTest, explicit_exterior)
     {
         interior.push_back({Sense::outside, d.make_interior()});
     }
-    inp.materials.push_back(
-        make_material(make_rdv("interior", std::move(interior)), 3));
+    append_material(inp, make_rdv("interior", std::move(interior)), 3);
 
     UnitProto const proto{std::move(inp)};
 
@@ -366,14 +376,14 @@ TEST_F(MotherTest, implicit_exterior)
     inp.boundary.interior = make_sph("bound", 10.0);
     inp.boundary.zorder = ZOrder::media;
     inp.label = "mother";
-    inp.materials.push_back(
-        make_material(make_translated(make_sph("leaf", 1), {0, 0, -5}), 1));
-    inp.materials.push_back(
-        make_material(make_translated(make_sph("leaf2", 1), {0, 0, 5}), 2));
-    inp.daughters.push_back({make_daughter("d1"), Translation{{0, 5, 0}}});
-    inp.daughters.push_back(
-        {make_daughter("d2"),
-         Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}}});
+    append_material(inp, make_translated(make_sph("leaf", 1), {0, 0, -5}), 1);
+    append_material(inp, make_translated(make_sph("leaf2", 1), {0, 0, 5}), 2);
+    append_daughter(inp, make_daughter("d1"), Translation{{0, 5, 0}}, "d");
+    append_daughter(
+        inp,
+        make_daughter("d2"),
+        Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}},
+        "e");
     inp.background.fill = GeoMatId{3};
 
     UnitProto const proto{std::move(inp)};
@@ -404,12 +414,12 @@ TEST_F(MotherTest, fuzziness)
     inp.boundary.interior = make_sph("bound", 10.0);
     inp.boundary.zorder = ZOrder::media;
     inp.label = "fuzzy";
-    inp.daughters.push_back({make_daughter("d1"), {}});
-    inp.materials.push_back(make_material(
-        make_rdv("interior",
-                 {{Sense::inside, inp.boundary.interior},
-                  {Sense::outside, make_sph("similar", 1.0001)}}),
-        1));
+    append_daughter(inp, make_daughter("d1"), {}, "d");
+    append_material(inp,
+                    make_rdv("interior",
+                             {{Sense::inside, inp.boundary.interior},
+                              {Sense::outside, make_sph("similar", 1.0001)}}),
+                    1);
 
     UnitProto const proto{std::move(inp)};
 
@@ -506,12 +516,12 @@ TEST_F(InputBuilderTest, globalspheres)
         auto inner = make_sph("inner", 5.0);
 
         // Construct "inside" cell
-        inp.materials.push_back(
-            make_material(make_rdv("shell",
-                                   {{Sense::inside, inp.boundary.interior},
-                                    {Sense::outside, inner}}),
-                          1));
-        inp.materials.push_back(make_material(std::move(inner), 2));
+        append_material(inp,
+                        make_rdv("shell",
+                                 {{Sense::inside, inp.boundary.interior},
+                                  {Sense::outside, inner}}),
+                        1);
+        append_material(inp, std::move(inner), 2);
         return inp;
     }()};
 
@@ -525,10 +535,10 @@ TEST_F(InputBuilderTest, bgspheres)
         inp.boundary.interior = make_sph("bound", 10.0);
         inp.label = "global";
 
-        inp.materials.push_back(make_material(
-            make_translated(make_sph("top", 2.0), {0, 0, 3}), 1));
-        inp.materials.push_back(make_material(
-            make_translated(make_sph("bottom", 3.0), {0, 0, -3}), 2));
+        append_material(
+            inp, make_translated(make_sph("top", 2.0), {0, 0, 3}), 1);
+        append_material(
+            inp, make_translated(make_sph("bottom", 3.0), {0, 0, -3}), 2);
         inp.background.fill = GeoMatId{3};
         return inp;
     }()};
@@ -546,8 +556,7 @@ TEST_F(InputBuilderTest, universes)
         inp.label = "most_inner";
         inp.boundary.interior = patricia;
         inp.boundary.zorder = ZOrder::media;
-        inp.materials.push_back(
-            make_material(make_rdv("patty", {{Sense::inside, patricia}}), 2));
+        append_material(inp, make_rdv("patty", {{Sense::inside, patricia}}), 2);
         return inp;
     }());
 
@@ -560,18 +569,17 @@ TEST_F(InputBuilderTest, universes)
         inp.label = "inner";
         inp.boundary.interior = gamma;
         inp.boundary.zorder = ZOrder::media;
-        inp.daughters.push_back({most_inner, Translation{{-2, -2, 0}}});
-        inp.materials.push_back(
-            make_material(make_rdv("a", {{Sense::inside, alpha}}), 0));
-        inp.materials.push_back(
-            make_material(make_rdv("b", {{Sense::inside, beta}}), 1));
-        inp.materials.push_back(make_material(
+        append_daughter(inp, most_inner, Translation{{-2, -2, 0}}, "p");
+        append_material(inp, make_rdv("a", {{Sense::inside, alpha}}), 0);
+        append_material(inp, make_rdv("b", {{Sense::inside, beta}}), 1);
+        append_material(
+            inp,
             make_rdv("c",
                      {{Sense::outside, alpha},
                       {Sense::outside, beta},
                       {Sense::inside, gamma},
                       {Sense::outside, inp.daughters[0].make_interior()}}),
-            2));
+            2);
         return inp;
     }());
 
@@ -583,19 +591,17 @@ TEST_F(InputBuilderTest, universes)
         inp.label = "outer";
         inp.boundary.interior = john;
         inp.boundary.zorder = ZOrder::media;
-        inp.daughters.push_back(
-            {inner, Translation{{2, -2, -0.5}}, ZOrder::media});
-        inp.daughters.push_back(
-            {inner, Translation{{2, -2, 0.5}}, ZOrder::media});
-        inp.materials.push_back(
-            make_material(make_rdv("bobby", {{Sense::inside, bob}}), 3));
-        inp.materials.push_back(make_material(
+        append_daughter(inp, inner, Translation{{2, -2, -0.5}}, "i0");
+        append_daughter(inp, inner, Translation{{2, -2, 0.5}}, "i1");
+        append_material(inp, make_rdv("bobby", {{Sense::inside, bob}}), 3);
+        append_material(
+            inp,
             make_rdv("johnny",
                      {{Sense::outside, bob},
                       {Sense::inside, john},
                       {Sense::outside, inp.daughters[0].make_interior()},
                       {Sense::outside, inp.daughters[1].make_interior()}}),
-            4));
+            4);
         return inp;
     }());
 
@@ -609,10 +615,10 @@ TEST_F(InputBuilderTest, hierarchy)
         inp.boundary.interior = make_cyl("bound", 1.0, 1.0);
         inp.boundary.zorder = ZOrder::media;
         inp.label = "leafy";
-        inp.materials.push_back(make_material(
-            make_translated(make_cyl("bottom", 1, 0.5), {0, 0, -0.5}), 1));
-        inp.materials.push_back(make_material(
-            make_translated(make_cyl("top", 1, 0.5), {0, 0, 0.5}), 2));
+        append_material(
+            inp, make_translated(make_cyl("bottom", 1, 0.5), {0, 0, -0.5}), 1);
+        append_material(
+            inp, make_translated(make_cyl("top", 1, 0.5), {0, 0, 0.5}), 2);
         return inp;
     }());
 
@@ -621,14 +627,16 @@ TEST_F(InputBuilderTest, hierarchy)
         inp.boundary.interior = make_sph("bound", 10.0);
         inp.boundary.zorder = ZOrder::exterior;
         inp.label = "filled_daughter";
-        inp.materials.push_back(make_material(
-            make_translated(make_sph("leaf1", 1), {0, 0, -5}), 1));
-        inp.materials.push_back(make_material(
-            make_translated(make_sph("leaf2", 1), {0, 0, 5}), 2));
-        inp.daughters.push_back({make_daughter("d1"), Translation{{0, 5, 0}}});
-        inp.daughters.push_back(
-            {make_daughter("d2"),
-             Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}}});
+        append_material(
+            inp, make_translated(make_sph("leaf1", 1), {0, 0, -5}), 1);
+        append_material(
+            inp, make_translated(make_sph("leaf2", 1), {0, 0, 5}), 2);
+        append_daughter(inp, make_daughter("d1"), Translation{{0, 5, 0}}, "d");
+        append_daughter(
+            inp,
+            make_daughter("d2"),
+            Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}},
+            "e");
         inp.background.fill = GeoMatId{3};
         return inp;
     }());
@@ -638,18 +646,21 @@ TEST_F(InputBuilderTest, hierarchy)
         inp.boundary.interior = make_sph("bound", 100.0);
         inp.boundary.zorder = ZOrder::media;
         inp.label = "global";
-        inp.daughters.push_back({make_daughter("d1"), Translation{{0, 5, 0}}});
-        inp.daughters.push_back(
-            {make_daughter("d2"),
-             Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}}});
-        inp.daughters.push_back({filled_daughter, Translation{{0, 0, -20}}});
-        inp.daughters.push_back({leaf, Translation{{0, 0, 20}}});
+        append_daughter(inp, make_daughter("d1"), Translation{{0, 5, 0}}, "d");
+        append_daughter(
+            inp,
+            make_daughter("d2"),
+            Transformation{make_rotation(Axis::x, Turn{0.25}), {0, -5, 0}},
+            "e");
+        append_daughter(inp, filled_daughter, Translation{{0, 0, -20}}, "fd");
+        append_daughter(inp, leaf, Translation{{0, 0, 20}}, "l");
 
-        inp.materials.push_back(make_material(
-            make_translated(make_sph("leaf1", 1), {0, 0, -5}), 1));
+        append_material(
+            inp, make_translated(make_sph("leaf1", 1), {0, 0, -5}), 1);
 
         // Construct "inside" cell
-        inp.materials.push_back(make_material(
+        append_material(
+            inp,
             make_rdv("interior",
                      [&] {
                          VecSenseObj interior
@@ -665,7 +676,7 @@ TEST_F(InputBuilderTest, hierarchy)
                          }
                          return interior;
                      }()),
-            3));
+            3);
 
         return inp;
     }());
@@ -687,12 +698,12 @@ TEST_F(InputBuilderTest, incomplete_bb)
                                    real_type{3},
                                    VR2{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}},
                                    VR2{{-2, -2}, {2, -2}, {2, 2}, {-2, 2}});
-        inp.materials.push_back(
-            make_material(make_rdv("fill",
-                                   {{Sense::inside, inp.boundary.interior},
-                                    {Sense::outside, trd}}),
-                          1));
-        inp.materials.push_back(make_material(std::move(trd), 2));
+        append_material(inp,
+                        make_rdv("fill",
+                                 {{Sense::inside, inp.boundary.interior},
+                                  {Sense::outside, trd}}),
+                        1);
+        append_material(inp, std::move(trd), 2);
         return inp;
     }());
 
@@ -702,13 +713,14 @@ TEST_F(InputBuilderTest, incomplete_bb)
         inp.boundary.zorder = ZOrder::media;
         inp.label = "global";
 
-        inp.daughters.push_back({inner, Translation{{2, 0, 0}}});
+        append_daughter(inp, inner, Translation{{2, 0, 0}});
 
-        inp.materials.push_back(make_material(
+        append_material(
+            inp,
             make_rdv("shell",
                      {{Sense::inside, inp.boundary.interior},
                       {Sense::outside, inp.daughters.front().make_interior()}}),
-            1));
+            1);
         return inp;
     }());
 
@@ -731,9 +743,8 @@ TEST_F(InputBuilderTest, universe_union_boundary)
         inp.boundary.zorder = ZOrder::media;
         inp.label = "inner";
 
-        inp.materials.push_back(make_material(SPConstObject{bottom}, 1));
-        inp.materials.push_back(
-            make_material(make_subtraction("bite", top, bottom), 1));
+        append_material(inp, SPConstObject{bottom}, 1);
+        append_material(inp, make_subtraction("bite", top, bottom), 1);
         return inp;
     }());
 
@@ -743,13 +754,14 @@ TEST_F(InputBuilderTest, universe_union_boundary)
         inp.boundary.zorder = ZOrder::media;
         inp.label = "global";
 
-        inp.daughters.push_back({inner, Translation{{0, 0, 1.234}}});
+        append_daughter(inp, inner, Translation{{0, 0, 1.234}});
 
-        inp.materials.push_back(make_material(
+        append_material(
+            inp,
             make_rdv("shell",
                      {{Sense::inside, inp.boundary.interior},
                       {Sense::outside, inp.daughters.front().make_interior()}}),
-            1));
+            1);
         return inp;
     }());
 
@@ -778,21 +790,21 @@ TEST_F(InputBuilderTest, involute)
         inp.boundary.zorder = ZOrder::media;
         inp.label = "involute";
 
-        inp.materials.push_back(make_material(SPConstObject{inner}, 1));
-        inp.materials.push_back(make_material(SPConstObject{invo1}, 2));
-        inp.materials.push_back(make_material(SPConstObject{invo2}, 3));
-        inp.materials.push_back(
-            make_material(make_rdv("rest",
-                                   {{Sense::inside, system},
-                                    {Sense::outside, inner},
-                                    {Sense::outside, invo1},
-                                    {Sense::outside, invo2}}),
-                          5));
-        inp.materials.push_back(
-            make_material(make_rdv("shell",
-                                   {{Sense::inside, inp.boundary.interior},
-                                    {Sense::outside, system}}),
-                          5));
+        append_material(inp, SPConstObject{inner}, 1);
+        append_material(inp, SPConstObject{invo1}, 2);
+        append_material(inp, SPConstObject{invo2}, 3);
+        append_material(inp,
+                        make_rdv("rest",
+                                 {{Sense::inside, system},
+                                  {Sense::outside, inner},
+                                  {Sense::outside, invo1},
+                                  {Sense::outside, invo2}}),
+                        5);
+        append_material(inp,
+                        make_rdv("shell",
+                                 {{Sense::inside, inp.boundary.interior},
+                                  {Sense::outside, system}}),
+                        5);
 
         return inp;
     }());
@@ -816,19 +828,19 @@ TEST_F(InputBuilderTest, involute_cw)
         inp.boundary.zorder = ZOrder::media;
         inp.label = "involute";
 
-        inp.materials.push_back(make_material(SPConstObject{inner}, 1));
-        inp.materials.push_back(make_material(SPConstObject{invo1}, 2));
-        inp.materials.push_back(
-            make_material(make_rdv("rest",
-                                   {{Sense::inside, system},
-                                    {Sense::outside, inner},
-                                    {Sense::outside, invo1}}),
-                          4));
-        inp.materials.push_back(
-            make_material(make_rdv("shell",
-                                   {{Sense::inside, inp.boundary.interior},
-                                    {Sense::outside, system}}),
-                          5));
+        append_material(inp, SPConstObject{inner}, 1);
+        append_material(inp, SPConstObject{invo1}, 2);
+        append_material(inp,
+                        make_rdv("rest",
+                                 {{Sense::inside, system},
+                                  {Sense::outside, inner},
+                                  {Sense::outside, invo1}}),
+                        4);
+        append_material(inp,
+                        make_rdv("shell",
+                                 {{Sense::inside, inp.boundary.interior},
+                                  {Sense::outside, system}}),
+                        5);
 
         return inp;
     }());
@@ -870,36 +882,39 @@ TEST_F(InputBuilderTest, involute_fuel)
         inp.boundary.zorder = ZOrder::media;
         inp.label = "involute";
 
-        inp.materials.push_back(make_material(SPConstObject{inner1}, 1));
-        inp.materials.push_back(make_material(SPConstObject{invo2}, 2));
-        inp.materials.push_back(make_material(
+        append_material(inp, SPConstObject{inner1}, 1);
+        append_material(inp, SPConstObject{invo2}, 2);
+        append_material(
+            inp,
             make_rdv("clad1", {{Sense::inside, invo1}, {Sense::outside, invo2}}),
-            3));
-        inp.materials.push_back(
-            make_material(make_rdv("rest1",
-                                   {{Sense::inside, outer1},
-                                    {Sense::outside, invo1},
-                                    {Sense::outside, inner1}}),
-                          4));
-        inp.materials.push_back(make_material(
+            3);
+        append_material(inp,
+                        make_rdv("rest1",
+                                 {{Sense::inside, outer1},
+                                  {Sense::outside, invo1},
+                                  {Sense::outside, inner1}}),
+                        4);
+        append_material(
+            inp,
             make_rdv("middle",
                      {{Sense::inside, inner2}, {Sense::outside, outer1}}),
-            5));
-        inp.materials.push_back(make_material(SPConstObject{invo4}, 6));
-        inp.materials.push_back(make_material(
+            5);
+        append_material(inp, SPConstObject{invo4}, 6);
+        append_material(
+            inp,
             make_rdv("clad2", {{Sense::inside, invo3}, {Sense::outside, invo4}}),
-            7));
-        inp.materials.push_back(
-            make_material(make_rdv("rest2",
-                                   {{Sense::inside, outer2},
-                                    {Sense::outside, invo3},
-                                    {Sense::outside, inner2}}),
-                          8));
-        inp.materials.push_back(
-            make_material(make_rdv("shell",
-                                   {{Sense::inside, inp.boundary.interior},
-                                    {Sense::outside, outer2}}),
-                          9));
+            7);
+        append_material(inp,
+                        make_rdv("rest2",
+                                 {{Sense::inside, outer2},
+                                  {Sense::outside, invo3},
+                                  {Sense::outside, inner2}}),
+                        8);
+        append_material(inp,
+                        make_rdv("shell",
+                                 {{Sense::inside, inp.boundary.interior},
+                                  {Sense::outside, outer2}}),
+                        9);
 
         return inp;
     }());


### PR DESCRIPTION
Closes #1749 by mapping during construction the volume params' IDs to ORANGE input. Two extra arrays indexed by ImplVolumeId ; they're constructed via the ORANGE input, where the "label" is now a choice between `Label` *or* `VolumeInstanceId`. The g4org conversion propagates the volume instances upward through construction, and the volume IDs are extracted from those.