### PR TITLE
Add SurfaceInteractionApplier and implement PostBoundaryAction

### DIFF
--- a/src/celeritas/optical/action/TrackSlotExecutor.hh
+++ b/src/celeritas/optical/action/TrackSlotExecutor.hh
@@ -155,6 +155,11 @@ struct AppliesValidVolumetric
 /*!
  * Whether the track is undergoing a surface crossing and it matches the given
  * step and model.
+ *
+ * After the interaction step, a track may be on a surface but exiting so it
+ * does not have a valid next surface model. The surface stepping action is
+ * instead used, since tracks exiting the surface will have the post-boundary
+ * action set instead.
  */
 struct IsSurfaceModelEqual
 {

--- a/src/celeritas/optical/action/TrackSlotExecutor.hh
+++ b/src/celeritas/optical/action/TrackSlotExecutor.hh
@@ -165,7 +165,8 @@ struct IsSurfaceModelEqual
     CELER_FUNCTION bool operator()(CoreTrackView const& track) const
     {
         auto s_phys = track.surface_physics();
-        return s_phys.is_crossing_boundary()
+        return IsStepActionEqual{s_phys.scalars().surface_stepping_action}(
+                   track)
                && s_phys.interface(step).surface_model_id() == model;
     }
 };

--- a/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
+++ b/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
@@ -109,9 +109,8 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
     CELER_ASSERT(
         is_entering_surface(geo.dir(), surface_physics.global_normal()));
 
-    // TODO: replace with surface stepping action when implemented
     track.sim().post_step_action(
-        surface_physics.scalars().post_boundary_action);
+        surface_physics.scalars().surface_stepping_action);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/model/DielectricInteractionData.hh
+++ b/src/celeritas/optical/surface/model/DielectricInteractionData.hh
@@ -22,7 +22,7 @@ namespace optical
 // TYPE ALIASES
 //---------------------------------------------------------------------------//
 // Dielectric interface type
-enum class DielectricInterface : bool
+enum class DielectricInterface
 {
     metal,
     dielectric,

--- a/src/celeritas/optical/surface/model/DielectricInteractionExecutor.hh
+++ b/src/celeritas/optical/surface/model/DielectricInteractionExecutor.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DielectricInteractionData.hh"
+#include "SurfaceInteraction.hh"
 
 namespace celeritas
 {
@@ -22,7 +23,10 @@ struct DielectricInteractionExecutor
     NativeCRef<DielectricData> dielectric_data;
     NativeCRef<UnifiedReflectionData> reflection_data;
 
-    inline CELER_FUNCTION void operator()(CoreTrackView&) const {}
+    inline CELER_FUNCTION SurfaceInteraction operator()(CoreTrackView const&) const
+    {
+        return SurfaceInteraction::from_absorption();
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/model/DielectricInteractionModel.cc
+++ b/src/celeritas/optical/surface/model/DielectricInteractionModel.cc
@@ -14,6 +14,7 @@
 #include "celeritas/optical/action/TrackSlotExecutor.hh"
 
 #include "DielectricInteractionExecutor.hh"
+#include "SurfaceInteractionApplier.hh"
 
 namespace celeritas
 {
@@ -72,8 +73,8 @@ void DielectricInteractionModel::step(CoreParams const& params,
             state.ptr(),
             SurfacePhysicsOrder::interaction,
             this->surface_model_id(),
-            DielectricInteractionExecutor{dielectric_data_.host_ref(),
-                                          reflection_data_.host_ref()}));
+            SurfaceInteractionApplier{DielectricInteractionExecutor{
+                dielectric_data_.host_ref(), reflection_data_.host_ref()}}));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/model/DielectricInteractionModel.cu
+++ b/src/celeritas/optical/surface/model/DielectricInteractionModel.cu
@@ -12,6 +12,7 @@
 #include "celeritas/optical/action/TrackSlotExecutor.hh"
 
 #include "DielectricInteractionExecutor.hh"
+#include "SurfaceInteractionApplier.hh"
 
 namespace celeritas
 {
@@ -29,8 +30,8 @@ void DielectricInteractionModel::step(CoreParams const& params,
         state.ptr(),
         SurfacePhysicsOrder::interaction,
         this->surface_model_id(),
-        DielectricInteractionExecutor{dielectric_data_.device_ref(),
-                                      reflection_data_.device_ref()});
+        SurfaceInteractionApplier{DielectricInteractionExecutor{
+            dielectric_data_.device_ref(), reflection_data_.device_ref()}});
 
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
     launch_kernel(state, execute);

--- a/src/celeritas/optical/surface/model/DielectricInteractionModel.hh
+++ b/src/celeritas/optical/surface/model/DielectricInteractionModel.hh
@@ -25,7 +25,7 @@ namespace optical
  * determine the reflectivity of a photon incident on the physical surface. The
  * reflectivity is sampled to determine whether the photon refracts into the
  * next material or reflects. Reflection follows the UNIFIED model (see \c
- * UnifiedReflectionSampler). Refracted waves fall into two cases:
+ * ReflectionFormSampler). Refracted waves fall into two cases:
  *
  *  1. dielectric-metal: the photon is immediately absorbed.
  *  2. dielectric-dielectric: refracted direction and polarization are

--- a/src/celeritas/optical/surface/model/SurfaceInteraction.hh
+++ b/src/celeritas/optical/surface/model/SurfaceInteraction.hh
@@ -1,0 +1,63 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/surface/model/SurfaceInteraction.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/math/ArrayUtils.hh"
+#include "corecel/math/SoftEqual.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Result of a surface physics interaction.
+ */
+struct SurfaceInteraction
+{
+    //! Interaction result category
+    enum class Action
+    {
+        absorbed,
+        reflected,
+        refracted
+    };
+
+    Action action{Action::absorbed};  //!< Flags for interaction result
+    Real3 direction;
+    Real3 polarization;
+
+    //! Return an interaction representing an absorbed photon
+    static inline CELER_FUNCTION SurfaceInteraction from_absorption();
+
+    //! Whether data is assigned and valid
+    CELER_FUNCTION bool is_valid() const
+    {
+        return action == Action::absorbed
+               || (is_soft_unit_vector(direction)
+                   && is_soft_unit_vector(polarization)
+                   && is_soft_orthogonal(direction, polarization));
+    }
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a surface interaction for an optical photon absorbed on the
+ * surface.
+ */
+CELER_FUNCTION SurfaceInteraction SurfaceInteraction::from_absorption()
+{
+    SurfaceInteraction result;
+    result.action = Action::absorbed;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas

--- a/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
+++ b/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
@@ -6,8 +6,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Macros.hh"
-#include "corecel/sys/KernelTraits.hh"
 #include "celeritas/optical/CoreTrackView.hh"
 
 #include "SurfaceInteraction.hh"
@@ -24,53 +22,11 @@ namespace optical
  * SurfaceInteraction.
  */
 template<class F>
-struct SurfaceInteractionApplierBaseImpl
+struct SurfaceInteractionApplier
 {
     F sample_interaction;
 
     inline CELER_FUNCTION void operator()(CoreTrackView const&) const;
-};
-
-//---------------------------------------------------------------------------//
-/*!
- * This class is partially specialized with a second template argument to
- * extract any launch bounds from the functor class.
- *
- * \todo Generalize this with the core interaction applier
- */
-template<class F, typename = void>
-struct SurfaceInteractionApplier : public SurfaceInteractionApplierBaseImpl<F>
-{
-    CELER_FUNCTION SurfaceInteractionApplier(F&& f)
-        : SurfaceInteractionApplierBaseImpl<F>{celeritas::forward<F>(f)}
-    {
-    }
-};
-
-template<class F>
-struct SurfaceInteractionApplier<F,
-                                 std::enable_if_t<kernel_max_blocks_min_warps<F>>>
-    : public SurfaceInteractionApplierBaseImpl<F>
-{
-    static constexpr int max_block_size = F::max_block_size;
-    static constexpr int min_warps_per_eu = F::min_warps_per_eu;
-
-    CELER_FUNCTION SurfaceInteractionApplier(F&& f)
-        : SurfaceInteractionApplierBaseImpl<F>{celeritas::forward<F>(f)}
-    {
-    }
-};
-
-template<class F>
-struct SurfaceInteractionApplier<F, std::enable_if_t<kernel_max_blocks<F>>>
-    : public SurfaceInteractionApplierBaseImpl<F>
-{
-    static constexpr int max_block_size = F::max_block_size;
-
-    CELER_FUNCTION SurfaceInteractionApplier(F&& f)
-        : SurfaceInteractionApplierBaseImpl<F>{celeritas::forward<F>(f)}
-    {
-    }
 };
 
 //---------------------------------------------------------------------------//
@@ -87,7 +43,7 @@ CELER_FUNCTION SurfaceInteractionApplier(F&&) -> SurfaceInteractionApplier<F>;
  */
 template<class F>
 CELER_FUNCTION void
-SurfaceInteractionApplierBaseImpl<F>::operator()(CoreTrackView const& track) const
+SurfaceInteractionApplier<F>::operator()(CoreTrackView const& track) const
 {
     // Sample interaction
     SurfaceInteraction result = this->sample_interaction(track);

--- a/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
+++ b/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
@@ -1,0 +1,126 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/surface/model/SurfaceInteractionApplier.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/sys/KernelTraits.hh"
+#include "celeritas/optical/CoreTrackView.hh"
+
+#include "SurfaceInteraction.hh"
+
+namespace celeritas
+{
+namespace optical
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Wrap a surface interaction executor and apply it to a track.
+ *
+ * The functor \c F must take a \c CoreTrackview and return a \c
+ * SurfaceInteraction.
+ */
+template<class F>
+struct SurfaceInteractionApplierBaseImpl
+{
+    F sample_interaction;
+
+    inline CELER_FUNCTION void operator()(CoreTrackView const&) const;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * This class is partially specialized with a second template argument to
+ * extract any launch bounds from the functor class.
+ *
+ * \todo Generalize this with the core interaction applier
+ */
+template<class F, typename = void>
+struct SurfaceInteractionApplier : public SurfaceInteractionApplierBaseImpl<F>
+{
+    CELER_FUNCTION SurfaceInteractionApplier(F&& f)
+        : SurfaceInteractionApplierBaseImpl<F>{celeritas::forward<F>(f)}
+    {
+    }
+};
+
+template<class F>
+struct SurfaceInteractionApplier<F,
+                                 std::enable_if_t<kernel_max_blocks_min_warps<F>>>
+    : public SurfaceInteractionApplierBaseImpl<F>
+{
+    static constexpr int max_block_size = F::max_block_size;
+    static constexpr int min_warps_per_eu = F::min_warps_per_eu;
+
+    CELER_FUNCTION SurfaceInteractionApplier(F&& f)
+        : SurfaceInteractionApplierBaseImpl<F>{celeritas::forward<F>(f)}
+    {
+    }
+};
+
+template<class F>
+struct SurfaceInteractionApplier<F, std::enable_if_t<kernel_max_blocks<F>>>
+    : public SurfaceInteractionApplierBaseImpl<F>
+{
+    static constexpr int max_block_size = F::max_block_size;
+
+    CELER_FUNCTION SurfaceInteractionApplier(F&& f)
+        : SurfaceInteractionApplierBaseImpl<F>{celeritas::forward<F>(f)}
+    {
+    }
+};
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+template<class F>
+CELER_FUNCTION SurfaceInteractionApplier(F&&) -> SurfaceInteractionApplier<F>;
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Apply sampled surface interaction to the track.
+ */
+template<class F>
+CELER_FUNCTION void
+SurfaceInteractionApplierBaseImpl<F>::operator()(CoreTrackView const& track) const
+{
+    // Sample interaction
+    SurfaceInteraction result = this->sample_interaction(track);
+
+    if (result.action == SurfaceInteraction::Action::absorbed)
+    {
+        // Mark particle as killed
+        track.sim().status(TrackStatus::killed);
+    }
+    else
+    {
+        // Cross boundary if refracted
+        auto surface_physics = track.surface_physics();
+        auto traverse = surface_physics.traversal();
+        if (result.action == SurfaceInteraction::Action::refracted)
+        {
+            traverse.cross_interface(traverse.dir());
+        }
+
+        // Update direction and polarization
+        track.geometry().set_dir(result.direction);
+        track.particle().polarization(result.polarization);
+        surface_physics.update_traversal_direction(result.direction);
+
+        if (traverse.is_exiting())
+        {
+            // End boundary crossing if exiting
+            track.sim().post_step_action(
+                surface_physics.scalars().post_boundary_action);
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace optical
+}  // namespace celeritas


### PR DESCRIPTION
Add `SurfaceInteraction` and `SurfaceInteractionApplier` to optical surface physics. The applier will be used by the interaction step to apply the `SurfaceInteraction` result to the track.

The `PostBoundaryExecutor` is also implemented since the `SurfaceInteractionApplier` may change tracks to the `is_exiting()` state and off the surface. This executor will correctly update the geometry volume and reset the surface physics state so the photon can continue propagating. While a photon is in the `is_exiting()` state, the next surface model is undefined so the conditional track executor is updated to use the `surface_stepping_action` to tell if it should do a surface physics step instead of just having a valid surface ID.