### PR TITLE
Add global VolumeParams and rename geant_geo->global_geant_geo

### DIFF
--- a/app/celer-geo/Runner.cc
+++ b/app/celer-geo/Runner.cc
@@ -47,9 +47,9 @@ Runner::Runner(ModelSetup const& input) : input_{input}
     if (CELERITAS_USE_GEANT4 && ends_with(input_.geometry_file, ".gdml"))
     {
         // Retain the Geant4 world for possible reuse across geometries
-        CELER_EXPECT(celeritas::geant_geo().expired());
+        CELER_EXPECT(celeritas::global_geant_geo().expired());
         this->load_geometry<Geometry::geant4>();
-        CELER_EXPECT(!celeritas::geant_geo().expired());
+        CELER_EXPECT(!celeritas::global_geant_geo().expired());
     }
 }
 

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -188,7 +188,7 @@ void GeantSimpleCalo::output(JsonPimpl* j) const
 
     // Save detector volumes
     {
-        auto ggp = celeritas::geant_geo().lock();
+        auto ggp = celeritas::global_geant_geo().lock();
         if (!ggp)
         {
             // This can happen if using this class without Celeritas offloading

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -269,7 +269,7 @@ SharedParams::SharedParams(SetupOptions const& options)
     // Load geant4 geometry adapter and save as "global"
     CELER_ASSERT(loaded.geo);
     geant_geo_ = std::move(loaded.geo);
-    celeritas::geant_geo(geant_geo_);
+    celeritas::global_geant_geo(geant_geo_);
 
     // Save built attributes
     output_reg_ = params_->output_reg();

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -622,7 +622,7 @@ import_optical_materials(detail::GeoOpticalIdMap const& geo_to_opt)
 inp::OpticalPhysics import_optical_physics()
 {
     inp::OpticalPhysics result;
-    auto geo = celeritas::geant_geo().lock();
+    auto geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geo, << "global Geant4 geometry is not loaded");
 
     MultiExceptionHandler handle;
@@ -1239,7 +1239,7 @@ ImportMuPairProductionTable import_mupp_table(PDGNumber pdg)
  */
 std::vector<ImportVolume> import_volumes()
 {
-    auto geo = celeritas::geant_geo().lock();
+    auto geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geo, << "global Geant4 geometry is not loaded");
 
     VolumeParams volume_params{geo->make_model_input().volumes};
@@ -1287,7 +1287,7 @@ std::vector<ImportVolume> import_volumes()
  */
 GeantImporter::GeantImporter()
 {
-    CELER_EXPECT(!celeritas::geant_geo().expired());
+    CELER_EXPECT(!celeritas::global_geant_geo().expired());
 }
 
 //---------------------------------------------------------------------------//
@@ -1297,7 +1297,7 @@ GeantImporter::GeantImporter()
 GeantImporter::GeantImporter(GeantSetup&& setup) : setup_(std::move(setup))
 {
     CELER_EXPECT(setup_);
-    CELER_EXPECT(!celeritas::geant_geo().expired());
+    CELER_EXPECT(!celeritas::global_geant_geo().expired());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -132,7 +132,7 @@ GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
     {
         // Create non-owning Geant4 geo wrapper and save as tracking geometry
         geo_ = std::make_shared<GeantGeoParams>(world, Ownership::reference);
-        celeritas::geant_geo(geo_);
+        celeritas::global_geant_geo(geo_);
     }
 
     CELER_ENSURE(*this);

--- a/src/celeritas/ext/GeantVolumeMapper.cc
+++ b/src/celeritas/ext/GeantVolumeMapper.cc
@@ -43,7 +43,7 @@ ImplVolumeId GeantVolumeMapper::operator()(G4LogicalVolume const& lv)
     }
 
     // Get geant volume ID and corresponding label
-    auto geant_geo = celeritas::geant_geo().lock();
+    auto geant_geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geant_geo, << "global Geant4 geometry is not loaded");
     id = geant_geo->geant_to_id(lv);
     CELER_VALIDATE(id,

--- a/src/celeritas/ext/detail/GeantSurfacePhysicsHelper.cc
+++ b/src/celeritas/ext/detail/GeantSurfacePhysicsHelper.cc
@@ -26,7 +26,7 @@ namespace detail
 GeantSurfacePhysicsHelper::GeantSurfacePhysicsHelper(SurfaceId sid) : sid_(sid)
 {
     CELER_EXPECT(sid_);
-    auto geo = celeritas::geant_geo().lock();
+    auto geo = celeritas::global_geant_geo().lock();
     CELER_ASSERT(geo);
     auto const* g4log_surf = geo->id_to_geant(sid);
     CELER_ASSERT(g4log_surf);

--- a/src/celeritas/setup/FrameworkInput.cc
+++ b/src/celeritas/setup/FrameworkInput.cc
@@ -36,7 +36,7 @@ FrameworkLoaded framework_input(inp::FrameworkInput& fi)
     setup::system(fi.system);
 
     // Load Geant4 geometry wrapper, which saves it as global
-    CELER_ASSERT(celeritas::geant_geo().expired());
+    CELER_ASSERT(celeritas::global_geant_geo().expired());
     auto geo = GeantGeoParams::from_tracking_manager();
     CELER_ASSERT(geo);
 

--- a/src/celeritas/setup/Model.cc
+++ b/src/celeritas/setup/Model.cc
@@ -108,6 +108,7 @@ ModelLoaded model(inp::Model const& m)
         CELER_LOG(debug) << "Volume structure data is unavailable";
     }
     result.volume = std::make_shared<VolumeParams>(m.volumes);
+    celeritas::global_volumes(result.volume);
 
     // Construct surfaces
     if (!m.surfaces)

--- a/src/celeritas/setup/Model.cc
+++ b/src/celeritas/setup/Model.cc
@@ -75,7 +75,7 @@ struct GeoBuilder
          */
         CELER_VALIDATE(world,
                        << "null world pointer in problem.model.geometry");
-        auto ggp = celeritas::geant_geo().lock();
+        auto ggp = celeritas::global_geant_geo().lock();
         CELER_VALIDATE(ggp && ggp->world() == world,
                        << "inconsistent Geant4 world pointer given to model "
                           "setup");

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -438,10 +438,10 @@ std::weak_ptr<GeantGeoParams const> g_geant_geo_;
  *
  * \note This should be done only during setup on the main thread.
  */
-void geant_geo(std::shared_ptr<GeantGeoParams const> const& gp)
+void global_geant_geo(std::shared_ptr<GeantGeoParams const> const& gp)
 {
     CELER_LOG(debug) << (gp ? "Setting" : "Clearing")
-                     << " celeritas::geant_geo";
+                     << " celeritas::global_geant_geo";
     CELER_VALIDATE(
         g_geant_geo_.expired() ||
             [&] {
@@ -461,7 +461,7 @@ void geant_geo(std::shared_ptr<GeantGeoParams const> const& gp)
  *
  * \return Weak pointer to the global Geant4 wrapper, which may be null.
  */
-std::weak_ptr<GeantGeoParams const> const& geant_geo()
+std::weak_ptr<GeantGeoParams const> const& global_geant_geo()
 {
     return g_geant_geo_;
 }
@@ -471,7 +471,7 @@ std::weak_ptr<GeantGeoParams const> const& geant_geo()
  * Create from a running Geant4 application.
  *
  * It saves the result to the global Celeritas Geant4 geometry weak pointer \c
- * geant_geo.
+ * global_geant_geo.
  */
 std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
 {
@@ -480,7 +480,7 @@ std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
                    << "cannot create Geant geometry wrapper: Geant4 tracking "
                       "manager is not active");
     auto result = std::make_shared<GeantGeoParams>(world, Ownership::reference);
-    celeritas::geant_geo(result);
+    celeritas::global_geant_geo(result);
     return result;
 }
 
@@ -490,7 +490,7 @@ std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
  *
  * This assumes that Celeritas is driving and will manage Geant4 logging
  * and exceptions. It saves the result to the global Celeritas Geant4 geometry
- * weak pointer \c geant_geo.
+ * weak pointer \c global_geant_geo.
  */
 std::shared_ptr<GeantGeoParams>
 GeantGeoParams::from_gdml(std::string const& filename)
@@ -509,7 +509,7 @@ GeantGeoParams::from_gdml(std::string const& filename)
 
     auto result = std::make_shared<GeantGeoParams>(load_gdml(filename),
                                                    Ownership::value);
-    celeritas::geant_geo(result);
+    celeritas::global_geant_geo(result);
     return result;
 }
 

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -205,20 +205,8 @@ class GeantGeoParams final : public GeoParamsInterface,
 // Set non-owning reference to global tracking geometry instance
 void global_geant_geo(std::shared_ptr<GeantGeoParams const> const&);
 
-// DEPRECATED alias
-inline void geant_geo(std::shared_ptr<GeantGeoParams const> const& g)
-{
-    global_geant_geo(g);
-}
-
 // Global tracking geometry instance: may be nullptr
 std::weak_ptr<GeantGeoParams const> const& global_geant_geo();
-
-// DEPRECATED alias
-inline std::weak_ptr<GeantGeoParams const> const& geant_geo()
-{
-    return global_geant_geo();
-}
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
@@ -288,11 +276,11 @@ VolumeId GeantGeoParams::volume_id(ImplVolumeId iv_id) const
 
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_GEANT4 && !defined(__DOXYGEN__)
-inline void geant_geo(std::shared_ptr<GeantGeoParams const> const&)
+inline void global_geant_geo(std::shared_ptr<GeantGeoParams const> const&)
 {
     CELER_ASSERT_UNREACHABLE();
 }
-inline std::weak_ptr<GeantGeoParams const> const& geant_geo()
+inline std::weak_ptr<GeantGeoParams const> const& global_geant_geo()
 {
     static std::weak_ptr<GeantGeoParams const> const temp_;
     return temp_;

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -203,10 +203,22 @@ class GeantGeoParams final : public GeoParamsInterface,
 
 //---------------------------------------------------------------------------//
 // Set non-owning reference to global tracking geometry instance
-void geant_geo(std::shared_ptr<GeantGeoParams const> const&);
+void global_geant_geo(std::shared_ptr<GeantGeoParams const> const&);
+
+// DEPRECATED alias
+inline void geant_geo(std::shared_ptr<GeantGeoParams const> const& g)
+{
+    global_geant_geo(g);
+}
 
 // Global tracking geometry instance: may be nullptr
-std::weak_ptr<GeantGeoParams const> const& geant_geo();
+std::weak_ptr<GeantGeoParams const> const& global_geant_geo();
+
+// DEPRECATED alias
+inline std::weak_ptr<GeantGeoParams const> const& geant_geo()
+{
+    return global_geant_geo();
+}
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/geocel/VolumeParams.cc
+++ b/src/geocel/VolumeParams.cc
@@ -94,6 +94,8 @@ VolumeParams::VolumeParams(inp::Volumes const& in)
     vi_labels_
         = VolInstMap("volume_instance", extract_labels(in.volume_instances));
 
+    // TODO: warn about duplicate labels (see LabelIdMultiMap::duplicates)
+
     // Unzip volume properties
     materials_.resize(this->num_volumes());
     children_.resize(this->num_volumes());

--- a/src/geocel/VolumeParams.cc
+++ b/src/geocel/VolumeParams.cc
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #include "VolumeParams.hh"
 
+#include "corecel/io/Logger.hh"
+
 #include "VolumeVisitor.hh"
 #include "inp/Model.hh"
 
@@ -30,7 +32,47 @@ LevelId::size_type calc_depth(VolumeParams const& params)
     return result;
 }
 
+//---------------------------------------------------------------------------//
+//! Volumes corresponding to global tracking model
+std::weak_ptr<VolumeParams const> g_volumes_;
+
+//---------------------------------------------------------------------------//
 }  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set global geometry instance.
+ *
+ * This allows many parts of the codebase to independently access Geant4
+ * metadata. It should be called during initialization of any Celeritas front
+ * end that integrates with Geant4. We can't use shared pointers here because
+ * of global initialization order issues (the low-level Geant4 objects may be
+ * cleared before a static celeritas::VolumeParams is destroyed).
+ *
+ * \note This should be done only during setup on the main thread.
+ */
+void global_volumes(std::shared_ptr<VolumeParams const> const& gv)
+{
+    CELER_LOG(debug) << (!gv                    ? "Clearing"
+                         : g_volumes_.expired() ? "Setting"
+                                                : "Updating")
+                     << " celeritas::volumes";
+    g_volumes_ = gv;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Access the global canonical volume metadata.
+ *
+ * This can be used by geometry-related helper functions throughout
+ * the code base.
+ *
+ * \return Weak pointer to the global VolumeParams wrapper, which may be null.
+ */
+std::weak_ptr<VolumeParams const> const& global_volumes()
+{
+    return g_volumes_;
+}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -6,6 +6,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "corecel/cont/LabelIdMultiMap.hh"
 #include "corecel/cont/Span.hh"
 

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -113,6 +113,15 @@ class VolumeParams
 };
 
 //---------------------------------------------------------------------------//
+// HACKY GLOBAL VARIABLES DURING REFACTORING
+//---------------------------------------------------------------------------//
+// Set non-owning reference to global canonical volumes
+void global_volumes(std::shared_ptr<VolumeParams const> const&);
+
+// Global canonical volumes: may be nullptr
+std::weak_ptr<VolumeParams const> const& global_volumes();
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -259,7 +259,7 @@ VecgeomParams::from_gdml(std::string const& filename)
 std::shared_ptr<VecgeomParams>
 VecgeomParams::from_gdml_g4(std::string const& filename)
 {
-    CELER_VALIDATE(celeritas::geant_geo().expired(),
+    CELER_VALIDATE(celeritas::global_geant_geo().expired(),
                    << "cannot load Geant4 geometry into VecGeom from a "
                       "file name: a global Geant4 geometry already exists");
 
@@ -436,7 +436,7 @@ VecgeomParams::VecgeomParams(vecgeom::GeoManager const& geo,
                                         make_physical_vol_labels(world)};
 
         // Construct ImplVolume -> Volume map
-        if (auto geant_geo = celeritas::geant_geo().lock())
+        if (auto geant_geo = celeritas::global_geant_geo().lock())
         {
             CELER_ASSERT(lv.size() <= this->impl_volumes().size());
 

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -54,7 +54,7 @@ namespace celeritas
 std::shared_ptr<OrangeParams>
 OrangeParams::from_gdml(std::string const& filename)
 {
-    CELER_VALIDATE(celeritas::geant_geo().expired(),
+    CELER_VALIDATE(celeritas::global_geant_geo().expired(),
                    << "cannot load Geant4 geometry into ORANGE from a "
                       "file name: a global Geant4 geometry already "
                       "exists");

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -159,7 +159,7 @@ auto GeantTestBase::load(std::string const& filename) const
         i->import = std::make_unique<GeantImporter>(GeantSetup{filename, opts});
         i->geo = i->import->geo_params();
         CELER_ASSERT(i->geo);
-        CELER_ASSERT(!celeritas::geant_geo().expired());
+        CELER_ASSERT(!celeritas::global_geant_geo().expired());
 
         i->imported = (*i->import)(sel);
         i->selection = sel;

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -64,7 +64,10 @@ GlobalTestBase::~GlobalTestBase()
             std::cerr << "Failed to write diagnostics: " << e.what();
         }
     }
+    // Reset global volumes that we set
+    celeritas::global_volumes(nullptr);
 }
+
 //---------------------------------------------------------------------------//
 /*!
  * Add primaries to be generated.
@@ -144,6 +147,7 @@ auto GlobalTestBase::build_geometry() -> SPConstCoreGeo
 
     auto mi = model_geo->make_model_input();
     volume_ = std::make_shared<VolumeParams>(mi.volumes);
+    celeritas::global_volumes(volume_);
     surface_ = std::make_shared<SurfaceParams>(mi.surfaces, *volume_);
 
     return core_geo;

--- a/test/geocel/GeantImportVolumeResult.cc
+++ b/test/geocel/GeantImportVolumeResult.cc
@@ -28,7 +28,7 @@ GeantImportVolumeResult::from_import(GeoParamsInterface const& geom)
 #if CELERITAS_USE_GEANT4
     using Result = GeantImportVolumeResult;
 
-    auto geant_geo = celeritas::geant_geo().lock();
+    auto geant_geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geant_geo, << "global Geant4 geometry is not loaded");
     Result result;
     result.volumes.resize(geant_geo->impl_volumes().size());

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -96,7 +96,7 @@ GenericGeoTestInterface::get_volume_instance_labels() const
 std::vector<std::string> GenericGeoTestInterface::get_g4pv_labels() const
 {
 #if CELERITAS_USE_GEANT4
-    auto geant_geo = celeritas::geant_geo().lock();
+    auto geant_geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geant_geo, << "global Geant4 geometry is not loaded");
 
     auto& geo = *this->geometry_interface();


### PR DESCRIPTION
This is needed in the short term to implement #1901 and #1903 . It allows other parts of the code to sneakily access the volume params. This *should* later be removed, and core+geant geometry passed through a params class.