### PR TITLE
Fix erroneous failure in gcov ci

### DIFF
--- a/scripts/ci/gcovr.cfg
+++ b/scripts/ci/gcovr.cfg
@@ -9,10 +9,10 @@ gcov-exclude = .*RootInterface.*
 #   see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080
 gcov-ignore-parse-errors = negative_hits.warn
 # (WARNING) - Thread-2 (worker) - Exception during parsing:
-	SuspiciousHits: .../src/corecel/cont/Array.hh:86 Got suspicious hit value in: 6280118000:   86:    CELER_CEF reference operator[](size_type i) { return d_[i]; }
+#	 SuspiciousHits: .../src/corecel/cont/Array.hh:86 Got suspicious hit value in: 6280118000:   86:    CELER_CEF reference operator[](size_type i) { return d_[i]; }
 # This is caused by a bug in gcov tool, see
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
 # --gcov-ignore-parse-errors with a value of suspicious_hits.warn,
-gcov-ignore-parse-errors  = suspicious_hits.warn
+gcov-ignore-parse-errors = suspicious_hits.warn
 
 exclude-unreachable-branches = yes

--- a/scripts/ci/gcovr.cfg
+++ b/scripts/ci/gcovr.cfg
@@ -1,9 +1,18 @@
+# Exclude ROOT dictionary from any reports
 exclude = .*/.*RootInterface.*
 gcov-exclude = .*RootInterface.*
+
 # gcovr.formats.gcov.parser.common.NegativeHits:
 #   ../src/celeritas/field/FieldDriverOptions.hh:82
 #   Got negative hit value in: # branch  1 taken -12
 #   This is caused by a bug in gcov tool:
 #   see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080
 gcov-ignore-parse-errors = negative_hits.warn
+# (WARNING) - Thread-2 (worker) - Exception during parsing:
+	SuspiciousHits: .../src/corecel/cont/Array.hh:86 Got suspicious hit value in: 6280118000:   86:    CELER_CEF reference operator[](size_type i) { return d_[i]; }
+# This is caused by a bug in gcov tool, see
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
+# --gcov-ignore-parse-errors with a value of suspicious_hits.warn,
+gcov-ignore-parse-errors  = suspicious_hits.warn
+
 exclude-unreachable-branches = yes


### PR DESCRIPTION
```
(WARNING) - Thread-2 (worker) - Unrecognized GCOV output for /home/runner/work/celeritas/celeritas/src/corecel/cont/Array.hh
          6280118000:   86:    CELER_CEF reference operator[](size_type i) { return d_[i]; }
          6280118000:   86-block  0
        This is indicative of a gcov output parse error.
        Please report this to the gcovr developers
        at <https://github.com/gcovr/gcovr/issues>.
Warning: (WARNING) Unrecognized GCOV output for /home/runner/work/celeritas/celeritas/src/corecel/cont/Array.hh
          6280118000:   86:    CELER_CEF reference operator[](size_type i) { return d_[i]; }
          6280118000:   86-block  0
        This is indicative of a gcov output parse error.
        Please report this to the gcovr developers
        at <https://github.com/gcovr/gcovr/issues>.
(WARNING) - Thread-2 (worker) - Exception during parsing:
        SuspiciousHits: /home/runner/work/celeritas/celeritas/src/corecel/cont/Array.hh:86 Got suspicious hit value in: 6280118000:   86:    CELER_CEF reference operator[](size_type i) { return d_[i]; }
This is caused by a bug in gcov tool, see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68080. Use option
--gcov-ignore-parse-errors with a value of suspicious_hits.warn,
or suspicious_hits.warn_once_per_file or change the threshold
for the detection with option --gcov-su^Cicious-hits-threshold.
```

Seen in https://github.com/celeritas-project/celeritas/actions/runs/19015460928/job/54303025640?pr=2092 of #2092