### PR TITLE
Allow multiple "activate device" calls if not modifying device

### DIFF
--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -345,7 +345,8 @@ void activate_device(Device&& device)
     std::lock_guard<std::mutex> scoped_lock{m};
     Device& d = global_device();
     CELER_VALIDATE(
-        !d, << R"(activate_device may be called only once per application)");
+        !d || d.device_id() == device.device_id(),
+        << R"(an active device is not allowed to change or deactivate during the run)");
 
     if (!device)
         return;

--- a/test/accel/CMakeLists.txt
+++ b/test/accel/CMakeLists.txt
@@ -47,11 +47,6 @@ set(_integration_tests
   UserActionIntegration
   TrackingManagerIntegration
 )
-
-# FIXME: test harness activate_device clashes with accel
-# (use a private CeleritasG4Tests variable to disable till the next PR)
-set(_disable_device TRUE)
-
 foreach(_basename IN LISTS _integration_tests)
   # Create the executable
   set(_target "${CELERITASTEST_DIR}_${_basename}")


### PR DESCRIPTION
This fixes an error @esseivaju / @drbenmorgan have run into with multiple runs and allows us to run the accel tests on GPU. (Previously the google test harness' device initialization conflicted with the one inside the accel helpers.)