### PR TITLE
Fix Mie scattering execution on device

### DIFF
--- a/src/celeritas/optical/interactor/MieInteractor.hh
+++ b/src/celeritas/optical/interactor/MieInteractor.hh
@@ -81,7 +81,7 @@ MieInteractor::MieInteractor(NativeCRef<MieData> const& shared,
     CELER_EXPECT(mat_id < shared.mie_record.size());
     CELER_EXPECT(is_soft_unit_vector(inc_dir_));
     CELER_EXPECT(is_soft_unit_vector(inc_pol_));
-    CELER_EXPECT(soft_zero(dot_product(inc_dir_, inc_pol_)));
+    CELER_EXPECT(is_soft_orthogonal(inc_dir_, inc_pol_));
 }
 
 //---------------------------------------------------------------------------//
@@ -141,7 +141,7 @@ CELER_FUNCTION Interaction MieInteractor::operator()(Engine& rng) const
 
     CELER_ENSURE(is_soft_unit_vector(new_dir));
     CELER_ENSURE(is_soft_unit_vector(new_pol));
-    CELER_ENSURE(soft_zero(dot_product(new_pol, new_dir)));
+    CELER_ENSURE(is_soft_orthogonal(new_pol, new_dir));
 
     return result;
 }

--- a/src/celeritas/optical/model/MieExecutor.hh
+++ b/src/celeritas/optical/model/MieExecutor.hh
@@ -36,6 +36,8 @@ struct MieExecutor
  */
 CELER_FUNCTION Interaction MieExecutor::operator()(CoreTrackView const& track)
 {
+    CELER_EXPECT(data);
+
     // Access the current particle track (optical photon)
     auto particle = track.particle();
     // Photon’s current direction
@@ -44,6 +46,7 @@ CELER_FUNCTION Interaction MieExecutor::operator()(CoreTrackView const& track)
     auto rng = track.rng();
     // Look up the Mie parameters for this material
     auto matid = track.material_record().material_id();
+    CELER_ASSERT(matid < data.mie_record.size());
 
     MieInteractor interact{data, particle, direction, matid};
 

--- a/src/celeritas/optical/model/MieModel.cu
+++ b/src/celeritas/optical/model/MieModel.cu
@@ -24,11 +24,11 @@ namespace optical
 
 void MieModel::step(CoreParams const& params, CoreStateDevice& state) const
 {
-    auto execute
-        = make_action_thread_executor(params.ptr<MemSpace::native>(),
-                                      state.ptr(),
-                                      this->action_id(),
-                                      InteractionApplier{MieExecutor{}});
+    auto execute = make_action_thread_executor(
+        params.ptr<MemSpace::native>(),
+        state.ptr(),
+        this->action_id(),
+        InteractionApplier{MieExecutor{this->device_ref()}});
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
     launch_kernel(state, execute);
 }


### PR DESCRIPTION
Tests with Mie scattering enabled were failing on device because the reference to the device data wasn't set in the executor.