### PR TITLE
Fix run manager construction in integration test base

### DIFF
--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -288,7 +288,7 @@ G4RunManager& IntegrationTestBase::run_manager()
 #if G4VERSION_NUMBER >= 1100
             G4RunManagerFactory::CreateRunManager()
 #else
-            std::shared_ptr<G4RunManager>()
+            std::make_shared<G4RunManager>()
 #endif
         };
         CELER_ASSERT(rm);


### PR DESCRIPTION
I just noticed the integration unit tests were failing with Geant4 v10:

```console
C++ exception with description "/home/runner/work/celeritas/celeritas/test/accel/IntegrationTestBase.cc:294:
celeritas: internal assertion failed: rm" thrown in the test body.
```

This wasn't obvious in the CI since we continue on error for older Geant4 versions.
