### PR TITLE
Fix calculation of distribution index in optical photon generation

### DIFF
--- a/src/celeritas/optical/gen/detail/GeneratorExecutor.hh
+++ b/src/celeritas/optical/gen/detail/GeneratorExecutor.hh
@@ -91,7 +91,8 @@ CELER_FUNCTION void GeneratorExecutor<G>::operator()(TrackSlotId tid) const
     Span<size_type> offsets{buffer_start, all_offsets.end()};
 
     // Find the distribution this thread will generate from
-    size_type dist_idx = find_distribution_index(offsets, tid.get());
+    size_type dist_idx = buffer_start - all_offsets.begin()
+                         + find_distribution_index(offsets, tid.get());
     CELER_ASSERT(dist_idx < offload.distributions.size());
     auto const& dist = offload.distributions[DistId(dist_idx)];
     CELER_ASSERT(dist);

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -543,7 +543,7 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        EXPECT_EQ(95, result.accum.step_iters);
+        EXPECT_EQ(94, result.accum.step_iters);
         EXPECT_EQ(1, result.accum.flushes);
         ASSERT_EQ(2, result.accum.generators.size());
 

--- a/test/celeritas/optical/OpticalUtils.test.cc
+++ b/test/celeritas/optical/OpticalUtils.test.cc
@@ -93,6 +93,7 @@ TEST(OpticalUtilsTest, find_distribution_index)
         auto start = celeritas::upper_bound(
             counts.begin(), counts.end(), size_type(0));
 
+        size_type offset = start - counts.begin();
         Span<size_type> span_counts{start, counts.end()};
 
         for (auto thread_idx : range(vacancies.size()))
@@ -100,7 +101,7 @@ TEST(OpticalUtilsTest, find_distribution_index)
             // In the vacsnt track slot, store the index of the distribution
             // that will generate the track
             result[vacancies[thread_idx]]
-                = find_distribution_index(span_counts, thread_idx);
+                = offset + find_distribution_index(span_counts, thread_idx);
         }
         return result;
     };

--- a/test/celeritas/optical/OpticalUtils.test.cc
+++ b/test/celeritas/optical/OpticalUtils.test.cc
@@ -79,22 +79,61 @@ TEST(OpticalUtilsTest, find_distribution_index)
     std::vector<size_type> counts(distributions.size());
     std::partial_sum(
         distributions.begin(), distributions.end(), counts.begin());
-
-    static unsigned int const expected_counts[]
-        = {1u, 2u, 7u, 9u, 14u, 22u, 23u, 29u, 36u, 43u};
-    EXPECT_VEC_EQ(expected_counts, counts);
-
-    std::vector<int> result(num_threads, -1);
-    for (auto thread_idx : range(vacancies.size()))
     {
-        // In the vacsnt track slot, store the index of the distribution that
-        // will generate the track
-        result[vacancies[thread_idx]]
-            = find_distribution_index(make_span(counts), thread_idx);
+        static unsigned int const expected_counts[]
+            = {1u, 2u, 7u, 9u, 14u, 22u, 23u, 29u, 36u, 43u};
+        EXPECT_VEC_EQ(expected_counts, counts);
     }
-    PRINT_EXPECTED(result);
-    static int const expected_result[] = {-1, 0, 1, -1, 2, -1, 2, 2};
-    EXPECT_VEC_EQ(expected_result, result);
+
+    auto fill_vacancies = [&]() {
+        std::vector<int> result(num_threads, -1);
+
+        // Find the index of the first distribution that has a nonzero number
+        // of primaries left to generate
+        auto start = celeritas::upper_bound(
+            counts.begin(), counts.end(), size_type(0));
+
+        Span<size_type> span_counts{start, counts.end()};
+
+        for (auto thread_idx : range(vacancies.size()))
+        {
+            // In the vacsnt track slot, store the index of the distribution
+            // that will generate the track
+            result[vacancies[thread_idx]]
+                = find_distribution_index(span_counts, thread_idx);
+        }
+        return result;
+    };
+
+    {
+        auto result = fill_vacancies();
+        static int const expected_result[] = {-1, 0, 1, -1, 2, -1, 2, 2};
+        EXPECT_VEC_EQ(expected_result, result);
+    }
+
+    size_type num_gen = vacancies.size();
+    for (auto thread_idx : range(counts.size()))
+    {
+        // Update the cumulative sum of the number of photons per distribution
+        if (counts[thread_idx] < num_gen)
+        {
+            counts[thread_idx] = 0;
+        }
+        else
+        {
+            counts[thread_idx] -= num_gen;
+        }
+    }
+    {
+        static unsigned int const expected_counts[]
+            = {0u, 0u, 2u, 4u, 9u, 17u, 18u, 24u, 31u, 38u};
+        EXPECT_VEC_EQ(expected_counts, counts);
+    }
+    {
+        auto result = fill_vacancies();
+        static int const expected_result[] = {-1, 2, 2, -1, 3, -1, 3, 4};
+        EXPECT_VEC_EQ(expected_result, result);
+    }
 }
 
 TEST(OpticalUtilsTest, copy_if_vacant_host)


### PR DESCRIPTION
When calculating the index of the distribution that a thread should generate photons from in the scintillation/Cherenkov generator, we weren't adding the offset from the start of the buffer. This meant that while we were generating the correct number of photons, we were repeatedly generating them from the distributions at the front of the buffer. This PR fixes that calculation and expands one of the tests to more accurately mirror the generation. Fortunately this didn't affect any of the performance results.