### PR TITLE
Create placeholder SDs when loading GeantGeoParams from GDML

### DIFF
--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -59,7 +59,7 @@ if(CELERITAS_USE_Geant4)
     g4/detail/GeantGeoNavCollection.cc
   )
 
-  celeritas_get_g4libs(_cg4_libs global geometry materials particles
+  celeritas_get_g4libs(_cg4_libs global geometry digits_hits materials particles
     persistency intercoms)
   celeritas_target_link_libraries(geocel_geant4
     PRIVATE

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -20,6 +20,7 @@
 #include <G4Transportation.hh>
 #include <G4TransportationManager.hh>
 #include <G4VPhysicalVolume.hh>
+#include <G4VSensitiveDetector.hh>
 #include <G4VSolid.hh>
 #include <G4Version.hh>
 #include <G4VisExtent.hh>
@@ -389,6 +390,19 @@ std::vector<inp::Surface> make_inp_surfaces(GeantGeoParams const& geo)
 std::weak_ptr<GeantGeoParams const> g_geant_geo_;
 
 //---------------------------------------------------------------------------//
+//! Placeholder SD class for generating model data from GDML
+class GdmlSensitiveDetector final : public G4VSensitiveDetector
+{
+  public:
+    GdmlSensitiveDetector(std::string const& name) : G4VSensitiveDetector{name}
+    {
+    }
+
+    void Initialize(G4HCofThisEvent*) final {}
+    bool ProcessHits(G4Step*, G4TouchableHistory*) final { return false; }
+};
+
+//---------------------------------------------------------------------------//
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -456,6 +470,8 @@ std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
  * This assumes that Celeritas is driving and will manage Geant4 logging
  * and exceptions. It saves the result to the global Celeritas Geant4 geometry
  * weak pointer \c global_geant_geo.
+ *
+ * It also loads sensitive detectors and assigns dummy
  */
 std::shared_ptr<GeantGeoParams>
 GeantGeoParams::from_gdml(std::string const& filename)
@@ -472,8 +488,41 @@ GeantGeoParams::from_gdml(std::string const& filename)
         CELER_LOG(warning) << "Expected '.gdml' extension for GDML input";
     }
 
-    auto result = std::make_shared<GeantGeoParams>(load_gdml(filename),
-                                                   Ownership::value);
+    // Load world and detectors
+    auto loaded = [&filename] {
+        GeantGdmlLoader::Options opts;
+        opts.detectors = true;
+        GeantGdmlLoader load(opts);
+        return load(filename);
+    }();
+
+    // Build placeholder SD
+    using MapDetCIter = GeantGdmlLoader::MapDetectors::const_iterator;
+    GeantGeoParams::MapStrDetector built_detectors;
+    foreach_detector(
+        loaded.detectors,
+        [&built_detectors](MapDetCIter iter, MapDetCIter stop) {
+            // Construct an SD based on the name
+            auto sd = std::make_shared<GdmlSensitiveDetector>(iter->first);
+            built_detectors.emplace(iter->first, sd);
+
+            // Attach sensitive detectors
+            for (; iter != stop; ++iter)
+            {
+                CELER_LOG(debug)
+                    << "Attaching dummy GDML SD '" << sd->GetName()
+                    << "' to volume '" << iter->second->GetName() << "'";
+                iter->second->SetSensitiveDetector(sd.get());
+            }
+        });
+
+    // Create geo params
+    auto result
+        = std::make_shared<GeantGeoParams>(loaded.world, Ownership::value);
+    // Set detectors (hack)
+    result->built_detectors_ = std::move(built_detectors);
+
+    // Save for use outside in Celeritas
     celeritas::global_geant_geo(result);
     return result;
 }

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -471,7 +471,18 @@ std::shared_ptr<GeantGeoParams> GeantGeoParams::from_tracking_manager()
  * and exceptions. It saves the result to the global Celeritas Geant4 geometry
  * weak pointer \c global_geant_geo.
  *
- * It also loads sensitive detectors and assigns dummy
+ * Due to limitations in the Geant4 GDML code, this task \c must be performed
+ * from the main thread.
+ *
+ * It also loads sensitive detectors and assigns dummy sensitive detectors to
+ * volumes annotated with <code>auxiliary auxtype="SensDet"</code> tags. It
+ * creates one detector per unique \c auxvalue name and shares that one among
+ * the volumes that use the same detector name. The resulting \c GeantGeoParams
+ * class retains ownership of the created detectors. Since this function is
+ * only called on the main thread, and the \c SensitiveDetector getter/setter
+ * on \c G4LogicalVolume uses a thread-local "split" class, <em>worker threads
+ * will not see the sensitive detectors this loader creates</em>. Use \c
+ * celeritas::DetectorConstruction if thread-local detectors are needed.
  */
 std::shared_ptr<GeantGeoParams>
 GeantGeoParams::from_gdml(std::string const& filename)

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 
@@ -26,6 +27,7 @@
 class G4LogicalSurface;
 class G4Material;
 class G4VPhysicalVolume;
+class G4VSensitiveDetector;
 
 namespace celeritas
 {
@@ -63,6 +65,10 @@ namespace celeritas
  * Geant4 object pointers, which is what the Geant4 implementation stores in a
  * table).  Surface labels are accessed via the SurfaceParams object, which can
  * be created by the model input returned by this class.
+ *
+ * \todo Much of the conversion should be factored out into a separate Model
+ * class which provides adapters to materials, detectors, and geometry
+ * structure.
  */
 class GeantGeoParams final : public GeoParamsInterface,
                              public ParamsDataInterface<GeantGeoParamsData>
@@ -161,10 +167,14 @@ class GeantGeoParams final : public GeoParamsInterface,
     }
 
   private:
+    using MapStrDetector
+        = std::map<std::string, std::shared_ptr<G4VSensitiveDetector>>;
+
     //// DATA ////
 
     Ownership ownership_{Ownership::reference};
     bool closed_geometry_{false};
+    MapStrDetector built_detectors_;
 
     // Host metadata/access
     ImplVolumeMap impl_volumes_;

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -7,6 +7,7 @@
 #include <regex>
 #include <string_view>
 #include <G4LogicalVolume.hh>
+#include <G4VSensitiveDetector.hh>
 
 #include "corecel/Config.hh"
 
@@ -408,6 +409,21 @@ TEST_F(MultiLevelTest, model)
     };
     ref.world = "world";
     EXPECT_REF_EQ(ref, result);
+}
+
+TEST_F(MultiLevelTest, sd_creation)
+{
+    auto const& geo = *this->geometry();
+
+    auto* lv = geo.id_to_geant(VolumeId{0});  // sph; see model above
+    auto* sd = lv->GetSensitiveDetector();
+    ASSERT_TRUE(sd);
+    EXPECT_EQ("sph_sd", sd->GetName());
+
+    auto* lv2 = geo.id_to_geant(VolumeId{5});  // sph_refl
+    auto* sd2 = lv2->GetSensitiveDetector();
+    ASSERT_TRUE(sd2);
+    EXPECT_EQ(sd, sd2);
 }
 
 TEST_F(MultiLevelTest, trace)


### PR DESCRIPTION
To support #1750 we want to be able to test that SDs get loaded from users (or GDML input). This adds a little code during GeantGeoParams setup that creates dummy SDs based on the aux data loaded from the GDML file. They can be replaced without consequence by the user or left in place.