### PR TITLE
Use environment variable values if set

### DIFF
--- a/doc/usage/execution/environment.rst
+++ b/doc/usage/execution/environment.rst
@@ -20,33 +20,38 @@ tell what variables are in use or may be useful.
  ======================= ========= ==========================================
  Variable                Component Brief description
  ======================= ========= ==========================================
- CELER_COLOR             corecel   Enable/disable ANSI color logging
- CELER_DEBUG_DEVICE      corecel   Increase device error checking and output
- CELER_DISABLE_DEVICE    corecel   Disable CUDA/HIP support
- CELER_DISABLE_PARALLEL  corecel   Disable MPI support
- CELER_DISABLE_ROOT      corecel   Disable ROOT I/O calls
- CELER_DEVICE_ASYNC      corecel   Flag for asynchronous memory allocation
- CELER_ENABLE_PROFILING  corecel   Set up NVTX/ROCTX profiling ranges [#pr]_
- CELER_LOG               corecel   Set the "global" logger verbosity
- CELER_LOG_LOCAL         corecel   Set the "local" logger verbosity
- CELER_MEMPOOL... [#mp]_ corecel   Change ``cudaMemPoolAttrReleaseThreshold``
- CELER_PERFETT... [#bs]_ corecel   Set the in-process tracing buffer size
- CELER_PROFILE_DEVICE    corecel   Record extra kernel launch information
- CUDA_HEAP_SIZE          geocel    Change ``cudaLimitMallocHeapSize`` (VG)
- CUDA_STACK_SIZE         geocel    Change ``cudaLimitStackSize`` for VecGeom
+ CELER_COLOR             corecel   Flag: log with ANSI colors
+ CELER_DEBUG_DEVICE      corecel   Flag: check device ID consistency
+ CELER_DISABLE_DEVICE    corecel   Flag: disable CUDA/HIP support
+ CELER_DISABLE_PARALLEL  corecel   Flag: disable MPI support
+ CELER_DISABLE_ROOT      corecel   Flag: disable ROOT I/O calls
+ CELER_DEVICE_ASYNC      corecel   Flag: allocate memory asynchronously
+ CELER_ENABLE_PROFILING  corecel   Flag: use NVTX/ROCTX profiling [#pr]_
+ CELER_LOG               corecel   Set "global" logger verbosity [#lg]_
+ CELER_LOG_LOCAL         corecel   Set "local" logger verbosity [#lg]_
+ CELER_MEMPOOL... [#mp]_ corecel   Set ``cudaMemPoolAttrReleaseThreshold``
+ CELER_PERFETT... [#bs]_ corecel   Set in-process tracing buffer size
+ CELER_PROFILE_DEVICE    corecel   Flag: record kernel launch counts
+ CUDA_HEAP_SIZE          geocel    Set ``cudaLimitMallocHeapSize`` (VG)
+ CUDA_STACK_SIZE         geocel    Set ``cudaLimitStackSize`` for VecGeom
  G4VG_COMPARE_VOLUMES    geocel    Check G4VG volume capacity when converting
- HEPMC3_VERBOSE          celeritas HepMC3 debug verbosity
- VECGEOM_VERBOSE         celeritas VecGeom CUDA verbosity
- CELER_DISABLE           accel     Disable Celeritas offloading entirely
- CELER_LOG_ALL_LOCAL     accel     Print log messages from all threads
- CELER_KILL_OFFLOAD      accel     Kill Celeritas-supported tracks in Geant4
- CELER_NONFATAL_FLUSH    accel     Instead of crashing, kill tracks [#nf]_
- CELER_STRIP_SOURCEDIR   accel     Strip directories from exception output
+ HEPMC3_VERBOSE          celeritas HepMC3 debug level integer
+ VECGEOM_VERBOSE         celeritas VecGeom CUDA verbosity integer
+ CELER_DISABLE           accel     Flag: disable Celeritas offloading entirely
+ CELER_LOG_ALL_LOCAL     accel     Flag: log more messages from all threads
+ CELER_KILL_OFFLOAD      accel     Flag: kill offloaded tracks [#ko]_
+ CELER_NONFATAL_FLUSH    accel     Flag: print and continue on failure [#nf]_
+ CELER_STRIP_SOURCEDIR   accel     Flag: clean exception output
  ======================= ========= ==========================================
 
-.. [#bs] CELER_PERFETTO_BUFFER_SIZE_MB
-.. [#mp] CELER_MEMPOOL_RELEASE_THRESHOLD
 .. [#pr] See :ref:`profiling`
+.. [#lg] See :ref:`logging`
+.. [#mp] CELER_MEMPOOL_RELEASE_THRESHOLD changes the amount of memory used for
+   the device asynchronous memory pool.
+.. [#bs] CELER_PERFETTO_BUFFER_SIZE_MB
+.. [#ko] This flag, used by ``accel``, omits Celeritas setup and instead kills
+   tracks that would have otherwise been offloaded. This capability can be used
+   to estimate a maximum speedup by using Celeritas.
 .. [#nf] Normally, exceeding the "maximum steps" or interrupting the stepping
    loop will call G4Exception, which normally kills the code. (In external
    frameworks this usually causes a stack trace and core dump.) Instead of

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -35,23 +35,16 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-bool determine_strip()
-{
-    if (!celeritas::getenv("CELER_STRIP_SOURCEDIR").empty())
-    {
-        return true;
-    }
-    return static_cast<bool>(CELERITAS_DEBUG);
-}
-
-//---------------------------------------------------------------------------//
 //! Try removing up to and including the filename from the reported path.
 std::string strip_source_dir(std::string const& filename)
 {
-    static bool const do_strip = determine_strip();
+    static bool const do_strip = [] {
+        auto result = getenv_flag("CELER_STRIP_SOURCEDIR", !CELERITAS_DEBUG);
+        return result.value;
+    }();
     if (!do_strip)
     {
-        // Don't strip in debug mode
+        // Don't strip in debug builds
         return filename;
     }
 

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -156,7 +156,7 @@ std::mutex& updating_mutex()
  *
  * This gets the value from environment variables and
  *
- * \todo This will be refactored for 0.6 to take a \c celeritas::inp object and
+ * \todo This will be refactored for 0.7 to take a \c celeritas::inp object and
  * determine values rather than from the environment .
  */
 auto SharedParams::GetMode() -> Mode
@@ -164,16 +164,18 @@ auto SharedParams::GetMode() -> Mode
     using Mode = SharedParams::Mode;
 
     static bool const kill_offload = [] {
-        if (celeritas::getenv("CELER_KILL_OFFLOAD").empty())
-            return false;
+        auto result = getenv_flag("CELER_KILL_OFFLOAD", false);
 
-        CELER_LOG(info) << "Killing Geant4 tracks supported by Celeritas "
-                           "offloading since the 'CELER_KILL_OFFLOAD' "
-                        << "environment variable is present and non-empty";
-        return true;
+        if (result.value)
+        {
+            CELER_LOG(info) << "Killing Geant4 tracks supported by Celeritas "
+                               "offloading";
+        }
+        return result.value;
     }();
     static bool const disabled = [] {
-        if (celeritas::getenv("CELER_DISABLE").empty())
+        auto result = getenv_flag("CELER_DISABLE", false);
+        if (!result.value)
             return false;
 
         if (kill_offload)

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -134,11 +134,7 @@ int Device::num_devices()
 bool Device::debug()
 {
     static bool const result = [] {
-        if constexpr (CELERITAS_DEBUG)
-        {
-            return true;
-        }
-        return !celeritas::getenv("CELER_DEBUG_DEVICE").empty();
+        return getenv_flag("CELER_DEBUG_DEVICE", CELERITAS_DEBUG).value;
     }();
     return result;
 }

--- a/src/corecel/sys/KernelRegistry.cc
+++ b/src/corecel/sys/KernelRegistry.cc
@@ -26,11 +26,7 @@ namespace celeritas
 bool KernelRegistry::profiling()
 {
     static bool const result = [] {
-        if constexpr (CELERITAS_DEBUG)
-        {
-            return true;
-        }
-        return !celeritas::getenv("CELER_PROFILE_DEVICE").empty();
+        return getenv_flag("CELER_PROFILE_DEVICE", CELERITAS_DEBUG).value;
     }();
     return result;
 }


### PR DESCRIPTION
This changes the use of many environment variables such as `CELER_KILL_OFFLOAD` to use `getenv_flag`, which compares the *value* of the variable, rather than the non-emptiness of it. With this change, `CELER_KILL_OFFLOAD=0` will leave the flag disabled rather than setting it to 'on'.

It also fixes the logic on the (mostly useless) `CELER_STRIP_SOURCEDIR` flag default and allows a few hardcoded values to be disabled when building with debug assertions.