### PR TITLE
Use JSON reference for CSG tree

### DIFF
--- a/scripts/dev/update-reference-json.py
+++ b/scripts/dev/update-reference-json.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+# Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+Update reference JSON values in googletest C++ test files based on actual output.
+
+This script reads googletest output from stdin, parses failure messages to
+extract actual JSON values, and safely replaces the corresponding expected
+values in the source test files.
+
+(NOTE: this script was written using Claude 4.0 via Copilot; its goal is
+utility over style.)
+"""
+
+import sys
+import re
+import os
+
+
+def parse_gtest_output(output_text):
+    """Parse googletest output to extract file paths, line numbers, and actual JSON values."""
+    failures = []
+
+    # Pattern to match file path and line number
+    file_pattern = r'(.*\.cc):(\d+): Failure'
+
+    lines = output_text.split('\n')
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Look for failure location
+        file_match = re.search(file_pattern, line)
+        if file_match:
+            file_path = file_match.group(1)
+            line_number = int(file_match.group(2))
+
+            # Look ahead for the actual JSON value
+            j = i + 1
+            actual_json = None
+            is_empty_expected = False
+
+            # Check if this is an "expected is an empty string" case
+            while j < len(lines) and j < i + 10:  # Look ahead up to 10 lines
+                if 'expected is an empty string' in lines[j]:
+                    is_empty_expected = True
+                elif re.match(r'/\**\s*ACTUAL\s*\*+/', lines[j]):
+                    # Found the start of actual section, collect until /******/
+                    actual_section = []
+                    j += 1
+                    while j < len(lines) and '/******/' not in lines[j]:
+                        actual_section.append(lines[j])
+                        j += 1
+
+                    actual_text = '\n'.join(actual_section)
+
+                    # Extract JSON from R"json(...)json" format
+                    json_match = re.search(r'R"json\((.*?)\)json"', actual_text, re.DOTALL)
+                    if json_match:
+                        actual_json = json_match.group(1)
+                        break
+                j += 1
+
+            if actual_json is not None:
+                failures.append({
+                    'file_path': file_path,
+                    'line_number': line_number,
+                    'actual_json': actual_json,
+                    'is_empty_expected': is_empty_expected
+                })
+
+        i += 1
+
+    return failures
+
+
+def update_test_file(file_path, line_number, actual_json, is_empty_expected):
+    """Update the test file with the actual JSON value at the specified line."""
+    if not os.path.exists(file_path):
+        print(f"Warning: File not found: {file_path}")
+        return False
+
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+
+        if line_number > len(lines):
+            print(f"Warning: Line number {line_number} exceeds file length in {file_path}")
+            return False
+
+        # Find the line with EXPECT_JSON_EQ (may be on the exact line or nearby)
+        target_line_idx = None
+        search_start = max(0, line_number - 3)
+        search_end = min(len(lines), line_number + 3)
+
+        for i in range(search_start, search_end):
+            if 'EXPECT_JSON_EQ' in lines[i]:
+                target_line_idx = i
+                break
+
+        if target_line_idx is None:
+            print(f"Warning: Could not find EXPECT_JSON_EQ near line {line_number} in {file_path}")
+            return False
+
+        # Update the line with the new JSON value
+        line = lines[target_line_idx]
+
+        if is_empty_expected:
+            # Replace empty string with actual JSON
+            new_line = re.sub(
+                r'EXPECT_JSON_EQ\s*\(\s*""\s*,',
+                f'EXPECT_JSON_EQ(R"json({actual_json})json",',
+                line
+            )
+        else:
+            # Replace existing R"json(...)json" with new value
+            new_line = re.sub(
+                r'R"json\(.*?\)json"',
+                f'R"json({actual_json})json"',
+                line
+            )
+
+        if new_line != line:
+            lines[target_line_idx] = new_line
+
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.writelines(lines)
+
+            print(f"Updated {file_path}:{line_number}")
+            return True
+        else:
+            print(f"Warning: No changes made to {file_path}:{line_number}")
+            return False
+
+    except Exception as e:
+        print(f"Error updating {file_path}: {e}")
+        return False
+
+
+def main():
+    """Main function to process stdin and update test files."""
+    if sys.stdin.isatty():
+        print("Usage: python update-reference-json.py < gtest_output.txt")
+        print("This script reads googletest output from stdin and updates test files.")
+        return 1
+
+    # Read all input from stdin
+    output_text = sys.stdin.read()
+
+    # Parse the googletest output
+    failures = parse_gtest_output(output_text)
+
+    if not failures:
+        print("No JSON failures found in the input")
+        return 0
+
+    print(f"Found {len(failures)} JSON failures to update")
+
+    updated_count = 0
+    current_file = None
+    for failure in failures:
+        file_path = failure['file_path']
+        if file_path != current_file:
+            print(f"Processing {file_path}...")
+            current_file = file_path
+        if update_test_file(
+            file_path,
+            failure['line_number'],
+            failure['actual_json'],
+            failure['is_empty_expected']
+        ):
+            updated_count += 1
+
+    print(f"\nSuccessfully updated {updated_count} out of {len(failures)} files")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/dev/update-reference-json.py
+++ b/scripts/dev/update-reference-json.py
@@ -7,11 +7,9 @@ Update reference JSON values in googletest C++ test files based on actual output
 This script reads googletest output from stdin, parses failure messages to
 extract actual JSON values, and safely replaces the corresponding expected
 values in the source test files.
-
-(NOTE: this script was written using Claude 4.0 via Copilot; its goal is
-utility over style.)
 """
 
+import itertools
 import sys
 import re
 import os
@@ -22,120 +20,116 @@ def parse_gtest_output(output_text):
     failures = []
 
     # Pattern to match file path and line number
-    file_pattern = r'(.*\.cc):(\d+): Failure'
+    file_pattern = r"(.*\.cc):(\d+): Failure"
 
-    lines = output_text.split('\n')
-    i = 0
+    failures = []
+    lines_iter = iter(output_text.split("\n"))
 
-    while i < len(lines):
-        line = lines[i]
-
-        # Look for failure location
+    for line in lines_iter:
+        # Check for file path and line number in failure message
         file_match = re.search(file_pattern, line)
-        if file_match:
-            file_path = file_match.group(1)
-            line_number = int(file_match.group(2))
+        if not file_match:
+            continue
 
-            # Look ahead for the actual JSON value
-            j = i + 1
-            actual_json = None
-            is_empty_expected = False
+        # Found a new failure
+        file_path = file_match.group(1)
+        line_number = int(file_match.group(2))
 
-            # Check if this is an "expected is an empty string" case
-            while j < len(lines) and j < i + 10:  # Look ahead up to 10 lines
-                if 'expected is an empty string' in lines[j]:
-                    is_empty_expected = True
-                elif re.match(r'/\**\s*ACTUAL\s*\*+/', lines[j]):
-                    # Found the start of actual section, collect until /******/
-                    actual_section = []
-                    j += 1
-                    while j < len(lines) and '/******/' not in lines[j]:
-                        actual_section.append(lines[j])
-                        j += 1
+        # Skip lines until we find the actual JSON section
+        line = next(
+            itertools.dropwhile(
+                lambda l: not re.match(r"/\**\s*ACTUAL\s*\*+/", l), lines_iter
+            ),
+            None,
+        )
 
-                    actual_text = '\n'.join(actual_section)
+        if line is None:  # Handle case where we don't find ACTUAL marker
+            continue
 
-                    # Extract JSON from R"json(...)json" format
-                    json_match = re.search(r'R"json\((.*?)\)json"', actual_text, re.DOTALL)
-                    if json_match:
-                        actual_json = json_match.group(1)
-                        break
-                j += 1
+        # Collect actual JSON until the end marker
+        actual_section = list(
+            itertools.takewhile(lambda l: "/******/" not in l, lines_iter)
+        )
 
-            if actual_json is not None:
-                failures.append({
-                    'file_path': file_path,
-                    'line_number': line_number,
-                    'actual_json': actual_json,
-                    'is_empty_expected': is_empty_expected
-                })
-
-        i += 1
+        # Add the collected failure
+        failures.append(
+            {
+                "file_path": file_path,
+                "line_number": int(line_number),
+                "actual_json": "".join(actual_section),
+            }
+        )
 
     return failures
 
 
-def update_test_file(file_path, line_number, actual_json, is_empty_expected):
-    """Update the test file with the actual JSON value at the specified line."""
+def group_failures_by_file(failures):
+    """Group failures by file path and sort by line number."""
+    from collections import defaultdict
+
+    grouped = defaultdict(list)
+    for failure in failures:
+        grouped[failure["file_path"]].append(failure)
+
+    # Sort failures within each file by line number (descending so we update from bottom up)
+    for file_path in grouped:
+        grouped[file_path].sort(key=lambda x: x["line_number"])
+
+    return dict(grouped)
+
+
+def update_test_file_batch(file_path, failures):
+    """Update the test file with multiple JSON values in a single read/write operation."""
     if not os.path.exists(file_path):
         print(f"Warning: File not found: {file_path}")
-        return False
+        return 0
 
-    try:
-        with open(file_path, 'r', encoding='utf-8') as f:
-            lines = f.readlines()
+    with open(file_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    updated_count = 0
+
+    # Process failures in reverse line order to avoid line number shifts
+    for failure in reversed(failures):
+        line_number = failure["line_number"] - 1  # Convert to 0-based index
+        actual_json = failure["actual_json"]
 
         if line_number > len(lines):
-            print(f"Warning: Line number {line_number} exceeds file length in {file_path}")
-            return False
+            print(
+                f"Warning: Line number {line_number} exceeds file length in {file_path}"
+            )
+            continue
 
         # Find the line with EXPECT_JSON_EQ (may be on the exact line or nearby)
-        target_line_idx = None
-        search_start = max(0, line_number - 3)
-        search_end = min(len(lines), line_number + 3)
+        # Find the target line near the reported line number
+        orig = "".join(lines[line_number : line_number + 2])
 
-        for i in range(search_start, search_end):
-            if 'EXPECT_JSON_EQ' in lines[i]:
-                target_line_idx = i
-                break
-
-        if target_line_idx is None:
-            print(f"Warning: Could not find EXPECT_JSON_EQ near line {line_number} in {file_path}")
-            return False
-
-        # Update the line with the new JSON value
-        line = lines[target_line_idx]
-
-        if is_empty_expected:
-            # Replace empty string with actual JSON
-            new_line = re.sub(
-                r'EXPECT_JSON_EQ\s*\(\s*""\s*,',
-                f'EXPECT_JSON_EQ(R"json({actual_json})json",',
-                line
+        # Match the EXPECT_JSON_EQ pattern with capture groups
+        match = re.search(
+            r'\s*EXPECT_JSON_EQ\(\s*(R"json\(.*?\)json"|"[^"]*"),\s*', orig
+        )
+        if not match:
+            print(
+                f"  Warning: Could not parse EXPECT_JSON_EQ format at line {line_number + 1}"
             )
+            continue
+
+        # Replace only the expected JSON part while preserving surrounding code
+        new = orig[: match.start(1)] + actual_json.strip() + orig[match.end(1) :]
+
+        if new != orig:
+            lines[line_number : line_number + 2] = new
+            print(f"  Updated line {line_number}")
+            updated_count += 1
         else:
-            # Replace existing R"json(...)json" with new value
-            new_line = re.sub(
-                r'R"json\(.*?\)json"',
-                f'R"json({actual_json})json"',
-                line
-            )
+            print(f"  Warning: No changes made at line {line_number}")
 
-        if new_line != line:
-            lines[target_line_idx] = new_line
+    # Write the file only if we made changes
+    if updated_count > 0:
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
 
-            with open(file_path, 'w', encoding='utf-8') as f:
-                f.writelines(lines)
-
-            print(f"Updated {file_path}:{line_number}")
-            return True
-        else:
-            print(f"Warning: No changes made to {file_path}:{line_number}")
-            return False
-
-    except Exception as e:
-        print(f"Error updating {file_path}: {e}")
-        return False
+    return updated_count
 
 
 def main():
@@ -157,24 +151,24 @@ def main():
 
     print(f"Found {len(failures)} JSON failures to update")
 
-    updated_count = 0
-    current_file = None
-    for failure in failures:
-        file_path = failure['file_path']
-        if file_path != current_file:
-            print(f"Processing {file_path}...")
-            current_file = file_path
-        if update_test_file(
-            file_path,
-            failure['line_number'],
-            failure['actual_json'],
-            failure['is_empty_expected']
-        ):
-            updated_count += 1
+    # Group failures by file to minimize file I/O
+    grouped_failures = group_failures_by_file(failures)
 
-    print(f"\nSuccessfully updated {updated_count} out of {len(failures)} files")
+    total_updated_count = 0
+    for file_path, file_failures in grouped_failures.items():
+        print(f"\nProcessing {file_path} ({len(file_failures)} failures)...")
+        try:
+            updated_count = update_test_file_batch(file_path, file_failures)
+        except Exception as e:
+            print(f"Error updating {file_path}: {e}")
+            return 0
+        total_updated_count += updated_count
+
+    print(
+        f"\nSuccessfully updated {total_updated_count} out of {len(failures)} failures across {len(grouped_failures)} files"
+    )
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/dev/update-reference-json.py
+++ b/scripts/dev/update-reference-json.py
@@ -16,7 +16,8 @@ import os
 
 
 def parse_gtest_output(output_text):
-    """Parse googletest output to extract file paths, line numbers, and actual JSON values."""
+    """Parse googletest output to extract file paths, line numbers, and actual
+    JSON values."""
     failures = []
 
     # Pattern to match file path and line number
@@ -36,27 +37,21 @@ def parse_gtest_output(output_text):
         line_number = int(file_match.group(2))
 
         # Skip lines until we find the actual JSON section
-        line = next(
-            itertools.dropwhile(
-                lambda l: not re.match(r"/\**\s*ACTUAL\s*\*+/", l), lines_iter
-            ),
-            None,
-        )
-
-        if line is None:  # Handle case where we don't find ACTUAL marker
-            continue
+        for line in lines_iter:
+            if re.match(r"/\*+\s*ACTUAL\s*\*+/", line):
+                break
 
         # Collect actual JSON until the end marker
-        actual_section = list(
-            itertools.takewhile(lambda l: "/******/" not in l, lines_iter)
+        actual_section = "".join(
+            itertools.takewhile(lambda l: not re.match(r"/\*+/", l), lines_iter)
         )
 
         # Add the collected failure
         failures.append(
             {
                 "file_path": file_path,
-                "line_number": int(line_number),
-                "actual_json": "".join(actual_section),
+                "line_number": line_number,
+                "actual_json": actual_section,
             }
         )
 
@@ -71,7 +66,8 @@ def group_failures_by_file(failures):
     for failure in failures:
         grouped[failure["file_path"]].append(failure)
 
-    # Sort failures within each file by line number (descending so we update from bottom up)
+    # Sort failures within each file by line number (descending so we update
+    # from bottom up)
     for file_path in grouped:
         grouped[file_path].sort(key=lambda x: x["line_number"])
 
@@ -91,7 +87,9 @@ def update_test_file_batch(file_path, failures):
 
     # Process failures in reverse line order to avoid line number shifts
     for failure in reversed(failures):
-        line_number = failure["line_number"] - 1  # Convert to 0-based index
+        assert failure["file_path"] == file_path
+        line_number = failure["line_number"] - 1 # Convert to 0-based index
+        line_slc = slice(line_number - 2, line_number + 2)
         actual_json = failure["actual_json"]
 
         if line_number > len(lines):
@@ -100,9 +98,9 @@ def update_test_file_batch(file_path, failures):
             )
             continue
 
-        # Find the line with EXPECT_JSON_EQ (may be on the exact line or nearby)
-        # Find the target line near the reported line number
-        orig = "".join(lines[line_number : line_number + 2])
+        # Find the line with EXPECT_JSON_EQ (may be at beginning or end of
+        # macro
+        orig = "".join(lines[line_slc])
 
         # Match the EXPECT_JSON_EQ pattern with capture groups
         match = re.search(
@@ -118,7 +116,7 @@ def update_test_file_batch(file_path, failures):
         new = orig[: match.start(1)] + actual_json.strip() + orig[match.end(1) :]
 
         if new != orig:
-            lines[line_number : line_number + 2] = new
+            lines[line_slc] = new
             print(f"  Updated line {line_number}")
             updated_count += 1
         else:

--- a/test/orange/orangeinp/CsgTreeUtils.test.cc
+++ b/test/orange/orangeinp/CsgTreeUtils.test.cc
@@ -261,9 +261,9 @@ TEST_F(CsgTreeUtilsTest, postfix_simplify)
     // Imply inside boundary
     replace_and_simplify(&tree_, bdy, True{});
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: ->{0}, 3: ->{1}, 4: ->{0}, 5: surface 2, 6: not{5}, 7: ->{6}, 8: surface 3, 9: not{8}, 10: ->{9}, 11: ->{5}, 12: all{5,9}, 13: ->{0}, 14: ->{0}, 15: ->{0}, 16: all{5,6,9}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["=",0],["=",1],["=",0],["S",2],["~",5],["=",6],["S",3],["~",8],["=",9],["=",5],["&",[5,9]],["=",0],["=",0],["=",0],["&",[5,6,9]]])json",
+        to_json_string(tree_));
 
     // Test postfix builder with remapping
     {
@@ -299,9 +299,9 @@ TEST_F(CsgTreeUtilsTest, infix_simplify)
     auto bdy = this->insert(Joined{op_and, {bdy_outer, mz, below_pz}});
     auto zslab = this->insert(Joined{op_and, {mz, below_pz}});
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: surface 2, 6: not{5}, 7: all{2,4,6}, 8: surface 3, 9: not{8}, 10: all{2,4,9}, 11: not{7}, 12: all{2,4,9,11}, 13: surface 4, 14: all{2,4,13}, 15: all{2,4}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["S",2],["~",5],["&",[2,4,6]],["S",3],["~",8],["&",[2,4,9]],["~",7],["&",[2,4,9,11]],["S",4],["&",[2,4,13]],["&",[2,4]]])json",
+        to_json_string(tree_));
 
     // Test infix and internal surface flagger
     InternalSurfaceFlagger has_internal_surfaces(tree_);
@@ -434,9 +434,9 @@ TEST_F(CsgTreeUtilsTest, infix_simplify)
     // Imply inside boundary
     replace_and_simplify(&tree_, bdy, True{});
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: ->{0}, 3: ->{1}, 4: ->{0}, 5: surface 2, 6: not{5}, 7: ->{6}, 8: surface 3, 9: not{8}, 10: ->{9}, 11: ->{5}, 12: all{5,9}, 13: ->{0}, 14: ->{0}, 15: ->{0}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["=",0],["=",1],["=",0],["S",2],["~",5],["=",6],["S",3],["~",8],["=",9],["=",5],["&",[5,9]],["=",0],["=",0],["=",0]])json",
+        to_json_string(tree_));
 
     // Test infix builder with remapping
     {
@@ -474,16 +474,16 @@ TEST_F(CsgTreeUtilsTest, tilecal_polycone_bug)
     EXPECT_EQ(N{14}, this->insert(Negated{N{13}}));  // outside muon box
     EXPECT_EQ(N{15}, this->insert(Joined{op_and, {N{14}, N{11}}}));  // interior
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: surface 2, 6: all{2,4,5}, 7: surface 3, 8: not{7}, 9: surface 4, 10: all{3,8,9}, 11: any{6,10}, 12: not{11}, 13: surface 5, 14: not{13}, 15: all{11,14}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["S",2],["&",[2,4,5]],["S",3],["~",7],["S",4],["&",[3,8,9]],["|",[6,10]],["~",11],["S",5],["~",13],["&",[11,14]]])json",
+        to_json_string(tree_));
 
     // Imply inside boundary
     replace_and_simplify(&tree_, N{12}, True{});
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: surface 2, 6: ->{1}, 7: surface 3, 8: not{7}, 9: surface 4, 10: ->{1}, 11: ->{1}, 12: ->{0}, 13: surface 5, 14: not{13}, 15: ->{1}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["S",2],["=",1],["S",3],["~",7],["S",4],["=",1],["=",1],["=",0],["S",5],["~",13],["=",1]])json",
+        to_json_string(tree_));
 }
 
 //! Cylinder segment didn't correctly propagate logic
@@ -531,16 +531,16 @@ TEST_F(CsgTreeUtilsTest, tilecal_barrel_bug)
 
     EXPECT_EQ(29, tree_.size());
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: surface 2, 6: not{5}, 7: all{2,4,6}, 8: surface 3, 9: not{8}, 10: all{2,4,9}, 11: not{10}, 12: surface 4, 13: surface 5, 14: all{12,13}, 15: all{2,4,6,11,12,13}, 16: not{15}, 17: surface 6, 18: surface 7, 19: not{18}, 20: all{6,17,19}, 21: all{9,17,19}, 22: not{21}, 23: surface 8, 24: surface 9, 25: all{23,24}, 26: all{6,17,19,22,23,24}, 27: not{26}, 28: all{2,4,6,11,12,13,27}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["S",2],["~",5],["&",[2,4,6]],["S",3],["~",8],["&",[2,4,9]],["~",10],["S",4],["S",5],["&",[12,13]],["&",[2,4,6,11,12,13]],["~",15],["S",6],["S",7],["~",18],["&",[6,17,19]],["&",[9,17,19]],["~",21],["S",8],["S",9],["&",[23,24]],["&",[6,17,19,22,23,24]],["~",26],["&",[2,4,6,11,12,13,27]]])json",
+        to_json_string(tree_));
 
     EXPECT_EQ("!all(+0, -1, -2, !all(+0, -1, -3), +4, +5)",
               build_infix_string(tree_, N{16}));
     replace_and_simplify(&tree_, N{16}, False{});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: ->{0}, 3: ->{1}, 4: ->{0}, 5: ->{1}, 6: ->{0}, 7: ->{0}, 8: ->{0}, 9: ->{1}, 10: ->{1}, 11: ->{0}, 12: ->{0}, 13: ->{0}, 14: ->{0}, 15: ->{0}, 16: ->{1}, 17: surface 6, 18: surface 7, 19: not{18}, 20: all{17,19}, 21: ->{1}, 22: ->{0}, 23: surface 8, 24: surface 9, 25: all{23,24}, 26: all{17,19,23,24}, 27: not{26}, 28: ->{27}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["=",0],["=",1],["=",0],["=",1],["=",0],["=",0],["=",0],["=",1],["=",1],["=",0],["=",0],["=",0],["=",0],["=",0],["=",1],["S",6],["S",7],["~",18],["&",[17,19]],["=",1],["=",0],["S",8],["S",9],["&",[23,24]],["&",[17,19,23,24]],["~",26],["=",27]])json",
+        to_json_string(tree_));
 }
 
 TEST_F(CsgTreeUtilsTest, replace_union)
@@ -551,15 +551,15 @@ TEST_F(CsgTreeUtilsTest, replace_union)
     auto inside_b = this->insert(Negated{b});
     auto inside_a_or_b = this->insert(Joined{op_or, {inside_a, inside_b}});
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: not{3}, 6: any{4,5}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",2],["~",3],["|",[4,5]]])json",
+        to_json_string(tree_));
 
     // Imply inside neither
     replace_and_simplify(&tree_, inside_a_or_b, False{});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: ->{0}, 3: ->{0}, 4: ->{1}, 5: ->{1}, 6: ->{1}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["=",0],["=",0],["=",1],["=",1],["=",1]])json",
+        to_json_string(tree_));
 }
 
 TEST_F(CsgTreeUtilsTest, replace_union_2)
@@ -568,14 +568,14 @@ TEST_F(CsgTreeUtilsTest, replace_union_2)
     auto b = this->insert(S{1});
     this->insert(Negated{b});
     auto outside_a_or_b = this->insert(Joined{op_or, {a, b}});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: any{2,3}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["|",[2,3]]])json",
+        to_json_string(tree_));
 
     // Imply !(a | b) -> a & b
     replace_and_simplify(&tree_, outside_a_or_b, False{});
-    EXPECT_EQ("{0: true, 1: not{0}, 2: ->{1}, 3: ->{1}, 4: ->{0}, 5: ->{1}, }",
-              to_string(tree_));
+    EXPECT_JSON_EQ(R"json(["t",["~",0],["=",1],["=",1],["=",0],["=",1]])json",
+                   to_json_string(tree_));
 }
 
 TEST_F(CsgTreeUtilsTest, calc_surfaces)
@@ -596,15 +596,15 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
     auto j0 = this->insert(Joined{op_and, {s0, n0}});
 
     // Check a well-formed tree
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]]])json",
+        to_json_string(tree_));
     // Check that we have a noop
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -619,15 +619,15 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
     auto n1 = this->insert(Negated{j0});
 
     // Check a well-formed tree
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5]])json",
+        to_json_string(tree_));
     // Check an easy case with just a single negated operand
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: any{3,4}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["|",[3,4]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -642,17 +642,17 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
 
     // Check a well-formed tree
     auto j1 = this->insert(Joined{op_or, {s0, n0}});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, 7: any{2,4}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5],["|",[2,4]]])json",
+        to_json_string(tree_));
 
     // Check that the non-negated operand maps to correct new node_ids and
     // that not{2} is not deleted
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: not{4}, 6: any{3,4}, 7: any{2,5}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["~",4],["|",[3,4]],["|",[2,5]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -668,16 +668,16 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
 
     // Check a well-formed tree
     auto n2 = this->insert(Negated{j1});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, 7: any{2,4}, 8: not{7}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5],["|",[2,4]],["~",7]])json",
+        to_json_string(tree_));
     // Check that the two operands are transformed, removing dangling
     // operators
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: any{3,4}, 6: all{3,4}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["|",[3,4]],["&",[3,4]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -695,15 +695,15 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
     // Check a well-formed tree
     auto s2 = this->insert(Surface{S{2}});
     this->insert(Negated{s2});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, 7: any{2,4}, 8: not{7}, 9: surface 2, 10: not{9}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5],["|",[2,4]],["~",7],["S",2],["~",9]])json",
+        to_json_string(tree_));
     // Check that disjoint trees are correctly handled
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: any{3,4}, 6: all{3,4}, 7: surface 2, 8: not{7}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["|",[3,4]],["&",[3,4]],["S",2],["~",7]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -722,16 +722,16 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
 
     // Check a well-formed tree
     auto j2 = this->insert(Joined{op_and, {j0, j1}});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, 7: any{2,4}, 8: not{7}, 9: surface 2, 10: not{9}, 11: all{2,4,7}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5],["|",[2,4]],["~",7],["S",2],["~",9],["&",[2,4,7]]])json",
+        to_json_string(tree_));
 
     // Add a non-transformed operand with suboperands
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: not{4}, 6: any{3,4}, 7: all{3,4}, 8: any{2,5}, 9: surface 2, 10: not{9}, 11: all{2,5,8}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["~",4],["|",[3,4]],["&",[3,4]],["|",[2,5]],["S",2],["~",9],["&",[2,5,8]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -751,17 +751,17 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
 
     // Check a well-formed tree
     auto n3 = this->insert(Negated{j2});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, 7: any{2,4}, 8: not{7}, 9: surface 2, 10: not{9}, 11: all{2,4,7}, 12: not{11}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5],["|",[2,4]],["~",7],["S",2],["~",9],["&",[2,4,7]],["~",11]])json",
+        to_json_string(tree_));
 
     // Top-level operand is negated and should be simplified, no need to
     // duplicate intermediary Joined nodes
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: any{3,4}, 6: all{3,4}, 7: surface 2, 8: not{7}, 9: any{3,4,6}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["|",[3,4]],["&",[3,4]],["S",2],["~",7],["|",[3,4,6]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -782,16 +782,16 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
 
     // Check a well-formed tree
     auto j3 = this->insert(Joined{op_and, {n1, n2, n3}});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, 7: any{2,4}, 8: not{7}, 9: surface 2, 10: not{9}, 11: all{2,4,7}, 12: not{11}, 13: all{6,8,12}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5],["|",[2,4]],["~",7],["S",2],["~",9],["&",[2,4,7]],["~",11],["&",[6,8,12]]])json",
+        to_json_string(tree_));
 
     // Top-level joined has Negated{Joined{}} chldrens
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: any{3,4}, 6: all{3,4}, 7: surface 2, 8: not{7}, 9: any{3,4,6}, 10: all{3,4,5,9}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["|",[3,4]],["&",[3,4]],["S",2],["~",7],["|",[3,4,6]],["&",[3,4,5,9]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -813,16 +813,16 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
 
     // Check a well-formed tree
     this->insert(Negated{j3});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: not{5}, 7: any{2,4}, 8: not{7}, 9: surface 2, 10: not{9}, 11: all{2,4,7}, 12: not{11}, 13: all{6,8,12}, 14: not{13}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["~",5],["|",[2,4]],["~",7],["S",2],["~",9],["&",[2,4,7]],["~",11],["&",[6,8,12]],["~",13]])json",
+        to_json_string(tree_));
 
     // Complex case with a negated join with negated join as children
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: not{4}, 6: any{3,4}, 7: all{2,5}, 8: all{3,4}, 9: any{2,5}, 10: surface 2, 11: not{10}, 12: any{3,4,8}, 13: all{2,5,9}, 14: any{2,5,7,13}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["~",4],["|",[3,4]],["&",[2,5]],["&",[3,4]],["|",[2,5]],["S",2],["~",10],["|",[3,4,8]],["&",[2,5,9]],["|",[2,5,7,13]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -855,16 +855,16 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
     auto n4 = this->insert(Negated{s2});
     this->insert(Joined{op_and, {n3, n4}});
     // Check a well-formed tree
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: not{3}, 6: any{4,5}, 7: not{6}, 8: surface 2, 9: not{8}, 10: all{7,9}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",2],["~",3],["|",[4,5]],["~",6],["S",2],["~",8],["&",[7,9]]])json",
+        to_json_string(tree_));
 
     // Complex case with a negated join with negated children
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: all{2,3}, 5: surface 2, 6: not{5}, 7: all{2,3,6}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["S",1],["&",[2,3]],["S",2],["~",5],["&",[2,3,6]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -889,14 +889,14 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins)
     this->insert(Joined{op_and, {n0, n1}});
     j0 = this->insert(Joined{op_or, {n0, n1}});
     this->insert(Negated{j0});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: not{3}, 6: all{4,5}, 7: any{4,5}, 8: not{7}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",2],["~",3],["&",[4,5]],["|",[4,5]],["~",7]])json",
+        to_json_string(tree_));
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: not{3}, 6: all{4,5}, 7: all{2,3}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["S",1],["~",2],["~",3],["&",[4,5]],["&",[2,3]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -927,16 +927,16 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins_with_volumes)
     tree_.insert_volume(j1);
     tree_.insert_volume(n3);
     // Check a well-formed tree
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: not{3}, 6: any{4,5}, 7: not{6}, 8: surface 2, 9: not{8}, 10: all{7,9}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",2],["~",3],["|",[4,5]],["~",6],["S",2],["~",8],["&",[7,9]]])json",
+        to_json_string(tree_));
 
     // Complex case with a negated join with negated children
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{2}, 5: not{3}, 6: all{2,3}, 7: any{4,5}, 8: surface 2, 9: not{8}, 10: all{2,3,9}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["S",1],["~",2],["~",3],["&",[2,3]],["|",[4,5]],["S",2],["~",8],["&",[2,3,9]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -978,9 +978,9 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins_with_volumes)
     tree_.insert_volume(inner_cyl);
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: not{4}, 6: surface 2, 7: not{6}, 8: any{3,4,6}, 9: all{2,5,7}, 10: surface 3, 11: not{10}, 12: all{2,5,11}, 13: all{2,5,8,11}, 14: surface 4, 15: all{2,5,14}, 16: all{2,5}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["~",4],["S",2],["~",6],["|",[3,4,6]],["&",[2,5,7]],["S",3],["~",10],["&",[2,5,11]],["&",[2,5,8,11]],["S",4],["&",[2,5,14]],["&",[2,5]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},
@@ -1047,16 +1047,16 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins_with_volumes)
     EXPECT_EQ(N{27}, this->insert(Negated{N{26}}));
     EXPECT_EQ(N{28}, this->insert(Joined{op_and, {N{15}, N{27}}}));
 
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: surface 2, 6: not{5}, 7: all{2,4,6}, 8: surface 3, 9: not{8}, 10: all{2,4,9}, 11: not{10}, 12: surface 4, 13: surface 5, 14: all{12,13}, 15: all{2,4,6,11,12,13}, 16: not{15}, 17: surface 6, 18: surface 7, 19: not{18}, 20: all{6,17,19}, 21: all{9,17,19}, 22: not{21}, 23: surface 8, 24: surface 9, 25: all{23,24}, 26: all{6,17,19,22,23,24}, 27: not{26}, 28: all{2,4,6,11,12,13,27}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["S",2],["~",5],["&",[2,4,6]],["S",3],["~",8],["&",[2,4,9]],["~",10],["S",4],["S",5],["&",[12,13]],["&",[2,4,6,11,12,13]],["~",15],["S",6],["S",7],["~",18],["&",[6,17,19]],["&",[9,17,19]],["~",21],["S",8],["S",9],["&",[23,24]],["&",[6,17,19,22,23,24]],["~",26],["&",[2,4,6,11,12,13,27]]])json",
+        to_json_string(tree_));
 
     tree_.insert_volume(N{16});
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: not{4}, 6: surface 2, 7: not{6}, 8: all{2,5,7}, 9: surface 3, 10: not{9}, 11: any{3,4,9}, 12: all{2,5,10}, 13: surface 4, 14: not{13}, 15: surface 5, 16: not{15}, 17: all{13,15}, 18: any{3,4,6,12,14,16}, 19: surface 6, 20: not{19}, 21: surface 7, 22: not{21}, 23: all{7,19,22}, 24: any{9,20,21}, 25: all{10,19,22}, 26: surface 8, 27: not{26}, 28: surface 9, 29: not{28}, 30: all{26,28}, 31: any{6,20,21,25,27,29}, 32: all{2,5,7,11,13,15,31}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["~",4],["S",2],["~",6],["&",[2,5,7]],["S",3],["~",9],["|",[3,4,9]],["&",[2,5,10]],["S",4],["~",13],["S",5],["~",15],["&",[13,15]],["|",[3,4,6,12,14,16]],["S",6],["~",19],["S",7],["~",21],["&",[7,19,22]],["|",[9,20,21]],["&",[10,19,22]],["S",8],["~",26],["S",9],["~",28],["&",[26,28]],["|",[6,20,21,25,27,29]],["&",[2,5,7,11,13,15,31]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[] = {
             N{0},  N{1},  N{2},  N{4},  N{5},  N{6},  N{7},  N{8},
             N{9},  N{10}, N{12}, N{11}, N{13}, N{15}, N{17}, N{},
@@ -1079,14 +1079,14 @@ TEST_F(CsgTreeUtilsTest, transform_negated_joins_with_aliases)
     auto j0 = this->insert(Joined{op_and, {s0, n0}});
     auto a0 = this->insert(Aliased{j0});
     this->insert(Negated{a0});
-    EXPECT_EQ(
-        R"({0: true, 1: not{0}, 2: surface 0, 3: surface 1, 4: not{3}, 5: all{2,4}, 6: ->{5}, 7: not{5}, })",
-        to_string(tree_));
+    EXPECT_JSON_EQ(
+        R"json(["t",["~",0],["S",0],["S",1],["~",3],["&",[2,4]],["=",5],["~",5]])json",
+        to_json_string(tree_));
     {
         auto simplified = transform_negated_joins(tree_);
-        EXPECT_EQ(
-            R"({0: true, 1: not{0}, 2: surface 0, 3: not{2}, 4: surface 1, 5: not{4}, 6: any{3,4}, 7: all{2,5}, })",
-            to_string(simplified.tree));
+        EXPECT_JSON_EQ(
+            R"json(["t",["~",0],["S",0],["~",2],["S",1],["~",4],["|",[3,4]],["&",[2,5]]])json",
+            to_json_string(simplified.tree));
         constexpr N expected_new_nodes[]{
             N{0},
             N{1},

--- a/test/testdetail/TestMacrosImpl.cc
+++ b/test/testdetail/TestMacrosImpl.cc
@@ -77,14 +77,13 @@ trunc_string(unsigned int digits, char const* str, char const* trunc)
     auto result = compare(expected, actual);
     if (!result)
     {
-        // Delete newlines from replacement
-        std::string new_actual{actual};
-        new_actual.erase(
-            std::remove(new_actual.begin(), new_actual.end(), '\n'),
-            new_actual.end());
+        // Delete newlines from replacement by copying and erasing \n
+        std::string oneline{actual};
+        oneline.erase(std::remove(oneline.begin(), oneline.end(), '\n'),
+                      oneline.end());
 
         // Print actual result for copy-pasting into "expected" expression
-        result << "\n/*** ACTUAL ***/\nR\"json(" << new_actual
+        result << "\n/*** ACTUAL ***/\nR\"json(" << oneline
                << ")json\"\n/******/";
     }
     return result;

--- a/test/testdetail/TestMacrosImpl.cc
+++ b/test/testdetail/TestMacrosImpl.cc
@@ -77,8 +77,14 @@ trunc_string(unsigned int digits, char const* str, char const* trunc)
     auto result = compare(expected, actual);
     if (!result)
     {
+        // Delete newlines from replacement
+        std::string new_actual{actual};
+        new_actual.erase(
+            std::remove(new_actual.begin(), new_actual.end(), '\n'),
+            new_actual.end());
+
         // Print actual result for copy-pasting into "expected" expression
-        result << "\n/*** ACTUAL ***/\nR\"json(" << actual
+        result << "\n/*** ACTUAL ***/\nR\"json(" << new_actual
                << ")json\"\n/******/";
     }
     return result;


### PR DESCRIPTION
I'm making some simplification improvements to the CSG tree simplification and wanted to be able to do a more detailed comparison than "string not equal". This rebaselines the CsgTree test to use `EXPECT_JSON_EQ` with the help of a Copilot-assisted script.