### PR TITLE
Add data() getter functions for the DeviceAllocation class

### DIFF
--- a/src/corecel/data/DeviceAllocation.hh
+++ b/src/corecel/data/DeviceAllocation.hh
@@ -81,6 +81,12 @@ class DeviceAllocation
     // Copy data to host
     void copy_to_host(SpanBytes bytes) const;
 
+    // Raw pointer to device data (dangerous!)
+    void* data() { return data_.get(); }
+
+    // Raw pointer to device data (dangerous!)
+    void const* data() const { return data_.get(); }
+
   private:
     struct DeviceFreeDeleter
     {


### PR DESCRIPTION
This PR allows access to the DeviceAllocation class data member in the same way that the DeviceVector class does. This is useful for low-level device memory allocations and access, such as what CUDA cub needs for working memory.