### PR TITLE
Add uniform JSON IO to OpaqueId

### DIFF
--- a/src/celeritas/grid/GridIdFinder.hh
+++ b/src/celeritas/grid/GridIdFinder.hh
@@ -16,7 +16,7 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Map an input grid to an ID type, returning invalid ID if outside bounds.
+ * Map an input grid to an ID type, returning null ID if outside bounds.
  *
  * The input grid should be a monotonic increasing series, and the
  * corresponding ID values should be one fewer (cell-centered data). Values

--- a/src/celeritas/mat/MaterialData.hh
+++ b/src/celeritas/mat/MaterialData.hh
@@ -124,7 +124,7 @@ struct MaterialRecord
  * This view is created from \c MaterialParams.
  *
  * If a material has optical properties defined, \c optical_id will give the
- * index into the optical properties data. Otherwise, it will be an invalid ID,
+ * index into the optical properties data. Otherwise, it will be a null ID,
  * or empty if no optical properties are present for any material.
  *
  * \sa MaterialParams (owns the pointed-to data)

--- a/src/celeritas/mat/MaterialView.hh
+++ b/src/celeritas/mat/MaterialView.hh
@@ -158,7 +158,7 @@ CELER_FUNCTION MatterState MaterialView::matter_state() const
 /*!
  * Get the index in the optical properties for this material.
  *
- * This will return an invalid ID if the material has no optical properties
+ * This will return a null ID if the material has no optical properties
  * attached.
  */
 CELER_FUNCTION OptMatId MaterialView::optical_material_id() const

--- a/src/celeritas/optical/ImportedModelAdapter.cc
+++ b/src/celeritas/optical/ImportedModelAdapter.cc
@@ -36,7 +36,7 @@ ImportedModels::from_import(ImportData const& io)
 ImportedModels::ImportedModels(std::vector<ImportOpticalModel> models)
     : models_(std::move(models))
 {
-    // Initialize built-in IMC map to invalid IDs
+    // Initialize built-in IMC map to null IDs
     std::fill(
         builtin_id_map_.begin(), builtin_id_map_.end(), ImportedModelId{});
 
@@ -47,7 +47,7 @@ ImportedModels::ImportedModels(std::vector<ImportOpticalModel> models)
 
         // Check imported data is consistent
         CELER_VALIDATE(model.model_class != IMC::size_,
-                       << "Invalid imported model class for optical model id '"
+                       << "invalid imported model class for optical model id '"
                        << model_id << "'");
 
         // Model MFP vectors may be empty, indicating the model should attempt
@@ -55,7 +55,7 @@ ImportedModels::ImportedModels(std::vector<ImportOpticalModel> models)
 
         CELER_VALIDATE(
             model.mfp_table.size() == models_.front().mfp_table.size(),
-            << "Imported optical model id '" << model_id << "' ("
+            << "imported optical model id '" << model_id << "' ("
             << model.model_class
             << ") MFP table has differing number of optical "
                "materials than other imported models");
@@ -63,7 +63,7 @@ ImportedModels::ImportedModels(std::vector<ImportOpticalModel> models)
         // Expect a 1-1 mapping for IMC to imported models
         auto& mapped_id = builtin_id_map_[model.model_class];
         CELER_VALIDATE(!mapped_id,
-                       << "Duplicate imported data for built-in optical model "
+                       << "duplicate imported data for built-in optical model "
                           "'"
                        << model.model_class
                        << "' (at most one built-in optical model of a given "
@@ -96,7 +96,7 @@ auto ImportedModels::num_models() const -> ImportedModelId::size_type
 /*!
  * Get imported model ID for the given built-in model class.
  *
- * Returns an invalid ID if the imported model data is not present.
+ * Returns a null ID if the imported model data is not present.
  */
 auto ImportedModels::builtin_model_id(IMC imc) const -> ImportedModelId
 {

--- a/src/celeritas/phys/PhysicsTrackView.hh
+++ b/src/celeritas/phys/PhysicsTrackView.hh
@@ -608,7 +608,7 @@ PhysicsTrackView::make_element_selector(UniformTableId table_id,
  * ID of the particle's at-rest process.
  *
  * If the particle can have a discrete interaction at rest, this returns the \c
- * ParticleProcessId of that process. Otherwise, it returns an invalid ID.
+ * ParticleProcessId of that process. Otherwise, it returns a null ID.
  */
 CELER_FUNCTION ParticleProcessId PhysicsTrackView::at_rest_process() const
 {

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -21,7 +21,7 @@ namespace detail
 //---------------------------------------------------------------------------//
 //! Sentinel value for an unassigned opaque ID
 template<class T>
-inline constexpr T invalid_opaqueid_value{static_cast<T>(-1)};
+inline constexpr T null_opaqueid_value{static_cast<T>(-1)};
 
 //---------------------------------------------------------------------------//
 //! Safely cast from one integer T to another U, avoiding the sentinel value
@@ -42,12 +42,12 @@ inline CELER_FUNCTION U id_cast_impl(T value) noexcept(!CELERITAS_DEBUG)
             CELER_EXPECT(static_cast<C>(value) >= 0);
         }
         CELER_EXPECT(static_cast<C>(value)
-                     < static_cast<C>(invalid_opaqueid_value<U>));
+                     < static_cast<C>(null_opaqueid_value<U>));
     }
     else
     {
-        // Check that value is *not* the invalid value
-        CELER_EXPECT(static_cast<U>(value) != invalid_opaqueid_value<U>);
+        // Check that value is *not* the null value
+        CELER_EXPECT(static_cast<U>(value) != null_opaqueid_value<U>);
     }
 
     return static_cast<U>(value);
@@ -72,7 +72,8 @@ inline CELER_FUNCTION U id_cast_impl(T value) noexcept(!CELERITAS_DEBUG)
  * <code>Foo operator[](OpaqueId<Foo>)</code>
  *
  * An \c OpaqueId object evaluates to \c true if it has a value, or \c false if
- * it does not (i.e., it has an "invalid" value).
+ * it does not (a "null" ID, analogous to a null pointer: it does not
+ * correspond to a valid value).
  *
  * See also \c id_cast below for checked construction of OpaqueIds from generic
  * integer values (avoid compile-time warnings or errors from signed/truncated
@@ -92,8 +93,8 @@ class OpaqueId
     //!@}
 
   public:
-    //! Default to invalid state
-    CELER_CONSTEXPR_FUNCTION OpaqueId() : value_(invalid_value_) {}
+    //! Default to null state
+    CELER_CONSTEXPR_FUNCTION OpaqueId() : value_(null_value_) {}
 
     //! Construct explicitly with stored value
     explicit CELER_CONSTEXPR_FUNCTION OpaqueId(size_type index) : value_(index)
@@ -103,7 +104,7 @@ class OpaqueId
     //! Whether this ID is in a valid (assigned) state
     explicit CELER_CONSTEXPR_FUNCTION operator bool() const
     {
-        return value_ != invalid_value_;
+        return value_ != null_value_;
     }
 
     //! Pre-increment of the ID
@@ -155,8 +156,8 @@ class OpaqueId
     size_type value_;
 
     //! Value indicating the ID is not assigned
-    static constexpr size_type invalid_value_
-        = detail::invalid_opaqueid_value<size_type>;
+    static constexpr size_type null_value_
+        = detail::null_opaqueid_value<size_type>;
 };
 
 //---------------------------------------------------------------------------//
@@ -168,7 +169,7 @@ class OpaqueId
  * This asserts that the integer is in the \em valid range of the target ID
  * type, and casts to it.
  *
- * \note The value cannot be the underlying "invalid" value, i.e.
+ * \note The value cannot be the underlying "null" value; i.e.
  * <code> static_cast<FooId>(FooId{}.unchecked_get()) </code> will not work.
  */
 template<class IdT, class T>

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -21,14 +21,14 @@ namespace detail
 //---------------------------------------------------------------------------//
 //! Sentinel value for an unassigned opaque ID
 template<class T>
-inline constexpr T null_opaqueid_value{static_cast<T>(-1)};
+inline constexpr T nullid_value{static_cast<T>(-1)};
 
 //---------------------------------------------------------------------------//
 //! Safely cast from one integer T to another U, avoiding the sentinel value
-template<class U, class T>
-inline CELER_FUNCTION U id_cast_impl(T value) noexcept(!CELERITAS_DEBUG)
+template<class T, class U>
+inline CELER_FUNCTION T id_cast_impl(U value) noexcept(!CELERITAS_DEBUG)
 {
-    if constexpr (!std::is_unsigned_v<T>)
+    if constexpr (std::is_signed_v<U>)
     {
         CELER_EXPECT(value >= 0);
     }
@@ -36,21 +36,20 @@ inline CELER_FUNCTION U id_cast_impl(T value) noexcept(!CELERITAS_DEBUG)
     if constexpr (!std::is_same_v<T, U>)
     {
         // Check that the cast value is within the integer range [0, N-1)
-        using C = std::common_type_t<U, std::make_unsigned_t<T>>;
-        if constexpr (!std::is_unsigned_v<C>)
+        using C = std::common_type_t<T, std::make_unsigned_t<U>>;
+        if constexpr (std::is_signed_v<C>)
         {
             CELER_EXPECT(static_cast<C>(value) >= 0);
         }
-        CELER_EXPECT(static_cast<C>(value)
-                     < static_cast<C>(null_opaqueid_value<U>));
+        CELER_EXPECT(static_cast<C>(value) < static_cast<C>(nullid_value<T>));
     }
     else
     {
         // Check that value is *not* the null value
-        CELER_EXPECT(static_cast<U>(value) != null_opaqueid_value<U>);
+        CELER_EXPECT(static_cast<T>(value) != nullid_value<T>);
     }
 
-    return static_cast<U>(value);
+    return static_cast<T>(value);
 }
 
 //---------------------------------------------------------------------------//
@@ -60,7 +59,7 @@ inline CELER_FUNCTION U id_cast_impl(T value) noexcept(!CELERITAS_DEBUG)
 /*!
  * Type-safe index for accessing an array or collection of data.
  *
- * \tparam ValueT Type of each item in an array
+ * \tparam ItemT Type of an item at the index corresponding to this ID
  * \tparam SizeT Unsigned integer index
  *
  * It's common for classes and functions to take multiple indices, especially
@@ -78,8 +77,12 @@ inline CELER_FUNCTION U id_cast_impl(T value) noexcept(!CELERITAS_DEBUG)
  * See also \c id_cast below for checked construction of OpaqueIds from generic
  * integer values (avoid compile-time warnings or errors from signed/truncated
  * integers).
+ *
+ * \todo This interface will be changed to be more like \c std::optional : \c
+ * size_type will become \c value_type (the value of a 'dereferenced' ID) and
+ * \c operator* or \c value will be used to access the integer.
  */
-template<class ValueT, class SizeT = ::celeritas::size_type>
+template<class ItemT, class SizeT = ::celeritas::size_type>
 class OpaqueId
 {
     static_assert(std::is_unsigned_v<SizeT> && !std::is_same_v<SizeT, bool>,
@@ -88,13 +91,13 @@ class OpaqueId
   public:
     //!@{
     //! \name Type aliases
-    using value_type = ValueT;
+    using value_type [[deprecated]] = ItemT;
     using size_type = SizeT;
     //!@}
 
   public:
     //! Default to null state
-    CELER_CONSTEXPR_FUNCTION OpaqueId() : value_(null_value_) {}
+    CELER_CONSTEXPR_FUNCTION OpaqueId() : value_(nullid_val_) {}
 
     //! Construct explicitly with stored value
     explicit CELER_CONSTEXPR_FUNCTION OpaqueId(size_type index) : value_(index)
@@ -104,7 +107,7 @@ class OpaqueId
     //! Whether this ID is in a valid (assigned) state
     explicit CELER_CONSTEXPR_FUNCTION operator bool() const
     {
-        return value_ != null_value_;
+        return value_ != nullid_val_;
     }
 
     //! Pre-increment of the ID
@@ -156,8 +159,7 @@ class OpaqueId
     size_type value_;
 
     //! Value indicating the ID is not assigned
-    static constexpr size_type null_value_
-        = detail::null_opaqueid_value<size_type>;
+    static constexpr size_type nullid_val_ = detail::nullid_value<size_type>;
 };
 
 //---------------------------------------------------------------------------//
@@ -172,20 +174,20 @@ class OpaqueId
  * \note The value cannot be the underlying "null" value; i.e.
  * <code> static_cast<FooId>(FooId{}.unchecked_get()) </code> will not work.
  */
-template<class IdT, class T>
-inline CELER_FUNCTION IdT id_cast(T value) noexcept(!CELERITAS_DEBUG)
+template<class IdT, class U>
+inline CELER_FUNCTION IdT id_cast(U value) noexcept(!CELERITAS_DEBUG)
 {
-    static_assert(std::is_integral_v<T>);
+    static_assert(std::is_integral_v<U>);
     static_assert(std::is_integral_v<typename IdT::size_type>);
 
-    return IdT{detail::id_cast_impl<typename IdT::size_type, T>(value)};
+    return IdT{detail::id_cast_impl<typename IdT::size_type, U>(value)};
 }
 
 //---------------------------------------------------------------------------//
 #define CELER_DEFINE_OPAQUEID_CMP(TOKEN)                             \
-    template<class V, class S>                                       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(OpaqueId<V, S> lhs, \
-                                                 OpaqueId<V, S> rhs) \
+    template<class I, class T>                                       \
+    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(OpaqueId<I, T> lhs, \
+                                                 OpaqueId<I, T> rhs) \
     {                                                                \
         return lhs.unchecked_get() TOKEN rhs.unchecked_get();        \
     }
@@ -204,8 +206,8 @@ CELER_DEFINE_OPAQUEID_CMP(>=)
 
 //---------------------------------------------------------------------------//
 //! Allow less-than comparison with *integer* for container comparison
-template<class V, class S, class U>
-CELER_CONSTEXPR_FUNCTION bool operator<(OpaqueId<V, S> lhs, U rhs)
+template<class I, class T, class U>
+CELER_CONSTEXPR_FUNCTION bool operator<(OpaqueId<I, T> lhs, U rhs)
 {
     // Cast to RHS
     return lhs && (U(lhs.unchecked_get()) < rhs);
@@ -213,8 +215,8 @@ CELER_CONSTEXPR_FUNCTION bool operator<(OpaqueId<V, S> lhs, U rhs)
 
 //---------------------------------------------------------------------------//
 //! Allow less-than-equal comparison with *integer* for container comparison
-template<class V, class S, class U>
-CELER_CONSTEXPR_FUNCTION bool operator<=(OpaqueId<V, S> lhs, U rhs)
+template<class I, class T, class U>
+CELER_CONSTEXPR_FUNCTION bool operator<=(OpaqueId<I, T> lhs, U rhs)
 {
     // Cast to RHS
     return lhs && (U(lhs.unchecked_get()) <= rhs);
@@ -222,8 +224,8 @@ CELER_CONSTEXPR_FUNCTION bool operator<=(OpaqueId<V, S> lhs, U rhs)
 
 //---------------------------------------------------------------------------//
 //! Get the distance between two opaque IDs
-template<class V, class S>
-inline CELER_FUNCTION S operator-(OpaqueId<V, S> self, OpaqueId<V, S> other)
+template<class I, class T>
+inline CELER_FUNCTION T operator-(OpaqueId<I, T> self, OpaqueId<I, T> other)
 {
     CELER_EXPECT(self);
     CELER_EXPECT(other);
@@ -232,24 +234,24 @@ inline CELER_FUNCTION S operator-(OpaqueId<V, S> self, OpaqueId<V, S> other)
 
 //---------------------------------------------------------------------------//
 //! Increment an opaque ID by an offset
-template<class V, class S>
-inline CELER_FUNCTION OpaqueId<V, S>
-operator+(OpaqueId<V, S> id, std::make_signed_t<S> offset)
+template<class I, class T>
+inline CELER_FUNCTION OpaqueId<I, T>
+operator+(OpaqueId<I, T> id, std::make_signed_t<T> offset)
 {
     CELER_EXPECT(id);
-    CELER_EXPECT(offset >= 0 || static_cast<S>(-offset) <= id.unchecked_get());
-    return OpaqueId<V, S>{id.unchecked_get() + static_cast<S>(offset)};
+    CELER_EXPECT(offset >= 0 || static_cast<T>(-offset) <= id.unchecked_get());
+    return OpaqueId<I, T>{id.unchecked_get() + static_cast<T>(offset)};
 }
 
 //---------------------------------------------------------------------------//
 //! Decrement an opaque ID by an offset
-template<class V, class S>
-inline CELER_FUNCTION OpaqueId<V, S>
-operator-(OpaqueId<V, S> id, std::make_signed_t<S> offset)
+template<class I, class T>
+inline CELER_FUNCTION OpaqueId<I, T>
+operator-(OpaqueId<I, T> id, std::make_signed_t<T> offset)
 {
     CELER_EXPECT(id);
-    CELER_EXPECT(offset <= 0 || static_cast<S>(offset) <= id.unchecked_get());
-    return OpaqueId<V, S>{id.unchecked_get() - static_cast<S>(offset)};
+    CELER_EXPECT(offset <= 0 || static_cast<T>(offset) <= id.unchecked_get());
+    return OpaqueId<I, T>{id.unchecked_get() - static_cast<T>(offset)};
 }
 
 //---------------------------------------------------------------------------//
@@ -260,12 +262,12 @@ operator-(OpaqueId<V, S> id, std::make_signed_t<S> offset)
 namespace std
 {
 //! Specialization for std::hash for unordered storage.
-template<class V, class S>
-struct hash<celeritas::OpaqueId<V, S>>
+template<class I, class T>
+struct hash<celeritas::OpaqueId<I, T>>
 {
-    std::size_t operator()(celeritas::OpaqueId<V, S> const& id) const noexcept
+    std::size_t operator()(celeritas::OpaqueId<I, T> const& id) const noexcept
     {
-        return std::hash<S>()(id.unchecked_get());
+        return std::hash<T>()(id.unchecked_get());
     }
 };
 }  // namespace std

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -16,6 +16,46 @@
 
 namespace celeritas
 {
+namespace detail
+{
+//---------------------------------------------------------------------------//
+//! Sentinel value for an unassigned opaque ID
+template<class T>
+inline constexpr T invalid_opaqueid_value{static_cast<T>(-1)};
+
+//---------------------------------------------------------------------------//
+//! Safely cast from one integer T to another U, avoiding the sentinel value
+template<class U, class T>
+inline CELER_FUNCTION U id_cast_impl(T value) noexcept(!CELERITAS_DEBUG)
+{
+    if constexpr (!std::is_unsigned_v<T>)
+    {
+        CELER_EXPECT(value >= 0);
+    }
+
+    if constexpr (!std::is_same_v<T, U>)
+    {
+        // Check that the cast value is within the integer range [0, N-1)
+        using C = std::common_type_t<U, std::make_unsigned_t<T>>;
+        if constexpr (!std::is_unsigned_v<C>)
+        {
+            CELER_EXPECT(static_cast<C>(value) >= 0);
+        }
+        CELER_EXPECT(static_cast<C>(value)
+                     < static_cast<C>(invalid_opaqueid_value<U>));
+    }
+    else
+    {
+        // Check that value is *not* the invalid value
+        CELER_EXPECT(static_cast<U>(value) != invalid_opaqueid_value<U>);
+    }
+
+    return static_cast<U>(value);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+
 //---------------------------------------------------------------------------//
 /*!
  * Type-safe index for accessing an array or collection of data.
@@ -53,7 +93,7 @@ class OpaqueId
 
   public:
     //! Default to invalid state
-    CELER_CONSTEXPR_FUNCTION OpaqueId() : value_(OpaqueId::invalid_value()) {}
+    CELER_CONSTEXPR_FUNCTION OpaqueId() : value_(invalid_value_) {}
 
     //! Construct explicitly with stored value
     explicit CELER_CONSTEXPR_FUNCTION OpaqueId(size_type index) : value_(index)
@@ -63,7 +103,7 @@ class OpaqueId
     //! Whether this ID is in a valid (assigned) state
     explicit CELER_CONSTEXPR_FUNCTION operator bool() const
     {
-        return value_ != invalid_value();
+        return value_ != invalid_value_;
     }
 
     //! Pre-increment of the ID
@@ -114,13 +154,9 @@ class OpaqueId
   private:
     size_type value_;
 
-    //// IMPLEMENTATION FUNCTIONS ////
-
     //! Value indicating the ID is not assigned
-    static CELER_CONSTEXPR_FUNCTION size_type invalid_value()
-    {
-        return static_cast<size_type>(-1);
-    }
+    static constexpr size_type invalid_value_
+        = detail::invalid_opaqueid_value<size_type>;
 };
 
 //---------------------------------------------------------------------------//
@@ -139,26 +175,9 @@ template<class IdT, class T>
 inline CELER_FUNCTION IdT id_cast(T value) noexcept(!CELERITAS_DEBUG)
 {
     static_assert(std::is_integral_v<T>);
-    if constexpr (!std::is_unsigned_v<T>)
-    {
-        CELER_EXPECT(value >= 0);
-    }
+    static_assert(std::is_integral_v<typename IdT::size_type>);
 
-    using IdSize = typename IdT::size_type;
-    if constexpr (!std::is_same_v<T, IdSize>)
-    {
-        // Check that value is within the integer range [0, N-1)
-        using U = std::common_type_t<IdSize, std::make_unsigned_t<T>>;
-        CELER_EXPECT(static_cast<U>(value)
-                     < static_cast<U>(IdT{}.unchecked_get()));
-    }
-    else
-    {
-        // Check that value is *not* the invalid value
-        CELER_EXPECT(value != IdT{}.unchecked_get());
-    }
-
-    return IdT{static_cast<IdSize>(value)};
+    return IdT{detail::id_cast_impl<typename IdT::size_type, T>(value)};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/OpaqueIdIO.hh
+++ b/src/corecel/OpaqueIdIO.hh
@@ -25,7 +25,7 @@ std::ostream& operator<<(std::ostream& os, OpaqueId<V, S> const& v)
     }
     else
     {
-        os << "<invalid>";
+        os << "<null>";
     }
     return os;
 }

--- a/src/corecel/cont/LabelIdMultiMap.hh
+++ b/src/corecel/cont/LabelIdMultiMap.hh
@@ -201,7 +201,7 @@ auto LabelIdMultiMap<I>::find_all(std::string const& name) const
 /*!
  * Find the ID corresponding to a label if exactly one exists.
  *
- * This will return an invalid ID if no labels match the given name, and it
+ * This will return an null ID if no labels match the given name, and it
  * will raise an exception if multiple labels do.
  */
 template<class I>

--- a/src/corecel/io/JsonUtils.json.hh
+++ b/src/corecel/io/JsonUtils.json.hh
@@ -118,4 +118,22 @@ void check_format(nlohmann::json const& j, std::string_view format);
 void check_units(nlohmann::json const& j, std::string_view format);
 
 //---------------------------------------------------------------------------//
+/*!
+ * Convert a vector of variants to a json array.
+ */
+template<class T>
+nlohmann::json variants_to_json(std::vector<T> const& values)
+{
+    auto result = nlohmann::json::array();
+    for (auto const& var : values)
+    {
+        auto j = nlohmann::json::object();
+        std::visit([&j](auto&& u) { to_json(j, u); }, var);
+        result.push_back(std::move(j));
+    }
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/io/JsonUtils.json.hh
+++ b/src/corecel/io/JsonUtils.json.hh
@@ -7,8 +7,10 @@
 #pragma once
 
 #include <string_view>
+#include <variant>
 #include <nlohmann/json.hpp>
 
+#include "corecel/OpaqueId.hh"
 #include "corecel/io/EnumStringMapper.hh"
 #include "corecel/io/Logger.hh"
 
@@ -133,6 +135,40 @@ nlohmann::json variants_to_json(std::vector<T> const& values)
     }
 
     return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Read an Opaque ID from JSON.
+ */
+template<class I, class T>
+void from_json(nlohmann::json const& j, OpaqueId<I, T>& value)
+{
+    if (j.is_null())
+    {
+        value = {};
+    }
+    else
+    {
+        value = id_cast<OpaqueId<I, T>>(j.get<T>());
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Write an Opaque ID to JSON.
+ */
+template<class I, class T>
+void to_json(nlohmann::json& j, OpaqueId<I, T> value)
+{
+    if (!value)
+    {
+        j = nullptr;
+    }
+    else
+    {
+        j = value.unchecked_get();
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/VolumeSurfaceView.hh
+++ b/src/geocel/VolumeSurfaceView.hh
@@ -117,7 +117,7 @@ CELER_FUNCTION bool VolumeSurfaceView::has_interface() const
  * for searching these sorted arrays, or (better) use a hash lookup for {pre,
  * post} -> surface.
  *
- * \return The surface ID if found, or an invalid ID if not found.
+ * \return The surface ID if found, or a null ID if not found.
  */
 CELER_FUNCTION SurfaceId VolumeSurfaceView::find_interface(
     VolumeInstanceId pre_id, VolumeInstanceId post_id) const

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -314,16 +314,8 @@ void to_json(nlohmann::json& j, UnitInput const& value)
         auto volume_labels = nlohmann::json::array();
         for (auto const& v : value.volumes)
         {
-            // TODO: add JSON IO for OpaqueID
-            volume_labels.push_back(
-                std::visit(return_as<nlohmann::json>(Overload{
-                               [](Label const& label) { return label; },
-                               [](VolumeInstanceId id) -> nlohmann::json {
-                                   if (!id)
-                                       return nullptr;
-                                   return id.unchecked_get();
-                               }}),
-                           v.label));
+            volume_labels.push_back(std::visit(
+                [](auto&& obj) -> nlohmann::json { return obj; }, v.label));
         }
         return volume_labels;
     }();

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -88,14 +88,7 @@ BBox get_bbox(nlohmann::json const& j)
 void from_json(nlohmann::json const& j, VolumeInput& value)
 {
     // Convert faces to OpaqueId
-    std::vector<LocalSurfaceId::size_type> temp_faces;
-    j.at("faces").get_to(temp_faces);
-    value.faces.reserve(temp_faces.size());
-    for (auto surf_id : temp_faces)
-    {
-        CELER_ASSERT(surf_id != LocalSurfaceId{}.unchecked_get());
-        value.faces.emplace_back(surf_id);
-    }
+    j.at("faces").get_to(value.faces);
 
     // Read scalars, including optional flags
     if (auto iter = j.find("flags"); iter != j.end())
@@ -162,14 +155,8 @@ void to_json(nlohmann::json& j, VolumeInput const& value)
 {
     CELER_EXPECT(value);
 
-    // Convert faces from OpaqueId
-    std::vector<LocalSurfaceId::size_type> temp_faces;
-    temp_faces.reserve(value.faces.size());
-    for (auto surf_id : value.faces)
-    {
-        temp_faces.emplace_back(surf_id.unchecked_get());
-    }
-    j["faces"] = std::move(temp_faces);
+    // Convert faces from OpaqueId (using JsonUtils)
+    j["faces"] = value.faces;
 
     // Convert logic string to vector
     if (!value.logic.empty())

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "corecel/Assert.hh"
+#include "corecel/OpaqueIdIO.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/ArrayIO.json.hh"
@@ -62,24 +63,6 @@ VariantTransform make_transform(Real3 const& translation)
         return NoTransformation{};
     }
     return Translation{translation};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Convert a vector of variants to a json array.
- */
-template<class T>
-nlohmann::json variants_to_json(std::vector<T> const& values)
-{
-    auto result = nlohmann::json::array();
-    for (auto const& var : values)
-    {
-        auto j = nlohmann::json::object();
-        std::visit([&j](auto&& u) { to_json(j, u); }, var);
-        result.push_back(std::move(j));
-    }
-
-    return result;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -58,9 +58,11 @@ size_type DeMorganSimplifier::Matrix2D::extent() const noexcept
 
 //---------------------------------------------------------------------------//
 /*!
+ * Find the simplified node corresponding to the original node.
+ *
  * For node_id in the original tree, find the equivalent node in the simplified
- * tree, i.e., either the DeMorgan simplification or the same node, return an
- * invalid id if there are no equivalent.
+ * tree, i.e., either the DeMorgan simplification or the same node. Return a
+ * null id if there are no equivalent.
  */
 NodeId DeMorganSimplifier::MatchingNodes::equivalent_node() const
 {

--- a/src/orange/orangeinp/detail/ProtoBuilder.hh
+++ b/src/orange/orangeinp/detail/ProtoBuilder.hh
@@ -69,8 +69,8 @@ class ProtoBuilder
     // Find a universe ID
     inline UniverseId find_universe_id(ProtoInterface const*) const;
 
-    //! Get the next universe ID
-    UniverseId next_id() const { return UniverseId(inp_->universes.size()); }
+    // Get the next universe ID
+    inline UniverseId next_id() const;
 
     // Get the bounding box of a universe
     inline BBox const& bbox(UniverseId) const;
@@ -100,6 +100,15 @@ class ProtoBuilder
 UniverseId ProtoBuilder::find_universe_id(ProtoInterface const* p) const
 {
     return protos_.find(p);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the next universe ID.
+ */
+UniverseId ProtoBuilder::next_id() const
+{
+    return id_cast<UniverseId>(inp_->universes.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -125,7 +125,7 @@ TEST_F(KernelContextExceptionTest, typical)
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             EXPECT_EQ(
-                R"(track slot 15 in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":-1,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.67e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
+                R"(track slot 15 in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":null,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.67e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
                 simplified_str)
                 << repr(simplified_str);
         }

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -189,7 +189,7 @@ TEST_F(SimpleComptonTest, fail_initialize)
 
         static char const* const expected_log_messages[] = {
             "Track started outside the geometry",
-            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
+            R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
         };
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
@@ -304,8 +304,8 @@ TEST_F(SimpleComptonTest, kill_active)
     EXPECT_EQ(0, counters.alive);
     static char const* const expected_log_messages[] = {
         "Killing 2 active tracks",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
     };
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS && CELERITAS_USE_GEANT4)
     {
@@ -409,7 +409,7 @@ TEST_F(BadGeometryTest, no_volume_host)
 
     static char const* const expected_log_messages[] = {
         R"(Failed to initialize geometry state: could not find associated volume in universe 0 at local position {-5, 0, 0})",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
         && CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
@@ -427,7 +427,7 @@ TEST_F(BadGeometryTest, no_material_host)
 
     static char const* const expected_log_messages[] = {
         "Track started in an unknown material",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"mat":"<invalid>","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
     };
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
@@ -443,7 +443,7 @@ TEST_F(BadGeometryTest, no_new_volume_host)
 
     static char const* const expected_log_messages[] = {
         R"(track failed to cross local surface 2 in universe 0 at local position {-6, 0, 0} along local direction {1, 0, 0})",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.001000,"cm"],"time":[3.336e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.001000,"cm"],"time":[3.336e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
@@ -462,7 +462,7 @@ TEST_F(BadGeometryTest, start_outside_host)
 
     static char const* const expected_log_messages[] = {
         "Track started outside the geometry",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":-1,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -68,8 +68,8 @@ TEST(ItemMap, basic)
     using ItemMap = ItemMap<T1, T2>;
 
     Collection<double, Ownership::value, MemSpace::host, T2> host_val;
-    std::vector<T2::value_type> data_a = {5, 6, 7, 8};
-    std::vector<T2::value_type> data_b = {9, 10, 11};
+    std::vector<int> data_a = {5, 6, 7, 8};
+    std::vector<int> data_b = {9, 10, 11};
 
     // Add both vectors to the Collection, creating a Range for each
     auto range_a


### PR DESCRIPTION
This writes OpaqueIDs as integers or "null" values to JSON. It also makes the nomenclature more consistent about the ID being "null", adjusts the template parameter names to prepare for a `std::optional`-like interface, and implements `id_cast` to reduce the number of template instantiations.