### PR TITLE
Only warn when imported particle data is larger than user-defined offload list

### DIFF
--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -127,10 +127,14 @@ void verify_offload(std::vector<G4ParticleDefinition*> const& offload,
                       "active in Celeritas: missing "
                    << join(missing.begin(), missing.end(), ", ", printable_pd));
 
-    CELER_VALIDATE(found_particle == std::vector<bool>(particles.size(), true),
-                   << "particles selected for offload are not in "
-                      "user-provided/default list (perhaps SetupOptions are "
-                      "set out of order?)");
+    if (found_particle != std::vector<bool>(particles.size(), true))
+    {
+        //! \todo Overhaul DataSelection Flags and GeantImporter
+        CELER_LOG(warning)
+            << "Mismatch between ParticlesParams (size " << particles.size()
+            << ") and user-defined offload list (size " << offload.size()
+            << "). Geant4 data import is not properly defined.";
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This PR temporarily reduces a `CELER_VALIDATE` to a `CELER_LOG(warning)` when verifying the _imported_ data against the list of offloaded particles provided by the user (PR #1910).

The data loaded in `ParticleParams` comes from `GeantImporter` and its `DataSelection` flags, which would require large changes to the import system to match individual particle selections for offload. Decreasing the level to a warning allows for individual particles and processes to be offloaded, despite Celeritas loading more data into memory than necessary.

A future overhaul of `GeantImporter` may take `inp` option data directly to consistently load information as needed.