### PR TITLE
Fix data selection in `SetupOptions` -> `FrameworkInput` conversion

### DIFF
--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -278,14 +278,11 @@ inp::FrameworkInput to_inp(SetupOptions const& so)
     inp::FrameworkInput result;
     result.system = load_system(so);
     result.geant.ignore_processes = so.ignore_processes;
-    result.geant.data_selection.particles = GeantImportDataSelection::em_basic
-                                            | GeantImportDataSelection::optical;
-    result.geant.data_selection.processes = GeantImportDataSelection::em_basic
-                                            | GeantImportDataSelection::optical;
     result.geant.data_selection.interpolation = so.interpolation;
 
     // Correctly assign DataSelection import flags when muons are present
-    auto const selection = includes_muon() ? GIDS::em : GIDS::em_basic;
+    auto const selection = GIDS::optical
+                           | (includes_muon() ? GIDS::em : GIDS::em_basic);
     result.geant.data_selection.particles = selection;
     result.geant.data_selection.processes = selection;
 


### PR DESCRIPTION
Little fix for the conversion from `SetupOptions` to `FrameworkInput` where the optical selection was being overwritten if muons were present.