### PR TITLE
Add JLSE env file

### DIFF
--- a/scripts/env/jlse.sh
+++ b/scripts/env/jlse.sh
@@ -5,17 +5,20 @@ export PROJ=/vast/projects/celeritas
 export SPACKROOT=$PROJ/spack
 . $SPACKROOT/share/spack/setup-env.sh
 
-qsub-gpu() {
-    # Usage: qsub-gpu [mi300x|h100] <qsub args>
-    [[ $(hostname) =~ ^jlselogin[0-9]+ ]] || {
-        echo "Error: must be on a jlselogin* host to submit jobs."
-        return 1
-    }
+qsub_gpu() {
+    # Usage: qsub_gpu [mi300x|h100] <qsub args>
 
-    case "$1" in
-        mi300x) queue="gpu_amd_mi300x" ;;
-        h100)   queue="gpu_h100" ;;
-        *)      echo "Error: unknown GPU type '$1'"; return 1 ;;
+    # Verify we are on a login node
+    h=$(uname -n 2>/dev/null || hostname 2>/dev/null || printf '')
+    if ! expr "$h" : 'jlselogin[0-9][0-9]*$' >/dev/null 2>&1; then
+        printf '%s\n' 'Error: must be on a login node to submit jobs.' >&2
+        return 1
+    fi
+
+    case ${1-} in
+        mi300x) queue=gpu_amd_mi300x ;;
+        h100)   queue=gpu_h100 ;;
+        *)      printf "Error: unknown GPU type '%s'\n" "${1-}" >&2; return 1 ;;
     esac
 
     shift

--- a/scripts/env/jlse.sh
+++ b/scripts/env/jlse.sh
@@ -2,14 +2,25 @@
 
 module use /soft/modulefiles
 export PROJ=/vast/projects/celeritas
-export SPACKROOT=/vast/projects/celeritas/spack
+export SPACKROOT=$PROJ/spack
 . $SPACKROOT/share/spack/setup-env.sh
 
-# Interactive job on an MI30
-alias mi300x="qsub -I -t 60 -n 1 -q gpu_amd_mi300x"
+qsub-gpu() {
+    # Usage: qsub-gpu [mi300x|h100] <qsub args>
+    [[ $(hostname) =~ ^jlselogin[0-9]+ ]] || {
+        echo "Error: must be on a jlselogin* host to submit jobs."
+        return 1
+    }
 
-# Interactive job on an H100
-alias h100="qsub -I -t 60 -n 1 -q gpu_h100"
+    case "$1" in
+        mi300x) queue="gpu_amd_mi300x" ;;
+        h100)   queue="gpu_h100" ;;
+        *)      echo "Error: unknown GPU type '$1'"; return 1 ;;
+    esac
+
+    shift
+    exec qsub -q "$queue" "$@"
+}
 
 # Load Nvidia/AMD environment if on a compute node
 if [[ "$(hostname -s)" == hopper* ]]; then

--- a/scripts/env/jlse.sh
+++ b/scripts/env/jlse.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+
+module use /soft/modulefiles
+export PROJ=/vast/projects/celeritas
+export SPACKROOT=/vast/projects/celeritas/spack
+. $SPACKROOT/share/spack/setup-env.sh
+
+# Interactive job on an MI30
+alias mi300x="qsub -I -t 60 -n 1 -q gpu_amd_mi300x"
+
+# Interactive job on an H100
+alias h100="qsub -I -t 60 -n 1 -q gpu_h100"
+
+# Load Nvidia/AMD environment if on a compute node
+if [[ "$(hostname -s)" == hopper* ]]; then
+  echo "Loading environment for H100"
+  module purge
+  module load cmake/3.28.3
+  module load cuda/12.9.1
+  spacktivate h100
+  export ENVFILE="$SPACKROOT/var/spack/environments/h100/spack.yaml"
+elif [[ "$(hostname -s)" == amdgpu* ]]; then
+  echo "Loading environment for MI300X"
+  module purge
+  module load cmake/3.28.3
+  module load aomp/rocm-6.4.1
+  spacktivate mi300x
+  export ENVFILE="$SPACKROOT/var/spack/environments/mi300x/spack.yaml"
+fi


### PR DESCRIPTION
This MR adds an env file for JLSE, leveraging a spack install on the Celeritas project space. The env file spactivates environments for H100 and MI250X nodes according to the host name. I have verified I can build and run celer-sim on both node types.