### PR TITLE
Fix edge case where imported lambda and lambda prime tables have overlapping range

### DIFF
--- a/src/celeritas/ext/detail/GeantProcessImporter.cc
+++ b/src/celeritas/ext/detail/GeantProcessImporter.cc
@@ -178,12 +178,14 @@ void assign_table(G4PhysicsTable const* g4table,
         table->grids.emplace_back(import_physics_log_vector(*g4vector, units));
 #if G4VERSION_NUMBER < 1100
         // Hardcode whether the lambda table uses spline for older Geant4
-        // versions. Always use spline for lambda, energy loss, range, and msc
+        // versions. Always use spline for lambda prime, energy loss, range,
+        // and msc.
         //! \todo Coulomb scattering disables spline when \c isCombined = false
         static std::unordered_set<ImportProcessClass> disable_spline{
             ImportProcessClass::rayleigh};
 
-        if (!disable_spline.count(process_class))
+        bool is_lambda_prim = table->y_units == ImportUnits::len_mev_inv;
+        if (!disable_spline.count(process_class) || is_lambda_prim)
 #else
         if (g4vector->GetSpline())
 #endif

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -385,6 +385,8 @@ auto TestEm3IntegrationMixin::make_physics_input() const -> PhysicsInput
 {
     PhysicsInput result = Base::make_physics_input();
     result.em_bins_per_decade = 14;
+    // Increase the lower energy limit of the physics tables
+    result.min_energy = units::MevEnergy{0.1};
     result.default_cutoff = 0.1 * units::centimeter;
     return result;
 }

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -383,10 +383,12 @@ auto LarSphereIntegrationMixin::make_sens_det(std::string const& sd_name)
  */
 auto TestEm3IntegrationMixin::make_physics_input() const -> PhysicsInput
 {
+    using MevEnergy = Quantity<units::Mev, double>;
+
     PhysicsInput result = Base::make_physics_input();
     result.em_bins_per_decade = 14;
     // Increase the lower energy limit of the physics tables
-    result.min_energy = units::MevEnergy{0.1};
+    result.min_energy = MevEnergy{0.1};
     result.default_cutoff = 0.1 * units::centimeter;
     return result;
 }


### PR DESCRIPTION
This fixes a failure due to an edge case in Geant4 that @sethrj inadvertently ran into in #1925 (https://github.com/celeritas-project/celeritas/pull/1925#discussion_r2322178014). If `minKinEnergy == minKinEnergyPrim`, both the low- and high-energy lambda tables are built in Geant4, but the range of the lower table is redundant with the upper table. This causes the contiguous-increasing check in Celeritas to fail; to prevent this, we can simply ignore the lower table in this case.

Also fixes the spline setting for the Rayleigh lambda prime table in older Geant4 versions.