### PR TITLE
Support discontinuities in nonuniform grid calculator

### DIFF
--- a/src/celeritas/grid/NonuniformGridCalculator.hh
+++ b/src/celeritas/grid/NonuniformGridCalculator.hh
@@ -58,6 +58,9 @@ class NonuniformGridCalculator
     // Make a calculator with x and y flipped
     inline CELER_FUNCTION NonuniformGridCalculator make_inverse() const;
 
+    //! Whether spline interpolation is used
+    CELER_FUNCTION bool use_spline() const { return !deriv_offset_.empty(); }
+
   private:
     //// TYPES ////
 
@@ -125,7 +128,7 @@ CELER_FUNCTION real_type NonuniformGridCalculator::operator()(real_type x) const
     CELER_ASSERT(lower_idx + 1 < x_grid_.size());
 
     real_type result;
-    if (deriv_offset_.empty())
+    if (!this->use_spline())
     {
         // Interpolate *linearly* on x using the bin data.
         result = LinearInterpolator<real_type>(
@@ -169,14 +172,14 @@ NonuniformGridCalculator::grid() const
 /*!
  * Make a calculator with x and y flipped.
  *
- * \pre The y values must be monotonic increasing.
+ * \pre The y values must be monotonic nondecreasing.
  *
- * \note Spline interpolation will not be used on an inverse grid.
+ * \note This method cannot be called for a grid with spline interpolation.
  */
 CELER_FUNCTION NonuniformGridCalculator
 NonuniformGridCalculator::make_inverse() const
 {
-    CELER_EXPECT(deriv_offset_.empty());
+    CELER_EXPECT(!this->use_spline());
     return NonuniformGridCalculator{reals_, y_offset_, x_grid_.offset(), {}};
 }
 

--- a/src/celeritas/grid/NonuniformGridCalculator.hh
+++ b/src/celeritas/grid/NonuniformGridCalculator.hh
@@ -113,14 +113,15 @@ NonuniformGridCalculator::NonuniformGridCalculator(
  */
 CELER_FUNCTION real_type NonuniformGridCalculator::operator()(real_type x) const
 {
-    // Snap out-of-bounds values to closest grid points
-    if (x <= x_grid_.front())
-    {
-        return (*this)[0];
-    }
+    // Snap out-of-bounds values to closest grid points, preferring back if the
+    // front and back are coincident (constant)
     if (x >= x_grid_.back())
     {
         return (*this)[x_grid_.size() - 1];
+    }
+    if (x <= x_grid_.front())
+    {
+        return (*this)[0];
     }
 
     // Locate the x bin

--- a/src/celeritas/grid/NonuniformGridInserter.hh
+++ b/src/celeritas/grid/NonuniformGridInserter.hh
@@ -24,7 +24,6 @@ namespace celeritas
 /*!
  * Construct a nonuniform grid and add it to the specified grid collection.
  *
- * \todo Use dedupe collection builder
  * \todo Validate input doesn't contain more than two coincident x grid points?
  */
 template<class Index>

--- a/src/celeritas/grid/NonuniformGridInserter.hh
+++ b/src/celeritas/grid/NonuniformGridInserter.hh
@@ -23,6 +23,9 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Construct a nonuniform grid and add it to the specified grid collection.
+ *
+ * \todo Use dedupe collection builder
+ * \todo Validate input doesn't contain more than two coincident x grid points?
  */
 template<class Index>
 class NonuniformGridInserter

--- a/src/corecel/grid/NonuniformGrid.hh
+++ b/src/corecel/grid/NonuniformGrid.hh
@@ -119,15 +119,14 @@ CELER_FUNCTION size_type NonuniformGrid<T>::find(value_type value) const
     CELER_EXPECT(value >= this->front() && value < this->back());
 
     auto iter = celeritas::upper_bound(
-        offset_.begin(),
-        offset_.end(),
+        offset_.begin() + 1,
+        offset_.end() - 1,
         value,
         [&v = storage_](T value, ItemId<T> i) { return value < v[i]; });
 
-    if (iter == offset_.end() || value != storage_[*iter])
+    if (value < storage_[*iter])
     {
-        // Exactly on end grid point, or not on a grid point at all: move to
-        // previous bin
+        // The start point belongs to the previous bin
         --iter;
     }
 

--- a/src/corecel/grid/NonuniformGrid.hh
+++ b/src/corecel/grid/NonuniformGrid.hh
@@ -19,7 +19,9 @@ namespace celeritas
  * Interact with a nonuniform grid of increasing values.
  *
  * This should have the same interface (aside from constructor) as
- * UniformGrid.
+ * UniformGrid. The grid is closed on the lower bound and open on the upper,
+ * and the same treatment is used for coincident grid points: the higher of
+ * the points will be chosen.
  */
 template<class T>
 class NonuniformGrid
@@ -104,7 +106,7 @@ CELER_FUNCTION auto NonuniformGrid<T>::operator[](size_type i) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Find the value bin such that storage[result] <= value < data[result + 1].
+ * Find the value bin such that data[result] <= value < data[result + 1].
  *
  * The given value *must* be in range, because out-of-bounds values usually
  * require different treatment (e.g. clipping to the boundary values rather
@@ -116,15 +118,13 @@ CELER_FUNCTION size_type NonuniformGrid<T>::find(value_type value) const
 {
     CELER_EXPECT(value >= this->front() && value < this->back());
 
-    using ItemIdT = ItemId<T>;
-    auto iter = celeritas::lower_bound(
+    auto iter = celeritas::upper_bound(
         offset_.begin(),
         offset_.end(),
         value,
-        [&v = storage_](ItemIdT i, T value) { return v[i] < value; });
-    CELER_ASSERT(iter != offset_.end());
+        [&v = storage_](T value, ItemId<T> i) { return value < v[i]; });
 
-    if (value != storage_[*iter])
+    if (iter == offset_.end() || value != storage_[*iter])
     {
         // Exactly on end grid point, or not on a grid point at all: move to
         // previous bin

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -304,7 +304,7 @@ CELER_FORCEINLINE_FUNCTION ForwardIt lower_bound_linear(ForwardIt first,
 
 //---------------------------------------------------------------------------//
 /*!
- * Find the first element which is greater than <value>
+ * Find the first element which is greater than <value>.
  */
 template<class ForwardIt, class T, class Compare>
 CELER_FORCEINLINE_FUNCTION ForwardIt
@@ -318,7 +318,7 @@ upper_bound(ForwardIt first, ForwardIt last, T const& value, Compare comp)
 //! \cond (CELERITAS_DOC_DEV)
 //---------------------------------------------------------------------------//
 /*!
- * Find the first element which is greater than <value>
+ * Find the first element which is greater than <value>.
  */
 template<class ForwardIt, class T>
 CELER_FORCEINLINE_FUNCTION ForwardIt upper_bound(ForwardIt first,

--- a/test/celeritas/grid/NonuniformGridCalculator.test.cc
+++ b/test/celeritas/grid/NonuniformGridCalculator.test.cc
@@ -98,17 +98,9 @@ TEST_F(NonuniformGridCalculatorTest, discontinuous)
     EXPECT_EQ(2.0, calc[3]);
 
     // Test on grid points
-    EXPECT_SOFT_EQ(1.0, calc(1));
-    if (CELERITAS_DEBUG)
-    {
-        EXPECT_THROW(calc(2), DebugError);
-    }
-    else
-    {
-        // NaN?
-        EXPECT_NE(calc(2), calc(2));
-    }
-    EXPECT_SOFT_EQ(2.0, calc(3));
+    EXPECT_SOFT_EQ(1.0, calc(1.0));
+    EXPECT_SOFT_EQ(2.0, calc(2.0));
+    EXPECT_SOFT_EQ(2.0, calc(3.0));
 
     // Test out-of-bounds
     EXPECT_SOFT_EQ(1.0, calc(0.0));

--- a/test/celeritas/grid/NonuniformGridCalculator.test.cc
+++ b/test/celeritas/grid/NonuniformGridCalculator.test.cc
@@ -128,6 +128,20 @@ TEST_F(NonuniformGridCalculatorTest, discontinuous_end)
     EXPECT_SOFT_EQ(1.0, calc(0.0));
     EXPECT_SOFT_EQ(2.0, calc(3.0));
 }
+TEST_F(NonuniformGridCalculatorTest, discontinuous_all)
+{
+    inp::Grid grid;
+    grid.x = {2.0, 2.0};
+    grid.y = {-1.0, 1.0};
+    this->build(grid);
+
+    NonuniformGridCalculator calc(grid_, reals_ref_);
+
+    // Test on and around the single coincident point
+    EXPECT_SOFT_EQ(-1.0, calc(1.9));
+    EXPECT_SOFT_EQ(-1.0, calc(2.0));
+    EXPECT_SOFT_EQ(1.0, calc(2.1));
+}
 
 TEST_F(NonuniformGridCalculatorTest, inverse)
 {

--- a/test/celeritas/grid/NonuniformGridCalculator.test.cc
+++ b/test/celeritas/grid/NonuniformGridCalculator.test.cc
@@ -84,6 +84,59 @@ TEST_F(NonuniformGridCalculatorTest, nonmonotonic)
     EXPECT_SOFT_EQ(2.0, calc(1e7));
 }
 
+TEST_F(NonuniformGridCalculatorTest, discontinuous)
+{
+    inp::Grid grid;
+    grid.x = {1.0, 2.0, 2.0, 3.0};
+    grid.y = {1.0, 1.0, 2.0, 2.0};
+    this->build(grid);
+
+    NonuniformGridCalculator calc(grid_, reals_ref_);
+
+    // Test accessing tabulated data
+    EXPECT_EQ(1.0, calc[0]);
+    EXPECT_EQ(2.0, calc[3]);
+
+    // Test on grid points
+    EXPECT_SOFT_EQ(1.0, calc(1));
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(calc(2), DebugError);
+    }
+    else
+    {
+        // NaN?
+        EXPECT_NE(calc(2), calc(2));
+    }
+    EXPECT_SOFT_EQ(2.0, calc(3));
+
+    // Test out-of-bounds
+    EXPECT_SOFT_EQ(1.0, calc(0.0));
+    EXPECT_SOFT_EQ(2.0, calc(4.0));
+}
+
+TEST_F(NonuniformGridCalculatorTest, discontinuous_end)
+{
+    inp::Grid grid;
+    grid.x = {1.0, 2.0, 2.0};
+    grid.y = {1.0, 1.0, 2.0};
+    this->build(grid);
+
+    NonuniformGridCalculator calc(grid_, reals_ref_);
+
+    // Test accessing tabulated data
+    EXPECT_EQ(1.0, calc[0]);
+    EXPECT_EQ(2.0, calc[2]);
+
+    // Test on grid points
+    EXPECT_SOFT_EQ(1.0, calc(1));
+    EXPECT_SOFT_EQ(2.0, calc(2));
+
+    // Test out-of-bounds
+    EXPECT_SOFT_EQ(1.0, calc(0.0));
+    EXPECT_SOFT_EQ(2.0, calc(3.0));
+}
+
 TEST_F(NonuniformGridCalculatorTest, inverse)
 {
     inp::Grid grid;

--- a/test/celeritas/grid/NonuniformGridCalculator.test.cc
+++ b/test/celeritas/grid/NonuniformGridCalculator.test.cc
@@ -139,7 +139,7 @@ TEST_F(NonuniformGridCalculatorTest, discontinuous_all)
 
     // Test on and around the single coincident point
     EXPECT_SOFT_EQ(-1.0, calc(1.9));
-    EXPECT_SOFT_EQ(-1.0, calc(2.0));
+    EXPECT_SOFT_EQ(1.0, calc(2.0));
     EXPECT_SOFT_EQ(1.0, calc(2.1));
 }
 

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -68,8 +68,8 @@ TEST(FindInterpTest, nonuniform)
     }
     {
         auto interp = find_interp(grid, 2.0);
-        EXPECT_EQ(3, interp.index);
-        EXPECT_TRUE(std::isnan(interp.fraction)) << repr(interp.fraction);
+        EXPECT_EQ(4, interp.index);
+        EXPECT_DOUBLE_EQ(0, interp.fraction);
     }
     if (CELERITAS_DEBUG)
     {

--- a/test/corecel/grid/NonuniformGrid.test.cc
+++ b/test/corecel/grid/NonuniformGrid.test.cc
@@ -56,6 +56,10 @@ TEST_F(NonuniformGridTest, find)
     {
         EXPECT_THROW(grid.find(-2), DebugError);
     }
+    else
+    {
+        EXPECT_EQ(0, grid.find(-2));
+    }
     EXPECT_EQ(0, grid.find(-1));
     EXPECT_EQ(0, grid.find(0));
     EXPECT_EQ(2, grid.find(1));
@@ -66,6 +70,11 @@ TEST_F(NonuniformGridTest, find)
     {
         EXPECT_THROW(grid.find(8), DebugError);
         EXPECT_THROW(grid.find(10), DebugError);
+    }
+    else
+    {
+        EXPECT_EQ(6, grid.find(10));
+        EXPECT_EQ(6, grid.find(10));
     }
 }
 
@@ -100,6 +109,10 @@ TEST_F(NonuniformGridTest, degenerate)
         {
             EXPECT_THROW(grid.find(1), DebugError);
         }
+        else
+        {
+            EXPECT_EQ(1, grid.find(1));
+        }
     }
     {
         SCOPED_TRACE("three coincident");
@@ -108,6 +121,10 @@ TEST_F(NonuniformGridTest, degenerate)
         if (CELERITAS_DEBUG)
         {
             EXPECT_THROW(grid.find(1), DebugError);
+        }
+        else
+        {
+            EXPECT_EQ(2, grid.find(1));
         }
     }
     {
@@ -126,6 +143,11 @@ TEST_F(NonuniformGridTest, degenerate)
         {
             EXPECT_THROW(grid.find(1), DebugError);
             EXPECT_THROW(grid.find(2), DebugError);
+        }
+        else
+        {
+            EXPECT_EQ(2, grid.find(1));
+            EXPECT_EQ(2, grid.find(2));
         }
     }
 }

--- a/test/corecel/grid/NonuniformGrid.test.cc
+++ b/test/corecel/grid/NonuniformGrid.test.cc
@@ -58,9 +58,9 @@ TEST_F(NonuniformGridTest, find)
     }
     EXPECT_EQ(0, grid.find(-1));
     EXPECT_EQ(0, grid.find(0));
-    EXPECT_EQ(1, grid.find(1));
+    EXPECT_EQ(2, grid.find(1));
     EXPECT_EQ(2, grid.find(2));
-    EXPECT_EQ(3, grid.find(3));
+    EXPECT_EQ(5, grid.find(3));
     EXPECT_EQ(5, grid.find(4));
     if (CELERITAS_DEBUG)
     {
@@ -114,7 +114,7 @@ TEST_F(NonuniformGridTest, degenerate)
         SCOPED_TRACE("front coincident");
         this->build({1, 1, 3});
         GridT grid(irange, ref);
-        EXPECT_EQ(0, grid.find(1));
+        EXPECT_EQ(1, grid.find(1));
         EXPECT_EQ(1, grid.find(2));
     }
     {

--- a/test/corecel/grid/NonuniformGrid.test.cc
+++ b/test/corecel/grid/NonuniformGrid.test.cc
@@ -23,10 +23,12 @@ class NonuniformGridTest : public Test
   protected:
     using GridT = NonuniformGrid<int>;
 
-    void SetUp() override
+    void SetUp() override { this->build({-1, 1, 1, 3, 3, 3, 8}); }
+
+    void build(std::initializer_list<int> grid)
     {
-        auto build = make_builder(&data);
-        irange = build.insert_back({0, 1, 3, 3, 7});
+        auto build = CollectionBuilder{&data};
+        irange = build.insert_back(grid);
         ref = data;
     }
 
@@ -39,29 +41,32 @@ TEST_F(NonuniformGridTest, accessors)
 {
     GridT grid(irange, ref);
 
-    EXPECT_EQ(5, grid.size());
-    EXPECT_EQ(0, grid.front());
-    EXPECT_EQ(7, grid.back());
-    EXPECT_EQ(0, grid[0]);
-    EXPECT_EQ(3, grid[2]);
+    EXPECT_EQ(7, grid.size());
+    EXPECT_EQ(-1, grid.front());
+    EXPECT_EQ(8, grid.back());
+    EXPECT_EQ(-1, grid[0]);
+    EXPECT_EQ(3, grid[3]);
 }
 
 TEST_F(NonuniformGridTest, find)
 {
     GridT grid(irange, ref);
 
-#if CELERITAS_DEBUG
-    EXPECT_THROW(grid.find(-1), DebugError);
-#endif
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(grid.find(-2), DebugError);
+    }
+    EXPECT_EQ(0, grid.find(-1));
     EXPECT_EQ(0, grid.find(0));
     EXPECT_EQ(1, grid.find(1));
-    EXPECT_EQ(1, grid.find(2));
-    EXPECT_EQ(2, grid.find(3));
-    EXPECT_EQ(3, grid.find(4));
-#if CELERITAS_DEBUG
-    EXPECT_THROW(grid.find(7), DebugError);
-    EXPECT_THROW(grid.find(10), DebugError);
-#endif
+    EXPECT_EQ(2, grid.find(2));
+    EXPECT_EQ(3, grid.find(3));
+    EXPECT_EQ(5, grid.find(4));
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(grid.find(8), DebugError);
+        EXPECT_THROW(grid.find(10), DebugError);
+    }
 }
 
 TEST_F(NonuniformGridTest, values)
@@ -76,6 +81,55 @@ TEST_F(NonuniformGridTest, values)
         EXPECT_EQ(grid[i], values[i]);
     }
 }
+
+TEST_F(NonuniformGridTest, degenerate)
+{
+    // Single-point grids are not allowed
+    if (CELERITAS_DEBUG)
+    {
+        SCOPED_TRACE("single point");
+        this->build({1});
+        EXPECT_THROW(GridT(irange, ref), DebugError);
+    }
+
+    {
+        SCOPED_TRACE("two coincident");
+        this->build({1, 1});
+        GridT grid(irange, ref);
+        if (CELERITAS_DEBUG)
+        {
+            EXPECT_THROW(grid.find(1), DebugError);
+        }
+    }
+    {
+        SCOPED_TRACE("three coincident");
+        this->build({1, 1, 1});
+        GridT grid(irange, ref);
+        if (CELERITAS_DEBUG)
+        {
+            EXPECT_THROW(grid.find(1), DebugError);
+        }
+    }
+    {
+        SCOPED_TRACE("front coincident");
+        this->build({1, 1, 3});
+        GridT grid(irange, ref);
+        EXPECT_EQ(0, grid.find(1));
+        EXPECT_EQ(1, grid.find(2));
+    }
+    {
+        SCOPED_TRACE("back coincident");
+        this->build({-1, 1, 1});
+        GridT grid(irange, ref);
+        EXPECT_EQ(0, grid.find(0));
+        if (CELERITAS_DEBUG)
+        {
+            EXPECT_THROW(grid.find(1), DebugError);
+            EXPECT_THROW(grid.find(2), DebugError);
+        }
+    }
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas


### PR DESCRIPTION
This should address the issues with inverting a non-monotonic-increasing grid in https://github.com/celeritas-project/celeritas/pull/1904. Since we define the grid on an interval `[a, b)` it follows that each grid "cell" should be defined on `[a, b)` as well, implying that the value at the discontinuity should be closed on the right. 

![discontinuity](https://github.com/user-attachments/assets/28196767-9410-42c1-b52c-82b0f9340910)

a82ac785de6378a822c3d1445f68e9f0d6166830 accomplishes this by using `upper_bound` instead of `lower_bound`, and 3556047eaa335389e784b73578a06b0a0bf3f23b reduces the search space required for the grid search, with the nice side effect of (if debug assertions are disabled) falling back to making out-of-bounds grid point searches appear at the end grid points.

This change also fixes an edge case in FindInterp: see https://github.com/celeritas-project/celeritas/pull/1906/commits/ca744cf6fb51ab2a8a79b9f9b1b8e38ec6da6adf  ; and since *that* is used in our RZ map field, cyl map field, etc., we should now be able to represent discontinuities in those.