### PR TITLE
Improve perfetto logger/failure integration

### DIFF
--- a/src/corecel/io/LogHandlers.cc
+++ b/src/corecel/io/LogHandlers.cc
@@ -22,7 +22,7 @@ void StreamLogHandler::operator()(LogProvenance prov,
                                   LogLevel lev,
                                   std::string msg) const
 {
-    if (lev == LogLevel::debug || lev >= LogLevel::warning)
+    if (lev < LogLevel::status || lev >= LogLevel::warning)
     {
         // Output problem line/file for debugging or high level
         os_ << color_code('x') << prov.file;

--- a/src/corecel/sys/TracingSession.hh
+++ b/src/corecel/sys/TracingSession.hh
@@ -49,10 +49,10 @@ class TracingSession
     static void flush() noexcept;
 
     // Configure a system session recording to a daemon
-    TracingSession() noexcept;
+    TracingSession();
 
     // Configure an in-process session recording to filename
-    explicit TracingSession(std::string const& filename) noexcept;
+    explicit TracingSession(std::string const& filename);
 
     // Start the profiling session (DEPRECATED: remove in v1.0)
     //! The session is now started on construction; this is now a null-op
@@ -80,8 +80,8 @@ inline void flush_tracing() noexcept
 }
 
 #if !CELERITAS_USE_PERFETTO
-inline TracingSession::TracingSession() noexcept = default;
-inline TracingSession::TracingSession(std::string const& s) noexcept
+inline TracingSession::TracingSession() = default;
+inline TracingSession::TracingSession(std::string const& s)
 {
     if (!s.empty())
     {

--- a/src/corecel/sys/TracingSession.perfetto.cc
+++ b/src/corecel/sys/TracingSession.perfetto.cc
@@ -11,6 +11,7 @@
 #include <perfetto.h>
 
 #include "corecel/Assert.hh"
+#include "corecel/io/Logger.hh"
 
 #include "Environment.hh"
 #include "ScopedProfiling.hh"
@@ -47,6 +48,31 @@ perfetto::TraceConfig configure_session() noexcept
     ds_cfg->set_name("track_event");
     ds_cfg->set_track_event_config_raw(track_event_cfg.SerializeAsString());
     return cfg;
+}
+
+//! Forward perfetto log messages to the Celeritas logger
+void perfetto_log_adapter(perfetto::LogMessageCallbackArgs args)
+{
+    // Map perfetto log levels to Celeritas log levels
+    LogLevel celer_level = [&] {
+        switch (args.level)
+        {
+            case perfetto::LogLev::kLogDebug:
+                return LogLevel::debug;
+            case perfetto::LogLev::kLogInfo:
+                return LogLevel::diagnostic;
+            case perfetto::LogLev::kLogImportant:
+                return LogLevel::info;
+            case perfetto::LogLev::kLogError:
+                return LogLevel::error;
+            default:
+                return LogLevel::diagnostic;
+        }
+    }();
+
+    // Create log provenance from perfetto's file/line info
+    char const* filename = args.filename ? args.filename : "perfetto";
+    world_logger()({filename, args.line}, celer_level) << args.message;
 }
 
 //---------------------------------------------------------------------------//
@@ -127,6 +153,7 @@ TracingSession::TracingSession(std::string const& filename)
     // Create implementation that stores tracing session and file handle
     impl_.reset(new Impl);
     perfetto::TracingInitArgs args;
+    args.log_message_callback = &perfetto_log_adapter;
     if (filename.empty())
     {
         CELER_LOG(info) << "Starting Perfetto system tracing session";

--- a/src/corecel/sys/TracingSession.perfetto.cc
+++ b/src/corecel/sys/TracingSession.perfetto.cc
@@ -106,13 +106,13 @@ void TracingSession::flush() noexcept
 /*!
  * Start a system tracing session.
  */
-TracingSession::TracingSession() noexcept : TracingSession(std::string{}) {}
+TracingSession::TracingSession() : TracingSession(std::string{}) {}
 
 //---------------------------------------------------------------------------//
 /*!
  * Start an in-process tracing session.
  */
-TracingSession::TracingSession(std::string const& filename) noexcept
+TracingSession::TracingSession(std::string const& filename)
 {
     if (!ScopedProfiling::enabled())
     {
@@ -146,21 +146,15 @@ TracingSession::TracingSession(std::string const& filename) noexcept
 
     // Start tracing and cancel if it failed
     perfetto::Tracing::Initialize(args);
-    if (!perfetto::Tracing::IsInitialized())
-    {
-        CELER_LOG(warning) << "Failed to initialize Perfetto";
-        impl_.reset();
-        return;
-    }
+    CELER_VALIDATE(
+        perfetto::Tracing::IsInitialized(),
+        << R"(failed to initialize Perfetto (re-run with CELER_ENABLE_PROFILING=0))");
 
     perfetto::TrackEvent::Register();
     auto session = perfetto::Tracing::NewTrace();
-    if (!session)
-    {
-        CELER_LOG(warning) << "Failed to open Perfetto tracing session";
-        impl_.reset();
-        return;
-    }
+    CELER_VALIDATE(
+        session,
+        << R"(failed to open Perfetto tracing session (re-run with CELER_ENABLE_PROFILING=0))");
 
     session->Setup(configure_session(), impl_->fd);
     session->StartBlocking();


### PR DESCRIPTION
This dispatches the Perfetto log messages to the Celeritas logger. It also throws runtime errors if initialization fails rather than just warning: if the user wants profiling, we should give them profiling.

Finally it adjusts the output so that `diagnostic` messages (e.g., startup messages from perfetto and GDML loading) write their source file path.