### PR TITLE
Improve version metadata for built-in packages and VecGeom

### DIFF
--- a/cmake/FindVecGeom.cmake
+++ b/cmake/FindVecGeom.cmake
@@ -79,4 +79,13 @@ if(VecGeom_FOUND AND VecGeom_CUDA_FOUND AND (TARGET VecGeom::vecgeomcuda OR TARG
   endif()
 endif()
 
+# Save VecGeom_NAV variable for diagnostics
+if(VecGeom_VERSION VERSION_LESS 2.0)
+  if(VECGEOM_USE_NAVINDEX)
+    set(VecGeom_NAV "index")
+  else()
+    set(VecGeom_NAV "path")
+  endif()
+endif()
+
 #-----------------------------------------------------------------------------#

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,7 +14,7 @@ macro(celer_fetch_external name version url sha)
   set(${name}_VERSION ${version} PARENT_SCOPE)
   set(${name}_VERSION_STRING "${version}+builtin" PARENT_SCOPE)
 
-  string(REGEX REPLACE "VERSION" "${version}" _url "${url}")
+  string(REGEX REPLACE "@VERSION@" "${version}" _url "${url}")
   FetchContent_Declare(
     "${name}"
     URL "${_url}"
@@ -31,7 +31,7 @@ endmacro()
 if(CELERITAS_BUILTIN_CLI11)
   celer_fetch_external(
     CLI11 2.5.0
-    "https://github.com/CLIUtils/CLI11/archive/refs/tags/vVERSION.tar.gz"
+    "https://github.com/CLIUtils/CLI11/archive/refs/tags/v@VERSION@.tar.gz"
     17e02b4cddc2fa348e5dbdbb582c59a3486fa2b2433e70a0c3bacb871334fd55
   )
 
@@ -48,7 +48,7 @@ endif()
 if(CELERITAS_BUILTIN_covfie)
   celer_fetch_external(
     covfie 0.14.0
-    "https://github.com/acts-project/covfie/archive/refs/tags/vVERSION.tar.gz"
+    "https://github.com/acts-project/covfie/archive/refs/tags/v@VERSION@.tar.gz"
     b4d8afa712c6fc0e2bc6474367d65fad652864b18d0255c5f2c18fd4c6943993
   )
   set(COVFIE_PLATFORM_CPU ON)
@@ -63,7 +63,7 @@ endif()
 if(CELERITAS_BUILTIN_GTest)
   celer_fetch_external(
     GTest 1.15.2
-    "https://github.com/google/googletest/archive/refs/tags/vVERSION.tar.gz"
+    "https://github.com/google/googletest/archive/refs/tags/v@VERSION@.tar.gz"
     7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
   )
 
@@ -80,7 +80,7 @@ endif()
 if(CELERITAS_BUILTIN_nlohmann_json)
   celer_fetch_external(
     nlohmann_json 3.11.3
-    "https://github.com/nlohmann/json/archive/vVERSION.tar.gz"
+    "https://github.com/nlohmann/json/archive/v@VERSION@.tar.gz"
     0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
   )
 
@@ -97,7 +97,7 @@ if(CELERITAS_BUILTIN_Perfetto)
   endif()
   celer_fetch_external(
     Perfetto 49.0
-    "https://github.com/google/perfetto/archive/refs/tags/vVERSION.tar.gz"
+    "https://github.com/google/perfetto/archive/refs/tags/v@VERSION@.tar.gz"
     0871a92a162ac5655b7d724f9359b15a75c4e92472716edbc4227a64a4680be4
   )
 endif()
@@ -109,7 +109,7 @@ endif()
 if(CELERITAS_BUILTIN_G4VG)
   celer_fetch_external(
     G4VG 1.0.4
-    "https://github.com/celeritas-project/g4vg/releases/download/vVERSION/g4vg-VERSION.tar.gz"
+    "https://github.com/celeritas-project/g4vg/releases/download/v@VERSION@/g4vg-@VERSION@.tar.gz"
     ac38878aedaf9fe628f498290cf4fa6cdd21980b7b83663ce8ef3c8f3ff31cb2
   )
   foreach(_var BUILD_TESTS DEBUG)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -7,12 +7,17 @@
 # silent otherwise
 set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
 
-# Download the package and add to a list
+# Download the package, save version, add to a list
 set(_celer_builtin_packages)
-macro(celer_fetch_external name url sha)
+macro(celer_fetch_external name version url sha)
+  # Save version and annotated string for corecel/Config.cc include
+  set(${name}_VERSION ${version} PARENT_SCOPE)
+  set(${name}_VERSION_STRING "${version}+builtin" PARENT_SCOPE)
+
+  string(REGEX REPLACE "VERSION" "${version}" _url "${url}")
   FetchContent_Declare(
     "${name}"
-    URL "${url}"
+    URL "${_url}"
     URL_HASH SHA256=${sha}
     DOWNLOAD_NO_PROGRESS TRUE
   )
@@ -25,8 +30,8 @@ endmacro()
 
 if(CELERITAS_BUILTIN_CLI11)
   celer_fetch_external(
-    CLI11
-    "https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.5.0.tar.gz"
+    CLI11 2.5.0
+    "https://github.com/CLIUtils/CLI11/archive/refs/tags/vVERSION.tar.gz"
     17e02b4cddc2fa348e5dbdbb582c59a3486fa2b2433e70a0c3bacb871334fd55
   )
 
@@ -42,8 +47,8 @@ endif()
 
 if(CELERITAS_BUILTIN_covfie)
   celer_fetch_external(
-    covfie
-    "https://github.com/acts-project/covfie/archive/refs/tags/v0.14.0.tar.gz"
+    covfie 0.14.0
+    "https://github.com/acts-project/covfie/archive/refs/tags/vVERSION.tar.gz"
     b4d8afa712c6fc0e2bc6474367d65fad652864b18d0255c5f2c18fd4c6943993
   )
   set(COVFIE_PLATFORM_CPU ON)
@@ -57,8 +62,8 @@ endif()
 
 if(CELERITAS_BUILTIN_GTest)
   celer_fetch_external(
-    GTest
-    "https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz"
+    GTest 1.15.2
+    "https://github.com/google/googletest/archive/refs/tags/vVERSION.tar.gz"
     7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
   )
 
@@ -74,8 +79,8 @@ endif()
 
 if(CELERITAS_BUILTIN_nlohmann_json)
   celer_fetch_external(
-    nlohmann_json
-    "https://github.com/nlohmann/json/archive/v3.11.3.tar.gz"
+    nlohmann_json 3.11.3
+    "https://github.com/nlohmann/json/archive/vVERSION.tar.gz"
     0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406
   )
 
@@ -91,8 +96,8 @@ if(CELERITAS_BUILTIN_Perfetto)
     set(FETCHCONTENT_SOURCE_DIR_PERFETTO "${PERFETTO_ROOT}")
   endif()
   celer_fetch_external(
-    Perfetto
-    "https://github.com/google/perfetto/archive/refs/tags/v49.0.tar.gz"
+    Perfetto 49.0
+    "https://github.com/google/perfetto/archive/refs/tags/vVERSION.tar.gz"
     0871a92a162ac5655b7d724f9359b15a75c4e92472716edbc4227a64a4680be4
   )
 endif()
@@ -103,8 +108,8 @@ endif()
 
 if(CELERITAS_BUILTIN_G4VG)
   celer_fetch_external(
-    G4VG
-    "https://github.com/celeritas-project/g4vg/releases/download/v1.0.4/g4vg-1.0.4.tar.gz"
+    G4VG 1.0.4
+    "https://github.com/celeritas-project/g4vg/releases/download/vVERSION/g4vg-VERSION.tar.gz"
     ac38878aedaf9fe628f498290cf4fa6cdd21980b7b83663ce8ef3c8f3ff31cb2
   )
   foreach(_var BUILD_TESTS DEBUG)

--- a/scripts/cmake-presets/goldfinger.json
+++ b/scripts/cmake-presets/goldfinger.json
@@ -104,6 +104,20 @@
       }
     },
     {
+      "name": "vglocal",
+      "displayName": "With local vecgeom",
+      "inherits": [".base", ".debug", "default"],
+      "cacheVariables": {
+        "CELERITAS_BUILTIN_G4VG": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "ON"}
+      },
+      "environment": {
+        "CMAKE_PREFIX_PATH": "/Users/seth/Code/vecgeom/install:/opt/spack/opt/spack/sequoia/geant4/11.3.1/b7lttaq:/opt/spack/opt/spack/sequoia/googletest/1.15.2/kqcyiil:/opt/spack/opt/spack/sequoia/cli11/2.5.0/nsqiz3t:/opt/spack/opt/spack/sequoia/nlohmann-json/3.11.3/fpe7aef:/opt/spack/opt/spack/sequoia/covfie/0.13.0/tabnbjs:/opt/spack/opt/spack/sequoia/zlib-ng/2.2.1/6s4rdcx"
+      }
+    },
+    {
       "name": "vgsurf",
       "displayName": "With vecgeom surface",
       "inherits": ["vecgeom"],
@@ -111,7 +125,6 @@
         "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "ON"}
       },
       "environment": {
-        "PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas-vgsurf/.spack-env/view/bin:$penv{PATH}",
         "CMAKE_PREFIX_PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas-vgsurf/.spack-env/view"
       }
     },

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -80,7 +80,7 @@ class VecgeomVgdmlTestBase : public VecgeomTestBaseImpl
     {
         using namespace celeritas::cmake;
         cout << color_code('x') << "VecGeom v" << vecgeom_version << " ("
-             << vecgeom_options << ") VGDML" << color_code(' ') << endl;
+             << vecgeom_options << ") using VGDML" << color_code(' ') << endl;
 
         ScopedLogStorer scoped_log_{&celeritas::world_logger(),
                                     LogLevel::warning};

--- a/test/geocel/vg/Vecgeom.test.cc
+++ b/test/geocel/vg/Vecgeom.test.cc
@@ -14,6 +14,7 @@
 #include "corecel/ScopedLogStorer.hh"
 #include "corecel/StringSimplifier.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/io/ColorUtils.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Environment.hh"
@@ -77,6 +78,10 @@ class VecgeomVgdmlTestBase : public VecgeomTestBaseImpl
   public:
     SPConstGeo build_geometry() const final
     {
+        using namespace celeritas::cmake;
+        cout << color_code('x') << "VecGeom v" << vecgeom_version << " ("
+             << vecgeom_options << ") VGDML" << color_code(' ') << endl;
+
         ScopedLogStorer scoped_log_{&celeritas::world_logger(),
                                     LogLevel::warning};
         std::string filename{this->gdml_basename()};
@@ -98,6 +103,11 @@ class VecgeomGeantTestBase : public VecgeomTestBaseImpl
     //! Construct via persistent geant_geo; see LazyGeantGeoManager
     SPConstGeo build_geometry() const final
     {
+        using namespace celeritas::cmake;
+        cout << color_code('x') << "VecGeom v" << vecgeom_version << " ("
+             << vecgeom_options << ") using G4VG v" << g4vg_version
+             << " and Geant4 v" << geant4_version << color_code(' ') << endl;
+
         ScopedLogStorer scoped_log_{&celeritas::world_logger(),
                                     LogLevel::warning};
         auto result = VecgeomTestBaseImpl::build_geometry();


### PR DESCRIPTION
- Exports and saves versions from "vendored" packages (e.g. G4VG)
- Correctly sets the `VecGeom_NAV` variable (either 'index' or 'path') for VecGeom 1.x
- Print vecgeom versioning information at the beginning of tests to help with debugging