### PR TITLE
Debug optical boundary crossing

### DIFF
--- a/src/celeritas/optical/Transporter.cc
+++ b/src/celeritas/optical/Transporter.cc
@@ -77,6 +77,9 @@ void Transporter::transport_impl(CoreState<M>& state) const
             action->step(*params_, state);
         }
 
+        CELER_LOG(info) << " step_iter " << num_step_iters << ": "
+                        << counters.num_active << " active tracks";
+
         num_steps += counters.num_active;
         if (CELER_UNLIKELY(++num_step_iters == max_step_iters_))
         {

--- a/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
+++ b/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
@@ -55,6 +55,22 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
     auto geo = track.geometry();
     CELER_EXPECT(geo.is_on_boundary());
 
+    // Move the particle across the boundary
+    geo.cross_boundary();
+    if (CELER_UNLIKELY(geo.failed()))
+    {
+        track.apply_errored();
+        return;
+    }
+
+    // If post volume is not an optical material, kill the track.
+    if (!track.material_record().material_id())
+    {
+        track.sim().status(TrackStatus::killed);
+        return;
+    }
+
+    /*
     // Surface selector must be created before crossing boundary to store
     // pre-volume information
     VolumeSurfaceSelector select_surface{track.surface(),
@@ -111,6 +127,7 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
 
     track.sim().post_step_action(
         surface_physics.scalars().surface_stepping_action);
+        */
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/vg/VecgeomTrackView.hh
+++ b/src/geocel/vg/VecgeomTrackView.hh
@@ -397,8 +397,9 @@ CELER_FUNCTION bool VecgeomTrackView::is_on_boundary() const
  */
 CELER_FUNCTION Real3 VecgeomTrackView::normal() const
 {
-    // FIXME: temporarily return a bogus but valid surface normal
-    return this->dir();
+    // // FIXME: temporarily return a bogus but valid surface normal
+    // return this->dir();
+    CELER_NOT_IMPLEMENTED("VecGeom Normals");
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ImportedDataTestBase.cc
+++ b/test/celeritas/ImportedDataTestBase.cc
@@ -39,7 +39,8 @@ auto ImportedDataTestBase::build_physics_options() const -> PhysicsOptions
 //---------------------------------------------------------------------------//
 auto ImportedDataTestBase::select_optical_models() const -> std::vector<IMC>
 {
-    return {IMC::absorption, IMC::rayleigh, IMC::wls};
+    return {};
+    // return {IMC::absorption, IMC::rayleigh, IMC::wls};
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
While working on implementing optical boundary crossing, I've encountered some failing tests for the optical `PrimaryGenerator` based on vecgeom + g4 versus orange + geant4. The vecgeom builds have slightly less step counters, and sometimes different step iterators than the orange + geant4 version.

This branch isolates some of the recent changes (e.g. vecgeom normals, optical surface physics) so that it's just moving photons across a surface with no other physics involved.

Closes #2041 