### PR TITLE
Fix oversimplification of simple quadrics

### DIFF
--- a/doc/_static/zotero.bib
+++ b/doc/_static/zotero.bib
@@ -146,6 +146,16 @@
   doi = {10.1002/cpe.5640}
 }
 
+@book{arvo-graphicsgems-1995,
+  title = {Graphics {{Gems}} 2},
+  shorttitle = {The {{AP}} Professional Graphics {{CD-ROM}}},
+  editor = {Arvo, James},
+  year = {1995},
+  publisher = {Academic Press},
+  address = {New York},
+  isbn = {978-0-12-059756-7}
+}
+
 @article{asai-penelopephysics-2021,
   title = {The {{PENELOPE Physics Models}} and {{Transport Mechanics}}. {{Implementation}} into {{Geant4}}},
   author = {Asai, Makoto and {Cort{\'e}s-Giraldo}, Miguel A. and {Gim{\'e}nez-Alventosa}, Vicent and Gim{\'e}nez G{\'o}mez, Vicent and Salvat, Francesc},
@@ -914,16 +924,16 @@
   title = {Celeritas: Toward {{GPU-based}} Particle Transport for Detector Simulations in {{HEP}} Experiments},
   author = {Evans, Thomas},
   year = {2020},
-  month = nov,
-  collaborator = {Johnson, Seth R and Canal, Philippe}
+  month = apr,
+  collaborator = {Johnson, Seth R and Tognini, Stefano}
 }
 
 @misc{evans-celeritasgpubased-2020a,
   title = {Celeritas: Toward {{GPU-based}} Particle Transport for Detector Simulations in {{HEP}} Experiments},
   author = {Evans, Thomas},
   year = {2020},
-  month = apr,
-  collaborator = {Johnson, Seth R and Tognini, Stefano}
+  month = nov,
+  collaborator = {Johnson, Seth R and Canal, Philippe}
 }
 
 @misc{evans-celeritasoverview-2023,
@@ -1302,7 +1312,7 @@
 }
 
 @article{haramato-jump-2008,
-  title = {Efficient {{Jump Ahead}} for {$\mathbb{F}$}{\textsubscript{2}} -{{Linear Random Number Generators}}},
+  title = {Efficient {{Jump Ahead}} for {{$\mathbb{F}$}}{\textsubscript{2}} -{{Linear Random Number Generators}}},
   author = {Haramoto, Hiroshi and Matsumoto, Makoto and Nishimura, Takuji and Panneton, Fran{\c c}ois and L'Ecuyer, Pierre},
   year = {2008},
   month = aug,
@@ -1538,20 +1548,20 @@
 }
 
 @misc{johnson-celeritasem-2023,
-  title = {Celeritas: {{EM}} Physics on {{GPUs}}},
-  author = {Johnson, Seth R.},
-  year = {2023},
-  month = jun,
-  url = {https://indico.fnal.gov/event/59490/}
-}
-
-@misc{johnson-celeritasem-2023a,
   title = {Celeritas: {{EM}} Physics on {{GPUs}} and a Path to Full-Featured Accelerated Detector Simulation},
   author = {Johnson, Seth R.},
   year = {2023},
   month = may,
   address = {Norfolk, VA},
   url = {https://indico.jlab.org/event/459/contributions/11818/attachments/9324/13745/srj-chep.pdf}
+}
+
+@misc{johnson-celeritasem-2023-calvision,
+  title = {Celeritas: {{EM}} Physics on {{GPUs}}},
+  author = {Johnson, Seth R.},
+  year = {2023},
+  month = jun,
+  url = {https://indico.fnal.gov/event/59490/}
 }
 
 @misc{johnson-celeritasgpu-2022,
@@ -1665,20 +1675,20 @@
 }
 
 @misc{johnson-celeritasv02-2023a,
-  title = {Celeritas v0.2: {{Geant4 Integration}} for {{CMS}}},
-  author = {Johnson, Seth R.},
-  year = {2023},
-  month = mar,
-  url = {https://indico.cern.ch/event/1247039/#16-celeritas-project}
-}
-
-@misc{johnson-celeritasv02-2023b,
   title = {Celeritas v0.2: {{Offloading EM}} Tracks to {{GPU}} from {{Geant4}}},
   author = {Johnson, Seth R.},
   year = {2023},
   month = feb,
   address = {LBNL},
   url = {https://rpm.physics.lbl.gov/event/speaker-seth-r-johnson-ornl-tittle-celeritas-v0-2-a-new-monte-carlo-particle-transport-code-for-detector-simulation-on-gpus/}
+}
+
+@misc{johnson-celeritasv02-2023b,
+  title = {Celeritas v0.2: {{Geant4 Integration}} for {{CMS}}},
+  author = {Johnson, Seth R.},
+  year = {2023},
+  month = mar,
+  url = {https://indico.cern.ch/event/1247039/#16-celeritas-project}
 }
 
 @misc{johnson-celeritasv03-2023,
@@ -2051,6 +2061,28 @@
   annotation = {UNIFIED model}
 }
 
+@article{levin-parametricalgorithm-1976,
+  title = {A Parametric Algorithm for Drawing Pictures of Solid Objects Composed of Quadric Surfaces},
+  author = {Levin, Joshua},
+  year = {1976},
+  month = oct,
+  journal = {Communications of the ACM},
+  volume = {19},
+  number = {10},
+  pages = {555--563},
+  issn = {0001-0782, 1557-7317},
+  doi = {10.1145/360349.360355}
+}
+
+@techreport{levin-parametricalgorithm-1976-report,
+  title = {A Parametric Algorithm for Drawing Pictures of Solid Objects},
+  author = {Levin, Joshua Zev},
+  year = {1976},
+  month = mar,
+  number = {CRL-46},
+  institution = {Rensselaer Polytechnic Institute}
+}
+
 @article{li-gpubasedoptical-2023,
   title = {Gpu-Based Optical Photon Simulation for the {{LHCb RICH}} 1 Detector},
   author = {Li, Yunlong and Davis, Adam and Easo, Sajan and Evans, Keith and Gersabeck, Evelina Mihova and Gersabeck, Marco and Girardey, Lucas George and Nandakumar, Raja and Pointer, Annabelle Jane},
@@ -2408,6 +2440,18 @@
   address = {Paris, France},
   doi = {10.1051/snamc/201402505},
   isbn = {978-2-7598-1269-1}
+}
+
+@misc{nextcollaboration-performanceoptical-2025,
+  title = {Performance of an {{Optical TPC Geant4 Simulation}} with {{Opticks GPU-Accelerated Photon Propagation}}},
+  author = {{NEXT Collaboration} and Parmaksiz, I. and Mistry, K. and Church, E. and Adams, C. and Asaadi, J. and {Baeza-Rubio}, J. and Bailey, K. and Byrnes, N. and Jones, B. J. P. and Moya, I. A. and Navarro, K. E. and Nygren, D. R. and Oyedele, P. and Rogers, L. and Samaniego, F. and Stogsdill, K. and Almaz{\'a}n, H. and {\'A}lvarez, V. and Aparicio, B. and Aranburu, A. I. and Arazi, L. and Arnquist, I. J. and {Auria-Luna}, F. and Ayet, S. and Azevedo, C. D. R. and Ballester, F. and del {Barrio-Torregrosa}, M. and Bayo, A. and {Benlloch-Rodr{\'i}guez}, J. M. and Borges, F. I. G. M. and Brodolin, A. and C{\'a}rcel, S. and Castillo, A. and Cid, L. and Conde, C. A. N. and Contreras, T. and Coss{\'i}o, F. P. and Coupe, R. and Dey, E. and D{\'i}az, G. and Echevarria, C. and Elorza, M. and Escada, J. and Esteve, R. and Felkai, R. and Fernandes, L. M. P. and Ferrario, P. and Ferreira, A. L. and Foss, F. W. and Freixa, Z. and {Garc{\'i}a-Barrena}, J. and {G{\'o}mez-Cadenas}, J. J. and Grocott, J. W. R. and Guenette, R. and Hauptman, J. and Henriques, C. A. O. and Morata, J. A. Hernando and {Herrero-G{\'o}mez}, P. and Herrero, V. and Carrete, C. Herv{\'e}s and Ifergan, Y. and Kellerer, F. and Larizgoitia, L. and Larumbe, A. and Lebrun, P. and Lopez, F. and {L{\'o}pez-March}, N. and Madigan, R. and Mano, R. D. P. and Marques, A. P. and {Mart{\'i}n-Albo}, J. and {Mart{\'i}nez-Lema}, G. and {Mart{\'i}nez-Vara}, M. and Miller, R. L. and {Molina-Canteras}, J. and Monrabal, F. and Monteiro, C. M. B. and Mora, F. J. and Novella, P. and Nu{\~n}ez, A. and Oblak, E. and Palacio, J. and Palmeiro, B. and Para, A. and Pazos, A. and Pelegrin, J. and Maneiro, M. P{\'e}rez and Querol, M. and Renner, J. and Rivilla, I. and Rogero, C. and Romeo, B. and {Romo-Luque}, C. and Nacienciano, V. San and Santos, F. P. and dos Santos, J. M. F. and Seemann, M. and Shomroni, I. and Silva, P. A. O. C. and Sim{\'o}n, A. and Soleti, S. R. and Sorel, M. and {Soto-Oton}, J. and Teixeira, J. M. R. and {Teruel-Pardo}, S. and Toledo, J. F. and Tonnel{\'e}, C. and Torelli, S. and Torrent, J. and Trettin, A. and Us{\'o}n, A. and Valle, P. R. G. and Veloso, J. F. C. A. and Waiton, J. and {Yubero-Navarro}, A.},
+  year = {2025},
+  month = jul,
+  number = {arXiv:2502.13215},
+  eprint = {2502.13215},
+  primaryclass = {physics},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2502.13215}
 }
 
 @misc{novak-geant4differentiable-2023,
@@ -2845,6 +2889,14 @@
   isbn = {978-1-61729-857-8 978-1-63835-678-3}
 }
 
+@phdthesis{shriwise-geometryquery-2018,
+  title = {Geometry {{Query Optimizations}} in {{CAD-based Tessellations}} for {{Monte Carlo Radiation Transport}}},
+  author = {Shriwise, Patrick C.},
+  year = {2018},
+  url = {https://search.library.wisc.edu/digital/AADF7ZBX54SP4A8L},
+  school = {University of Wisconsin-Madison}
+}
+
 @techreport{si-2019,
   title = {The {{International System}} of {{Units}}},
   author = {{Bureau International des Poids et Mesures}},
@@ -3060,6 +3112,19 @@
   doi = {10.1145/357346.357348}
 }
 
+@article{torrance-theoryoffspecular-1967,
+  title = {Theory for {{Off-Specular Reflection From Roughened Surfaces}}*},
+  author = {Torrance, K. E. and Sparrow, E. M.},
+  year = {1967},
+  month = sep,
+  journal = {Journal of the Optical Society of America},
+  volume = {57},
+  number = {9},
+  pages = {1105},
+  issn = {0030-3941},
+  doi = {10.1364/JOSA.57.001105}
+}
+
 @article{tsai-1974,
   title = {Pair Production and Bremsstrahlung of Charged Leptons},
   author = {Tsai, Yung-Su},
@@ -3101,6 +3166,18 @@
   month = apr,
   address = {Paris, France},
   url = {https://s3.cern.ch/inspire-prod-files-d/d72cea91048dd2561e9cfe15fdb72ac3}
+}
+
+@misc{vaidyanathan-watertightray-2016,
+  title = {Watertight {{Ray Traversal}} with {{Reduced Precision}}},
+  author = {Vaidyanathan, Karthik and {Akenine-M{\"o}ller}, Tomas and Salvi, Marco},
+  year = {2016},
+  journal = {Eurographics/ ACM SIGGRAPH Symposium on High Performance Graphics},
+  pages = {8 pages},
+  publisher = {The Eurographics Association},
+  issn = {2079-8679},
+  doi = {10.2312/HPG.20161190},
+  isbn = {9783038680086}
 }
 
 @article{valassi-usinghep-2020,
@@ -3189,6 +3266,11 @@
   address = {Ulm},
   doi = {10.1109/RT.2007.4342588},
   isbn = {978-1-4244-1629-5}
+}
+
+@article{walter-microfacetmodels-,
+  title = {Microfacet {{Models}} for {{Refraction}} through {{Rough Surfaces}}},
+  author = {Walter, Bruce and Marschner, Stephen R and Li, Hongsong and Torrance, Kenneth E}
 }
 
 @article{wanchantseung-fastgpubased-2015,

--- a/src/orange/surf/SimpleQuadric.cc
+++ b/src/orange/surf/SimpleQuadric.cc
@@ -21,10 +21,6 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Construct with coefficients.
- *
- * The quadric is ill-defined if all non-constants are zero.
- *
- * TODO: normalize so that largest eigenvalue is unity?
  */
 SimpleQuadric::SimpleQuadric(Real3 const& abc, Real3 const& def, real_type g)
     : a_(abc[0])

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -40,7 +40,7 @@ class Sphere;
  * cylinders, etc.  The quadric is ill-defined if all non-constants are zero.
  *
  * Even though this equation can be scaled arbitrarily, the quadratic solver
- * is sensitive to the scale of the coefficients to avoid numerical precisoin
+ * is sensitive to the scale of the coefficients to avoid numerical precision
  * loss. If present, the first-order coefficients should be on the length scale
  * of the problem (i.e., translations avoid catastrophic precision loss).
  * In most non-pathological cases, the scale of the second-order components

--- a/src/orange/surf/SimpleQuadric.hh
+++ b/src/orange/surf/SimpleQuadric.hh
@@ -37,7 +37,15 @@ class Sphere;
   \f]
  *
  * This can represent axis-aligned hyperboloids, ellipsoids, elliptical
- * cylinders, etc.
+ * cylinders, etc.  The quadric is ill-defined if all non-constants are zero.
+ *
+ * Even though this equation can be scaled arbitrarily, the quadratic solver
+ * is sensitive to the scale of the coefficients to avoid numerical precisoin
+ * loss. If present, the first-order coefficients should be on the length scale
+ * of the problem (i.e., translations avoid catastrophic precision loss).
+ * In most non-pathological cases, the scale of the second-order components
+ * should be unity, as is the case when promoting spheres, cones, and
+ * cylinders.
  */
 class SimpleQuadric
 {

--- a/src/orange/surf/SurfaceSimplifier.cc
+++ b/src/orange/surf/SurfaceSimplifier.cc
@@ -287,7 +287,9 @@ auto SurfaceSimplifier::operator()(Sphere const& s) const
  * The sign can also be reversed as part of regularization.
  *
  * \note Differently scaled SQs are *not* simplified at the moment due to small
- * changes in the intercept distances that haven't yet been investigated.
+ * changes in the intercept distances. Normalization of the values should be
+ * performed during the IntersectRegion construction: see, e.g., Ellipsoid,
+ * Paraboloid, etc.
  */
 auto SurfaceSimplifier::operator()(SimpleQuadric const& sq) const
     -> Optional<Plane,

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -404,7 +404,7 @@ TEST_F(EllipsoidTest, standard)
 
     static char const expected_node[] = "-0";
     static char const* const expected_surfaces[]
-        = {"SQuadric: {4,9,36} {0,0,0} -36"};
+        = {"SQuadric: {0.33333,0.75,3} {0,0,0} -3"};
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
@@ -416,6 +416,18 @@ TEST_F(EllipsoidTest, standard)
         result.interior.upper());
     EXPECT_VEC_SOFT_EQ((Real3{-3, -2, -1}), result.exterior.lower());
     EXPECT_VEC_SOFT_EQ((Real3{3, 2, 1}), result.exterior.upper());
+}
+
+TEST_F(EllipsoidTest, tiny)
+{
+    auto result = this->test(Ellipsoid({0.008, 0.004, 0.005}));
+
+    static char const expected_node[] = "-0";
+    static char const* const expected_surfaces[]
+        = {"SQuadric: {0.5,2,1.28} {0,0,0} -3.2e-05"};
+
+    EXPECT_EQ(expected_node, result.node);
+    EXPECT_VEC_EQ(expected_surfaces, result.surfaces);
 }
 
 //---------------------------------------------------------------------------//
@@ -444,8 +456,11 @@ TEST_F(EllipticalCylinderTest, standard)
     auto result = this->test(EllipticalCylinder({3, 2}, 0.5));
 
     static char const expected_node[] = "all(+0, -1, -2)";
-    static char const* const expected_surfaces[]
-        = {"Plane: z=-0.5", "Plane: z=0.5", "SQuadric: {4,9,0} {0,0,0} -36"};
+    static char const* const expected_surfaces[] = {
+        "Plane: z=-0.5",
+        "Plane: z=0.5",
+        "SQuadric: {0.66667,1.5,0} {0,0,0} -6",
+    };
 
     EXPECT_EQ(expected_node, result.node);
     EXPECT_VEC_EQ(expected_surfaces, result.surfaces);

--- a/test/orange/orangeinp/IntersectTestResult.cc
+++ b/test/orange/orangeinp/IntersectTestResult.cc
@@ -82,6 +82,7 @@ void IntersectTestResult::print_expected() const
     IRE_COMPARE(surfaces);
 
     // Special handling for BBox objects
+    // FIXME: don't use exact comparison here, use soft equality
     if (val1.interior != val2.interior)
     {
         result.fail() << "Expected interior: " << repr(val1.interior)

--- a/test/orange/orangeinp/Truncated.test.cc
+++ b/test/orange/orangeinp/Truncated.test.cc
@@ -55,7 +55,7 @@ TEST_F(TruncatedTest, ellipsoid)
                                   Plane{Sense::outside, Axis::z, -0.5}}));
 
     static char const* const expected_surface_strings[]
-        = {"SQuadric: {1,9,0.5625} {0,0,0} -2.25",
+        = {"SQuadric: {0.44444,4,0.25} {0,0,0} -1",
            "Plane: z=1.25",
            "Plane: z=-0.5"};
     static char const* const expected_md_strings[] = {

--- a/test/orange/surf/SimpleQuadric.test.cc
+++ b/test/orange/surf/SimpleQuadric.test.cc
@@ -8,6 +8,7 @@
 
 #include "corecel/Constants.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/math/ArrayOperators.hh"
 #include "orange/surf/ConeAligned.hh"
 #include "orange/surf/CylAligned.hh"
 #include "orange/surf/Plane.hh"
@@ -60,6 +61,76 @@ TEST(SimpleQuadricTest, construction)
 }
 
 TEST(SimpleQuadricTest, ellipsoid)
+{
+    // 1 x 2.5 x .3 radii
+    Real3 const second{ipow<2>(2.5) * ipow<2>(0.3),
+                       ipow<2>(1.0) * ipow<2>(0.3),
+                       ipow<2>(1.0) * ipow<2>(2.5)};
+    real_type const zeroth = -ipow<2>(1) * ipow<2>(2.5) * ipow<2>(0.3);
+
+    SimpleQuadric sq{second, {0, 0, 0}, zeroth};
+
+    EXPECT_VEC_SOFT_EQ(second, sq.second());
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, 0}), sq.first());
+    EXPECT_SOFT_EQ(zeroth, sq.zeroth());
+
+    // Test intersections along major axes
+    EXPECT_EQ(SignedSense::outside, sq.calc_sense({-2.5, 0, 0}));
+    auto distances
+        = sq.calc_intersections({-2.5, 0, 0}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(1.5, distances[0]);
+    EXPECT_SOFT_EQ(1.5 + 2.0, distances[1]);
+
+    EXPECT_EQ(SignedSense::on, sq.calc_sense({0, 2.5, 0}));
+    distances
+        = sq.calc_intersections({0, 2.5, 0}, {0, -1, 0}, SurfaceState::on);
+    EXPECT_SOFT_EQ(5.0, distances[0]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+
+    EXPECT_EQ(SignedSense::inside, sq.calc_sense({0, 0, 0}));
+    distances = sq.calc_intersections({0, 0, 0}, {0, 0, 1}, SurfaceState::off);
+    EXPECT_SOFT_EQ(0.3, distances[1]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
+
+    // Test normals
+    EXPECT_VEC_SOFT_EQ((Real3{0, 0, -1}), sq.calc_normal({0, 0, -0.3}));
+    EXPECT_VEC_SOFT_EQ((Real3{0, 1, 0}), sq.calc_normal({0, 2.5, 0}));
+    EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), sq.calc_normal({-1, 0, 0}));
+}
+
+// This ellipsoid is tiny but scaled incorrectly so that the quadratic solver
+// sees a loss of precision
+TEST(SimpleQuadricTest, scaled_ellipsoid)
+{
+    Real3 const radii{1e-3, 2.5e-3, 0.3e-3};
+    Real3 const second{ipow<2>(radii[1]) * ipow<2>(radii[2]),
+                       ipow<2>(radii[2]) * ipow<2>(radii[0]),
+                       ipow<2>(radii[0]) * ipow<2>(radii[1])};
+    real_type const zeroth = -ipow<2>(radii[0]) * ipow<2>(radii[1])
+                             * ipow<2>(radii[2]);
+    SimpleQuadric sq{second, {0, 0, 0}, zeroth};
+
+    // Test intersections along major axes: should be like above (but scaled by
+    // 1e-3), but all intersections are missed due to the 'a' term being too
+    // small.
+    EXPECT_EQ(SignedSense::outside, sq.calc_sense({-2.5e-3, 0, 0}));
+    auto distances
+        = sq.calc_intersections({-2.5e-3, 0, 0}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+
+    distances
+        = sq.calc_intersections({0, 2.5e-3, 0}, {0, -1, 0}, SurfaceState::on);
+    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+
+    EXPECT_EQ(SignedSense::inside, sq.calc_sense({0, 0, 0}));
+    distances = sq.calc_intersections({0, 0, 0}, {0, 0, 1}, SurfaceState::off);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
+}
+
+TEST(SimpleQuadricTest, small_ellipsoid)
 {
     // 1 x 2.5 x .3 radii
     Real3 const second{ipow<2>(2.5) * ipow<2>(0.3),

--- a/test/orange/surf/SurfaceSimplifier.test.cc
+++ b/test/orange/surf/SurfaceSimplifier.test.cc
@@ -349,6 +349,9 @@ TEST_F(SimpleQuadricTest, ellipsoid)
     // Unchanged
     this->check_unchanged(
         SimpleQuadric{{0.5625, 0.09, 6.25}, {0, 0, 0}, -0.5625});
+
+    // Small (from Ellipsoid({0.008, 0.004, 0.005}))
+    this->check_unchanged(SimpleQuadric{{0.5, 2, 1.28}, {0, 0, 0}, -3.2e-05});
 }
 
 TEST_F(SimpleQuadricTest, hyperboloid)

--- a/test/orange/surf/SurfaceSimplifier.test.cc
+++ b/test/orange/surf/SurfaceSimplifier.test.cc
@@ -114,39 +114,76 @@ class SurfaceSimplifierTest : public ::celeritas::test::Test
 };
 
 //---------------------------------------------------------------------------//
+// PLANE ALIGNED
+//---------------------------------------------------------------------------//
+using PlaneAlignedTest = SurfaceSimplifierTest;
 
-TEST_F(SurfaceSimplifierTest, plane_aligned)
+TEST_F(PlaneAlignedTest, unchanged)
 {
     this->check_unchanged(PlaneX{4.0});
+}
 
+TEST_F(PlaneAlignedTest, simplifies_to_zero)
+{
     this->check_simplifies_to(PlaneX{1e-8}, PlaneX{0});
 }
 
-TEST_F(SurfaceSimplifierTest, cyl_centered)
+//---------------------------------------------------------------------------//
+// CYLINDER CENTERED
+//---------------------------------------------------------------------------//
+using CylCenteredTest = SurfaceSimplifierTest;
+
+TEST_F(CylCenteredTest, unchanged)
 {
     this->check_unchanged(CCylX{1e-8});
 }
 
-TEST_F(SurfaceSimplifierTest, sphere_centered)
+//---------------------------------------------------------------------------//
+// SPHERE CENTERED
+//---------------------------------------------------------------------------//
+using SphereCenteredTest = SurfaceSimplifierTest;
+
+TEST_F(SphereCenteredTest, unchanged)
 {
     this->check_unchanged(SphereCentered{1e-8});
 }
 
-TEST_F(SurfaceSimplifierTest, cyl_aligned)
+//---------------------------------------------------------------------------//
+// CYLINDER ALIGNED
+//---------------------------------------------------------------------------//
+using CylAlignedTest = SurfaceSimplifierTest;
+
+TEST_F(CylAlignedTest, unchanged)
 {
     this->check_unchanged(CylZ{{1, 2, 3}, 0.5});
-
-    this->check_round_trip<CylX>(CCylX{4.0});
-    this->check_round_trip<CylY>(CCylY{1.0});
-    this->check_round_trip<CylZ>(CCylZ{0.1});
-
-    {
-        SCOPED_TRACE("near center");
-        this->check_simplifies_to(CylZ{{1e-8, -1e-9, 1e-10}, 0.5}, CCylZ{0.5});
-    }
 }
 
-TEST_F(SurfaceSimplifierTest, plane)
+TEST_F(CylAlignedTest, round_trip_x)
+{
+    this->check_round_trip<CylX>(CCylX{4.0});
+}
+
+TEST_F(CylAlignedTest, round_trip_y)
+{
+    this->check_round_trip<CylY>(CCylY{1.0});
+}
+
+TEST_F(CylAlignedTest, round_trip_z)
+{
+    this->check_round_trip<CylZ>(CCylZ{0.1});
+}
+
+TEST_F(CylAlignedTest, near_center)
+{
+    this->check_simplifies_to(CylZ{{1e-8, -1e-9, 1e-10}, 0.5}, CCylZ{0.5});
+}
+
+//---------------------------------------------------------------------------//
+// PLANE
+//---------------------------------------------------------------------------//
+using PlaneTest = SurfaceSimplifierTest;
+
+TEST_F(PlaneTest, unchanged)
 {
     this->check_unchanged(Plane{{1 / sqrt_two, 0, 1 / sqrt_two}, 2.0});
     this->check_unchanged(Plane{{1 / sqrt_two, 0, 1 / sqrt_two}, 0.0});
@@ -154,11 +191,17 @@ TEST_F(SurfaceSimplifierTest, plane)
         Plane{{1 / sqrt_three, -1 / sqrt_three, 1 / sqrt_three}, 0.0});
     this->check_unchanged(
         Plane{{-1 / sqrt_three, 1 / sqrt_three, 1 / sqrt_three}, 0.0});
+}
 
+TEST_F(PlaneTest, round_trip_aligned)
+{
     this->check_round_trip<Plane>(PlaneX{4.0});
     this->check_round_trip<Plane>(PlaneY{-1.0});
     this->check_round_trip<Plane>(PlaneZ{1.0});
+}
 
+TEST_F(PlaneTest, simplifies_with_sense_flip)
+{
     this->check_simplifies_to(
         Plane{{-1 / sqrt_two, -1 / sqrt_two, 0.0}, -2 * sqrt_two},
         Plane{{1 / sqrt_two, 1 / sqrt_two, 0.0}, 2 * sqrt_two},
@@ -168,152 +211,186 @@ TEST_F(SurfaceSimplifierTest, plane)
               -2 * sqrt_three},
         Plane{{-1 / sqrt_three, 1 / sqrt_three, 1 / sqrt_three}, 2 * sqrt_three},
         Sense::outside);
+}
 
+TEST_F(PlaneTest, zero_displacement)
+{
     this->check_simplifies_to(Plane{{sqrt_three / 2, 0.5, 0.0}, 1e-15},
                               Plane{{sqrt_three / 2, 0.5, 0.0}, 0});
+}
 
+TEST_F(PlaneTest, vector_normalization)
+{
     // Check vector/displacement normalization
     Real3 n = make_unit_vector(Real3{1, 0, 1e-7});
     this->check_simplifies_to(Plane{n, {5.0, 0, 0}}, PlaneX{5.0});
+}
 
+TEST_F(PlaneTest, first_pass_normalization)
+{
     // First pass should normalize
-    n = make_unit_vector(Real3{-1, 0, 1e-7});
+    Real3 n = make_unit_vector(Real3{-1, 0, 1e-7});
     this->check_simplifies_to(
         Plane{n, {5.0, 0, 0}}, Plane{{1, 0, -1e-7}, {5, 0, 0}}, Sense::outside);
 }
 
-TEST_F(SurfaceSimplifierTest, sphere)
+//---------------------------------------------------------------------------//
+// SPHERE
+//---------------------------------------------------------------------------//
+using SphereTest = SurfaceSimplifierTest;
+
+TEST_F(SphereTest, unchanged)
 {
     this->check_unchanged(Sphere{{1, 2, 3}, 0.5});
+}
 
+TEST_F(SphereTest, round_trip)
+{
     this->check_round_trip<Sphere>(SphereCentered{0.2});
+}
 
+TEST_F(SphereTest, simplifies_to_centered)
+{
     this->check_simplifies_to(Sphere{{1e-7, -1e-7, 1e-9}, 0.5},
                               SphereCentered{0.5});
 }
 
-TEST_F(SurfaceSimplifierTest, cone_aligned)
+//---------------------------------------------------------------------------//
+// CONE ALIGNED
+//---------------------------------------------------------------------------//
+using ConeAlignedTest = SurfaceSimplifierTest;
+
+TEST_F(ConeAlignedTest, unchanged)
 {
     this->check_unchanged(ConeX{{1, 2, 3}, 0.5});
-    this->check_simplifies_to(ConeX{{1e-7, -1e-7, 1e-9}, 0.5},
-                              ConeX{{0, 0, 0}, 0.5});
-    this->check_simplifies_to(ConeY{{10, -1e-7, 1}, 0.5},
-                              ConeY{{10, 0, 1}, 0.5});
     this->check_unchanged(ConeX{{0, 0, 0}, 0.5});
 }
 
-TEST_F(SurfaceSimplifierTest, simple_quadric)
+TEST_F(ConeAlignedTest, simplifies_to_origin)
 {
-    {
-        SCOPED_TRACE("plane");
-        this->check_round_trip<SimpleQuadric>(
-            Plane{{1 / sqrt_two, 1 / sqrt_two, 0.0}, 2 * sqrt_two});
-    }
-    {
-        SCOPED_TRACE("cylinder");
-        this->check_round_trip<SimpleQuadric>(CylX{{4, 5, -1}, 4.0});
-        this->check_round_trip<SimpleQuadric>(CylY{{4, 5, -1}, 1.0});
-
-        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
-        {
-            this->check_round_trip<SimpleQuadric>(CylZ{{4, 5, -1}, 0.1});
-        }
-    }
-
-    {
-        SCOPED_TRACE("cone");
-        this->check_round_trip<SimpleQuadric>(ConeX{{2, 5, -1}, 10.0});
-        this->check_round_trip<SimpleQuadric>(ConeY{{2, 5, -1}, 1.0});
-        this->check_round_trip<SimpleQuadric>(ConeZ{{2, 5, -1}, 0.1});
-    }
-
-    {
-        SCOPED_TRACE("sphere");
-        // {1,1,1} {-2,-4,-6} 13.75
-        this->check_round_trip<SimpleQuadric>(Sphere{{1, 2, 3}, 0.5});
-        this->check_simplifies_to(SimpleQuadric{{4, 4, 4}, {-8, -16, -24}, 55},
-                                  Sphere{{1, 2, 3}, 0.5});
-        // Complex radius
-        this->check_unchanged(SimpleQuadric{{2, 2, 2}, {0, 0, 0}, 10});
-    }
-
-    {
-        SCOPED_TRACE("inverted ellipsoid");
-        this->check_simplifies_to(
-            SimpleQuadric{{-0.5625, -0.09, -6.25}, {0, 0, 0}, 0.5625},
-            SimpleQuadric{{0.5625, 0.09, 6.25}, {0, 0, 0}, -0.5625},
-            Sense::outside);
-        this->check_unchanged(
-            SimpleQuadric{{0.5625, 0.09, 6.25}, {0, 0, 0}, -0.5625});
-    }
-
-    {
-        SCOPED_TRACE("inverted scaled cone");
-        // {-0.5625,1,1} {1.6875,-4.5,-7.5} 17.859375
-        this->check_simplifies_to(
-            SimpleQuadric{{2.25, -4, -4}, {-6.75, 18.0, 30.0}, -71.4375},
-            SimpleQuadric{{-2.25, 4, 4}, {6.75, -18.0, -30.0}, 71.4375},
-            Sense::outside);
-        this->check_simplifies_to(
-            SimpleQuadric{{-2.25, 4, 4}, {6.75, -18.0, -30.0}, 71.4375},
-            ConeX{{1.5, 2.25, 3.75}, 0.75});
-    }
-
-    {
-        SCOPED_TRACE("scaled near-cylinder");
-        // CylY{{1,2,3}, 2.5} -> SQ{{1,0,1}, {-2,0,-6}, 3.75}
-        this->check_simplifies_to(
-            SimpleQuadric{{1, 1e-9, 1}, {-2, 0, -6}, 3.75},
-            CylY{{1, 2, 3}, 2.5});
-    }
-
-    {
-        SCOPED_TRACE("scaled negative cylinder");
-        this->check_simplifies_to(
-            SimpleQuadric{{-2, 0, -2}, {4, 0, 12}, -2 * 3.75},
-            SimpleQuadric{{2, 0, 2}, {-4, 0, -12}, 2 * 3.75},
-            Sense::outside);
-
-        this->check_simplifies_to(
-            SimpleQuadric{{2, 0, 2}, {-4, 0, -12}, 2 * 3.75},
-            CylY{{1, 2, 3}, 2.5});
-    }
-
-    {
-        SCOPED_TRACE("hyperboloid");  // (not a cone!)
-        this->check_unchanged(
-            SimpleQuadric{{0.5625, 0.09, -6.25}, {0, 0, 0}, -0.5625});
-    }
+    this->check_simplifies_to(ConeX{{1e-7, -1e-7, 1e-9}, 0.5},
+                              ConeX{{0, 0, 0}, 0.5});
 }
 
-TEST_F(SurfaceSimplifierTest, general_quadric)
+TEST_F(ConeAlignedTest, simplifies_y_coordinate)
 {
+    this->check_simplifies_to(ConeY{{10, -1e-7, 1}, 0.5},
+                              ConeY{{10, 0, 1}, 0.5});
+}
+
+//---------------------------------------------------------------------------//
+// SIMPLE QUADRIC
+//---------------------------------------------------------------------------//
+using SimpleQuadricTest = SurfaceSimplifierTest;
+
+TEST_F(SimpleQuadricTest, plane)
+{
+    this->check_round_trip<SimpleQuadric>(
+        Plane{{1 / sqrt_two, 1 / sqrt_two, 0.0}, 2 * sqrt_two});
+}
+
+TEST_F(SimpleQuadricTest, cylinder)
+{
+    this->check_round_trip<SimpleQuadric>(CylX{{4, 5, -1}, 4.0});
+    this->check_round_trip<SimpleQuadric>(CylY{{4, 5, -1}, 1.0});
+
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        SCOPED_TRACE("Rotated ellipsoid");
-        this->check_unchanged(GeneralQuadric{
-            {10.3125, 22.9375, 15.75},
-            {-21.867141445557, -20.25, 11.69134295109},
-            {-11.964745962156, -9.1328585544429, -65.69134295109},
-            77.652245962156});
+        this->check_round_trip<SimpleQuadric>(CylZ{{4, 5, -1}, 0.1});
     }
-    {
-        SCOPED_TRACE("Axis-aligned ellipsoid");
-        this->check_simplifies_to(
-            GeneralQuadric{{-2, 0, -2}, {0, 0, 0}, {4, 0, 12}, -2 * 3.75},
-            SimpleQuadric{{-2, 0, -2}, {4, 0, 12}, -2 * 3.75});
-    }
-    {
-        this->check_unchanged(
-            GeneralQuadric{{0, 0, 0}, {0, 0.5, 0}, {2, 0.5, 0}, 0});
-        this->check_simplifies_to(
-            GeneralQuadric{{0, 0, 0}, {0, -0.5, 0}, {-2, -0.5, 0}, 0},
-            GeneralQuadric{{0, 0, 0}, {0, 0.5, 0}, {2, 0.5, 0}, 0},
-            Sense::outside);
-        this->check_simplifies_to(
-            GeneralQuadric{{0, 0, 0}, {-1, 1, 0}, {1, 1, 0}, 0},
-            GeneralQuadric{{0, 0, 0}, {1, -1, 0}, {-1, -1, 0}, 0},
-            Sense::outside);
-    }
+
+    // Inverted
+    this->check_simplifies_to(SimpleQuadric{{-2, 0, -2}, {4, 0, 12}, -2 * 3.75},
+                              SimpleQuadric{{2, 0, 2}, {-4, 0, -12}, 2 * 3.75},
+                              Sense::outside);
+
+    // CylY{{1,2,3}, 2.5} -> SQ{{1,0,1}, {-2,0,-6}, 3.75}
+    this->check_simplifies_to(SimpleQuadric{{1, 1e-9, 1}, {-2, 0, -6}, 3.75},
+                              CylY{{1, 2, 3}, 2.5});
+    this->check_simplifies_to(SimpleQuadric{{2, 0, 2}, {-4, 0, -12}, 2 * 3.75},
+                              CylY{{1, 2, 3}, 2.5});
+}
+
+TEST_F(SimpleQuadricTest, cone)
+{
+    this->check_round_trip<SimpleQuadric>(ConeX{{2, 5, -1}, 10.0});
+    this->check_round_trip<SimpleQuadric>(ConeY{{2, 5, -1}, 1.0});
+    this->check_round_trip<SimpleQuadric>(ConeZ{{2, 5, -1}, 0.1});
+
+    // Inverted
+    this->check_simplifies_to(
+        SimpleQuadric{{2.25, -4, -4}, {-6.75, 18.0, 30.0}, -71.4375},
+        SimpleQuadric{{-2.25, 4, 4}, {6.75, -18.0, -30.0}, 71.4375},
+        Sense::outside);
+    // Then just a cone
+    this->check_simplifies_to(
+        SimpleQuadric{{-2.25, 4, 4}, {6.75, -18.0, -30.0}, 71.4375},
+        ConeX{{1.5, 2.25, 3.75}, 0.75});
+}
+
+TEST_F(SimpleQuadricTest, sphere)
+{
+    // {1,1,1} {-2,-4,-6} 13.75
+    this->check_round_trip<SimpleQuadric>(Sphere{{1, 2, 3}, 0.5});
+    this->check_simplifies_to(SimpleQuadric{{4, 4, 4}, {-8, -16, -24}, 55},
+                              Sphere{{1, 2, 3}, 0.5});
+    // Complex radius
+    this->check_unchanged(SimpleQuadric{{2, 2, 2}, {0, 0, 0}, 10});
+}
+
+TEST_F(SimpleQuadricTest, ellipsoid)
+{
+    // Inverted
+    this->check_simplifies_to(
+        SimpleQuadric{{-0.5625, -0.09, -6.25}, {0, 0, 0}, 0.5625},
+        SimpleQuadric{{0.5625, 0.09, 6.25}, {0, 0, 0}, -0.5625},
+        Sense::outside);
+
+    // Unchanged
+    this->check_unchanged(
+        SimpleQuadric{{0.5625, 0.09, 6.25}, {0, 0, 0}, -0.5625});
+}
+
+TEST_F(SimpleQuadricTest, hyperboloid)
+{
+    // (not a cone!)
+    this->check_unchanged(
+        SimpleQuadric{{0.5625, 0.09, -6.25}, {0, 0, 0}, -0.5625});
+}
+
+//---------------------------------------------------------------------------//
+// GENERAL QUADRIC
+//---------------------------------------------------------------------------//
+using GeneralQuadricTest = SurfaceSimplifierTest;
+
+TEST_F(GeneralQuadricTest, rotated_ellipsoid)
+{
+    this->check_unchanged(
+        GeneralQuadric{{10.3125, 22.9375, 15.75},
+                       {-21.867141445557, -20.25, 11.69134295109},
+                       {-11.964745962156, -9.1328585544429, -65.69134295109},
+                       77.652245962156});
+}
+
+TEST_F(GeneralQuadricTest, axis_aligned_ellipsoid)
+{
+    this->check_simplifies_to(
+        GeneralQuadric{{-2, 0, -2}, {0, 0, 0}, {4, 0, 12}, -2 * 3.75},
+        SimpleQuadric{{-2, 0, -2}, {4, 0, 12}, -2 * 3.75});
+}
+
+TEST_F(GeneralQuadricTest, general_surface)
+{
+    this->check_unchanged(
+        GeneralQuadric{{0, 0, 0}, {0, 0.5, 0}, {2, 0.5, 0}, 0});
+    this->check_simplifies_to(
+        GeneralQuadric{{0, 0, 0}, {0, -0.5, 0}, {-2, -0.5, 0}, 0},
+        GeneralQuadric{{0, 0, 0}, {0, 0.5, 0}, {2, 0.5, 0}, 0},
+        Sense::outside);
+    this->check_simplifies_to(
+        GeneralQuadric{{0, 0, 0}, {-1, 1, 0}, {1, 1, 0}, 0},
+        GeneralQuadric{{0, 0, 0}, {1, -1, 0}, {-1, -1, 0}, 0},
+        Sense::outside);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/detail/SurfaceTranslator.test.cc
+++ b/test/orange/surf/detail/SurfaceTranslator.test.cc
@@ -95,6 +95,21 @@ TEST_F(SurfaceTranslatorTest, simple_quadric)
     distances = sq.calc_intersections({2, 3, 4}, {0, 0, 1}, SurfaceState::off);
     EXPECT_SOFT_EQ(0.3, distances[1]);
     EXPECT_SOFT_EQ(no_intersection(), distances[0]);
+
+    // Tiny ellipsoid translated in macro length scale: {0.008, 0.004, 0.005}))
+    sq = translate(SimpleQuadric{{0.5, 2, 1.28}, {0, 0, 0}, -3.2e-05});
+    constexpr auto coarse_eps = Test::fine_eps * 100;
+
+    distances = sq.calc_intersections({1, 3, 4}, {1, 0, 0}, SurfaceState::off);
+    EXPECT_SOFT_EQ(1 - 0.008, distances[0]);
+    EXPECT_SOFT_EQ(1 + 0.008, distances[1]);
+    distances
+        = sq.calc_intersections({2, 3.004, 4}, {0, -1, 0}, SurfaceState::on);
+    EXPECT_SOFT_NEAR(0.008, distances[0], coarse_eps);
+    EXPECT_SOFT_EQ(no_intersection(), distances[1]);
+    distances = sq.calc_intersections({2, 3, 4}, {0, 0, 1}, SurfaceState::off);
+    EXPECT_SOFT_NEAR(0.005, distances[1], coarse_eps);
+    EXPECT_SOFT_EQ(no_intersection(), distances[0]);
 }
 
 TEST_F(SurfaceTranslatorTest, general_quadric)

--- a/test/orange/surf/detail/SurfaceTranslator.test.cc
+++ b/test/orange/surf/detail/SurfaceTranslator.test.cc
@@ -98,17 +98,18 @@ TEST_F(SurfaceTranslatorTest, simple_quadric)
 
     // Tiny ellipsoid translated in macro length scale: {0.008, 0.004, 0.005}))
     sq = translate(SimpleQuadric{{0.5, 2, 1.28}, {0, 0, 0}, -3.2e-05});
-    constexpr auto coarse_eps = Test::fine_eps * 100;
+    constexpr auto coarse_eps
+        = (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE ? 1e-11 : 1e-3);
 
     distances = sq.calc_intersections({1, 3, 4}, {1, 0, 0}, SurfaceState::off);
-    EXPECT_SOFT_EQ(1 - 0.008, distances[0]);
-    EXPECT_SOFT_EQ(1 + 0.008, distances[1]);
+    EXPECT_SOFT_NEAR(1 - 0.008, distances[0], coarse_eps);
+    EXPECT_SOFT_NEAR(1 + 0.008, distances[1], coarse_eps);
     distances
         = sq.calc_intersections({2, 3.004, 4}, {0, -1, 0}, SurfaceState::on);
     EXPECT_SOFT_NEAR(0.008, distances[0], coarse_eps);
     EXPECT_SOFT_EQ(no_intersection(), distances[1]);
     distances = sq.calc_intersections({2, 3, 4}, {0, 0, 1}, SurfaceState::off);
-    EXPECT_SOFT_NEAR(0.005, distances[1], coarse_eps);
+    EXPECT_SOFT_NEAR(0.005, distances[1], 10 * coarse_eps);
     EXPECT_SOFT_EQ(no_intersection(), distances[0]);
 }
 


### PR DESCRIPTION
A recent SCALE bug report (see [internal issue](https://code-int.ornl.gov/rnsd/scale/-/issues/1988)) demonstrated that small ellipsoids are being incorrectly oversimplified. This is not as I thought a bug in the SurfaceSimplifier but actually an issue with how the quadrics are normalized. The ellipsoid implementation resulted in second-order terms scaling with $`r^2`$ rather than being first-order as is the case with transformed cylinders etc.; this resulted in the terms being incorrectly dropped. Further exploration showed that such scaling also negatively affects the quadratic solver, which drops second order terms when they're below a certain absolute magnitude.

With this change, the ellipsoid quadric equation is normalized by the product of the min and max radii so that it will produce the same equation as a sphere when the radii are equal. The elliptical cylinder needed a similar correction.