### PR TITLE
Add iostream wrappers for Geant physics options

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -62,7 +62,6 @@ celeritas_target_link_libraries(orange-update
 celeritas_add_executable(celer-export-geant celer-export-geant.cc)
 celeritas_target_link_libraries(celer-export-geant
   Celeritas::celeritas
-  nlohmann_json::nlohmann_json
   CLI11::CLI11
   celer_app_utils
 )

--- a/app/celer-export-geant.cc
+++ b/app/celer-export-geant.cc
@@ -14,7 +14,6 @@
 #include <string>
 #include <vector>
 #include <CLI/CLI.hpp>
-#include <nlohmann/json.hpp>
 
 #include "corecel/Assert.hh"
 #include "corecel/io/FileOrConsole.hh"
@@ -23,7 +22,6 @@
 #include "corecel/sys/ScopedMpiInit.hh"
 #include "celeritas/ext/GeantImporter.hh"
 #include "celeritas/ext/GeantPhysicsOptions.hh"
-#include "celeritas/ext/GeantPhysicsOptionsIO.json.hh"
 #include "celeritas/ext/GeantSetup.hh"
 #include "celeritas/ext/RootExporter.hh"
 #include "celeritas/ext/RootJsonDumper.hh"
@@ -54,10 +52,9 @@ GeantPhysicsOptions load_options(std::string const& option_filename)
     else
     {
         FileOrStdin infile(option_filename);
-        nlohmann::json::parse(infile).get_to(options);
+        infile >> options;
         CELER_LOG(info) << "Loaded Geant4 setup options from "
-                        << infile.filename() << ": "
-                        << nlohmann::json{options}.dump();
+                        << infile.filename() << ": " << options;
     }
     return options;
 }
@@ -120,9 +117,7 @@ void run(std::string const& gdml_filename,
 
 void run_dump_default()
 {
-    GeantPhysicsOptions options;
-    constexpr int indent = 1;
-    std::cout << nlohmann::json{options}.dump(indent) << std::endl;
+    std::cout << GeantPhysicsOptions{} << std::endl;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/GeantPhysicsOptions.hh
+++ b/src/celeritas/ext/GeantPhysicsOptions.hh
@@ -296,4 +296,22 @@ char const* to_cstring(MscModelSelection value);
 char const* to_cstring(RelaxationSelection value);
 
 //---------------------------------------------------------------------------//
+/*!
+ * Helper to read the field from a file or stream.
+ *
+ * Example to read from a file:
+ * \code
+   GeantPhysicsOptions inp;
+   std::ifstream("foo.json") >> inp;
+ * \endcode
+ */
+std::istream& operator>>(std::istream& is, GeantPhysicsOptions&);
+
+//---------------------------------------------------------------------------//
+/*!
+ * Helper to write the field to a file or stream.
+ */
+std::ostream& operator<<(std::ostream& os, GeantPhysicsOptions const&);
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantPhysicsOptionsIO.json.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "GeantPhysicsOptionsIO.json.hh"
 
+#include <iostream>
 #include <string>
 
 #include "corecel/io/JsonUtils.json.hh"
@@ -234,6 +235,24 @@ void to_json(nlohmann::json& j, GeantPhysicsOptions const& inp)
 
     save_format(j, format_str);
     save_units(j);
+}
+
+//---------------------------------------------------------------------------//
+// Helper to read the options from a file or stream.
+std::istream& operator>>(std::istream& is, GeantPhysicsOptions& inp)
+{
+    auto j = nlohmann::json::parse(is);
+    j.get_to(inp);
+    return is;
+}
+
+//---------------------------------------------------------------------------//
+// Helper to write the options to a file or stream.
+std::ostream& operator<<(std::ostream& os, GeantPhysicsOptions const& inp)
+{
+    nlohmann::json j = inp;
+    os << j.dump(0);
+    return os;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Tiny change pulled from #1962 that allows us to use stream operators to read and write IO options.