### PR TITLE
Release v0.6.2

### DIFF
--- a/doc/release-history/v0.6.rst
+++ b/doc/release-history/v0.6.rst
@@ -7,6 +7,53 @@ Series 0.6
 Major development version 0.6 can be cited through its Zenodo code release
 :cite:p:`celeritas-0-6`.
 
+.. _release_v0.6.2:
+
+Version 0.6.2
+-------------
+*Released 2025/09/23*
+
+Version 0.6.2 is a minor bug fix update.
+- Fixed reconstruction of track weights in returned Geant4 hits
+- Improved documentation and use of ``CELER_USE_PROFILING``
+- Added push/flush profiling counters in accel interface
+- Update externals to latest versions (including G4VG 1.0.5 with VecGeom/CUDA fix)
+
+Changes since v0.6.1 follow.
+
+New features
+^^^^^^^^^^^^
+
+* Warn user when running large problems on debug build *(@sethrj, #1971)*
+* Improve version metadata for built-in packages and VecGeom *(@sethrj, #1929)*
+
+Bug fixes
+^^^^^^^^^
+
+* Fix propagation of weight from primary to track to secondary *(@sethrj, #1965)*
+
+Documentation improvements
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Add documentation and use flag for CELER_USE_PROFILING *(@sethrj, #1966)*
+* Fix cache clearing *(@sethrj, #1979)*
+
+Minor internal changes
+^^^^^^^^^^^^^^^^^^^^^^
+
+* Add push/flush profiling to accel interface *(@sethrj, #1968)*
+* Update externals *(@sethrj, #1977)*
+* Add iostream wrappers for Geant physics options *(@sethrj, #1981)*
+
+Reviewers
+^^^^^^^^^
+
+* Philippe Canal *(@pcanal)*: 4
+* Amanda Lund *(@amandalund)*: 3
+* Rashika Gupta *(@Rashika-Gupta)*: 1
+
+**Full Changelog**: https://github.com/celeritas-project/celeritas/compare/v0.6.1...v0.6.2
+
 .. _release_v0.6.1:
 
 Version 0.6.1


### PR DESCRIPTION
The gap from the previous release is small but I think it's important to get the weight reconstruction fix out for ATLAS.

## Pre-merge checklist

- [x] Ensure all CI jobs on the branch to be released (develop or backports/vX.Y) pass. https://github.com/celeritas-project/celeritas/actions/runs/17947683844
- [ ] ~~If releasing from develop, tag the develop branch with ``vX.Y.Z-rc.N`` where N starts with 1, and increment for every time you return to this step due to new pull requests.~~
- [ ] ~~Run performance regression tests on Perlmutter, Frontier, and an additional machine with debug assertions enabled (e.g., Wildstyle).~~
- [x] Update documentation with release notes from all pull requests newly included in the release.
- [x] Ensure PDF documentation builds without error.
- [ ] ~~For a major release, check for (and delete if found) code marked as "deprecated: to be removed in vX".~~

## Post-merge checklist

- [x] If releasing a backported version branch, cherry-pick this documentation commit into the backport branch.
- [x] Use the [release scripts](https://github.com/celeritas-project/release-scripts) to create a new release with the documentation update that was just added.

## Post-release checklist

- [x] Use the release script to update the archive.
- [x] Pull locally (make sure to use the ``--tags`` option) and build PDF user documentation for the release, and upload it. Ensure breathe is activated (so the API is listed) and that the version is embedded correctly.
- [x] Update the Spack recipe for Celeritas with the new version and the sha256 value returned by the release script. Submit a [pull request to the Spack project](https://github.com/spack/spack/pull).
- [x] Mark the GitHub [release milestone](https://github.com/celeritas-project/celeritas/milestones) as completed.
