### PR TITLE
Add `CELER_` prefix to G4 material property names specific to Celeritas

### DIFF
--- a/app/data/lar-sphere.gdml
+++ b/app/data/lar-sphere.gdml
@@ -16,8 +16,6 @@
     <matrix name="ISY" coldim="2" values="1.0e-6 2000 6 4000"/>
     <matrix name="ESY" coldim="2" values="1.0e-6 3750 6 5000"/>
     <matrix name="ESY1" coldim="1" values="4000"/>
-    <matrix name="ELM1" coldim="1" values="1e-4"/>
-    <matrix name="ELS1" coldim="1" values="1e-5"/>
     <matrix name="ERT1" coldim="1" values="15"/>
     <matrix name="ETC1" coldim="1" values="5"/>
     <!-- End of particle scintillation data -->
@@ -106,8 +104,6 @@
       <property name="ELECTRONSCINTILLATIONYIELD1" ref="ESY1"/>
       <property name="ELECTRONSCINTILLATIONRISETIME1" ref="ERT1"/>
       <property name="ELECTRONSCINTILLATIONTIMECONSTANT1" ref="ETC1"/>
-      <property name="CELER_ELECTRONSCINTILLATIONLAMBDAMEAN1" ref="ELM1"/>
-      <property name="CELER_ELECTRONSCINTILLATIONLAMBDASIGMA1" ref="ELS1"/>
       <property name="RAYLEIGH" ref="RAY"/>
       <property name="ISOTHERMAL_COMPRESSIBILITY" ref="IC"/>
       <property name="ABSLENGTH" ref="ABS"/>

--- a/app/data/lar-sphere.gdml
+++ b/app/data/lar-sphere.gdml
@@ -92,10 +92,10 @@
       <property name="SCINTILLATIONTIMECONSTANT1" ref="TC1"/>
       <property name="SCINTILLATIONTIMECONSTANT2" ref="TC2"/>
       <property name="SCINTILLATIONTIMECONSTANT3" ref="TC3"/>
-      <property name="SCINTILLATIONLAMBDAMEAN1" ref="LM1"/>
-      <property name="SCINTILLATIONLAMBDAMEAN2" ref="LM2"/>
-      <property name="SCINTILLATIONLAMBDASIGMA1" ref="LS1"/>
-      <property name="SCINTILLATIONLAMBDASIGMA2" ref="LS2"/>
+      <property name="CELER_SCINTILLATIONLAMBDAMEAN1" ref="LM1"/>
+      <property name="CELER_SCINTILLATIONLAMBDAMEAN2" ref="LM2"/>
+      <property name="CELER_SCINTILLATIONLAMBDASIGMA1" ref="LS1"/>
+      <property name="CELER_SCINTILLATIONLAMBDASIGMA2" ref="LS2"/>
       <property name="SCINTILLATIONCOMPONENT3" ref="SC3"/>
       <property name="PROTONSCINTILLATIONYIELD" ref="PSY"/>
       <property name="DEUTERONSCINTILLATIONYIELD" ref="DSY"/>
@@ -106,8 +106,8 @@
       <property name="ELECTRONSCINTILLATIONYIELD1" ref="ESY1"/>
       <property name="ELECTRONSCINTILLATIONRISETIME1" ref="ERT1"/>
       <property name="ELECTRONSCINTILLATIONTIMECONSTANT1" ref="ETC1"/>
-      <property name="ELECTRONSCINTILLATIONLAMBDAMEAN1" ref="ELM1"/>
-      <property name="ELECTRONSCINTILLATIONLAMBDASIGMA1" ref="ELS1"/>
+      <property name="CELER_ELECTRONSCINTILLATIONLAMBDAMEAN1" ref="ELM1"/>
+      <property name="CELER_ELECTRONSCINTILLATIONLAMBDASIGMA1" ref="ELS1"/>
       <property name="RAYLEIGH" ref="RAY"/>
       <property name="ISOTHERMAL_COMPRESSIBILITY" ref="IC"/>
       <property name="ABSLENGTH" ref="ABS"/>

--- a/doc/implementation/geometry/geant4.rst
+++ b/doc/implementation/geometry/geant4.rst
@@ -1,6 +1,8 @@
 .. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 .. SPDX-License-Identifier: CC-BY-4.0
 
+.. _api_geant4_geo:
+
 Geant4 geometry
 ===============
 

--- a/doc/implementation/optical-physics.rst
+++ b/doc/implementation/optical-physics.rst
@@ -90,15 +90,6 @@ Celeritas-only physics. The following table
    +-------------------------------------+-------------------------------------------------------------+
    | :code:`SCINTILLATIONLAMBDASIGMA`    | Standard deviation of the Gaussian scintillation peak [mm]  |
    +-------------------------------------+-------------------------------------------------------------+
-   | :samp:`{P}SCINTILLATIONLAMBDAMEAN`  | Particle-dependent [#par]_ scintillation peak [mm]          |
-   +-------------------------------------+-------------------------------------------------------------+
-   | :samp:`{P}SCINTILLATIONLAMBDASIGMA` | Particle-dependent [#par]_ scintillation peak spread [mm]   |
-   +-------------------------------------+-------------------------------------------------------------+
-
-.. [#par] *P* is allowed to be "PROTON", "DEUTERON", "TRITON", "ALPHA", "ION",
-   and "ELECTRON". For particle-dependent scintillation other particle types
-   use "electron" behavior. Particle-dependent scintillation is not currently
-   supported since electrons are the only particle we track!!
 
 
 Offloading

--- a/doc/implementation/optical-physics.rst
+++ b/doc/implementation/optical-physics.rst
@@ -61,14 +61,45 @@ tracking loop:
 Optical materials
 =================
 
-Each "physics material" (see :cpp:class:`celeritas::ImportPhysMaterial`) can
-have an associated "optical material." When importing from Geant4, each optical
-material corresponds to a single "geometry material" (see
-:cpp:class:`celeritas::ImportGeoMaterial`) that has a ``RINDEX`` material
-property, and all physical materials that use the geometry material share
-the same optical material.
+Each "physics material" (i.e., a combination of material and physics options) can
+have an associated "optical material" (compatible with optical photons).
 
 .. doxygenclass:: celeritas::optical::MaterialParams
+
+Geant4 integration
+------------------
+
+When importing from Geant4, each optical material corresponds to a single
+:cpp:class:`G4MaterialPropertiesTable` that has a ``RINDEX`` material property.
+(It also provides a special case for water if no material table is associated,
+allowing Rayleigh scattering by default by providing an isothermal
+compressibility and assuming STP.)
+All physical materials that use the geometry material or property table share
+the same optical material.
+
+Celeritas translates many Geant4 material properties into its internal physics
+input parameters. It also allows material-specific user configuration of
+Celeritas-only physics. The following table
+
+.. table:: Celeritas-only properties, with the ``CELER_`` prefix omitted.
+
+   +-------------------------------------+-------------------------------------------------------------+
+   | Name                                | Description                                                 |
+   +=====================================+=============================================================+
+   | :code:`SCINTILLATIONLAMBDAMEAN`     | Mean wavelength of the Gaussian scintillation peak [mm]     |
+   +-------------------------------------+-------------------------------------------------------------+
+   | :code:`SCINTILLATIONLAMBDASIGMA`    | Standard deviation of the Gaussian scintillation peak [mm]  |
+   +-------------------------------------+-------------------------------------------------------------+
+   | :samp:`{P}SCINTILLATIONLAMBDAMEAN`  | Particle-dependent [#par]_ scintillation peak [mm]          |
+   +-------------------------------------+-------------------------------------------------------------+
+   | :samp:`{P}SCINTILLATIONLAMBDASIGMA` | Particle-dependent [#par]_ scintillation peak spread [mm]   |
+   +-------------------------------------+-------------------------------------------------------------+
+
+.. [#par] *P* is allowed to be "PROTON", "DEUTERON", "TRITON", "ALPHA", "ION",
+   and "ELECTRON". For particle-dependent scintillation other particle types
+   use "electron" behavior. Particle-dependent scintillation is not currently
+   supported since electrons are the only particle we track!!
+
 
 Offloading
 ==========
@@ -113,26 +144,15 @@ Surface processes
 =================
 
 Optical photons also have special interactions at material boundaries,
-specified largely by user-provided material properties. The surface
-definitions are translated from Geant4 "skin" and "border" surfaces to
-Celeritas "boundary" and "interface" surfaces, respectively (see
-:ref:`api_geometry`). The "boundary" of a volume is currently defined, from
-Geant4 input, as a *directional* property.
+specified largely by user-provided material properties.
+Users can define "boundary" and "interface" surfaces representing,
+respectively, the entire surface of a volume (including interior surfaces
+created implicitly by child volumes) and the common face between two adjacent
+volume instances.
+See :ref:`api_geometry` for a discussion of these definitions and
+:ref:`api_geant4_geo` for their translation from Geant4.
 
-Celeritas surface physics currently uses the following heuristic to reproduce
-Geant4 boundary physics behavior.  Given a pair of old→new volume instances
-P0→P1 corresponding to volumes L0→L1, the surface properties are determined in
-decreasing precedence by:
-
-1. The interface surface from P0 to P1
-2. If L1 is the child of L0 (crossing into an "enclosed" volume), then the
-   boundary surface of L1
-3. The boundary surface of L0
-4. The boundary surface of L1
-5. The volumetric material properties of L0 and L1
-
-.. todo:: Once surface models are implemented, move the
-   precedence above into SurfacePhysics documentation.
+.. doxygenclass:: celeritas::optical::VolumeSurfaceSelector
 
 Surface normals are defined by the track position in the geometry. Corrections
 may be applied to the geometric surface normal by sampling from a "microfacet

--- a/doc/implementation/optical-physics.rst
+++ b/doc/implementation/optical-physics.rst
@@ -74,12 +74,10 @@ When importing from Geant4, each optical material corresponds to a single
 (It also provides a special case for water if no material table is associated,
 allowing Rayleigh scattering by default by providing an isothermal
 compressibility and assuming STP.)
-All physical materials that use the geometry material or property table share
-the same optical material.
 
 Celeritas translates many Geant4 material properties into its internal physics
 input parameters. It also allows material-specific user configuration of
-Celeritas-only physics. The following table
+Celeritas-only physics, using properties listed in the following table.
 
 .. table:: Celeritas-only properties, with the ``CELER_`` prefix omitted.
 
@@ -135,12 +133,11 @@ Surface processes
 =================
 
 Optical photons also have special interactions at material boundaries,
-specified largely by user-provided material properties.
+specified by user-provided surface properties.
 Users can define "boundary" and "interface" surfaces representing,
-respectively, the entire surface of a volume (including interior surfaces
-created implicitly by child volumes) and the common face between two adjacent
-volume instances.
-See :ref:`api_geometry` for a discussion of these definitions and
+respectively, the entire boundary of a volume (all points where it touches the
+parent or child volumes) and the common face between two adjacent volume
+instances.  See :ref:`api_geometry` for a discussion of these definitions and
 :ref:`api_geant4_geo` for their translation from Geant4.
 
 .. doxygenclass:: celeritas::optical::VolumeSurfaceSelector

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -213,7 +213,8 @@ fill_vec_import_scint_comp(detail::GeantMaterialPropertyGetter& get_property,
     {
         bool any_found = false;
         auto get = [&](double* dst, std::string const& ext, ImportUnits u) {
-            any_found |= get_property(dst, prefix + ext, comp_idx, u);
+            bool one_found = get_property(dst, prefix + ext, comp_idx, u);
+            any_found = any_found || one_found;
         };
 
         ImportScintComponent comp;
@@ -917,14 +918,15 @@ std::vector<ImportRegion> import_regions()
  * Return a populated \c ImportProcess vector.
  */
 auto import_processes(GeantImporter::DataSelection selected,
-                      std::vector<inp::Particle> const& particles,
-                      std::vector<ImportElement> const& elements,
-                      std::vector<ImportPhysMaterial> const& materials,
                       detail::GeoOpticalIdMap const& geo_to_opt,
                       ImportData& imported)
 {
     ParticleFilter include_particle{selected.processes};
     ProcessFilter include_process{selected.processes};
+
+    auto const& particles = imported.particles;
+    auto const& elements = imported.elements;
+    auto const& materials = imported.phys_materials;
 
     auto& processes = imported.processes;
     auto& msc_models = imported.msc_models;
@@ -1419,12 +1421,7 @@ ImportData GeantImporter::operator()(DataSelection const& selected)
         }
         if (selected.processes != DataSelection::none)
         {
-            import_processes(selected,
-                             imported.particles,
-                             imported.elements,
-                             imported.phys_materials,
-                             geo_to_opt,
-                             imported);
+            import_processes(selected, geo_to_opt, imported);
 
             if (have_process(ImportProcessClass::mu_pair_prod))
             {

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -215,14 +215,30 @@ fill_vec_import_scint_comp(detail::GeantMaterialPropertyGetter& get_property,
         auto get = [&](double* dst, std::string const& ext, ImportUnits u) {
             bool one_found = get_property(dst, prefix + ext, comp_idx, u);
             any_found = any_found || one_found;
+            return one_found;
         };
 
         ImportScintComponent comp;
         get(&comp.yield_frac, "YIELD", ImportUnits::inv_mev);
 
         // Custom-defined properties not available in G4MaterialPropertyIndex
-        get(&comp.lambda_mean, "LAMBDAMEAN", ImportUnits::len);
-        get(&comp.lambda_sigma, "LAMBDASIGMA", ImportUnits::len);
+        for (auto&& [prop, label] : {
+                 std::pair{&comp.lambda_mean, "LAMBDAMEAN"},
+                 std::pair{&comp.lambda_sigma, "LAMBDASIGMA"},
+             })
+        {
+            if (get_property(
+                    prop, "CELER_" + prefix + label, comp_idx, ImportUnits::len))
+            {
+                any_found = true;
+            }
+            else if (get(prop, label, ImportUnits::len))
+            {
+                CELER_LOG(warning)
+                    << "Deprecated property name " << prefix << label
+                    << ": use CELER_" << prefix << label;
+            }
+        }
 
         // Rise time is not defined for particle type in Geant4
         get(&comp.rise_time, "RISETIME", ImportUnits::time);

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -284,9 +284,9 @@ fill_vec_import_scint_comp(detail::GeantMaterialPropertyGetter& get_property,
                                "as a Gaussian ";
                     }
                     CELER_LOG(info)
-                        << "Estimated custom properties " << prefix
+                        << "Estimated custom properties CELER_" << prefix
                         << "LAMBDAMEAN" << comp_idx << "=" << comp.lambda_mean
-                        << " and " << prefix << "LAMBDASIGMA" << comp_idx
+                        << " and CELER_" << prefix << "LAMBDASIGMA" << comp_idx
                         << "=" << comp.lambda_sigma
                         << " from Geant4-defined property " << name;
                 }

--- a/test/celeritas/ext/GeantImporter.test.cc
+++ b/test/celeritas/ext/GeantImporter.test.cc
@@ -1686,7 +1686,7 @@ TEST_F(LarSphere, optical)
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
     {
         static std::string const expected_messages
-            = R"(Estimated custom properties SCINTILLATIONLAMBDAMEAN3=2e-5 and SCINTILLATIONLAMBDASIGMA3=2.010e-6 from Geant4-defined property SCINTILLATIONCOMPONENT3)";
+            = R"(Estimated custom properties CELER_SCINTILLATIONLAMBDAMEAN3=2e-5 and CELER_SCINTILLATIONLAMBDASIGMA3=2.010e-6 from Geant4-defined property SCINTILLATIONCOMPONENT3)";
         EXPECT_VEC_EQ(expected_messages, scoped_log.messages()[1])
             << scoped_log;
     }

--- a/test/geocel/data/lar-sphere.gdml
+++ b/test/geocel/data/lar-sphere.gdml
@@ -17,8 +17,6 @@
     <matrix name="ISY" coldim="2" values="1.0e-6 2000 6 4000"/>
     <matrix name="ESY" coldim="2" values="1.0e-6 3750 6 5000"/>
     <matrix name="ESY1" coldim="1" values="4000"/>
-    <matrix name="ELM1" coldim="1" values="1e-4"/>
-    <matrix name="ELS1" coldim="1" values="1e-5"/>
     <matrix name="ERT1" coldim="1" values="15"/>
     <matrix name="ETC1" coldim="1" values="5"/>
     <matrix name="LM1" coldim="1" values="1.28e-4"/>
@@ -110,8 +108,6 @@
       <property name="ELECTRONSCINTILLATIONYIELD1" ref="ESY1"/>
       <property name="ELECTRONSCINTILLATIONRISETIME1" ref="ERT1"/>
       <property name="ELECTRONSCINTILLATIONTIMECONSTANT1" ref="ETC1"/>
-      <property name="CELER_ELECTRONSCINTILLATIONLAMBDAMEAN1" ref="ELM1"/>
-      <property name="CELER_ELECTRONSCINTILLATIONLAMBDASIGMA1" ref="ELS1"/>
       <property name="RAYLEIGH" ref="RAY"/>
       <property name="ISOTHERMAL_COMPRESSIBILITY" ref="IC"/>
       <property name="ABSLENGTH" ref="ABS"/>

--- a/test/geocel/data/lar-sphere.gdml
+++ b/test/geocel/data/lar-sphere.gdml
@@ -96,10 +96,10 @@
       <property name="SCINTILLATIONTIMECONSTANT1" ref="TC1"/>
       <property name="SCINTILLATIONTIMECONSTANT2" ref="TC2"/>
       <property name="SCINTILLATIONTIMECONSTANT3" ref="TC3"/>
-      <property name="SCINTILLATIONLAMBDAMEAN1" ref="LM1"/>
-      <property name="SCINTILLATIONLAMBDAMEAN2" ref="LM2"/>
-      <property name="SCINTILLATIONLAMBDASIGMA1" ref="LS1"/>
-      <property name="SCINTILLATIONLAMBDASIGMA2" ref="LS2"/>
+      <property name="CELER_SCINTILLATIONLAMBDAMEAN1" ref="LM1"/>
+      <property name="CELER_SCINTILLATIONLAMBDAMEAN2" ref="LM2"/>
+      <property name="CELER_SCINTILLATIONLAMBDASIGMA1" ref="LS1"/>
+      <property name="CELER_SCINTILLATIONLAMBDASIGMA2" ref="LS2"/>
       <property name="SCINTILLATIONCOMPONENT3" ref="SC3"/>
       <property name="PROTONSCINTILLATIONYIELD" ref="PSY"/>
       <property name="DEUTERONSCINTILLATIONYIELD" ref="DSY"/>
@@ -110,8 +110,8 @@
       <property name="ELECTRONSCINTILLATIONYIELD1" ref="ESY1"/>
       <property name="ELECTRONSCINTILLATIONRISETIME1" ref="ERT1"/>
       <property name="ELECTRONSCINTILLATIONTIMECONSTANT1" ref="ETC1"/>
-      <property name="ELECTRONSCINTILLATIONLAMBDAMEAN1" ref="ELM1"/>
-      <property name="ELECTRONSCINTILLATIONLAMBDASIGMA1" ref="ELS1"/>
+      <property name="CELER_ELECTRONSCINTILLATIONLAMBDAMEAN1" ref="ELM1"/>
+      <property name="CELER_ELECTRONSCINTILLATIONLAMBDASIGMA1" ref="ELS1"/>
       <property name="RAYLEIGH" ref="RAY"/>
       <property name="ISOTHERMAL_COMPRESSIBILITY" ref="IC"/>
       <property name="ABSLENGTH" ref="ABS"/>


### PR DESCRIPTION
Following up on our discussion in #1974, this adds a `CELER_` prefix to Celeritas-specific material properties for optical physics. It still supports the existing ones for backward compatibility and gives a warning. It adds documentation for the new parameters.