### PR TITLE
Fix initialization when starting on an internal surface

### DIFF
--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -176,6 +176,7 @@ SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
     // a surface in the found volume
     detail::OnFace on_surface;
     auto is_inside = [this, &state, &on_surface](LocalVolumeId id) -> bool {
+        on_surface = {};
         VolumeView vol = this->make_local_volume(id);
         auto calc_senses = detail::LazySenseCalculator(
             this->make_surface_visitor(), vol, state.pos, on_surface);

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -23,6 +23,14 @@
 #include "detail/Types.hh"
 #include "detail/Utils.hh"
 
+#if 1
+#    include <iostream>
+
+#    include "corecel/OpaqueIdIO.hh"
+using std::cout;
+using std::endl;
+#endif
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -161,10 +169,6 @@ SimpleUnitTracker::SimpleUnitTracker(ParamsRef const& params, SimpleUnitId suid)
  *
  * To avoid edge cases and inconsistent logical/physical states, it is
  * prohibited to initialize from an arbitrary point directly onto a surface.
- *
- * \todo This prohibition currently also extends to *internal* surfaces, even
- * if both sides of that surface are "in" the current cell. We may need to
- * relax that.
  */
 CELER_FUNCTION auto
 SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
@@ -176,10 +180,18 @@ SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
     // a surface in the found volume
     detail::OnFace on_surface;
     auto is_inside = [this, &state, &on_surface](LocalVolumeId id) -> bool {
+        cout << "-> Testing volume " << id;
+        if (on_surface)
+        {
+            cout << " on face " << on_surface.id();
+        }
+        cout << endl;
         VolumeView vol = this->make_local_volume(id);
         auto calc_senses = detail::LazySenseCalculator(
             this->make_surface_visitor(), vol, state.pos, on_surface);
-        return detail::LogicEvaluator(vol.logic())(calc_senses);
+        auto result = detail::LogicEvaluator(vol.logic())(calc_senses);
+        cout << "<- " << (result ? "inside" : "not inside") << endl;
+        return result;
     };
     LocalVolumeId id = this->find_volume_where(state.pos, is_inside);
 

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -23,14 +23,6 @@
 #include "detail/Types.hh"
 #include "detail/Utils.hh"
 
-#if 1
-#    include <iostream>
-
-#    include "corecel/OpaqueIdIO.hh"
-using std::cout;
-using std::endl;
-#endif
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -169,6 +161,10 @@ SimpleUnitTracker::SimpleUnitTracker(ParamsRef const& params, SimpleUnitId suid)
  *
  * To avoid edge cases and inconsistent logical/physical states, it is
  * prohibited to initialize from an arbitrary point directly onto a surface.
+ *
+ * \todo This prohibition currently also extends to *internal* surfaces, even
+ * if both sides of that surface are "in" the current cell. We may need to
+ * relax that.
  */
 CELER_FUNCTION auto
 SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
@@ -180,18 +176,10 @@ SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
     // a surface in the found volume
     detail::OnFace on_surface;
     auto is_inside = [this, &state, &on_surface](LocalVolumeId id) -> bool {
-        cout << "-> Testing volume " << id;
-        if (on_surface)
-        {
-            cout << " on face " << on_surface.id();
-        }
-        cout << endl;
         VolumeView vol = this->make_local_volume(id);
         auto calc_senses = detail::LazySenseCalculator(
             this->make_surface_visitor(), vol, state.pos, on_surface);
-        auto result = detail::LogicEvaluator(vol.logic())(calc_senses);
-        cout << "<- " << (result ? "inside" : "not inside") << endl;
-        return result;
+        return detail::LogicEvaluator(vol.logic())(calc_senses);
     };
     LocalVolumeId id = this->find_volume_where(state.pos, is_inside);
 

--- a/src/orange/univ/detail/LazySenseCalculator.hh
+++ b/src/orange/univ/detail/LazySenseCalculator.hh
@@ -16,6 +16,14 @@
 #include "Types.hh"
 #include "../VolumeView.hh"
 
+#if 1
+#    include <iostream>
+
+#    include "corecel/OpaqueIdIO.hh"
+using std::cout;
+using std::endl;
+#endif
+
 namespace celeritas
 {
 namespace detail
@@ -100,6 +108,11 @@ CELER_FUNCTION auto LazySenseCalculator::operator()(FaceId face_id) -> Sense
         {
             // This is the first face that we're exactly on: save it
             face_ = {face_id, sense};
+            cout << " * Saving face " << face_id << endl;
+        }
+        else if (ss == SignedSense::on)
+        {
+            cout << " * Ignoring face " << face_id << endl;
         }
     }
     else

--- a/src/orange/univ/detail/LazySenseCalculator.hh
+++ b/src/orange/univ/detail/LazySenseCalculator.hh
@@ -16,14 +16,6 @@
 #include "Types.hh"
 #include "../VolumeView.hh"
 
-#if 1
-#    include <iostream>
-
-#    include "corecel/OpaqueIdIO.hh"
-using std::cout;
-using std::endl;
-#endif
-
 namespace celeritas
 {
 namespace detail
@@ -108,11 +100,6 @@ CELER_FUNCTION auto LazySenseCalculator::operator()(FaceId face_id) -> Sense
         {
             // This is the first face that we're exactly on: save it
             face_ = {face_id, sense};
-            cout << " * Saving face " << face_id << endl;
-        }
-        else if (ss == SignedSense::on)
-        {
-            cout << " * Ignoring face " << face_id << endl;
         }
     }
     else

--- a/test/geocel/GenericGeoResults.cc
+++ b/test/geocel/GenericGeoResults.cc
@@ -150,7 +150,8 @@ void GenericGeoTrackingResult::print_expected() const
     {
         IRE_VEC_SOFT_EQ(dot_normal, tol.normal);
     }
-    IRE_VEC_SOFT_EQ(halfway_safeties, SoftEqual(tol.safety, tol.safety));
+    IRE_VEC_SOFT_EQ(halfway_safeties,
+                    EqualOr{SoftEqual(tol.safety, tol.safety)});
     IRE_VEC_SOFT_EQ(bumps, SoftEqual(tol.safety, tol.safety));
 
 #undef IRE_VEC_EQ

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -762,6 +762,43 @@ TEST_F(InputBuilderTest, globalspheres)
 }
 
 //---------------------------------------------------------------------------//
+
+TEST_F(InputBuilderTest, lar_split_detector)
+{
+    {
+        auto result = this->track({0, 0, -16}, {0, 0, 1});
+
+        GenericGeoTrackingResult ref;
+        ref.volumes = {
+            "[OUTSIDE]",
+            "outer_region",
+            "lower_shell",
+            "inner",
+            "upper_shell",
+            "outer_region",
+        };
+        ref.volume_instances = {
+            "outer_region@global",
+            "lower_shell@global",
+            "inner@global",
+            "upper_shell@global",
+            "outer_region@global",
+        };
+        ref.distances = {1, 5, 5, 10, 5, 5};
+        ref.halfway_safeties = {2.5, 2.5, inf, 2.5, 2.5};
+        ref.bumps = {};
+        auto tol = this->tracking_tol();
+        EXPECT_REF_NEAR(ref, result, tol);
+    }
+
+    {
+        SCOPED_TRACE("Initialize on irrelevant surface");
+        auto geo = this->make_geo_track_view();
+        EXPECT_NO_THROW((geo = Initializer_t{{1, 2, 0}, {0, 0, 1}}));
+    }
+}
+
+//---------------------------------------------------------------------------//
 TEST_F(InputBuilderTest, bgspheres)
 {
     {

--- a/test/orange/data/inputbuilder-lar-split-detector.org.json
+++ b/test/orange/data/inputbuilder-lar-split-detector.org.json
@@ -1,0 +1,145 @@
+{
+"_format": "ORANGE",
+"_version": 0,
+"tol": {
+"abs": 1e-05,
+"rel": 1e-05
+},
+"universes": [
+{
+"_type": "unit",
+"background": null,
+"bbox": [
+[
+-15.0,
+-15.0,
+-15.0
+],
+[
+15.0,
+15.0,
+15.0
+]
+],
+"md": {
+"name": "global"
+},
+"surface_labels": [
+"[EXTERIOR]",
+"middle@s",
+"inner@s",
+"negsplit"
+],
+"surfaces": {
+"data": [
+225.0,
+100.0,
+25.0,
+0.0
+],
+"sizes": [
+1,
+1,
+1,
+1
+],
+"types": [
+"sc",
+"sc",
+"sc",
+"pz"
+]
+},
+"volume_labels": [
+"[EXTERIOR]@global",
+"outer_region",
+"null_subtracted_daughters",
+"lower_shell",
+"upper_shell",
+"inner"
+],
+"volumes": [
+{
+"faces": [
+0
+],
+"logic": "0"
+},
+{
+"bbox": [
+[
+-15.0,
+-15.0,
+-15.0
+],
+[
+15.0,
+15.0,
+15.0
+]
+],
+"faces": [
+0,
+1
+],
+"logic": "0 ~ 1 &"
+},
+{
+"bbox": [
+[
+-10.0,
+-10.0,
+-10.0
+],
+[
+10.0,
+10.0,
+10.0
+]
+],
+"faces": [
+1,
+2,
+3
+],
+"flags": 1,
+"logic": "0 ~ 1 & 0 ~ 1 & 2 ~ & ~ & 0 ~ 1 & 2 & ~ &"
+},
+{
+"faces": [
+1,
+2,
+3
+],
+"logic": "0 ~ 1 & 2 ~ &"
+},
+{
+"faces": [
+1,
+2,
+3
+],
+"logic": "0 ~ 1 & 2 &"
+},
+{
+"bbox": [
+[
+-5.0,
+-5.0,
+-5.0
+],
+[
+5.0,
+5.0,
+5.0
+]
+],
+"faces": [
+2
+],
+"logic": "0 ~"
+}
+]
+}
+]
+}

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -564,7 +564,7 @@ TEST_F(InputBuilderTest, lar_split_detector)
             "full_shell",
             {{Sense::inside, middle_sphere}, {Sense::outside, inner_sphere}});
 
-        // Construct exterior, shell, shell halvs, interior
+        // Construct exterior, shell, shell halves, interior
         append_material(inp,
                         make_rdv("outer_region",
                                  {{Sense::inside, inp.boundary.interior},

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -14,6 +14,7 @@
 #include "corecel/io/Join.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
+#include "geocel/Types.hh"
 #include "orange/OrangeInputIO.json.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/orangeinp/CsgObject.hh"
@@ -526,6 +527,61 @@ TEST_F(InputBuilderTest, globalspheres)
                                   {Sense::outside, inner}}),
                         1);
         append_material(inp, std::move(inner), 2);
+        return inp;
+    }()};
+
+    this->run_test(global);
+}
+
+TEST_F(InputBuilderTest, lar_split_detector)
+{
+    UnitProto global{[] {
+        UnitProto::Input inp;
+        inp.boundary.interior = make_sph("outer_bound", 15.0);
+        inp.boundary.zorder = ZOrder::media;
+        inp.label = "global";
+
+        auto inner_sphere = make_sph("inner", 5.0);
+        auto middle_sphere = make_sph("middle", 10.0);
+
+        auto split = std::make_shared<Shape<InfPlane>>(
+            "split", InfPlane{Sense::inside, Axis::z, 0});
+        auto lower_half = std::make_shared<AllObjects>(
+            "lower_half", AllObjects::VecObject{middle_sphere, split});
+        auto upper_half = std::make_shared<AllObjects>(
+            "upper_half",
+            AllObjects::VecObject{
+                middle_sphere,
+                std::make_shared<NegatedObject>("negsplit", split)});
+
+        auto lower_shell = make_rdv(
+            "lower_shell",
+            {{Sense::inside, lower_half}, {Sense::outside, inner_sphere}});
+        auto upper_shell = make_rdv(
+            "upper_shell",
+            {{Sense::inside, upper_half}, {Sense::outside, inner_sphere}});
+        auto full_shell = make_rdv(
+            "full_shell",
+            {{Sense::inside, middle_sphere}, {Sense::outside, inner_sphere}});
+
+        // Construct exterior, shell, shell halvs, interior
+        append_material(inp,
+                        make_rdv("outer_region",
+                                 {{Sense::inside, inp.boundary.interior},
+                                  {Sense::outside, middle_sphere}}),
+                        4);
+        append_material(inp,
+                        make_rdv("null_subtracted_daughters",
+                                 {
+                                     {Sense::inside, full_shell},
+                                     {Sense::outside, lower_shell},
+                                     {Sense::outside, upper_shell},
+                                 }),
+                        0);
+        append_material(inp, std::move(lower_shell), 2);
+        append_material(inp, std::move(upper_shell), 3);
+        append_material(inp, std::move(inner_sphere), 1);
+
         return inp;
     }()};
 


### PR DESCRIPTION
While trying to add a split shell around the lAr detector I found that ORANGE crashed when starting tracks at the origin. To make a long story short, we were using the `on_surface` local variable as a side effect return object for when we found a legitimate volume. However, if an earlier volume tried to initialize "on" a surface but wasn't in that volume after all, we wouldn't clear the on-surface flag before testing the next volume.