### PR TITLE
Fix offloaded particles in celer-g4

### DIFF
--- a/app/celer-g4/GlobalSetup.cc
+++ b/app/celer-g4/GlobalSetup.cc
@@ -18,6 +18,7 @@
 #include "corecel/sys/Environment.hh"
 #include "celeritas/ext/RootFileManager.hh"
 #include "accel/SetupOptionsMessenger.hh"
+#include "accel/SharedParams.hh"
 
 #include "RunInputIO.json.hh"
 
@@ -132,6 +133,13 @@ void GlobalSetup::ReadInput(std::string const& filename)
                 << fi_hack_envname << "='" << filename << "'";
             options_->geometry_file = filename;
         }
+    }
+
+    if (input_.physics_options.muon)
+    {
+        // Offload muons in addition to EM tracks if enabled
+        options_->offload_particles
+            = SharedParams::supported_offload_particles();
     }
 
     // Output options


### PR DESCRIPTION
Muons were no longer being offloaded through the celer-g4 app even when muon physics was enabled since we moved to a hardcoded list of offload particles. This adds a quick fix which checks whether muons are enabled in physics options and sets the offload particles to the "supported" particles if so. However, it seems like in the long term it might be better to detect the offload particles automatically; is there a reason we moved away from doing this? 