### PR TITLE
Use double-precision energy for input energy distributions

### DIFF
--- a/src/celeritas/inp/Events.hh
+++ b/src/celeritas/inp/Events.hh
@@ -60,7 +60,9 @@ using AngleDistribution
 //! Generate primaries at a single energy value
 struct MonoenergeticDistribution
 {
-    units::MevEnergy energy;
+    using MevEnergy = Quantity<units::Mev, double>;
+
+    MevEnergy energy;
 };
 
 //! Choose an energy distribution for the primary generator

--- a/src/celeritas/phys/PrimaryGeneratorOptions.cc
+++ b/src/celeritas/phys/PrimaryGeneratorOptions.cc
@@ -49,13 +49,15 @@ void check_params_size(char const* sampler,
 // Helper: Convert energy distribution to inp::EnergyDistribution
 inp::EnergyDistribution inp_from_energy(DistributionOptions const& options)
 {
+    using MevEnergy = Quantity<units::Mev, double>;
+
     char const sampler_name[] = "energy";
     check_params_size(sampler_name, 1, options);
     auto const& p = options.params;
     switch (options.distribution)
     {
         case DistributionSelection::delta:
-            return inp::MonoenergeticDistribution{units::MevEnergy{p[0]}};
+            return inp::MonoenergeticDistribution{MevEnergy(p[0])};
         default:
             CELER_VALIDATE(false,
                            << "invalid distribution type '"

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -105,6 +105,17 @@ class Quantity
     {
     }
 
+    //! Construct with quantity of same unit but different value type
+    template<class ValueT2,
+             std::enable_if_t<!std::is_same_v<ValueT, ValueT2>
+                                  && std::is_convertible_v<ValueT2, ValueT>,
+                              int>
+             = 0>
+    CELER_CONSTEXPR_FUNCTION Quantity(Quantity<UnitT, ValueT2> other) noexcept
+        : value_(static_cast<ValueT>(other.value()))
+    {
+    }
+
     //!@{
     //! Access the underlying numeric value, discarding units
     CELER_CONSTEXPR_FUNCTION value_type& value() & noexcept { return value_; }

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -353,7 +353,7 @@ auto LarSphereIntegrationMixin::make_physics_input() const -> PhysicsInput
  */
 auto LarSphereIntegrationMixin::make_primary_input() const -> PrimaryInput
 {
-    using units::MevEnergy;
+    using MevEnergy = Quantity<units::Mev, double>;
 
     PrimaryInput result;
     result.pdg = {pdg::electron()};
@@ -395,7 +395,7 @@ auto TestEm3IntegrationMixin::make_physics_input() const -> PhysicsInput
  */
 auto TestEm3IntegrationMixin::make_primary_input() const -> PrimaryInput
 {
-    using units::MevEnergy;
+    using MevEnergy = Quantity<units::Mev, double>;
 
     PrimaryInput result;
     result.pdg = {pdg::electron()};

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -112,6 +112,10 @@ TEST(QuantityTest, mixed_precision)
     {
         auto two_dozen_flt = native_value_to<DozenFlt>(24);
         EXPECT_SOFT_EQ(2, two_dozen_flt.value());
+
+        DozenFlt demoted{4};
+        demoted = DozenDbl{6.5};
+        EXPECT_FLOAT_EQ(6.5f, demoted.value());
     }
 }
 


### PR DESCRIPTION
The `units::MevEnergy` quantity has precision `real_type`, but we've agreed to use `double` for all the input and move toward converting to `real_type` during the runtime. This adds an implicit conversion for quantities that share the same unit type.