### PR TITLE
Fix propagation of weight from primary to track to secondary

### DIFF
--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -282,13 +282,6 @@ void LocalTransporter::Push(G4Track& g4track)
     track.direction = convert_from_geant(g4track.GetMomentumDirection(), 1);
     track.time = convert_from_geant(g4track.GetGlobalTime(), clhep_time);
     track.weight = g4track.GetWeight();
-    if (CELER_UNLIKELY(g4track.GetWeight() != 1.0))
-    {
-        //! \todo Non-unit weights: see issue #1268
-        CELER_LOG(error) << "incoming track (PDG " << pdg.get()
-                         << ", track ID " << g4track.GetTrackID()
-                         << ") has non-unit weight " << g4track.GetWeight();
-    }
 
     /*!
      * \todo Eliminate event ID from primary.

--- a/src/celeritas/track/detail/ProcessPrimariesExecutor.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesExecutor.hh
@@ -66,6 +66,7 @@ CELER_FUNCTION void ProcessPrimariesExecutor::operator()(ThreadId tid) const
     ti.sim.primary_id = primary.primary_id;
     ti.sim.event_id = primary.event_id;
     ti.sim.time = primary.time;
+    ti.sim.weight = primary.weight;
     ti.geo.pos = primary.position;
     ti.geo.dir = primary.direction;
     ti.particle.particle_id = primary.particle_id;

--- a/src/celeritas/track/detail/ProcessSecondariesExecutor.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesExecutor.hh
@@ -103,6 +103,7 @@ ProcessSecondariesExecutor::operator()(TrackSlotId tid) const
             ti.sim.parent_id = track_id;
             ti.sim.event_id = sim.event_id();
             ti.sim.time = sim.time();
+            ti.sim.weight = sim.weight();
             ti.geo.pos = geo.pos();
             ti.geo.dir = secondary.direction;
             ti.particle.particle_id = secondary.particle_id;

--- a/test/accel/IntegrationTestBase.hh
+++ b/test/accel/IntegrationTestBase.hh
@@ -21,6 +21,7 @@ class G4UserTrackingAction;
 class G4Event;
 class G4VModularPhysicsList;
 class G4VSensitiveDetector;
+class G4Step;
 
 namespace celeritas
 {
@@ -105,7 +106,7 @@ class IntegrationTestBase : public ::celeritas::test::Test
 };
 
 //---------------------------------------------------------------------------//
-//! Generate LAr sphere geometry with 10 MeV electrons
+//! Generate LAr sphere geometry with 10 MeV electrons and functional hit call
 class LarSphereIntegrationMixin : virtual public IntegrationTestBase
 {
     using Base = IntegrationTestBase;
@@ -114,7 +115,9 @@ class LarSphereIntegrationMixin : virtual public IntegrationTestBase
     std::string_view gdml_basename() const final { return "lar-sphere"; }
     PrimaryInput make_primary_input() const override;
     PhysicsInput make_physics_input() const override;
-    UPSensDet make_sens_det(std::string const&) override;
+    UPSensDet make_sens_det(std::string const&) final;
+
+    virtual void process_hit(G4Step const*);
 };
 
 //---------------------------------------------------------------------------//

--- a/test/accel/ShimSensitiveDetector.hh
+++ b/test/accel/ShimSensitiveDetector.hh
@@ -1,0 +1,52 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file accel/ShimSensitiveDetector.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <functional>
+#include <utility>
+#include <G4VSensitiveDetector.hh>
+
+#include "corecel/Assert.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Forward hits to a \c std::function.
+ */
+class ShimSensitiveDetector final : public G4VSensitiveDetector
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using HitProcessor = std::function<void(G4Step const*)>;
+    //!@}
+
+  public:
+    // Construct with name and function
+    ShimSensitiveDetector(std::string const& name, HitProcessor&& process_hit)
+        : G4VSensitiveDetector(name), process_hit_{std::move(process_hit)}
+    {
+        CELER_EXPECT(process_hit_);
+    }
+
+    void Initialize(G4HCofThisEvent*) final { this->clear(); }
+    bool ProcessHits(G4Step* step, G4TouchableHistory*) final
+    {
+        process_hit_(step);
+        return true;  // ignored by Geant4
+    }
+
+  private:
+    HitProcessor process_hit_;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
There were a few assignments missing in step initialization. This adds a front-to-back test for the track weights, as well as a helper class to easily check hits inside the integration unit test.