### PR TITLE
Fix option to kill tracks after user-specified number of steps

### DIFF
--- a/src/celeritas/inp/Tracking.hh
+++ b/src/celeritas/inp/Tracking.hh
@@ -30,7 +30,7 @@ struct TrackingLimits
     //! Step iterations before aborting the optical stepping loop
     size_type optical_step_iters{unlimited};
     //! Integration substeps during field propagation before ending the step
-    size_type field_substeps{100};
+    size_type field_substeps{10};
 
     //! Stop electron/positron below this energy
     // TODO: Energy electron_energy = Energy{0.001};

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -469,8 +469,11 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
 
     // Construct simulation params
     params.sim = std::make_shared<SimParams>([&] {
-        auto input = SimParams::Input::from_import(
-            imported, params.particle, p.tracking.limits.field_substeps);
+        auto input
+            = SimParams::Input::from_import(imported,
+                                            params.particle,
+                                            p.tracking.limits.steps,
+                                            p.tracking.limits.field_substeps);
         return input;
     }());
 

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -469,11 +469,8 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
 
     // Construct simulation params
     params.sim = std::make_shared<SimParams>([&] {
-        auto input
-            = SimParams::Input::from_import(imported,
-                                            params.particle,
-                                            p.tracking.limits.steps,
-                                            p.tracking.limits.field_substeps);
+        auto input = SimParams::Input::from_import(
+            imported, params.particle, p.tracking.limits);
         return input;
     }());
 

--- a/src/celeritas/track/SimParams.cc
+++ b/src/celeritas/track/SimParams.cc
@@ -26,20 +26,18 @@ namespace celeritas
 SimParams::Input SimParams::Input::from_import(ImportData const& data,
                                                SPConstParticles particle_params)
 {
-    return SimParams::Input::from_import(data,
-                                         std::move(particle_params),
-                                         SimParams::Input{}.max_steps,
-                                         FieldDriverOptions{}.max_substeps);
+    return SimParams::Input::from_import(
+        data, std::move(particle_params), inp::TrackingLimits{});
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct with imported data.
  */
-SimParams::Input SimParams::Input::from_import(ImportData const& data,
-                                               SPConstParticles particle_params,
-                                               size_type max_steps,
-                                               size_type max_field_substeps)
+SimParams::Input
+SimParams::Input::from_import(ImportData const& data,
+                              SPConstParticles particle_params,
+                              inp::TrackingLimits const& limits)
 {
     CELER_EXPECT(particle_params);
     CELER_EXPECT(data.trans_params);
@@ -47,10 +45,10 @@ SimParams::Input SimParams::Input::from_import(ImportData const& data,
 
     using MaxSubstepsInt = decltype(FieldDriverOptions{}.max_substeps);
 
-    CELER_VALIDATE(max_field_substeps > 0
-                       && max_field_substeps
+    CELER_VALIDATE(limits.field_substeps > 0
+                       && limits.field_substeps
                               <= std::numeric_limits<MaxSubstepsInt>::max(),
-                   << "maximum field substep limit " << max_field_substeps
+                   << "maximum field substep limit " << limits.field_substeps
                    << " is out of range (should be in (0, "
                    << std::numeric_limits<MaxSubstepsInt>::max() << "])");
 
@@ -61,9 +59,9 @@ SimParams::Input SimParams::Input::from_import(ImportData const& data,
     // can take while looping (ceil(max Geant4 field propagator substeps / max
     // Celeritas field propagator substeps))
     CELER_ASSERT(data.trans_params.max_substeps
-                 >= static_cast<int>(max_field_substeps));
+                 >= static_cast<int>(limits.field_substeps));
     auto max_subthreshold_steps = ceil_div<size_type>(
-        data.trans_params.max_substeps, max_field_substeps);
+        data.trans_params.max_substeps, limits.field_substeps);
 
     for (auto pid : range(ParticleId{input.particles->size()}))
     {
@@ -80,7 +78,7 @@ SimParams::Input SimParams::Input::from_import(ImportData const& data,
             = LoopingThreshold::Energy(iter->second.important_energy);
         input.looping.insert({pdg, looping});
     }
-    input.max_steps = max_steps;
+    input.max_steps = limits.steps;
 
     return input;
 }

--- a/src/celeritas/track/SimParams.cc
+++ b/src/celeritas/track/SimParams.cc
@@ -52,7 +52,7 @@ SimParams::Input SimParams::Input::from_import(ImportData const& data,
                               <= std::numeric_limits<MaxSubstepsInt>::max(),
                    << "maximum field substep limit " << max_field_substeps
                    << " is out of range (should be in (0, "
-                   << std::numeric_limits<MaxSubstepsInt>::max() << "))");
+                   << std::numeric_limits<MaxSubstepsInt>::max() << "])");
 
     SimParams::Input input;
     input.particles = std::move(particle_params);
@@ -97,7 +97,7 @@ SimParams::SimParams(Input const& input)
             && input.max_steps <= std::numeric_limits<size_type>::max(),
         << "maximum step limit " << input.max_steps
         << " is out of range (should be in (0, "
-        << std::numeric_limits<size_type>::max() << "))");
+        << std::numeric_limits<size_type>::max() << "])");
 
     HostVal<SimParamsData> host_data;
 

--- a/src/celeritas/track/SimParams.cc
+++ b/src/celeritas/track/SimParams.cc
@@ -26,8 +26,10 @@ namespace celeritas
 SimParams::Input SimParams::Input::from_import(ImportData const& data,
                                                SPConstParticles particle_params)
 {
-    return SimParams::Input::from_import(
-        data, std::move(particle_params), FieldDriverOptions{}.max_substeps);
+    return SimParams::Input::from_import(data,
+                                         std::move(particle_params),
+                                         SimParams::Input{}.max_steps,
+                                         FieldDriverOptions{}.max_substeps);
 }
 
 //---------------------------------------------------------------------------//
@@ -36,6 +38,7 @@ SimParams::Input SimParams::Input::from_import(ImportData const& data,
  */
 SimParams::Input SimParams::Input::from_import(ImportData const& data,
                                                SPConstParticles particle_params,
+                                               size_type max_steps,
                                                size_type max_field_substeps)
 {
     CELER_EXPECT(particle_params);
@@ -77,6 +80,7 @@ SimParams::Input SimParams::Input::from_import(ImportData const& data,
             = LoopingThreshold::Energy(iter->second.important_energy);
         input.looping.insert({pdg, looping});
     }
+    input.max_steps = max_steps;
 
     return input;
 }

--- a/src/celeritas/track/SimParams.hh
+++ b/src/celeritas/track/SimParams.hh
@@ -42,6 +42,7 @@ class SimParams final : public ParamsDataInterface<SimParamsData>
         // Construct with imported data and max field substeps
         static Input from_import(ImportData const&,
                                  SPConstParticles,
+                                 size_type max_steps,
                                  size_type max_field_substeps);
 
         //// DATA ////

--- a/src/celeritas/track/SimParams.hh
+++ b/src/celeritas/track/SimParams.hh
@@ -12,6 +12,7 @@
 #include "corecel/data/CollectionMirror.hh"
 #include "corecel/data/ParamsDataInterface.hh"
 #include "corecel/math/NumericLimits.hh"
+#include "celeritas/inp/Tracking.hh"
 #include "celeritas/phys/PDGNumber.hh"
 
 #include "SimData.hh"
@@ -42,8 +43,7 @@ class SimParams final : public ParamsDataInterface<SimParamsData>
         // Construct with imported data and max field substeps
         static Input from_import(ImportData const&,
                                  SPConstParticles,
-                                 size_type max_steps,
-                                 size_type max_field_substeps);
+                                 inp::TrackingLimits const& limits);
 
         //// DATA ////
 


### PR DESCRIPTION
Tracks weren't being killed when `max_steps` was specified as the options wasn't being propagated to the `SimParams`.