### PR TITLE
Prevent build.sh exiting if pre-commit not found at start

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -129,7 +129,7 @@ SYSTEM_NAME=$(fancy_hostname)
 
 # Check whether cmake changes from environment
 OLD_CMAKE=$(which cmake 2>/dev/null || echo "")
-OLD_PRE_COMMIT=$(which pre-commit 2>/dev/null)
+OLD_PRE_COMMIT=$(which pre-commit 2>/dev/null || echo "")
 
 # Load environment paths
 _env_script="scripts/env/${SYSTEM_NAME}.sh"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -124,8 +124,13 @@ install_precommit_if_git() {
 # source dir)
 cd "$(dirname $0)"/..
 
-# Determine system name
+# Determine system name, failing on an empty string
 SYSTEM_NAME=$(fancy_hostname)
+if [ -z "${SYSTEM_NAME}" ]; then
+  log warning "Could not determine SYSTEM_NAME from LMOD_SYSTEM_NAME or HOSTNAME"
+  log error "Empty SYSTEM_NAME"
+  exit 1
+fi
 
 # Check whether cmake changes from environment
 OLD_CMAKE=$(which cmake 2>/dev/null || echo "")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -141,6 +141,7 @@ else
 fi
 
 NEW_CMAKE=$(which cmake 2>/dev/null || echo "cmake unavailable")
+NEW_PRE_COMMIT=$(which pre-commit 2>/dev/null || echo "")
 
 # Link preset file
 ln_presets "${SYSTEM_NAME}"
@@ -180,6 +181,11 @@ if cmake --build --preset=${CMAKE_PRESET}; then
   fi
 
   install_precommit_if_git
+  if [ "${NEW_PRE_COMMIT}" != "${OLD_PRE_COMMIT}" ]; then
+    log warning "Local environment script uses a different pre-commit than your \$PATH:"
+    log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"
+  fi
+
   if [ "${NEW_CMAKE}" != "${OLD_CMAKE}" ]; then
     log warning "Local environment script uses a different CMake than your \$PATH:"
     log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"


### PR DESCRIPTION
Starting a fresh build locally, I found that running the recommended `build.sh` script did nothing more than:

```
$ ./scripts/build.sh dev
Determined system name: Mac (override with LMOD_SYSTEM_NAME)
```

I triaged this to the line that sticks the path of `pre-commit` into `OLD_PRE_COMMIT`. Since I _didn't_ have `pre-commit` installed this just failed and exited silently. The change here "protects" that detection in the same way as the CMake check, though I'm not sure it's truly needed as the `OLD_PRE_COMMIT` variable doesn't appear to be used elsewhere.

I still get an error at the end of the script when it tries to install the pre-commit hook, but that tells me what to do!