### PR TITLE
Update particle speed calculation to be more robust against round-off error

### DIFF
--- a/src/celeritas/alongstep/detail/TimeUpdater.hh
+++ b/src/celeritas/alongstep/detail/TimeUpdater.hh
@@ -34,14 +34,10 @@ CELER_FUNCTION void TimeUpdater::operator()(CoreTrackView const& track)
 
     auto particle = track.particle();
     real_type speed = native_value_from(particle.speed());
-    CELER_ASSERT(speed >= 0);
-    if (speed > 0)
-    {
-        // For very small energies (< numeric_limits<real_type>::epsilon)
-        // the calculated speed can be zero.
-        real_type delta_time = sim.step_length() / speed;
-        sim.add_time(delta_time);
-    }
+    CELER_ASSERT(speed > 0);
+
+    real_type delta_time = sim.step_length() / speed;
+    sim.add_time(delta_time);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -290,7 +290,7 @@ TEST_F(MockAlongStepTest, basic)
         auto result = this->run(inp, num_tracks);
         EXPECT_SOFT_EQ(1.0540925533894607e-10, result.displacement);
         EXPECT_SOFT_EQ(1, result.angle);
-        EXPECT_SOFT_EQ(0, result.time);
+        EXPECT_SOFT_EQ(2.4862399723875997e-12, result.time);
         EXPECT_SOFT_EQ(1.0540925533894607e-10, result.step);
         EXPECT_EQ("eloss-range", result.action);
     }

--- a/test/celeritas/phys/Particle.test.cc
+++ b/test/celeritas/phys/Particle.test.cc
@@ -246,6 +246,37 @@ TEST_F(ParticleTestHost, neutron)
     EXPECT_TRUE(particle.is_heavy());
 }
 
+TEST_F(ParticleTestHost, speed)
+{
+    // Low energy neutron
+    {
+        ParticleTrackView particle(
+            particle_params->host_ref(), state_ref, TrackSlotId(0));
+        particle = Initializer_t{ParticleId{2}, MevEnergy{1e-3}};
+
+        EXPECT_SOFT_EQ(0.001458986053668544,
+                       value_as<units::LightSpeed>(particle.speed()));
+
+        particle.energy(MevEnergy(1e-5));
+
+        EXPECT_SOFT_EQ(0.00014589872077707921,
+                       value_as<units::LightSpeed>(particle.speed()));
+    }
+    // Low energy electron
+    {
+        ParticleTrackView particle(
+            particle_params->host_ref(), state_ref, TrackSlotId(0));
+        particle = Initializer_t{ParticleId{0}, MevEnergy{1e-5}};
+
+        EXPECT_SOFT_EQ(0.0062560271021109186,
+                       value_as<units::LightSpeed>(particle.speed()));
+
+        particle.energy(MevEnergy(1e-18));
+
+        EXPECT_EQ(value_as<units::LightSpeed>(particle.speed()), 0);
+    }
+}
+
 //---------------------------------------------------------------------------//
 // DEVICE TESTS
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/Particle.test.cc
+++ b/test/celeritas/phys/Particle.test.cc
@@ -198,6 +198,13 @@ TEST_F(ParticleTestHost, electron)
     particle.energy(zero_quantity());
     EXPECT_TRUE(particle.is_stopped());
     EXPECT_REAL_EQ(0.0, particle.energy().value());
+
+    {
+        SCOPED_TRACE("High energy electron");
+        particle = Initializer_t{ParticleId{0}, MevEnergy{1e12}};
+        EXPECT_LE(particle.speed().value(), 1);
+        EXPECT_LE(particle.beta_sq(), 1);
+    }
 }
 
 TEST_F(ParticleTestHost, positron)

--- a/test/celeritas/phys/Particle.test.cc
+++ b/test/celeritas/phys/Particle.test.cc
@@ -254,12 +254,12 @@ TEST_F(ParticleTestHost, speed)
             particle_params->host_ref(), state_ref, TrackSlotId(0));
         particle = Initializer_t{ParticleId{2}, MevEnergy{1e-3}};
 
-        EXPECT_SOFT_EQ(0.001458986053668544,
+        EXPECT_SOFT_EQ(0.0014589860536436555,
                        value_as<units::LightSpeed>(particle.speed()));
 
         particle.energy(MevEnergy(1e-5));
 
-        EXPECT_SOFT_EQ(0.00014589872077707921,
+        EXPECT_SOFT_EQ(0.00014589872066202113,
                        value_as<units::LightSpeed>(particle.speed()));
     }
     // Low energy electron
@@ -268,12 +268,12 @@ TEST_F(ParticleTestHost, speed)
             particle_params->host_ref(), state_ref, TrackSlotId(0));
         particle = Initializer_t{ParticleId{0}, MevEnergy{1e-5}};
 
-        EXPECT_SOFT_EQ(0.0062560271021109186,
+        EXPECT_SOFT_EQ(0.0062560271021212888,
                        value_as<units::LightSpeed>(particle.speed()));
 
         particle.energy(MevEnergy(1e-18));
 
-        EXPECT_EQ(value_as<units::LightSpeed>(particle.speed()), 0);
+        EXPECT_GT(value_as<units::LightSpeed>(particle.speed()), 0);
     }
 }
 

--- a/test/celeritas/phys/Particle.test.cc
+++ b/test/celeritas/phys/Particle.test.cc
@@ -219,16 +219,16 @@ TEST_F(ParticleTestHost, gamma)
 {
     ParticleTrackView particle(
         particle_params->host_ref(), state_ref, TrackSlotId(0));
-    particle = Initializer_t{ParticleId{1}, MevEnergy{10}};
+    particle = Initializer_t{ParticleId{1}, MevEnergy{1.234}};
 
     EXPECT_REAL_EQ(0, particle.mass().value());
-    EXPECT_REAL_EQ(10, particle.energy().value());
+    EXPECT_REAL_EQ(1.234, particle.energy().value());
     EXPECT_FALSE(particle.is_antiparticle());
     EXPECT_TRUE(particle.is_stable());
-    EXPECT_REAL_EQ(10, particle.total_energy().value());
-    EXPECT_REAL_EQ(1.0, particle.beta_sq());
-    EXPECT_REAL_EQ(1.0, particle.speed().value());
-    EXPECT_REAL_EQ(10, particle.momentum().value());
+    EXPECT_REAL_EQ(1.234, particle.total_energy().value());
+    EXPECT_EQ(1, particle.beta_sq());
+    EXPECT_EQ(1, particle.speed().value());
+    EXPECT_REAL_EQ(1.234, particle.momentum().value());
     EXPECT_FALSE(particle.is_heavy());
 }
 
@@ -248,8 +248,8 @@ TEST_F(ParticleTestHost, neutron)
 
 TEST_F(ParticleTestHost, speed)
 {
-    // Low energy neutron
     {
+        SCOPED_TRACE("Low energy neutron");
         ParticleTrackView particle(
             particle_params->host_ref(), state_ref, TrackSlotId(0));
         particle = Initializer_t{ParticleId{2}, MevEnergy{1e-3}};
@@ -262,8 +262,8 @@ TEST_F(ParticleTestHost, speed)
         EXPECT_SOFT_EQ(0.00014589872066202113,
                        value_as<units::LightSpeed>(particle.speed()));
     }
-    // Low energy electron
     {
+        SCOPED_TRACE("Low energy electron");
         ParticleTrackView particle(
             particle_params->host_ref(), state_ref, TrackSlotId(0));
         particle = Initializer_t{ParticleId{0}, MevEnergy{1e-5}};


### PR DESCRIPTION
Following the suggestion in https://github.com/openmc-dev/openmc/pull/3526#pullrequestreview-3128611619, this modifies the calculation of the particle speed to use an expression that's less susceptible to round-off errors.