### PR TITLE
Fix sincos on device when math/Turn.hh is included

### DIFF
--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -729,7 +729,7 @@ CELER_FORCEINLINE_FUNCTION double rsqrt(double value)
 }
 
 #if defined(CELER_DEVICE_SOURCE)
-// CUDA/HIP define in global namespace
+// CUDA/HIP define ::sinpi, ::sincos, ... (in global namespace)
 #    define CELER_SINCOS_MANGLED(FUNC) ::FUNC
 #elif defined(CELERITAS_SINCOSPI_PREFIX)
 // Apple-supplied headers define __sinpi, __sinpif, __sincospi, ...

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -728,19 +728,19 @@ CELER_FORCEINLINE_FUNCTION double rsqrt(double value)
 #endif
 }
 
-#ifndef CELER_DEVICE_SOURCE
-// CUDA/HIP define sinpi, cospi, sinpif, cospif, ...
-#    ifdef CELERITAS_SINCOSPI_PREFIX
+#if defined(CELER_DEVICE_SOURCE)
+// CUDA/HIP define in global namespace
+#    define CELER_SINCOS_MANGLED(FUNC) ::FUNC
+#elif defined(CELERITAS_SINCOSPI_PREFIX)
 // Apple-supplied headers define __sinpi, __sinpif, __sincospi, ...
-#        define CELER_CONCAT_IMPL(PREFIX, FUNC) PREFIX##FUNC
-#        define CELER_CONCAT(PREFIX, FUNC) CELER_CONCAT_IMPL(PREFIX, FUNC)
-#        define CELER_SINCOS_MANGLED(FUNC) \
-            CELER_CONCAT(CELERITAS_SINCOSPI_PREFIX, FUNC)
-#    else
+#    define CELER_CONCAT_IMPL(PREFIX, FUNC) PREFIX##FUNC
+#    define CELER_CONCAT(PREFIX, FUNC) CELER_CONCAT_IMPL(PREFIX, FUNC)
+#    define CELER_SINCOS_MANGLED(FUNC) \
+        CELER_CONCAT(CELERITAS_SINCOSPI_PREFIX, FUNC)
+#else
 // Use implementations from detail/MathImpl.hh
-#        define CELERITAS_SINCOSPI_PREFIX ::celeritas::detail::
-#        define CELER_SINCOS_MANGLED(FUNC) ::celeritas::detail::FUNC
-#    endif
+#    define CELER_SINCOS_MANGLED(FUNC) ::celeritas::detail::FUNC
+#endif
 //!@{
 //! Get the sine or cosine of a value multiplied by pi for increased precision
 CELER_FORCEINLINE_FUNCTION float sinpi(float a)
@@ -784,7 +784,6 @@ CELER_FORCEINLINE_FUNCTION void sincospi(double a, double* s, double* c)
     return CELER_SINCOS_MANGLED(sincospi)(a, s, c);
 }
 //!@}
-#endif
 
 //!@}
 

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -663,6 +663,10 @@ TEST(MathTest, TEST_IF_CELER_DEVICE(device))
             = {0.92626575101906661, 1.0, 0.0, -1.0, 0.0};
         EXPECT_VEC_SOFT_EQ(expected_sinpi, host_output.sinpi[threads]);
         EXPECT_VEC_SOFT_EQ(expected_cospi, host_output.cospi[threads]);
+
+        // Single precision without using sincos
+        EXPECT_VEC_SOFT_EQ(expected_sinpi, host_output.sin[threads]);
+        EXPECT_VEC_SOFT_EQ(expected_cospi, host_output.cos[threads]);
     }
     {
         // fastpow

--- a/test/corecel/math/Algorithms.test.cu
+++ b/test/corecel/math/Algorithms.test.cu
@@ -9,6 +9,8 @@
 
 #include "corecel/DeviceRuntimeApi.hh"
 
+#include "corecel/Constants.hh"
+#include "corecel/math/Turn.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
 
@@ -32,6 +34,9 @@ __global__ void alg_test_kernel(AlgorithmTestData data)
     if (tid.get() < inp.pi_frac.size())
     {
         sincospi(inp.pi_frac[tid], &out.sinpi[tid], &out.cospi[tid]);
+        sincospi(inp.pi_frac[tid], &out.sinpi[tid], &out.cospi[tid]);
+        float radians = constants::pi * inp.pi_frac[tid];
+        sincos(radians, &out.sin[tid], &out.cos[tid]);
     }
     if (tid.get() < inp.a.size())
     {

--- a/test/corecel/math/Algorithms.test.cu
+++ b/test/corecel/math/Algorithms.test.cu
@@ -34,7 +34,6 @@ __global__ void alg_test_kernel(AlgorithmTestData data)
     if (tid.get() < inp.pi_frac.size())
     {
         sincospi(inp.pi_frac[tid], &out.sinpi[tid], &out.cospi[tid]);
-        sincospi(inp.pi_frac[tid], &out.sinpi[tid], &out.cospi[tid]);
         float radians = constants::pi * inp.pi_frac[tid];
         sincos(radians, &out.sin[tid], &out.cos[tid]);
     }

--- a/test/corecel/math/Algorithms.test.hh
+++ b/test/corecel/math/Algorithms.test.hh
@@ -65,6 +65,8 @@ struct AlgorithmOutputData
     // Test sincospi
     Items<double> sinpi;
     Items<double> cospi;
+    Items<float> sin;
+    Items<float> cos;
 
     // Test fastpow
     Items<double> fastpow;
@@ -76,6 +78,7 @@ struct AlgorithmOutputData
     explicit CELER_FUNCTION operator bool() const
     {
         return !sinpi.empty() && sinpi.size() == cospi.size()
+               && sin.size() == cospi.size() && cos.size() == cospi.size()
                && !fastpow.empty() && !hypot.empty();
     }
 
@@ -86,6 +89,8 @@ struct AlgorithmOutputData
         CELER_EXPECT(other);
         sinpi = other.sinpi;
         cospi = other.cospi;
+        sin = other.sin;
+        cos = other.cos;
         fastpow = other.fastpow;
         hypot = other.hypot;
         CELER_ENSURE(*this);
@@ -107,6 +112,8 @@ inline void resize(AlgorithmOutputData<Ownership::value, M>* output,
 
     resize(&output->sinpi, input.pi_frac.size());
     resize(&output->cospi, input.pi_frac.size());
+    resize(&output->sin, input.pi_frac.size());
+    resize(&output->cos, input.pi_frac.size());
 
     resize(&output->fastpow, input.a.size());
 


### PR DESCRIPTION
When a `sincos` in the `celeritas` namespace is available that has an incompatible signature with the `::sincos` defined by CUDA's headers, using `sincos` inside the celeritas namespace causes an error. This fixes the conflict by making sure that there's a compatible `sincos` that correctly overloads with the celeritas Turn one; it simply forwards to CUDA (but correctly overloads float/double values).