### PR TITLE
Fix ORANGE surface normal calculation on boundary of daughter universes

### DIFF
--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -1334,7 +1334,8 @@ CELER_FUNCTION Real3 OrangeTrackView::geo_normal() const
     // Rotate normal up to global coordinates
     auto apply_transform = TransformVisitor{params_};
     auto rotate_up = [&normal](auto&& t) { normal = t.rotate_up(normal); };
-    for (auto level : range<int>(this->level().unchecked_get()).step(-1))
+    for (auto level :
+         range<int>(this->surface_level().unchecked_get()).step(-1))
     {
         apply_transform(rotate_up, this->get_transform(LevelId(level)));
     }

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -1326,10 +1326,10 @@ CELER_FUNCTION Real3 OrangeTrackView::geo_normal() const
     auto normal = [this] {
         auto lsa = this->make_lsa(this->surface_level());
         auto const& pos = lsa.pos();
-        auto surf = this->surf();
+        auto local_surf = this->surf();
         TrackerVisitor visit_tracker{params_};
         return visit_tracker(
-            [&](auto&& t) { return t.normal(pos, local_surface); },
+            [&](auto&& t) { return t.normal(pos, local_surf); },
             lsa.universe());
     }();
 

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -1323,21 +1323,23 @@ CELER_FUNCTION Real3 OrangeTrackView::geo_normal() const
 {
     CELER_EXPECT(this->is_on_boundary());
 
-    auto lsa = this->make_lsa(this->surface_level());
-    TrackerVisitor visit_tracker{params_};
-    auto normal = visit_tracker(
-        [pos = lsa.pos(), local_surface = this->surf()](auto&& t) {
-            return t.normal(pos, local_surface);
-        },
-        lsa.universe());
+    auto normal = [this] {
+        auto lsa = this->make_lsa(this->surface_level());
+        TrackerVisitor visit_tracker{params_};
+        return visit_tracker(
+            [pos = lsa.pos(), local_surface = this->surf()](auto&& t) {
+                return t.normal(pos, local_surface);
+            },
+            lsa.universe());
+    }();
 
     // Rotate normal up to global coordinates
     auto apply_transform = TransformVisitor{params_};
     auto rotate_up = [&normal](auto&& t) { normal = t.rotate_up(normal); };
-    for (auto level :
-         range<int>(this->surface_level().unchecked_get()).step(-1))
+    for (auto level : range<int>(this->surface_level().get()).step(-1))
     {
-        apply_transform(rotate_up, this->get_transform(LevelId(level)));
+        apply_transform(rotate_up,
+                        this->get_transform(id_cast<LevelId>(level)));
     }
 
     CELER_ENSURE(is_soft_unit_vector(normal));

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -1325,11 +1325,11 @@ CELER_FUNCTION Real3 OrangeTrackView::geo_normal() const
 
     auto normal = [this] {
         auto lsa = this->make_lsa(this->surface_level());
+        auto const& pos = lsa.pos();
+        auto surf = this->surf();
         TrackerVisitor visit_tracker{params_};
         return visit_tracker(
-            [pos = lsa.pos(), local_surface = this->surf()](auto&& t) {
-                return t.normal(pos, local_surface);
-            },
+            [&](auto&& t) { return t.normal(pos, local_surface); },
             lsa.universe());
     }();
 

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -918,6 +918,11 @@ void ReplicaGeoTest::test_trace() const
             0.13950317547305, 0.13950317547305, 0.13950317547305,
             0.13950317547309, 0.13950317547309, 131.90432759775, };
         // clang-format on
+        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_FLOAT)
+        {
+            // All along the track to soft precision
+            ref.clear_boring_normals();
+        }
 
         delete_orange_safety(*test_, ref, result);
         EXPECT_REF_NEAR(ref, result, tol);

--- a/test/orange/OrangeGeant.test.cc
+++ b/test/orange/OrangeGeant.test.cc
@@ -74,9 +74,6 @@ TEST_F(FourLevelsTest, detailed_track)
 class MultiLevelTest
     : public GenericGeoParameterizedTest<GeantOrangeTest, MultiLevelGeoTest>
 {
-  public:
-    // FIXME: normal is inconsistent between topbox3 and world_PV
-    bool supports_surface_normal() const override { return false; }
 };
 
 TEST_F(MultiLevelTest, trace)
@@ -125,10 +122,6 @@ class ReplicaTest
     : public GenericGeoParameterizedTest<GeantOrangeTest, ReplicaGeoTest>
 {
   public:
-    // FIXME: normal is inconsistent between fSecondArmPhys/HadCalScinti
-    // and world_PV
-    bool supports_surface_normal() const override { return false; }
-
     //! Distance is slightly off for single precision
     GenericGeoTrackingTolerance tracking_tol() const override
     {

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -63,12 +63,6 @@ class InputBuilderTest : public JsonOrangeTest
         return geometry_basename();
     }
 
-    // FIXME: normal is inconsistent between topbox3 and world_PV
-    bool supports_surface_normal() const override
-    {
-        return supports_surface_normal_;
-    }
-
   protected:
     bool supports_surface_normal_{true};
 


### PR DESCRIPTION
This fixes a bug in the calculation of surface normals identified in #1934 . When on the boundary of a universe (except for the top-level one), the *surface* level is less than (shallower/more global compared to) the *volume* level. This updates the transform loop to apply only from the surface level to the global level.