### PR TITLE
Fix weight reconstruction for GeantSd

### DIFF
--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -92,6 +92,7 @@ GeantSd::GeantSd(ParticleParams const& par,
 
     // Convert setup options to step data
     selection_.particle = setup.track;
+    selection_.weight = setup.track;
     selection_.energy_deposition = setup.energy_deposition;
     selection_.step_length = setup.step_length;
     for (auto p : range(StepPoint::size_))

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -319,9 +319,6 @@ SetupOptions IntegrationTestBase::make_setup_options()
     // Use a uniform (zero) magnetic field
     opts.make_along_step = celeritas::UniformAlongStepFactory();
 
-    // FIXME: weight flag isn't being set in GeantSd
-    opts.sd.track = false;
-
     // Save diagnostic file to a unique name
     opts.output_file = this->make_unique_filename(".out.json");
     return opts;


### PR DESCRIPTION
There was one final missing propagation of flags/data in the long chain of code. Follow-on to #1853 .