### PR TITLE
Support G4MultiUnion in ORANGE

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -25,6 +25,7 @@
 #include <G4GenericTrap.hh>
 #include <G4Hype.hh>
 #include <G4IntersectionSolid.hh>
+#include <G4MultiUnion.hh>
 #include <G4Orb.hh>
 #include <G4Para.hh>
 #include <G4Paraboloid.hh>
@@ -344,6 +345,7 @@ auto SolidConverter::convert_impl(arg_type solid_base) -> result_type
         SC_TYPE_FUNC(GenericTrap      , generictrap),
         SC_TYPE_FUNC(Hype             , hype),
         SC_TYPE_FUNC(IntersectionSolid, intersectionsolid),
+        SC_TYPE_FUNC(MultiUnion       , multiunion),
         SC_TYPE_FUNC(Orb              , orb),
         SC_TYPE_FUNC(Para             , para),
         SC_TYPE_FUNC(Paraboloid       , paraboloid),
@@ -611,6 +613,25 @@ auto SolidConverter::intersectionsolid(arg_type solid_base) -> result_type
     return std::make_shared<AllObjects>(
         std::string{solid_base.GetName()},
         std::vector{std::move(vols[0]), std::move(vols[1])});
+}
+
+//---------------------------------------------------------------------------//
+//! Convert a multiunion
+auto SolidConverter::multiunion(arg_type solid_base) -> result_type
+{
+    auto const& mu = static_cast<G4MultiUnion const&>(solid_base);
+    auto n = mu.GetNumberOfSolids();
+    std::vector<result_type> vols(n);
+
+    for (auto i : range(n))
+    {
+        auto vol = (*this)(*(mu.GetSolid(i)));
+        vols[i] = std::make_shared<Transformed>(
+            std::move(vol), transform_(mu.GetTransformation(i)));
+    }
+
+    return std::make_shared<AnyObjects>(std::string{solid_base.GetName()},
+                                        std::move(vols));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -619,7 +619,7 @@ auto SolidConverter::intersectionsolid(arg_type solid_base) -> result_type
 //! Convert a multiunion
 auto SolidConverter::multiunion(arg_type solid_base) -> result_type
 {
-    auto const& mu = static_cast<G4MultiUnion const&>(solid_base);
+    auto const& mu = dynamic_cast<G4MultiUnion const&>(solid_base);
     auto n = mu.GetNumberOfSolids();
     std::vector<result_type> vols(n);
 

--- a/src/orange/g4org/SolidConverter.hh
+++ b/src/orange/g4org/SolidConverter.hh
@@ -76,6 +76,7 @@ class SolidConverter
     result_type generictrap(arg_type);
     result_type hype(arg_type);
     result_type intersectionsolid(arg_type);
+    result_type multiunion(arg_type);
     result_type orb(arg_type);
     result_type para(arg_type);
     result_type paraboloid(arg_type);


### PR DESCRIPTION
This MR adds support for `G4MultiUnion` within `g4org::SolidConverter`. Whereas, Geant4 uses a voxelization approach for acceleration, this MR uses the naive approach of simply `or`-ing all constituent volumes. A more general approach for sub-volume-level acceleration should be use for all volumes, not just converted multiunions.