### PR TITLE
Fix failing celer-sim unit test with simple calo

### DIFF
--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -72,6 +72,9 @@ if core_geo == "orange-json":
 simple_calo = []
 if not rootout_filename and "cms" in geometry_filename:
     simple_calo = ["si_tracker", "em_calorimeter"]
+    # Volumes (needed for the simple calo) are currently only loaded if Geant4
+    # import is enabled
+    physics_filename = None
 
 num_tracks = 128 * 32 if use_device else 32
 num_primaries = 3 * 15 # assuming test hepmc input


### PR DESCRIPTION
The celer-sim cms GPU test (which uses the simple calo) was failing after #1903:

```console
/home/alund/celeritas_project/celeritas/src/geocel/VolumeIdBuilder.cc:79: error: Failed to find volume corresponding to label 'si_tracker'
/home/alund/celeritas_project/celeritas/src/geocel/VolumeIdBuilder.cc:79: error: Failed to find volume corresponding to label 'em_calorimeter'
status: Resetting Geant4 geometry stores
/home/alund/celeritas_project/celeritas/build-reldeb/bin/celer-sim: critical: runtime error: failed to find one or more volumes while constructing SimpleCalo
/home/alund/celeritas_project/celeritas/src/celeritas/user/SimpleCalo.cc:49: 'std::all_of(volume_ids_.begin(), volume_ids_.end(), Identity{})' failed
```

This resolves the failure by using the Geant4 importer  rather than ROOT import for that test so the volumes are available.