### PR TITLE
Remove `weight` field from `Secondary`

### DIFF
--- a/src/celeritas/phys/InteractionApplier.hh
+++ b/src/celeritas/phys/InteractionApplier.hh
@@ -148,13 +148,12 @@ InteractionApplierBaseImpl<F>::operator()(celeritas::CoreTrackView const& track)
         // Kill secondaries with energies below the production cut
         for (auto& secondary : result.secondaries)
         {
-            secondary.weight = sim.weight();
             if (cutoff.apply(secondary))
             {
                 // Secondary is an electron, positron or gamma with energy
                 // below the production cut -- deposit the energy locally
                 // and clear the secondary
-                deposition += secondary.energy.value() * secondary.weight;
+                deposition += secondary.energy.value() * sim.weight();
                 auto sec_par = track.particle_record(secondary.particle_id);
                 if (sec_par.is_antiparticle())
                 {

--- a/src/celeritas/phys/Secondary.hh
+++ b/src/celeritas/phys/Secondary.hh
@@ -24,7 +24,7 @@ struct Secondary
     ParticleId particle_id;  //!< New particle type
     units::MevEnergy energy;  //!< New kinetic energy
     Real3 direction;  //!< New direction
-    real_type weight{1.0};
+
     //! Whether the secondary survived cutoffs
     explicit CELER_FUNCTION operator bool() const
     {

--- a/src/celeritas/phys/Secondary.hh
+++ b/src/celeritas/phys/Secondary.hh
@@ -18,13 +18,16 @@ namespace celeritas
  *
  * It will be converted into a "track initializer" using the parent track's
  * information.
+ *
+ * \note Avoid value-initialization of fields to work around nvlink bug
  */
 struct Secondary
 {
     ParticleId particle_id;  //!< New particle type
     units::MevEnergy energy;  //!< New kinetic energy
     Real3 direction;  //!< New direction
-    real_type weight{1.0};
+    real_type weight;
+
     //! Whether the secondary survived cutoffs
     explicit CELER_FUNCTION operator bool() const
     {

--- a/src/celeritas/phys/Secondary.hh
+++ b/src/celeritas/phys/Secondary.hh
@@ -18,16 +18,13 @@ namespace celeritas
  *
  * It will be converted into a "track initializer" using the parent track's
  * information.
- *
- * \note Avoid value-initialization of fields to work around nvlink bug
  */
 struct Secondary
 {
     ParticleId particle_id;  //!< New particle type
     units::MevEnergy energy;  //!< New kinetic energy
     Real3 direction;  //!< New direction
-    real_type weight;
-
+    real_type weight{1.0};
     //! Whether the secondary survived cutoffs
     explicit CELER_FUNCTION operator bool() const
     {


### PR DESCRIPTION
EDIT: Workaround didn't end up working, so this just removes the `weight` field from `Secondary` since it's unnecessary.

Long ago we kept running into an nvlink error (#118 #215 https://github.com/celeritas-project/celeritas/pull/257#issuecomment-868994741) and trying various workarounds to avoid it. What seemed to finally resolve it was removing member initialization from `Secondary`: https://github.com/celeritas-project/celeritas/pull/257#issuecomment-870251676.

I just started hitting a similar error on a branch I'm working on:
```console
nvlink error   : Size doesn't match for '_ZN9celeritas14StackAllocatorINS_9SecondaryEEclEj$188' in '/home/alund/celeritas_project/celeritas/build-reldeb/lib64/libceleritas_static.a:MollerBhabhaModel.cu.o', first specified in '/home/alund/celeritas_project/celeritas/build-reldeb/lib64/libceleritas_static.a:MuDecayChannel.cu.o' (target: sm_70)
nvlink fatal   : merge_elf failed (target: sm_70)
```
Removing initialization of the recently-added `weight` field in `Secondary` again appears to fix it. I _think_ we correctly set the weight elsewhere and don't need to initialize it to one here, but wanted to double check since we've had to fix this in several places already.