### PR TITLE
Add full support for G4GenericPolycone

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -57,6 +57,7 @@
 #include "orange/orangeinp/CsgObject.hh"
 #include "orange/orangeinp/IntersectRegion.hh"
 #include "orange/orangeinp/PolySolid.hh"
+#include "orange/orangeinp/RevolvedPolygon.hh"
 #include "orange/orangeinp/Shape.hh"
 #include "orange/orangeinp/Solid.hh"
 #include "orange/orangeinp/StackedExtrudedPolygon.hh"
@@ -551,8 +552,23 @@ auto SolidConverter::extrudedsolid(arg_type solid_base) -> result_type
 auto SolidConverter::genericpolycone(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4GenericPolycone const&>(solid_base);
-    CELER_DISCARD(solid);
-    CELER_NOT_IMPLEMENTED("genericpolycone");
+
+    size_type num_points = solid.GetNumRZCorner();
+
+    // Get the polygon. Although Geant4 prefers clockwise order upone input,
+    // GetCorner actually returns points in counterclockwise order, as used
+    // by ORANGE.
+    std::vector<Real2> polygon;
+    polygon.reserve(num_points);
+    for (auto i : range(num_points))
+    {
+        auto point = solid.GetCorner(i);
+        polygon.push_back(Real2{scale_(point.r), scale_(point.z)});
+    }
+
+    return std::make_shared<RevolvedPolygon>(std::string{solid.GetName()},
+                                             std::move(polygon),
+                                             enclosed_azi_from_poly(solid));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -562,7 +562,7 @@ auto SolidConverter::genericpolycone(arg_type solid_base) -> result_type
     for (auto i : range(num_points))
     {
         auto point = solid.GetCorner(i);
-        polygon.push_back(Real2{scale_(point.r), scale_(point.z)});
+        polygon.push_back(scale_.to<Real2>(point.r, point.z));
     }
 
     return std::make_shared<RevolvedPolygon>(std::string{solid.GetName()},

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -553,11 +553,10 @@ auto SolidConverter::genericpolycone(arg_type solid_base) -> result_type
 {
     auto const& solid = dynamic_cast<G4GenericPolycone const&>(solid_base);
 
-    size_type num_points = solid.GetNumRZCorner();
-
-    // Get the polygon. Although Geant4 prefers clockwise order upone input,
+    // Get the polygon. Although Geant4 prefers clockwise order upon input,
     // GetCorner actually returns points in counterclockwise order, as used
     // by ORANGE.
+    size_type num_points = solid.GetNumRZCorner();
     std::vector<Real2> polygon;
     polygon.reserve(num_points);
     for (auto i : range(num_points))

--- a/src/orange/orangeinp/ObjectIO.json.cc
+++ b/src/orange/orangeinp/ObjectIO.json.cc
@@ -107,6 +107,10 @@ void to_json(nlohmann::json& j, RevolvedPolygon const& obj)
         SIO_ATTR_PAIR(obj, label),
         SIO_ATTR_PAIR(obj, polygon),
     };
+    if (auto azi = obj.enclosed_azi())
+    {
+        j["enclosed_azi"] = azi;
+    }
 }
 
 void to_json(nlohmann::json& j, ShapeBase const& obj)

--- a/src/orange/orangeinp/PolySolid.cc
+++ b/src/orange/orangeinp/PolySolid.cc
@@ -94,8 +94,8 @@ template<class T>
         // The enclosed angle is "true" (specified by the user to truncate the
         // shape azimuthally): construct a wedge to be added or deleted
         auto&& [sense, wedge] = azi.make_sense_region();
-        NodeId wedge_id
-            = build_intersect_region(vb, base.label(), "angle", wedge);
+        char const* ext = (sense == Sense::outside ? "~azi" : "azi");
+        NodeId wedge_id = build_intersect_region(vb, base.label(), ext, wedge);
         if (sense == Sense::outside)
         {
             wedge_id = vb.insert_region({}, Negated{wedge_id});

--- a/src/orange/orangeinp/RevolvedPolygon.cc
+++ b/src/orange/orangeinp/RevolvedPolygon.cc
@@ -33,8 +33,12 @@ enum
 /*!
  * Construct from a polygon.
  */
-RevolvedPolygon::RevolvedPolygon(std::string&& label, VecReal2&& polygon)
-    : label_{std::move(label)}, polygon_{std::move(polygon)}
+RevolvedPolygon::RevolvedPolygon(std::string&& label,
+                                 VecReal2&& polygon,
+                                 EnclosedAzi&& enclosed)
+    : label_{std::move(label)}
+    , polygon_{std::move(polygon)}
+    , enclosed_{std::move(enclosed)}
 {
     CELER_VALIDATE(polygon_.size() >= 3,
                    << "polygon must have at least 3 vertices");
@@ -62,7 +66,23 @@ NodeId RevolvedPolygon::build(VolumeBuilder& vb) const
 
     // Start the recursion process
     SubIndex ri;
-    return this->make_levels(vb, filtered_polygon, ri);
+    auto result = this->make_levels(vb, filtered_polygon, ri);
+
+    if (enclosed_)
+    {
+        // Handle azimuthal truncation
+        auto&& [sense, wedge] = enclosed_.make_sense_region();
+        NodeId wedge_id = build_intersect_region(vb, label_, "angle", wedge);
+        if (sense == Sense::outside)
+        {
+            wedge_id = vb.insert_region(Label{label_, "negated_angle"},
+                                        Negated{wedge_id});
+        }
+        result = vb.insert_region(Label{label_, "restricted"},
+                                  Joined{op_and, {result, wedge_id}});
+    }
+
+    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/RevolvedPolygon.cc
+++ b/src/orange/orangeinp/RevolvedPolygon.cc
@@ -72,11 +72,11 @@ NodeId RevolvedPolygon::build(VolumeBuilder& vb) const
     {
         // Handle azimuthal truncation
         auto&& [sense, wedge] = enclosed_.make_sense_region();
-        NodeId wedge_id = build_intersect_region(vb, label_, "angle", wedge);
+        char const* ext = (sense == Sense::outside ? "~azi" : "azi");
+        NodeId wedge_id = build_intersect_region(vb, label_, ext, wedge);
         if (sense == Sense::outside)
         {
-            wedge_id = vb.insert_region(Label{label_, "negated_angle"},
-                                        Negated{wedge_id});
+            wedge_id = vb.insert_region({}, Negated{wedge_id});
         }
         result = vb.insert_region(Label{label_, "restricted"},
                                   Joined{op_and, {result, wedge_id}});

--- a/src/orange/orangeinp/RevolvedPolygon.hh
+++ b/src/orange/orangeinp/RevolvedPolygon.hh
@@ -16,7 +16,7 @@ namespace celeritas
 namespace orangeinp
 {
 //---------------------------------------------------------------------------//
-/*! An arbitrary (possibly concave) polygon revolved around the \em z axis.
+/*! An azimuthally sliced arbitrary polygon revolved around the \em z axis.
  *
  * The polygon must be specified in counterclockwise order and may not be self
  * intersecting. The polygon cannot cross the \em z axis, i.e., all vertices
@@ -57,11 +57,15 @@ namespace orangeinp
         r axis ->
    \endverbatim
  * In this example, level 1 region 0 is formed from only two subregions, but
- * the general case is handed via:
+ * the general case is handled via:
  *
  * region = union(outer subregions) - union(inner subregions).
  *
- * \internal When labeing nodes in the CSG output, the following shorthand
+ * The final step in construction is azimuthal truncation, which is done
+ through
+ * a union operation with a negated or non-negated EnclosedAzi.
+ *
+ * \internal When labeling nodes in the CSG output, the following shorthand
  * format is used: `label@level.region.subregion`. For example, the final
  * subregion in the example above might be named `my_shape@1.0.1`. For each
  * level, additional nodes are created in the form: `label@level.suffix` where
@@ -78,6 +82,15 @@ namespace orangeinp
  * 2) .iu : the union of nodes that comprise the inner boundary of the region,
  * 3) .nui : the negation of .ui,
  * 4) .d : the difference between .ou and .iu.
+ *
+ * If the supplied EnclosedAzi object is not [0, 2pi] the following additional
+ * nodes are added:
+ *
+ * 1) label@angle : the enclosed azimuthal angle,
+ * 2) label@negated_angle : the negation of "angle", when less than a half turn
+ *    is enclosed,
+ * 3) label@restricted : the intersection of the revolved polygon and
+ *    angle/negated_angle.
  */
 class RevolvedPolygon final : public ObjectInterface
 {
@@ -153,7 +166,7 @@ class RevolvedPolygon final : public ObjectInterface
     // Make a label extension for a region within a level
     std::string make_region_ext(SubIndex si) const;
 
-    // Make a extension label for a subregion within a region
+    // Make a label extension for a subregion within a region
     std::string make_subregion_ext(SubIndex si) const;
 
     //// DATA ////

--- a/src/orange/orangeinp/RevolvedPolygon.hh
+++ b/src/orange/orangeinp/RevolvedPolygon.hh
@@ -83,13 +83,14 @@ namespace orangeinp
  * 3) .nui : the negation of .ui,
  * 4) .d : the difference between .ou and .iu.
  *
- * If the supplied EnclosedAzi object is not [0, 2pi] the following additional
- * nodes are added:
+ * If the supplied EnclosedAzi object is not [0, 2pi], additional nodes with
+ the
+ * following extensions are added:
  *
- * 1) label@angle : the enclosed azimuthal angle,
- * 2) label@negated_angle : the negation of "angle", when less than a half turn
- *    is enclosed,
- * 3) label@restricted : the intersection of the revolved polygon and
+ * 1) angle : the enclosed azimuthal angle,
+ * 2) negated_angle : the negation of "angle", when less than a half turn is
+ * enclosed,
+ * 3) restricted : the intersection of the revolved polygon and
  *    angle/negated_angle.
  */
 class RevolvedPolygon final : public ObjectInterface

--- a/src/orange/orangeinp/RevolvedPolygon.hh
+++ b/src/orange/orangeinp/RevolvedPolygon.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "ObjectInterface.hh"
+#include "Solid.hh"
 
 #include "detail/VolumeBuilder.hh"
 
@@ -88,7 +89,9 @@ class RevolvedPolygon final : public ObjectInterface
     //!@}
 
     // Construct from a polygon
-    RevolvedPolygon(std::string&& label, VecReal2&& polygon);
+    RevolvedPolygon(std::string&& label,
+                    VecReal2&& polygon,
+                    EnclosedAzi&& enclosed);
 
     //// INTERFACE ////
 
@@ -105,6 +108,9 @@ class RevolvedPolygon final : public ObjectInterface
 
     //! Get the polygon
     VecReal2 const& polygon() const { return polygon_; };
+
+    //! Get the azimuthal angular restriction
+    EnclosedAzi const& enclosed_azi() const { return enclosed_; }
 
   private:
     /// TYPES ///
@@ -154,6 +160,7 @@ class RevolvedPolygon final : public ObjectInterface
 
     std::string label_;
     VecReal2 polygon_;
+    EnclosedAzi enclosed_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/RevolvedPolygon.hh
+++ b/src/orange/orangeinp/RevolvedPolygon.hh
@@ -62,8 +62,7 @@ namespace orangeinp
  * region = union(outer subregions) - union(inner subregions).
  *
  * The final step in construction is azimuthal truncation, which is done
- through
- * a union operation with a negated or non-negated EnclosedAzi.
+ * through a union operation with a negated or non-negated EnclosedAzi.
  *
  * \internal When labeling nodes in the CSG output, the following shorthand
  * format is used: `label@level.region.subregion`. For example, the final
@@ -84,14 +83,10 @@ namespace orangeinp
  * 4) .d : the difference between .ou and .iu.
  *
  * If the supplied EnclosedAzi object is not [0, 2pi], additional nodes with
- the
- * following extensions are added:
+ * the following extensions are added:
  *
- * 1) angle : the enclosed azimuthal angle,
- * 2) negated_angle : the negation of "angle", when less than a half turn is
- * enclosed,
- * 3) restricted : the intersection of the revolved polygon and
- *    angle/negated_angle.
+ * 1) azi/~azi : the enclosed, possibly negated, azimuthal angle,
+ * 2) restricted : the intersection of the revolved polygon and azi/~azi.
  */
 class RevolvedPolygon final : public ObjectInterface
 {

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -297,7 +297,6 @@ TEST_F(SolidConverterTest, ellipticalcone)
  * Test xtru with 4 levels of concavity. Points are supplied in clockwise
  order,
  * as preferred by Geant4.
- *
  \verbatim
                    7
  1                 |\
@@ -317,20 +316,18 @@ TEST_F(SolidConverterTest, extrudedsolid_concave)
     using ZSection = G4ExtrudedSolid::ZSection;
 
     // Setup G4Extruded solid construction commands
-    std::vector<G4TwoVector> polygon = {
-        {0, 0},
-        {-0.3, 1},
-        {0.15, 0.5},
-        {0.4, 0.7},
-        {0.45, 0.6},
-        {0.5, 0.7},
-        {0.8, 0.4},
-        {0.9, 1.2},
-        {1.2, 0.5},
-        {1, 0},
-        {0.1, 0},
-        {0.05, 0.01},
-    };
+    std::vector<G4TwoVector> polygon = {{0, 0},
+                                        {-0.3, 1},
+                                        {0.15, 0.5},
+                                        {0.4, 0.7},
+                                        {0.45, 0.6},
+                                        {0.5, 0.7},
+                                        {0.8, 0.4},
+                                        {0.9, 1.2},
+                                        {1.2, 0.5},
+                                        {1, 0},
+                                        {0.1, 0},
+                                        {0.05, 0.01}};
 
     ZSection bot(0, {0, 0}, 1);
     ZSection mid(1, {10, 5}, 0.5);
@@ -392,33 +389,9 @@ TEST_F(SolidConverterTest, generic_polycone)
     G4double phi_start = 0 * deg;
     G4double phi_end = 90 * deg;
     std::vector<G4double> r{
-        0.3,
-        0.0,
-        0.45,
-        0.7,
-        0.75,
-        0.8,
-        1.1,
-        1.2,
-        1.5,
-        1.3,
-        0.4,
-        0.35,
-    };
+        0.3, 0.0, 0.45, 0.7, 0.75, 0.8, 1.1, 1.2, 1.5, 1.3, 0.4, 0.35};
     std::vector<G4double> z{
-        -0.5,
-        0.5,
-        0.0,
-        0.2,
-        0.1,
-        0.2,
-        -0.1,
-        0.7,
-        0.0,
-        -0.5,
-        -0.5,
-        -0.49,
-    };
+        -0.5, 0.5, 0.0, 0.2, 0.1, 0.2, -0.1, 0.7, 0.0, -0.5, -0.5, -0.49};
 
     // Test 5 points near tricky corners and 2 outside of the azimuthal range
     this->build_and_test(

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -372,8 +372,7 @@ TEST_F(SolidConverterTest, extrudedsolid_simple)
 //---------------------------------------------------------------------------//
 /*
  * Test GenericPolygon with 4 levels of concavity. Points are supplied in
- clockwise order,
- * as preferred by Geant4.
+ * clockwise order, as preferred by Geant4.
  \verbatim
                    7
  1                 |\
@@ -394,7 +393,7 @@ TEST_F(SolidConverterTest, generic_polycone)
     G4double phi_end = 90 * deg;
     std::vector<G4double> r{
         0.3,
-        0,
+        0.0,
         0.45,
         0.7,
         0.75,
@@ -407,22 +406,21 @@ TEST_F(SolidConverterTest, generic_polycone)
         0.35,
     };
     std::vector<G4double> z{
-        0,
-        1,
+        -0.5,
         0.5,
+        0.0,
+        0.2,
+        0.1,
+        0.2,
+        -0.1,
         0.7,
-        0.6,
-        0.7,
-        0.4,
-        1.2,
-        0.5,
-        0,
-        0,
-        0.01,
+        0.0,
+        -0.5,
+        -0.5,
+        -0.49,
     };
 
-    // Test 5 points near tricky corners, last two outside of the azimuthal
-    // range
+    // Test 5 points near tricky corners and 2 outside of the azimuthal range
     this->build_and_test(
         G4GenericPolycone("testGenericPolycone",
                           phi_start,
@@ -430,15 +428,15 @@ TEST_F(SolidConverterTest, generic_polycone)
                           r.size(),
                           r.data(),
                           z.data()),
-        R"json({"_type":"revolvedpolygon","enclosed_azi":{"start":0.0,"stop":0.25},"label":"testGenericPolycone","polygon":[[0.034999999999999996,0.001],[0.04000000000000001,0.0],[0.13,0.0],[0.15000000000000002,0.05],[0.12,0.12],[0.11000000000000001,0.04000000000000001],[0.08000000000000002,0.06999999999999999],[0.07500000000000001,0.06],[0.06999999999999999,0.06999999999999999],[0.045000000000000005,0.05],[0.0,0.1],[0.03,0.0]]})json",
+        R"json({"_type":"revolvedpolygon","enclosed_azi":{"start":0.0,"stop":0.25},"label":"testGenericPolycone","polygon":[[0.034999999999999996,-0.049],[0.04000000000000001,-0.05],[0.13,-0.05],[0.15000000000000002,0.0],[0.12,0.06999999999999999],[0.11000000000000001,-0.010000000000000002],[0.08000000000000002,0.020000000000000004],[0.07500000000000001,0.010000000000000002],[0.06999999999999999,0.020000000000000004],[0.045000000000000005,0.0],[0.0,0.05],[0.03,-0.05]]})json",
         {
-            {0.01, 0.011, 0.3},
-            {0.39, 0.79, 1.5},
-            {0.79, 0.39, 1.1},
-            {0.81, 0.4, 0.3},
-            {0.89, 1.18, 0.5},
-            {-0.81, 0.4, 0.3},
-            {-0.81, -0.4, 0.3},
+            {0.01, 0.011, -0.2},
+            {0.39, 0.79, 1.0},
+            {0.79, 0.39, 0.6},
+            {0.81, 0.4, -0.2},
+            {0.89, 1.18, 0.0},
+            {-0.81, 0.4, -0.2},
+            {-0.81, -0.4, -0.2},
         });
 }
 

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -294,37 +294,43 @@ TEST_F(SolidConverterTest, ellipticalcone)
 
 //---------------------------------------------------------------------------//
 /*
- * Test xtru with 4 levels of concavity.
+ * Test xtru with 4 levels of concavity. Points are supplied in clockwise
+ order,
+ * as preferred by Geant4.
  *
- *                     7
- *   1                 |\
- *   \\                | \
- *    \ \      3  5    |  \
- *     \  \    /\/\    |   \
- *      \   \/   4  \  |    \ 8
- *       \   2        \|    /
- *        \            6   /
- *         \ 11           /
- *          \/\__________/
- *          0  10        9
+ \verbatim
+                   7
+ 1                 |\
+ \\                | \
+  \ \      3  5    |  \
+   \  \    /\/\    |   \
+    \   \/   4  \  |    \ 8
+     \   2        \|    /
+      \            6   /
+       \ 11           /
+        \/\__________/
+        0  10        9
+ \endverbatim
  */
 TEST_F(SolidConverterTest, extrudedsolid_concave)
 {
     using ZSection = G4ExtrudedSolid::ZSection;
 
     // Setup G4Extruded solid construction commands
-    std::vector<G4TwoVector> polygon = {{0.05, 0.01},
-                                        {0.1, 0},
-                                        {1, 0},
-                                        {1.2, 0.5},
-                                        {0.9, 1.2},
-                                        {0.8, 0.4},
-                                        {0.5, 0.7},
-                                        {0.45, 0.6},
-                                        {0.4, 0.7},
-                                        {0.15, 0.5},
-                                        {-0.3, 1},
-                                        {0, 0}};
+    std::vector<G4TwoVector> polygon = {
+        {0, 0},
+        {-0.3, 1},
+        {0.15, 0.5},
+        {0.4, 0.7},
+        {0.45, 0.6},
+        {0.5, 0.7},
+        {0.8, 0.4},
+        {0.9, 1.2},
+        {1.2, 0.5},
+        {1, 0},
+        {0.1, 0},
+        {0.05, 0.01},
+    };
 
     ZSection bot(0, {0, 0}, 1);
     ZSection mid(1, {10, 5}, 0.5);
@@ -361,6 +367,79 @@ TEST_F(SolidConverterTest, extrudedsolid_simple)
         G4ExtrudedSolid("testExtrudedSolid", polygon, z_sections),
         R"json({"_type":"shape","interior":{"_type":"extrudedpolygon","bot_line_segment_point":[0.0,0.0,0.0],"bot_scaling_factor":1.0,"polygon":[[0.1,0.0],[0.1,0.1],[0.0,0.1],[0.0,0.0]],"top_line_segment_point":[0.1,0.2,0.1],"top_scaling_factor":1.5},"label":"testExtrudedSolid"})json",
         {{0.5, 0.5, 0.5}, {-1, 0.5, 0.5}});
+}
+
+//---------------------------------------------------------------------------//
+/*
+ * Test GenericPolygon with 4 levels of concavity. Points are supplied in
+ clockwise order,
+ * as preferred by Geant4.
+ \verbatim
+                   7
+ 1                 |\
+ \\                | \
+  \ \      3  5    |  \
+   \  \    /\/\    |   \
+    \   \/   4  \  |    \ 8
+     \   2        \|    /
+      \            6   /
+       \ 11           /
+        \/\__________/
+        0  10        9
+ \endverbatim
+ */
+TEST_F(SolidConverterTest, generic_polycone)
+{
+    G4double phi_start = 0 * deg;
+    G4double phi_end = 90 * deg;
+    std::vector<G4double> r{
+        0.3,
+        0,
+        0.45,
+        0.7,
+        0.75,
+        0.8,
+        1.1,
+        1.2,
+        1.5,
+        1.3,
+        0.4,
+        0.35,
+    };
+    std::vector<G4double> z{
+        0,
+        1,
+        0.5,
+        0.7,
+        0.6,
+        0.7,
+        0.4,
+        1.2,
+        0.5,
+        0,
+        0,
+        0.01,
+    };
+
+    // Test 5 points near tricky corners, last two outside of the azimuthal
+    // range
+    this->build_and_test(
+        G4GenericPolycone("testGenericPolycone",
+                          phi_start,
+                          phi_end,
+                          r.size(),
+                          r.data(),
+                          z.data()),
+        R"json({"_type":"revolvedpolygon","enclosed_azi":{"start":0.0,"stop":0.25},"label":"testGenericPolycone","polygon":[[0.034999999999999996,0.001],[0.04000000000000001,0.0],[0.13,0.0],[0.15000000000000002,0.05],[0.12,0.12],[0.11000000000000001,0.04000000000000001],[0.08000000000000002,0.06999999999999999],[0.07500000000000001,0.06],[0.06999999999999999,0.06999999999999999],[0.045000000000000005,0.05],[0.0,0.1],[0.03,0.0]]})json",
+        {
+            {0.01, 0.011, 0.3},
+            {0.39, 0.79, 1.5},
+            {0.79, 0.39, 1.1},
+            {0.81, 0.4, 0.3},
+            {0.89, 1.18, 0.5},
+            {-0.81, 0.4, 0.3},
+            {-0.81, -0.4, 0.3},
+        });
 }
 
 TEST_F(SolidConverterTest, generictrap)

--- a/test/orange/orangeinp/PolySolid.test.cc
+++ b/test/orange/orangeinp/PolySolid.test.cc
@@ -213,7 +213,7 @@ TEST_F(PolyconeTest, sliced)
         "pc@segments",
         "pc@awm",
         "pc@awp",
-        "pc@angle",
+        "pc@~azi",
         "",
         "pc@restricted",
     };

--- a/test/orange/orangeinp/RevolvedPolygon.test.cc
+++ b/test/orange/orangeinp/RevolvedPolygon.test.cc
@@ -44,6 +44,7 @@ class RevolvedPolygonTest : public ObjectTestBase
     /// DATA  ///
     LocalVolumeId vol_id_;
 };
+
 //---------------------------------------------------------------------------//
 /* Test the simplest case: a single subregion.
  \verbatim
@@ -63,7 +64,8 @@ TEST_F(RevolvedPolygonTest, one_subregion)
 {
     VecReal2 polygon{{0, 0}, {3, 0}, {3, 2}, {0, 2}};
 
-    vol_id_ = this->build_volume(RevolvedPolygon{"rp", std::move(polygon)});
+    vol_id_ = this->build_volume(
+        RevolvedPolygon{"rp", std::move(polygon), EnclosedAzi{}});
 
     static char const* const expected_surface_strings[]
         = {"Plane: z=0", "Plane: z=2", "Cyl z: r=3"};
@@ -106,6 +108,76 @@ TEST_F(RevolvedPolygonTest, one_subregion)
 }
 
 //---------------------------------------------------------------------------//
+/* Test a single subregion with a restricted angle
+ \verbatim
+    3 _
+       |
+    2 _|______________
+ z     |              |
+    1 _|              |   With cos(theta) >= 0
+       |              |
+    0 _|______________|__________
+       |    |    |    |    |    |
+       0    1    2    3    4    5
+                   r
+ \endverbatim
+ */
+TEST_F(RevolvedPolygonTest, one_subregion_with_enclosed)
+{
+    VecReal2 polygon{{0, 0}, {3, 0}, {3, 2}, {0, 2}};
+
+    vol_id_ = this->build_volume(RevolvedPolygon{
+        "rp", std::move(polygon), EnclosedAzi{Turn{-0.25}, Turn{0.25}}});
+
+    static char const* const expected_surface_strings[]
+        = {"Plane: z=0", "Plane: z=2", "Cyl z: r=3", "Plane: x=0"};
+
+    static char const* const expected_volume_strings[] = {
+        "all(+0, -1, -2, +3)",
+    };
+
+    static char const* const expected_md_strings[] = {
+        "",
+        "",
+        "rp@0.0.0.mz",
+        "rp@0.0.0.pz",
+        "",
+        "rp@0.0.0.cz",
+        "",
+        "rp@0.0.0,rp@0.0.ou",
+        "rp@angle,rp@awm,rp@awp",
+        "rp@restricted",
+    };
+
+    static char const* const expected_bound_strings[] = {
+        "7: {{{-2.12,-2.12,0}, {2.12,2.12,2}}, {{-3,-3,0}, {3,3,2}}}",
+        "8: {{{0,-inf,-inf}, {inf,inf,inf}}, {{0,-inf,-inf}, {inf,inf,inf}}}",
+        "9: {{{0,-2.12,0}, {2.12,2.12,2}}, {{0,-3,0}, {3,3,2}}}"};
+
+    // Test construction
+    auto const& u = this->unit();
+    EXPECT_VEC_EQ(expected_surface_strings, surface_strings(u));
+    EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
+    EXPECT_VEC_EQ(expected_md_strings, md_strings(u));
+    EXPECT_VEC_EQ(expected_bound_strings, bound_strings(u));
+
+    // Test senses
+    EXPECT_EQ(SignedSense::inside, this->eval_sense({0.1, 0.1, 1}));
+    EXPECT_EQ(SignedSense::inside, this->eval_sense({2, 2, 1}));
+
+    EXPECT_EQ(SignedSense::on, this->eval_sense({0, 0, 1}));
+    EXPECT_EQ(SignedSense::on, this->eval_sense({0, 0, 0}));
+    EXPECT_EQ(SignedSense::on, this->eval_sense({3, 0, 1}));
+    EXPECT_EQ(SignedSense::on, this->eval_sense({0, 3, 1}));
+
+    EXPECT_EQ(SignedSense::outside, this->eval_sense({-0.1, -0.1, 1}));
+    EXPECT_EQ(SignedSense::outside, this->eval_sense({-2, -2, 1}));
+    EXPECT_EQ(SignedSense::outside, this->eval_sense({0, 0, -1}));
+    EXPECT_EQ(SignedSense::outside, this->eval_sense({3.1, 0, 1}));
+    EXPECT_EQ(SignedSense::outside, this->eval_sense({0, -3.1, 1}));
+}
+
+//---------------------------------------------------------------------------//
 /* Test two-subregion case consisting of a cone subtracted from a cylinder.
  \verbatim
     3 _
@@ -124,7 +196,8 @@ TEST_F(RevolvedPolygonTest, two_subregion)
 {
     VecReal2 polygon{{1, 2}, {0, 0}, {3, 0}, {3, 2}};
 
-    vol_id_ = this->build_volume(RevolvedPolygon{"rp", std::move(polygon)});
+    vol_id_ = this->build_volume(
+        RevolvedPolygon{"rp", std::move(polygon), EnclosedAzi{}});
 
     static char const* const expected_surface_strings[] = {
         "Plane: z=0", "Plane: z=2", "Cone z: t=0.5 at {0,0,0}", "Cyl z: r=3"};
@@ -198,7 +271,8 @@ TEST_F(RevolvedPolygonTest, two_levels)
 {
     VecReal2 polygon{{1, 2}, {1.2, 1.5}, {0, 0}, {3, 0}, {3, 2}};
 
-    vol_id_ = this->build_volume(RevolvedPolygon{"rp", std::move(polygon)});
+    vol_id_ = this->build_volume(
+        RevolvedPolygon{"rp", std::move(polygon), EnclosedAzi{}});
 
     static char const* const expected_surface_strings[]
         = {"Plane: z=0",
@@ -310,7 +384,8 @@ TEST_F(RevolvedPolygonTest, three_levels)
                      {0.33, 3},
                      {0.33, 0.5}};
 
-    vol_id_ = this->build_volume(RevolvedPolygon{"rp", std::move(polygon)});
+    vol_id_ = this->build_volume(
+        RevolvedPolygon{"rp", std::move(polygon), EnclosedAzi{}});
 
     static char const* const expected_surface_strings[] = {
         "Plane: z=0.5",
@@ -393,22 +468,6 @@ TEST_F(RevolvedPolygonTest, three_levels)
     EXPECT_VEC_EQ(expected_volume_strings, volume_strings(u));
     EXPECT_VEC_EQ(expected_md_strings, md_strings(u));
     EXPECT_VEC_EQ(expected_bound_strings, bound_strings(u));
-
-    //---------------------------------------------------------------------------//
-    /* These cases with nested concavity.
-     \verbatim
-       3 __  __ . . . . . . .  ____
-          | |  |              |    |
-       2 _| |  |     ____     |    |
-     z    | |  |    |    |    |    |
-       1 _| |  |____|. . |____|    |
-          | |______________________|
-       0 _|________________________
-          |    |    |    |    |    |
-          0    1    2    3    4    5
-                      r
-      \endverbatim
-     */
 
     // Test senses
     EXPECT_EQ(SignedSense::inside, this->eval_sense({0.6, 0, 2}));

--- a/test/orange/orangeinp/RevolvedPolygon.test.cc
+++ b/test/orange/orangeinp/RevolvedPolygon.test.cc
@@ -145,7 +145,7 @@ TEST_F(RevolvedPolygonTest, one_subregion_with_enclosed)
         "rp@0.0.0.cz",
         "",
         "rp@0.0.0,rp@0.0.ou",
-        "rp@angle,rp@awm,rp@awp",
+        "rp@awm,rp@awp,rp@azi",
         "rp@restricted",
     };
 


### PR DESCRIPTION
This MR does two things:
1) add `EnclosedAzi` support to `RevolvedPolygon`,
2) hook up `RevolvedPolygon` to `SolidConverter` to add full support for `G4GenericPolycone`.

One thing I didn't implement here is an `or_solid`-like method, that only makes cylinders or cones. I don't think the actual surface logic changes significantly in these cases. An `or_polycone` could be added for cases where generic polygons are not required, but detecting this case would take some work.