### PR TITLE
Add mapping from ImplVolumeId to VolumeId

### DIFF
--- a/app/celer-geo/Runner.cc
+++ b/app/celer-geo/Runner.cc
@@ -48,7 +48,8 @@ Runner::Runner(ModelSetup const& input) : input_{input}
     {
         // Retain the Geant4 world for possible reuse across geometries
         CELER_EXPECT(celeritas::geant_geo().expired());
-        celeritas::geant_geo(this->load_geometry<Geometry::geant4>());
+        this->load_geometry<Geometry::geant4>();
+        CELER_EXPECT(!celeritas::geant_geo().expired());
     }
 }
 

--- a/src/celeritas/ext/GeantVolumeMapper.cc
+++ b/src/celeritas/ext/GeantVolumeMapper.cc
@@ -34,7 +34,7 @@ GeantVolumeMapper::GeantVolumeMapper(GeoParamsInterface const& geo) : geo_{geo}
  */
 ImplVolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv)
 {
-    // TODO: move pointer->id mapping to GeantGeoParams
+    // TODO: use pointer->id mapping from GeantGeoParams
     ImplVolumeId id = geo_.find_volume(&lv);
     if (id)
     {

--- a/src/celeritas/ext/detail/GeoOpticalIdMap.hh
+++ b/src/celeritas/ext/detail/GeoOpticalIdMap.hh
@@ -25,6 +25,10 @@ namespace detail
  *
  * As a reminder, \em geometry materials correspond to \c G4Material and
  * \em physics materials correspond to \c G4MaterialCutsCouple .
+ *
+ * \todo Use GeantGeoParams (or an upcoming GeantModel) to translate geometry
+ * IDs: the G4Material's "index" can be offset from the GeantGeoParams material
+ * if the geometry has been reloaded.
  */
 class GeoOpticalIdMap
 {

--- a/src/celeritas/geo/GeoMaterialParams.hh
+++ b/src/celeritas/geo/GeoMaterialParams.hh
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
+#include <variant>
 #include <vector>
 
 #include "corecel/Types.hh"
@@ -14,7 +16,6 @@
 #include "corecel/data/ParamsDataInterface.hh"
 #include "corecel/io/Label.hh"
 #include "celeritas/Types.hh"
-#include "celeritas/mat/MaterialParams.hh"
 
 #include "GeoFwd.hh"
 #include "GeoMaterialData.hh"
@@ -22,6 +23,8 @@
 namespace celeritas
 {
 struct ImportData;
+class MaterialParams;
+class VolumeParams;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -53,15 +56,23 @@ class GeoMaterialParams final
     //! \name Type aliases
     using SPConstCoreGeo = std::shared_ptr<CoreGeoParams const>;
     using SPConstMaterial = std::shared_ptr<MaterialParams const>;
+    using SPConstVolume = std::shared_ptr<VolumeParams const>;
     //!@}
 
     //! Input parameters
     struct Input
     {
+        //! Vector for each canonical VolumeId
+        using VecMat = std::vector<PhysMatId>;
+        //! Map using labels
+        using MapLabelMat = std::unordered_map<Label, PhysMatId>;
+        //! Map using implementation volume IDs
+        using MapImplMat = std::unordered_map<ImplVolumeId, PhysMatId>;
+
         SPConstCoreGeo geometry;
         SPConstMaterial materials;
-        std::vector<PhysMatId> volume_to_mat;
-        std::vector<Label> volume_labels;  // Optional
+
+        std::variant<VecMat, MapLabelMat, MapImplMat> volume_to_mat;
     };
 
   public:
@@ -69,10 +80,11 @@ class GeoMaterialParams final
     static std::shared_ptr<GeoMaterialParams>
     from_import(ImportData const& data,
                 SPConstCoreGeo geo_params,
+                SPConstVolume vol_params,
                 SPConstMaterial material_params);
 
     // Construct from geometry and material params
-    explicit GeoMaterialParams(Input);
+    explicit GeoMaterialParams(Input const&);
 
     //! Access material properties on the host
     HostRef const& host_ref() const final { return data_.host_ref(); }

--- a/src/celeritas/geo/GeoMaterialParams.hh
+++ b/src/celeritas/geo/GeoMaterialParams.hh
@@ -40,6 +40,10 @@ struct ImportData;
  * the corresponding volume name is empty (corresponding perhaps to a "parallel
  * world" or otherwise unused volume) or is enclosed with braces (used for
  * virtual volumes such as `[EXTERIOR]` or temporary boolean/reflected volumes.
+ *
+ * \todo This class's functionality should be split between VolumeParams (for
+ * mapping volume IDs to GeoMatId) and the physics (for determining the
+ * PhysMatId from the geometry/material/region state).
  */
 class GeoMaterialParams final
     : public ParamsDataInterface<GeoMaterialParamsData>

--- a/src/celeritas/io/ImportVolume.hh
+++ b/src/celeritas/io/ImportVolume.hh
@@ -27,10 +27,12 @@ struct ImportRegion
  * Store logical volume properties.
  *
  * \note The "phys material ID" is the index of the MaterialCutsCouple, and the
- * "geo material ID" is the index of the Material (physical properties).
+ * "geo material ID" is the index of the G4Material (physical properties).
+ * (TODO: these should be indexed using a future GeantModel class, not using
+ * the internal GetIndex method).
  *
- * \note The index of this volume in the \c volumes vector is the "instance ID"
- * which is not necessarily reproducible.
+ * \note The index of this volume in the \c volumes vector is the canonical
+ * \c VolumeId created by the Geant4 geometry model.
  */
 struct ImportVolume
 {

--- a/src/celeritas/setup/FrameworkInput.cc
+++ b/src/celeritas/setup/FrameworkInput.cc
@@ -35,11 +35,10 @@ FrameworkLoaded framework_input(inp::FrameworkInput& fi)
     // Set up system
     setup::system(fi.system);
 
-    // Load Geant4 geometry wrapper and save as global
+    // Load Geant4 geometry wrapper, which saves it as global
     CELER_ASSERT(celeritas::geant_geo().expired());
     auto geo = GeantGeoParams::from_tracking_manager();
     CELER_ASSERT(geo);
-    celeritas::geant_geo(geo);
 
     // Import physics data
     ImportData imported = GeantImporter{}(fi.geant.data_selection);

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -435,7 +435,7 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
 
     // Create geometry/material coupling
     params.geomaterial = GeoMaterialParams::from_import(
-        imported, params.geometry, params.material);
+        imported, params.geometry, params.volume, params.material);
 
     // Construct particle params
     params.particle = ParticleParams::from_import(imported);

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -434,8 +434,17 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
     params.material = MaterialParams::from_import(imported);
 
     // Create geometry/material coupling
-    params.geomaterial = GeoMaterialParams::from_import(
-        imported, params.geometry, params.volume, params.material);
+    params.geomaterial = [&] {
+        GeoMaterialParams::SPConstVolume volume_params;
+        if constexpr (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+        {
+            // FIXME: ORANGE doesn't support volume/material conversion
+            volume_params = params.volume;
+        }
+
+        return GeoMaterialParams::from_import(
+            imported, params.geometry, volume_params, params.material);
+    }();
 
     // Construct particle params
     params.particle = ParticleParams::from_import(imported);

--- a/src/celeritas/setup/StandaloneInput.cc
+++ b/src/celeritas/setup/StandaloneInput.cc
@@ -65,7 +65,6 @@ StandaloneLoaded standalone_input(inp::StandaloneInput& si)
         // Keep the geant4 geometry and set it as global
         ggp = geant_setup->geo_params();
         CELER_ASSERT(ggp);
-        celeritas::geant_geo(ggp);
 
         // Load geometry, surfaces, regions from Geant4 world pointer
         problem->model = ggp->make_model_input();

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -146,7 +146,7 @@ void append_skin_surfaces(GeantGeoParams const& geo,
 {
     // Translate "skin" (boundary) surfaces
     using G4Surface = G4LogicalSkinSurface;
-    std::map<ImplVolumeId, G4Surface const*> temp;
+    std::map<VolumeId, G4Surface const*> temp;
     auto const* table = G4Surface::GetSurfaceTable();
     CELER_ASSERT(table);
     size_type num_null_surfaces{0};

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -441,6 +441,8 @@ std::weak_ptr<GeantGeoParams const> g_geant_geo_;
  */
 void geant_geo(std::shared_ptr<GeantGeoParams const> const& gp)
 {
+    CELER_LOG(debug) << (gp ? "Setting" : "Clearing")
+                     << " celeritas::geant_geo";
     CELER_VALIDATE(
         g_geant_geo_.expired() ||
             [&] {
@@ -468,6 +470,9 @@ std::weak_ptr<GeantGeoParams const> const& geant_geo()
 //---------------------------------------------------------------------------//
 /*!
  * Create from a running Geant4 application.
+ *
+ * It saves the result to the global Celeritas Geant4 geometry weak pointer \c
+ * geant_geo.
  */
 std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
 {
@@ -475,7 +480,9 @@ std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
     CELER_VALIDATE(world,
                    << "cannot create Geant geometry wrapper: Geant4 tracking "
                       "manager is not active");
-    return std::make_shared<GeantGeoParams>(world, Ownership::reference);
+    auto result = std::make_shared<GeantGeoParams>(world, Ownership::reference);
+    celeritas::geant_geo(result);
+    return result;
 }
 
 //---------------------------------------------------------------------------//
@@ -483,7 +490,8 @@ std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
  * Construct from a GDML input.
  *
  * This assumes that Celeritas is driving and will manage Geant4 logging
- * and exceptions.
+ * and exceptions. It saves the result to the global Celeritas Geant4 geometry
+ * weak pointer \c geant_geo.
  */
 std::shared_ptr<GeantGeoParams>
 GeantGeoParams::from_gdml(std::string const& filename)
@@ -500,8 +508,10 @@ GeantGeoParams::from_gdml(std::string const& filename)
         CELER_LOG(warning) << "Expected '.gdml' extension for GDML input";
     }
 
-    return std::make_shared<GeantGeoParams>(load_gdml(filename),
-                                            Ownership::value);
+    auto result = std::make_shared<GeantGeoParams>(load_gdml(filename),
+                                                   Ownership::value);
+    celeritas::geant_geo(result);
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -678,7 +678,7 @@ GeantPhysicalInstance GeantGeoParams::id_to_geant(VolumeInstanceId id) const
  *
  * If the input volume ID is unassigned, a null pointer will be returned.
  */
-G4LogicalVolume const* GeantGeoParams::id_to_geant(ImplVolumeId id) const
+G4LogicalVolume const* GeantGeoParams::id_to_geant(VolumeId id) const
 {
     CELER_EXPECT(!id || id < volumes_.size());
     if (!id)

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -113,7 +113,10 @@ class GeantGeoParams final : public GeoParamsInterface,
     GeantPhysicalInstance id_to_geant(VolumeInstanceId vol_id) const final;
 
     // Get the Geant4 logical volume corresponding to a volume ID
-    G4LogicalVolume const* id_to_geant(ImplVolumeId vol_id) const;
+    G4LogicalVolume const* id_to_geant(VolumeId vol_id) const;
+
+    // Get the canonical volume IDs corresponding to an implementation volume
+    inline VolumeId volume_id(ImplVolumeId) const final;
 
     //// SURFACES ////
 
@@ -137,10 +140,10 @@ class GeantGeoParams final : public GeoParamsInterface,
 
     //// G4 ACCESSORS ////
 
-    //! Get the volume ID corresponding to a Geant4 logical volume
-    ImplVolumeId geant_to_id(G4LogicalVolume const& volume) const
+    //! Get the canonical volume ID corresponding to a Geant4 logical volume
+    VolumeId geant_to_id(G4LogicalVolume const& volume) const
     {
-        return this->find_volume(&volume);
+        return this->volume_id(this->find_volume(&volume));
     }
 
     // Get the volume ID corresponding to a Geant4 physical volume
@@ -243,12 +246,28 @@ auto GeantGeoParams::volume_instances() const -> VolInstanceMap const&
 G4LogicalSurface const* GeantGeoParams::id_to_geant(SurfaceId id) const
 {
     CELER_EXPECT(!id || id < surfaces_.size());
-    if (!id)
+    if (CELER_UNLIKELY(!id))
     {
         return {};
     }
 
     return surfaces_[id.unchecked_get()];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the canonical volume IDs corresponding to an implementation volume.
+ *
+ * \note See make_inp_volumes : for now, volume IDs and impl IDs are identical
+ */
+VolumeId GeantGeoParams::volume_id(ImplVolumeId iv_id) const
+{
+    if (CELER_UNLIKELY(!iv_id))
+    {
+        return {};
+    }
+
+    return id_cast<VolumeId>(iv_id.get());
 }
 
 //---------------------------------------------------------------------------//
@@ -287,7 +306,7 @@ inline inp::Model GeantGeoParams::make_model_input() const
 {
     CELER_ASSERT_UNREACHABLE();
 }
-inline ImplVolumeId GeantGeoParams::find_volume(G4LogicalVolume const*) const
+inline VolumeId GeantGeoParams::find_volume(G4LogicalVolume const*) const
 {
     CELER_ASSERT_UNREACHABLE();
 }
@@ -295,7 +314,7 @@ inline GeantPhysicalInstance GeantGeoParams::id_to_geant(VolumeInstanceId) const
 {
     CELER_ASSERT_UNREACHABLE();
 }
-inline G4LogicalVolume const* GeantGeoParams::id_to_geant(ImplVolumeId) const
+inline G4LogicalVolume const* GeantGeoParams::id_to_geant(VolumeId) const
 {
     CELER_ASSERT_UNREACHABLE();
 }

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -89,6 +89,9 @@ class GeoParamsInterface
     //! Get volume metadata
     virtual ImplVolumeMap const& impl_volumes() const = 0;
 
+    //! Get the canonical volume IDs corresponding to an implementation volume
+    virtual VolumeId volume_id(ImplVolumeId) const = 0;
+
     //// TO BE DELETED SOON ////
 
     //! Get volume instance metadata

--- a/src/geocel/Types.hh
+++ b/src/geocel/Types.hh
@@ -55,14 +55,17 @@ using VolumeInstanceId = OpaqueId<struct VolumeInstance_, unsigned int>;
 using VolumeUniqueInstanceId = OpaqueId<struct VolumeInstance_, ull_int>;
 
 //---------------------------------------------------------------------------//
-//!{ Geometry-specific implementation details used by
+//!@{
+//! \name Geometry-specific implementation details
 
 //! Implementation detail surface (for surface-based geometries)
 using ImplSurfaceId = OpaqueId<struct Surface_>;
 
 //! Implementation detail "global" volume index
+//! \todo This will become an independent type soon
 using ImplVolumeId = VolumeId;
 
+//!@}
 //---------------------------------------------------------------------------//
 // ENUMERATIONS
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -106,6 +106,9 @@ class OrangeParams final : public GeoParamsInterface,
     inline GeantPhysicalInstance
     id_to_geant(VolumeInstanceId vol_id) const final;
 
+    // Get the canonical volume IDs corresponding to an implementation volume
+    inline VolumeId volume_id(ImplVolumeId) const final;
+
     //// DATA ACCESS ////
 
     //! Reference to CPU geometry data
@@ -183,7 +186,7 @@ auto OrangeParams::volume_instances() const -> VolInstanceMap const&
 /*!
  * Locate the volume ID corresponding to a Geant4 volume.
  *
- * \todo Implement using \c g4org::Converter
+ * \todo Replace with GeantGeoParams + VolumeId
  */
 ImplVolumeId OrangeParams::find_volume(G4LogicalVolume const*) const
 {
@@ -197,6 +200,15 @@ ImplVolumeId OrangeParams::find_volume(G4LogicalVolume const*) const
  * \todo Implement using \c g4org::Converter
  */
 GeantPhysicalInstance OrangeParams::id_to_geant(VolumeInstanceId) const
+{
+    return {};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the canonical volume IDs corresponding to an implementation volume.
+ */
+VolumeId OrangeParams::volume_id(ImplVolumeId) const
 {
     return {};
 }

--- a/test/celeritas/GlobalGeoTestBase.cc
+++ b/test/celeritas/GlobalGeoTestBase.cc
@@ -71,7 +71,6 @@ auto GlobalGeoTestBase::build_fresh_geometry(std::string_view basename)
 
         pgg.clear();
         auto new_geo = GeantGeoParams::from_gdml(filename);
-        celeritas::geant_geo(new_geo);
         pgg.set(std::string{basename}, std::move(new_geo));
 
         // Geant4 loading is supported

--- a/test/celeritas/GlobalTestBase.hh
+++ b/test/celeritas/GlobalTestBase.hh
@@ -23,26 +23,29 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 
-class ActionRegistry;
 class AtomicRelaxationParams;
 class CherenkovParams;
 class CutoffParams;
+class ExtendFromPrimariesAction;
 class GeoMaterialParams;
 class MaterialParams;
 class ParticleParams;
 class PhysicsParams;
 class ScintillationParams;
 class SimParams;
+class SurfaceParams;
 class TrackInitParams;
-class AuxParamsRegistry;
+class VolumeParams;
 class WentzelOKVIParams;
-class ExtendFromPrimariesAction;
+
+class ActionRegistry;
+class AuxParamsRegistry;
+class OutputRegistry;
 
 class CoreParams;
 template<MemSpace M>
 class CoreState;
 class CoreStateInterface;
-class OutputRegistry;
 
 struct Primary;
 
@@ -74,22 +77,25 @@ class GlobalTestBase : public Test
     template<class T>
     using SP = std::shared_ptr<T>;
 
-    using SPConstCoreGeo = SP<CoreGeoParams const>;
-    using SPConstMaterial = SP<MaterialParams const>;
-    using SPConstGeoMaterial = SP<GeoMaterialParams const>;
-    using SPConstParticle = SP<ParticleParams const>;
-    using SPConstCutoff = SP<CutoffParams const>;
-    using SPConstPhysics = SP<PhysicsParams const>;
     using SPConstAction = SP<CoreStepActionInterface const>;
+    using SPConstCoreGeo = SP<CoreGeoParams const>;
+    using SPConstCutoff = SP<CutoffParams const>;
+    using SPConstGeoMaterial = SP<GeoMaterialParams const>;
+    using SPConstMaterial = SP<MaterialParams const>;
+    using SPConstParticle = SP<ParticleParams const>;
+    using SPConstPhysics = SP<PhysicsParams const>;
     using SPConstRng = SP<RngParams const>;
     using SPConstSim = SP<SimParams const>;
     using SPConstTrackInit = SP<TrackInitParams const>;
+    using SPConstSurface = SP<SurfaceParams const>;
+    using SPConstVolume = SP<VolumeParams const>;
     using SPConstWentzelOKVI = SP<WentzelOKVIParams const>;
-    using SPConstCore = SP<CoreParams const>;
 
     using SPActionRegistry = SP<ActionRegistry>;
     using SPOutputRegistry = SP<OutputRegistry>;
     using SPUserRegistry = SP<AuxParamsRegistry>;
+
+    using SPConstCore = SP<CoreParams const>;
 
     using SPConstCherenkov = SP<CherenkovParams const>;
     using SPConstOpticalMaterial = SP<optical::MaterialParams const>;
@@ -184,6 +190,11 @@ class GlobalTestBase : public Test
     // Do not insert StatusChecker
     void disable_status_checker();
 
+    // Build surface and volume; called during build_core
+    void setup_model();
+    SPConstSurface const& surface() const { return surface_; }
+    SPConstVolume const& volume() const { return volume_; }
+
   private:
     SPConstRng build_rng() const;
     SPActionRegistry build_action_reg() const;
@@ -208,6 +219,11 @@ class GlobalTestBase : public Test
     SPConstWentzelOKVI wentzel_;
     SPConstCore core_;
     SPOutputRegistry output_reg_;
+
+    // NOTE: these may not be built
+    SPConstSurface surface_;
+    SPConstVolume volume_;
+
     SPConstCherenkov cherenkov_;
     SPActionRegistry optical_action_reg_;
     SPConstOpticalMaterial optical_material_;

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -49,11 +49,17 @@ auto ImportedDataTestBase::build_material() -> SPConstMaterial
 //---------------------------------------------------------------------------//
 auto ImportedDataTestBase::build_geomaterial() -> SPConstGeoMaterial
 {
-    this->setup_model();
+    SPConstVolume volume_params;
+    if constexpr (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_ORANGE)
+    {
+        // FIXME: ORANGE doesn't support volume/material conversion
+        this->setup_model();
+        volume_params = this->volume();
+    }
 
     return GeoMaterialParams::from_import(this->imported_data(),
                                           this->geometry(),
-                                          this->volume(),
+                                          volume_params,
                                           this->material());
 }
 

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -49,8 +49,12 @@ auto ImportedDataTestBase::build_material() -> SPConstMaterial
 //---------------------------------------------------------------------------//
 auto ImportedDataTestBase::build_geomaterial() -> SPConstGeoMaterial
 {
-    return GeoMaterialParams::from_import(
-        this->imported_data(), this->geometry(), this->material());
+    this->setup_model();
+
+    return GeoMaterialParams::from_import(this->imported_data(),
+                                          this->geometry(),
+                                          this->volume(),
+                                          this->material());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/InvalidOrangeTestBase.cc
+++ b/test/celeritas/InvalidOrangeTestBase.cc
@@ -109,22 +109,14 @@ auto InvalidOrangeTestBase::build_geometry() -> SPConstCoreGeo
 //---------------------------------------------------------------------------//
 auto InvalidOrangeTestBase::build_geomaterial() -> SPConstGeoMaterial
 {
-    GeoMaterialParams::Input input;
+    using Input = GeoMaterialParams::Input;
+    Input input;
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat = {
-        PhysMatId{0},
-        PhysMatId{0},
-        PhysMatId{1},
-        PhysMatId{},
-        PhysMatId{},
-    };
-    input.volume_labels = {
-        Label{"interior"},
-        Label{"also-interior"},
-        Label{"world"},
-        Label{"[missing material]"},
-        Label{"[EXTERIOR]"},
+    input.volume_to_mat = Input::MapLabelMat{
+        {"interior", PhysMatId{0}},
+        {"also-interior", PhysMatId{0}},
+        {"world", PhysMatId{1}},
     };
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }

--- a/test/celeritas/MockTestBase.cc
+++ b/test/celeritas/MockTestBase.cc
@@ -90,13 +90,18 @@ auto MockTestBase::build_material() -> SPConstMaterial
 //---------------------------------------------------------------------------//
 auto MockTestBase::build_geomaterial() -> SPConstGeoMaterial
 {
-    GeoMaterialParams::Input input;
+    using Input = GeoMaterialParams::Input;
+    Input input;
+
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat
-        = {PhysMatId{0}, PhysMatId{2}, PhysMatId{1}, PhysMatId{3}};
-    input.volume_labels
-        = {Label{"inner"}, Label{"middle"}, Label{"outer"}, Label{"world"}};
+    input.volume_to_mat = Input::MapLabelMat{
+        {"inner", PhysMatId{0}},
+        {"middle", PhysMatId{2}},
+        {"outer", PhysMatId{1}},
+        {"world", PhysMatId{3}},
+    };
+
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }
 

--- a/test/celeritas/SimpleTestBase.cc
+++ b/test/celeritas/SimpleTestBase.cc
@@ -46,11 +46,15 @@ auto SimpleTestBase::build_material() -> SPConstMaterial
 //---------------------------------------------------------------------------//
 auto SimpleTestBase::build_geomaterial() -> SPConstGeoMaterial
 {
-    GeoMaterialParams::Input input;
+    using Input = GeoMaterialParams::Input;
+    Input input;
+
     input.geometry = this->geometry();
     input.materials = this->material();
-    input.volume_to_mat = {PhysMatId{0}, PhysMatId{1}, PhysMatId{}};
-    input.volume_labels = {Label{"inner"}, Label{"world"}, Label{"[EXTERIOR]"}};
+    input.volume_to_mat = Input::MapLabelMat{
+        {"inner", PhysMatId{0}},
+        {"world", PhysMatId{1}},
+    };
     return std::make_shared<GeoMaterialParams>(std::move(input));
 }
 

--- a/test/celeritas/ext/GeantVolumeMapper.test.cc
+++ b/test/celeritas/ext/GeantVolumeMapper.test.cc
@@ -73,7 +73,6 @@ class GeantVolumeMapperTestBase : public ::celeritas::test::Test
         {
             this->build_g4();
             CELER_ASSERT(geant_geo_params_);
-            celeritas::geant_geo(geant_geo_params_);
         }
         CELER_ASSERT(!logical_.empty());
 

--- a/test/geocel/GenericGeoTestBase.t.hh
+++ b/test/geocel/GenericGeoTestBase.t.hh
@@ -56,11 +56,6 @@ auto GenericGeoTestBase<HP>::build_geometry_from_basename() -> SPConstGeo
     std::string test_file
         = test_data_path("geocel", this->geometry_basename() + ".gdml");
     auto result = HP::from_gdml(test_file);
-    if constexpr (std::is_same_v<HP, GeantGeoParams>)
-    {
-        // Save global geant geometry
-        ::celeritas::geant_geo(result);
-    }
     return result;
 }
 

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -112,7 +112,6 @@ class VecgeomGeantTestBase : public VecgeomTestBaseImpl
         {
             pgg.clear();
             auto new_geo = GeantGeoParams::from_gdml(filename);
-            celeritas::geant_geo(new_geo);
             pgg.set(std::string{filename}, std::move(new_geo));
         }
         CELER_ASSERT(pgg.value());


### PR DESCRIPTION
Currently most of our runtime code uses ImplVolumeId to map from the geometry state to attributes like detector volumes, materials, etc. To set up the materials correctly for #1886 we'll store `ImportVolume` properties corresponding to `VolumeParams` volumes rather than Geant4 implementation (or geometry implementation) volumes. Up to this point we've been relying on labels to construct those.

This adds a `volume_id(ImplVolumeId) -> VolumeId` method for GeoParamsInterface that maps from the implementation ID to the canonical ID. It also adds support for the GeoMaterialParams to be constructed from a map of ImplVolumeId (basically the original way of doing it), a map of labels (which ORANGE currently relies on), and a map of VolumeId (which #1886 requires).