### PR TITLE
Define throw helper functions to reduce code bloat and improve performance

### DIFF
--- a/src/corecel/Assert.cc
+++ b/src/corecel/Assert.cc
@@ -144,6 +144,24 @@ std::string mpi_error_to_string(int errorcode)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Throw a debug error.
+ */
+[[noreturn]] void throw_debug_error(DebugErrorDetails&& d)
+{
+    throw DebugError{std::move(d)};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Throw a runtime error.
+ */
+[[noreturn]] void throw_runtime_error(RuntimeErrorDetails&& d)
+{
+    throw RuntimeError{std::move(d)};
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct a debug exception from detailed attributes.
  */
 DebugError::DebugError(DebugErrorDetails&& d)

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -142,7 +142,7 @@
 #if !defined(__HIP__) && !defined(__CUDA_ARCH__)
 // Throw in host code
 #    define CELER_DEBUG_THROW_(MSG, WHICH) \
-        throw ::celeritas::DebugError(     \
+        ::celeritas::throw_debug_error(    \
             {::celeritas::DebugErrorType::WHICH, MSG, __FILE__, __LINE__})
 #elif defined(__CUDA_ARCH__) && !defined(NDEBUG)
 // Use the assert macro for CUDA when supported
@@ -189,7 +189,7 @@
 
 #if !CELER_DEVICE_COMPILE
 #    define CELER_RUNTIME_THROW(WHICH, WHAT, COND) \
-        throw ::celeritas::RuntimeError({          \
+        ::celeritas::throw_runtime_error({         \
             WHICH,                                 \
             WHAT,                                  \
             COND,                                  \
@@ -377,6 +377,12 @@ char const* to_cstring(DebugErrorType which);
 // Get an MPI error string
 std::string mpi_error_to_string(int);
 
+// Throw a debug error
+[[noreturn]] void throw_debug_error(DebugErrorDetails&&);
+
+// Throw a runtime error
+[[noreturn]] void throw_runtime_error(RuntimeErrorDetails&&);
+
 //---------------------------------------------------------------------------//
 // TYPES
 //---------------------------------------------------------------------------//
@@ -473,7 +479,7 @@ inline __host__ void device_debug_error(DebugErrorType which,
                                         char const* file,
                                         int line)
 {
-    throw DebugError({which, condition, file, line});
+    return ::celeritas::throw_debug_error({which, condition, file, line});
 }
 
 //! Device-only call for HIP (must always be declared; only used if


### PR DESCRIPTION
This uses an old trick from [Draco](https://github.com/lanl/Draco/blob/28ab37f48196b4f2eb2de475f86303e7969b1d10/src/dsxx/Assert.cc#L56)/Nemesis that defines a `toss_cookies` helper function to throw an exception, reducing the amount of duplicate exception handling code across the code base. With the advent of the `[[noreturn]]` annotation it's now possible to inform the compiler that the data with function call can be moved to a "cold" code section, improving efficiency. 

Measuring the optical collector "host generate" test (the most expensive "unit" test in our code) shows a 1% performance boost for debug+assert build, and about a 2% improvement for a reldeb (RelWithDebInfo plus assertions) build. The code size for a debug build is reduced by 2% as well.