### PR TITLE
Add Geant4 options to unit test and build output

### DIFF
--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -157,6 +157,16 @@ endif()
 list(JOIN _vecgeom_opts "," _vecgeom_opts)
 celeritas_append_cmake_string("vecgeom_options" "${_vecgeom_opts}")
 
+# Save Geant4 options for verbose output: start with optional TLS model
+set(_g4_opts ${Geant4_TLS_MODEL})
+foreach(_opt multithreaded shared static smartstack gdml usolids)
+  if(Geant4_${_opt}_FOUND)
+    list(APPEND _g4_opts "${_opt}")
+  endif()
+endforeach()
+list(JOIN _g4_opts "," _g4_opts)
+celeritas_append_cmake_string("geant4_options" "${_g4_opts}")
+
 # Convert lists to newline-separated strings
 foreach(_ext CMAKE_STRINGS_DECL CMAKE_STRINGS_DEF VECGEOM_CONFIG DEPENDENCY_VERSIONS)
   list(JOIN CELERITAS_${_ext} "\n" CELERITAS_${_ext})

--- a/src/corecel/io/BuildOutput.cc
+++ b/src/corecel/io/BuildOutput.cc
@@ -88,6 +88,11 @@ void BuildOutput::output(JsonPimpl* j) const
             return deps;
         }();
 
+        if constexpr (CELERITAS_USE_GEANT4)
+        {
+            cfg["geant4"] = std::string(cmake::geant4_options);
+        }
+
         if constexpr (CELERITAS_USE_VECGEOM)
         {
             cfg["vecgeom"] = std::string(cmake::vecgeom_options);

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -56,7 +56,7 @@ class GeantGeoTest : public GeantGeoTestBase
         static bool const have_printed_ = [] {
             using namespace celeritas::cmake;
             cout << color_code('x') << "Using Geant4 v" << geant4_version
-                 << color_code(' ') << endl;
+                 << " (" << geant4_options << ")" << color_code(' ') << endl;
             return true;
         }();
         EXPECT_TRUE(have_printed_);


### PR DESCRIPTION
Save and output Geant4 configuration options for easier debugging of users' configurations.

Output difference from `celer-sim --config`:
```diff
--- old.json	2025-10-26 07:18:06
+++ new.json	2025-10-26 07:17:58
@@ -6,6 +6,7 @@
     "core_geo": "ORANGE",
     "core_rng": "xorwow",
     "debug": true,
+    "geant4": "global-dynamic,multithreaded,shared,gdml",
     "gpu_architectures": "",
     "hostname": "goldfinger",
     "openmp": "disabled",
```