### PR TITLE
Fail at runtime rather than link time for G4 10 with tracking manager integration

### DIFF
--- a/example/geant4/CMakeLists.txt
+++ b/example/geant4/CMakeLists.txt
@@ -21,6 +21,16 @@ celeritas_target_link_libraries(simple-offload
   ${Geant4_LIBRARIES}
 )
 
+if(Geant4_VERSION VERSION_LESS 11.0)
+  message(WARNING "Tracking manager offload requires Geant4 11.0 or higher")
+endif()
+
+add_executable(trackingmanager-offload trackingmanager-offload.cc)
+celeritas_target_link_libraries(trackingmanager-offload
+  Celeritas::G4
+  ${Geant4_LIBRARIES}
+)
+
 if(Geant4_VERSION VERSION_LESS 11.1)
   message(WARNING "Fast simulation offload requires Geant4 11.1 or higher")
 endif()
@@ -30,16 +40,6 @@ celeritas_target_link_libraries(fastsim-offload
   Celeritas::G4
   ${Geant4_LIBRARIES}
 )
-
-if(Geant4_VERSION VERSION_LESS 11.0)
-  message(WARNING "G4VTrackingManager offload requires Geant4 11.0 or higher")
-else()
-  add_executable(trackingmanager-offload trackingmanager-offload.cc)
-  celeritas_target_link_libraries(trackingmanager-offload
-    Celeritas::G4
-    ${Geant4_LIBRARIES}
-  )
-endif()
 
 # END EXAMPLE CODE
 
@@ -56,15 +56,15 @@ celeritas_get_disable_device(CELER_DISABLE_DEVICE)
 
 #-----------------------------------------------------------------------------#
 
+set(_needs_g410)
+if(Geant4_VERSION VERSION_LESS 11.0)
+  set(_needs_g410 DISABLE)
+endif()
 set(_needs_g411)
 if(Geant4_VERSION VERSION_LESS 11.1)
   set(_needs_g411 DISABLE)
 endif()
 
 celeritas_g4_add_tests(simple-offload)
+celeritas_g4_add_tests(trackingmanager-offload ${_needs_g410})
 celeritas_g4_add_tests(fastsim-offload ${_needs_g411})
-
-if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
-  # Requires 11.0 to build
-  celeritas_g4_add_tests(trackingmanager-offload)
-endif()

--- a/example/geant4/CMakeLists.txt
+++ b/example/geant4/CMakeLists.txt
@@ -56,9 +56,10 @@ celeritas_get_disable_device(CELER_DISABLE_DEVICE)
 
 #-----------------------------------------------------------------------------#
 
-set(_needs_g4_11_0)
+# Some features require *at least* major version 11 or minor version 11.1
+set(_needs_g4_11)
 if(Geant4_VERSION VERSION_LESS 11.0)
-  set(_needs_g4_11_0 DISABLE)
+  set(_needs_g4_11 DISABLE)
 endif()
 set(_needs_g4_11_1)
 if(Geant4_VERSION VERSION_LESS 11.1)

--- a/example/geant4/CMakeLists.txt
+++ b/example/geant4/CMakeLists.txt
@@ -56,15 +56,15 @@ celeritas_get_disable_device(CELER_DISABLE_DEVICE)
 
 #-----------------------------------------------------------------------------#
 
-set(_needs_g410)
+set(_needs_g4_11_0)
 if(Geant4_VERSION VERSION_LESS 11.0)
-  set(_needs_g410 DISABLE)
+  set(_needs_g4_11_0 DISABLE)
 endif()
-set(_needs_g411)
+set(_needs_g4_11_1)
 if(Geant4_VERSION VERSION_LESS 11.1)
-  set(_needs_g411 DISABLE)
+  set(_needs_g4_11_1 DISABLE)
 endif()
 
 celeritas_g4_add_tests(simple-offload)
-celeritas_g4_add_tests(trackingmanager-offload ${_needs_g410})
-celeritas_g4_add_tests(fastsim-offload ${_needs_g411})
+celeritas_g4_add_tests(trackingmanager-offload ${_needs_g4_11})
+celeritas_g4_add_tests(fastsim-offload ${_needs_g4_11_1})

--- a/example/geant4/trackingmanager-offload.cc
+++ b/example/geant4/trackingmanager-offload.cc
@@ -28,6 +28,11 @@
 #include <G4VUserDetectorConstruction.hh>
 #include <G4VUserPrimaryGeneratorAction.hh>
 #include <G4Version.hh>
+#if G4VERSION_NUMBER >= 1100
+#    include <G4RunManagerFactory.hh>
+#else
+#    include <G4MTRunManager.hh>
+#endif
 
 // Celeritas
 #include <CeleritasG4.hh>
@@ -213,8 +218,14 @@ celeritas::SetupOptions MakeOptions()
 
 int main()
 {
-    auto run_manager = std::unique_ptr<G4RunManager>{
-        G4RunManagerFactory::CreateRunManager()};
+    auto run_manager = [] {
+#if G4VERSION_NUMBER >= 1100
+        return std::unique_ptr<G4RunManager>{
+            G4RunManagerFactory::CreateRunManager()};
+#else
+        return std::make_unique<G4RunManager>();
+#endif
+    }();
 
     run_manager->SetUserInitialization(new DetectorConstruction{});
 

--- a/example/geant4/trackingmanager-offload.cc
+++ b/example/geant4/trackingmanager-offload.cc
@@ -17,7 +17,6 @@
 #include <G4PVPlacement.hh>
 #include <G4ParticleGun.hh>
 #include <G4ParticleTable.hh>
-#include <G4RunManagerFactory.hh>
 #include <G4SDManager.hh>
 #include <G4SystemOfUnits.hh>
 #include <G4ThreeVector.hh>

--- a/example/offload-template/run-offload.cc
+++ b/example/offload-template/run-offload.cc
@@ -34,9 +34,8 @@ int main(int argc, char* argv[])
 
     using namespace celeritas::example;
 
-    std::unique_ptr<G4RunManager> run_manager;
-    run_manager.reset(
-        G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default));
+    std::unique_ptr<G4RunManager> run_manager{
+        G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default)};
 
     // Initialize Celeritas
     auto& tmi = celeritas::TrackingManagerIntegration::Instance();

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -63,6 +63,9 @@ if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
     # Run offload-template only on Geant4 v11
     G4FORCENUMBEROFTHREADS=4 G4RUN_MANAGER_TYPE=MT \
       ./run-offload
+  if [ "${G4VERSION_NUMBER}" -lt 1070 ]; then
+    # RunManagerFactory isn't available
+    echo "Skipping offload template: Geant4 version is too old"
   else
     # Test that it fails
     echo "*** THE FOLLOWING EXECUTION SHOULD FAIL ***"

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -23,7 +23,7 @@ test -n "${CMAKE_PRESET}" || (
 build_local() {
   git clean -fxd .
   EXAMPLE_INSTALL=${PWD}/install
-  printf "\e[32mTesting in ${PWD}\e[m\n"
+  printf "\e[32mBuilding in ${PWD}\e[m\n"
   mkdir build
   cd build
   cmake -G Ninja --log-level=verbose \
@@ -41,14 +41,14 @@ build_local
 
 # Run Geant4 app examples
 if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
-  G4VERSION_STRING="unknown"
+  G4VERSION_STRING="auto"
   if [ -z "${G4VERSION_NUMBER}" ]; then
     # Get the geant4 version 11.2.3, failing if config isn't found
     G4VERSION_STRING=$(geant4-config --version)
     # Replace . with ' ' and convert to MMmp (major/minor/patch)
     G4VERSION_NUMBER=$(echo "${G4VERSION_STRING}" | tr '.' ' ' | xargs printf '%d%01d%01d')
-    echo "Set G4VERSION_NUMBER=\"${G4VERSION_NUMBER}\" (version ${G4VERSION_STRING})"
   fi
+  echo "Using G4VERSION_NUMBER=\"${G4VERSION_NUMBER}\" (version ${G4VERSION_STRING})"
 
   # Run small Geant4 examples, ensuring the documentation diff is still valid
   cd "${CELER_SOURCE_DIR}/example/geant4"
@@ -57,25 +57,27 @@ if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
   build_local
   ctest -V --no-tests=error
 
-  cd "${CELER_SOURCE_DIR}/example/offload-template"
-  build_local
-  if [ "${G4VERSION_NUMBER}" -ge 1100 ]; then
-    # Run offload-template only on Geant4 v11
-    G4FORCENUMBEROFTHREADS=4 G4RUN_MANAGER_TYPE=MT \
-      ./run-offload
-  elif [ "${G4VERSION_NUMBER}" -lt 1070 ]; then
+  if [ "${G4VERSION_NUMBER}" -ge 1070 ]; then
+    cd "${CELER_SOURCE_DIR}/example/offload-template"
+    build_local
+    if [ "${G4VERSION_NUMBER}" -ge 1100 ]; then
+      # Run offload-template only on Geant4 v11
+      G4FORCENUMBEROFTHREADS=4 G4RUN_MANAGER_TYPE=MT \
+        ./run-offload
+    else
+      # Test that it fails
+      echo "*** THE FOLLOWING EXECUTION SHOULD FAIL ***"
+      echo "*** (Requires Geant4 11.0 but we have ${G4VERSION_STRING}) ***"
+      ./run-offload && (
+        echo "Expected run-offload to fail but it PASSED"
+        exit 1
+      )
+      echo "***      EXPECTED FAILURE ABOVE         ***"
+      echo "*** *********************************** ***"
+    fi
+  else
     # RunManagerFactory isn't available
     echo "Skipping offload template: Geant4 version is too old"
-  else
-    # Test that it fails
-    echo "*** THE FOLLOWING EXECUTION SHOULD FAIL ***"
-    echo "*** (Requires Geant4 11.0 but we have ${G4VERSION_STRING}) ***"
-    ./run-offload && (
-      echo "Expected run-offload to fail but it PASSED"
-      exit 1
-    )
-    echo "***      EXPECTED FAILURE ABOVE         ***"
-    echo "*** *********************************** ***"
   fi
 else
   printf "\e[31mSkipping Geant4 tests due to insufficient requirements\e[m\n"

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -41,12 +41,13 @@ build_local
 
 # Run Geant4 app examples
 if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
+  G4VERSION_STRING="unknown"
   if [ -z "${G4VERSION_NUMBER}" ]; then
     # Get the geant4 version 11.2.3, failing if config isn't found
-    _vers=$(geant4-config --version)
+    G4VERSION_STRING=$(geant4-config --version)
     # Replace . with ' ' and convert to MMmp (major/minor/patch)
-    G4VERSION_NUMBER=$(echo "${_vers}" | tr '.' ' ' | xargs printf '%d%01d%01d')
-    echo "Set G4VERSION_NUMBER=\"${G4VERSION_NUMBER}\""
+    G4VERSION_NUMBER=$(echo "${G4VERSION_STRING}" | tr '.' ' ' | xargs printf '%d%01d%01d')
+    echo "Set G4VERSION_NUMBER=\"${G4VERSION_NUMBER}\" (version ${G4VERSION_STRING})"
   fi
 
   # Run small Geant4 examples, ensuring the documentation diff is still valid
@@ -65,10 +66,13 @@ if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
   else
     # Test that it fails
     echo "*** THE FOLLOWING EXECUTION SHOULD FAIL ***"
+    echo "*** (Requires Geant4 11.0 but we have ${G4VERSION_STRING}) ***"
     ./run-offload && (
       echo "Expected run-offload to fail but it PASSED"
       exit 1
     )
+    echo "***      EXPECTED FAILURE ABOVE         ***"
+    echo "*** *********************************** ***"
   fi
 else
   printf "\e[31mSkipping Geant4 tests due to insufficient requirements\e[m\n"

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -63,7 +63,7 @@ if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
     # Run offload-template only on Geant4 v11
     G4FORCENUMBEROFTHREADS=4 G4RUN_MANAGER_TYPE=MT \
       ./run-offload
-  if [ "${G4VERSION_NUMBER}" -lt 1070 ]; then
+  elif [ "${G4VERSION_NUMBER}" -lt 1070 ]; then
     # RunManagerFactory isn't available
     echo "Skipping offload template: Geant4 version is too old"
   else

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -56,12 +56,19 @@ if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
   build_local
   ctest -V --no-tests=error
 
+  cd "${CELER_SOURCE_DIR}/example/offload-template"
+  build_local
   if [ "${G4VERSION_NUMBER}" -ge 1100 ]; then
     # Run offload-template only on Geant4 v11
-    cd "${CELER_SOURCE_DIR}/example/offload-template"
-    build_local
     G4FORCENUMBEROFTHREADS=4 G4RUN_MANAGER_TYPE=MT \
       ./run-offload
+  else
+    # Test that it fails
+    echo "*** THE FOLLOWING EXECUTION SHOULD FAIL ***"
+    ./run-offload && (
+      echo "Expected run-offload to fail but it PASSED"
+      exit 1
+    )
   fi
 else
   printf "\e[31mSkipping Geant4 tests due to insufficient requirements\e[m\n"

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -38,6 +38,8 @@ list(APPEND SOURCES
   SharedParams.cc
   SimpleOffload.cc
   TimeOutput.cc
+  TrackingManagerConstructor.cc
+  TrackingManagerIntegration.cc
   UserActionIntegration.cc
   detail/GeantSimpleCaloSD.cc
   detail/IntegrationSingleton.cc
@@ -47,9 +49,7 @@ celeritas_polysource(ExceptionConverter)
 
 if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
   list(APPEND SOURCES
-    TrackingManagerIntegration.cc
     TrackingManager.cc
-    TrackingManagerConstructor.cc
   )
 endif()
 

--- a/src/accel/FastSimulationModel.cc
+++ b/src/accel/FastSimulationModel.cc
@@ -56,7 +56,7 @@ FastSimulationModel::FastSimulationModel(G4String const& name,
     CELER_VALIDATE(G4VERSION_NUMBER >= 1110,
                    << "the current version of Geant4 (" << G4VERSION_NUMBER
                    << ") is too old to support the fast simulation Flush() "
-                      "interface");
+                      "interface (11.1 or higher is required)");
     CELER_EXPECT(region);
     CELER_EXPECT(params);
     CELER_EXPECT(local);

--- a/src/accel/TrackingManagerConstructor.cc
+++ b/src/accel/TrackingManagerConstructor.cc
@@ -7,12 +7,15 @@
 #include "TrackingManagerConstructor.hh"
 
 #include <G4BuilderType.hh>
+#include <G4Version.hh>
+#if G4VERSION_NUMBER >= 1100
+#    include "TrackingManager.hh"
+#endif
 
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 
 #include "SharedParams.hh"
-#include "TrackingManager.hh"
 #include "TrackingManagerIntegration.hh"
 
 #include "detail/IntegrationSingleton.hh"
@@ -33,6 +36,11 @@ TrackingManagerConstructor::TrackingManagerConstructor(
 {
     // The special "unknown" type will not conflict with any other physics
     this->SetPhysicsType(G4BuilderType::bUnknown);
+
+    CELER_VALIDATE(G4VERSION_NUMBER >= 1100,
+                   << "the current version of Geant4 (" << G4VERSION_NUMBER
+                   << ") is too old to support the tracking manager offload "
+                      "interface");
 }
 
 //---------------------------------------------------------------------------//
@@ -93,6 +101,7 @@ void TrackingManagerConstructor::ConstructProcess()
     auto* transporter = this->get_local_transporter();
     CELER_VALIDATE(transporter, << "invalid null local transporter");
 
+#if G4VERSION_NUMBER >= 1100
     // Create *thread-local* tracking manager with pointers to *global*
     // shared params and *thread-local* transporter.
     auto manager = std::make_unique<TrackingManager>(shared_, transporter);
@@ -113,6 +122,7 @@ void TrackingManagerConstructor::ConstructProcess()
                             [](G4ParticleDefinition const* pd) {
                                 return pd->GetParticleName();
                             });
+#endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/TrackingManagerConstructor.cc
+++ b/src/accel/TrackingManagerConstructor.cc
@@ -40,7 +40,7 @@ TrackingManagerConstructor::TrackingManagerConstructor(
     CELER_VALIDATE(G4VERSION_NUMBER >= 1100,
                    << "the current version of Geant4 (" << G4VERSION_NUMBER
                    << ") is too old to support the tracking manager offload "
-                      "interface");
+                      "interface (11.0 or higher is required)");
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/TrackingManagerIntegration.cc
+++ b/src/accel/TrackingManagerIntegration.cc
@@ -11,7 +11,10 @@
 #include <G4ParticleDefinition.hh>
 #include <G4Threading.hh>
 #include <G4Version.hh>
+
 #if G4VERSION_NUMBER >= 1100
+#    include <G4VTrackingManager.hh>
+
 #    include "TrackingManager.hh"
 #endif
 
@@ -49,8 +52,6 @@ void verify_tracking_managers(Span<G4PD const* const> expected,
     std::set<G4PD const*> not_offloaded{actual.begin(), actual.end()};
     std::vector<G4PD const*> missing;
 
-    TypeDemangler<G4VTrackingManager> demangle_tm;
-
     bool all_attached_correctly{true};
     auto log_tm_failure = [&all_attached_correctly](G4PD const* p) {
         all_attached_correctly = false;
@@ -74,6 +75,8 @@ void verify_tracking_managers(Span<G4PD const* const> expected,
         }
 
 #if G4VERSION_NUMBER >= 1100
+        static TypeDemangler<G4VTrackingManager> demangle_tm;
+
         // Check tracking manager setup: note that this is *thread-local*
         // whereas the offloaded track list is *global*
         if (auto* tm = p->GetTrackingManager())
@@ -103,6 +106,8 @@ void verify_tracking_managers(Span<G4PD const* const> expected,
             log_tm_failure(p) << "is not attached";
         }
 #else
+        CELER_DISCARD(expected_shared);
+        CELER_DISCARD(expected_local);
         CELER_ASSERT_UNREACHABLE();
 #endif
     }

--- a/src/accel/TrackingManagerIntegration.cc
+++ b/src/accel/TrackingManagerIntegration.cc
@@ -108,6 +108,7 @@ void verify_tracking_managers(Span<G4PD const* const> expected,
 #else
         CELER_DISCARD(expected_shared);
         CELER_DISCARD(expected_local);
+        CELER_DISCARD(log_tm_failure);
         CELER_ASSERT_UNREACHABLE();
 #endif
     }

--- a/src/accel/TrackingManagerIntegration.cc
+++ b/src/accel/TrackingManagerIntegration.cc
@@ -152,7 +152,7 @@ void TrackingManagerIntegration::BeginOfRunAction(G4Run const*)
     CELER_VALIDATE(G4VERSION_NUMBER >= 1100,
                    << "the current version of Geant4 (" << G4VERSION_NUMBER
                    << ") is too old to support the tracking manager offload "
-                      "interface");
+                      "interface (11.0 or higher is required)");
 
     Stopwatch get_setup_time;
 

--- a/src/accel/TrackingManagerIntegration.cc
+++ b/src/accel/TrackingManagerIntegration.cc
@@ -10,6 +10,10 @@
 #include <set>
 #include <G4ParticleDefinition.hh>
 #include <G4Threading.hh>
+#include <G4Version.hh>
+#if G4VERSION_NUMBER >= 1100
+#    include "TrackingManager.hh"
+#endif
 
 #include "corecel/io/Join.hh"
 #include "corecel/sys/Stopwatch.hh"
@@ -18,7 +22,6 @@
 
 #include "ExceptionConverter.hh"
 #include "TimeOutput.hh"
-#include "TrackingManager.hh"
 #include "TrackingManagerConstructor.hh"
 
 #include "detail/IntegrationSingleton.hh"
@@ -70,6 +73,7 @@ void verify_tracking_managers(Span<G4PD const* const> expected,
             not_offloaded.erase(iter);
         }
 
+#if G4VERSION_NUMBER >= 1100
         // Check tracking manager setup: note that this is *thread-local*
         // whereas the offloaded track list is *global*
         if (auto* tm = p->GetTrackingManager())
@@ -98,6 +102,9 @@ void verify_tracking_managers(Span<G4PD const* const> expected,
         {
             log_tm_failure(p) << "is not attached";
         }
+#else
+        CELER_ASSERT_UNREACHABLE();
+#endif
     }
 
     auto printable_pd = [](G4PD const* p) { return PrintablePD{p}; };
@@ -142,6 +149,11 @@ TrackingManagerIntegration& TrackingManagerIntegration::Instance()
  */
 void TrackingManagerIntegration::BeginOfRunAction(G4Run const*)
 {
+    CELER_VALIDATE(G4VERSION_NUMBER >= 1100,
+                   << "the current version of Geant4 (" << G4VERSION_NUMBER
+                   << ") is too old to support the tracking manager offload "
+                      "interface");
+
     Stopwatch get_setup_time;
 
     auto& singleton = detail::IntegrationSingleton::instance();


### PR DESCRIPTION
Previously, including the tracking manager integration in a code compiled with Geant4 < 11 would produce a link error. This allows Celeritas to fully build and compile but to raise a runtime error when the unsupported feature is activated.

Split from #1925.