### PR TITLE
Fix setting CUDA heapSize through G4UI

### DIFF
--- a/src/celeritas/setup/System.cc
+++ b/src/celeritas/setup/System.cc
@@ -50,7 +50,7 @@ void system(inp::System const& sys)
         }
         if (auto size = sys.device->heap_size)
         {
-            set_cuda_stack_size(size);
+            set_cuda_heap_size(size);
         }
     }
 }


### PR DESCRIPTION
Correctly call `set_cuda_heap_size` when specifying the heap size through Geant4 UI commands / SetupOptions.