### PR TITLE
Fix stack allocator/CUDA RDC weirdness

### DIFF
--- a/src/corecel/data/StackAllocator.hh
+++ b/src/corecel/data/StackAllocator.hh
@@ -225,12 +225,10 @@ CELER_FUNCTION auto StackAllocator<T>::operator()(size_type count)
     }
 
     // Initialize the data at the newly "allocated" address
-    value_type* result = new (&data_.storage[StorageId{start}]) value_type;
-    for (size_type i = 1; i < count; ++i)
+    value_type* result = &data_.storage[StorageId{start}];
+    for (size_type i = 0; i < count; ++i)
     {
-        // Initialize remaining values
-        CELER_ASSERT(&data_.storage[StorageId{start + i}] == result + i);
-        new (&data_.storage[StorageId{start + i}]) value_type;
+        result[i] = value_type{};
     }
     return result;
 }


### PR DESCRIPTION
I think there's a long lived bug in the use of `operator new` in CUDA code that's caused intermittent bizarre RDC errors over time, e.g. #118,  #1985, #2074. On develop, relocation data for `celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)` shows up in model kernel files three times and is called many more:
```console
$ cuobjdump --dump-ptx ./src/celeritas/CMakeFiles/celeritas_objects.dir/em/model/EPlusGGModel.cu.o | c++filt | grep 'StackAllocator.*operator'
.weak .global .align 4 .b8 celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)[4];
.weak .global .align 8 .b8 celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)[40] = {255, 255, 255, 255};
.weak .global .align 8 .b8 celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)[40] = {255, 255, 255, 255};
ld.global.u32 %r67, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)];
ld.global.v2.u32 {%r69, %r70}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)];
ld.global.v2.u32 {%r73, %r74}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+8];
ld.global.v2.u32 {%r77, %r78}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+16];
ld.global.v2.u32 {%r81, %r82}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+24];
ld.global.v2.u32 {%r85, %r86}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+32];
ld.global.v2.u32 {%r90, %r91}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)];
ld.global.v2.u32 {%r94, %r95}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+8];
ld.global.v2.u32 {%r98, %r99}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+16];
ld.global.v2.u32 {%r102, %r103}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+24];
ld.global.v2.u32 {%r106, %r107}, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)+32];
```

On this branch:
```console
$ cuobjdump --dump-ptx ./src/celeritas/CMakeFiles/celeritas_objects.dir/em/model/EPlusGGModel.cu.o | cu++filt | grep 'StackAllocator.*operator'
.weak .global .align 4 .b8 celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)[4];
ld.global.u32 %r67, [celeritas::StackAllocator<celeritas::Secondary>::operator ()(unsigned int)];
```

The difference between the develop and broken code in #2074 is inconsequential, which corresponds to the seemingly random changes we've seen. However this change is substantial which makes me think that it's fixing once and for all.

(There is incidentally no change in the register usage/occupancy for our kernels in either vecgeom or orange.)