### PR TITLE
Work around spurious -Wmaybe-uninitialized warning with GCC

### DIFF
--- a/src/orange/g4org/ProtoConstructor.cc
+++ b/src/orange/g4org/ProtoConstructor.cc
@@ -213,8 +213,13 @@ void ProtoConstructor::place_pv(VariantTransform const& parent_transform,
             --depth_;
         }
         CELER_ASSERT(iter->second);
-        proto->daughters.push_back(
-            {iter->second, transform, ZOrder::media, pv.id});
+
+        UnitProto::DaughterInput daughter;
+        daughter.fill = iter->second;
+        daughter.transform = transform;
+        daughter.zorder = ZOrder::media;
+        daughter.label = pv.id;
+        proto->daughters.push_back(std::move(daughter));
 
         if (CELER_UNLIKELY(verbose_))
         {


### PR DESCRIPTION
This avoids a false-positive -Wmaybe-uninitialized error when initializing the `std::variant<Label, VolumeInstanceId>` field of a temporary `UnitProto::DaughterInput`, where GCC incorrectly assumes a `std::string` may be accessed uninitialized.