### PR TITLE
Silence some egregious shadowing warnings

### DIFF
--- a/src/celeritas/alongstep/detail/ElossApplier.hh
+++ b/src/celeritas/alongstep/detail/ElossApplier.hh
@@ -58,8 +58,8 @@ CELER_FUNCTION void ElossApplier<EH>::operator()(CoreTrackView const& track)
     if (deposited > zero_quantity())
     {
         // Deposit energy loss
-        auto step = track.physics_step();
-        step.deposit_energy(deposited);
+        auto phys_step = track.physics_step();
+        phys_step.deposit_energy(deposited);
         particle.subtract_energy(deposited);
     }
 

--- a/src/celeritas/em/msc/UrbanMsc.hh
+++ b/src/celeritas/em/msc/UrbanMsc.hh
@@ -170,16 +170,16 @@ CELER_FUNCTION void UrbanMsc::limit_step(CoreTrackView const& track)
                                             par.energy(),
                                             msc_helper.msc_mfp(),
                                             phys.dedx_range());
-        auto gp = calc_geom_path(true_path);
+        auto result = calc_geom_path(true_path);
 
         // Limit geometrical step to 1 MSC MFP
-        if (gp.step > msc_helper.msc_mfp())
+        if (result.step > msc_helper.msc_mfp())
         {
-            gp.step = msc_helper.msc_mfp();
+            result.step = msc_helper.msc_mfp();
             limited = true;
         }
 
-        return gp;
+        return result;
     }();
     CELER_ASSERT(0 < gp.step && gp.step <= true_path);
 

--- a/src/celeritas/em/msc/detail/MscStepFromGeo.hh
+++ b/src/celeritas/em/msc/detail/MscStepFromGeo.hh
@@ -112,13 +112,13 @@ CELER_FUNCTION real_type MscStepFromGeo::operator()(real_type gstep) const
             // Cross section was assumed to be constant over the step:
             // z = lambda * (1 - exp(-g / lambda))
             // => g = -lambda * log(1 - g / lambda)
-            real_type tstep = -lambda_ * std::log1p(-gstep / lambda_);
-            if (tstep < params_.min_step_transform)
+            real_type result = -lambda_ * std::log1p(-gstep / lambda_);
+            if (result < params_.min_step_transform)
             {
                 // Very small step: did not transform path length
                 return gstep;
             }
-            return tstep;
+            return result;
         }
 
         real_type w = 1 + 1 / (alpha_ * lambda_);

--- a/src/celeritas/phys/PhysicsStepUtils.hh
+++ b/src/celeritas/phys/PhysicsStepUtils.hh
@@ -61,7 +61,7 @@ find_ppid(MaterialView const& material,
 
     // Sample the process from the pre-calculated per-process cross section
     ParticleProcessId ppid = celeritas::make_selector(
-        [&pstep](ParticleProcessId ppid) { return pstep.per_process_xs(ppid); },
+        [&pstep](ParticleProcessId i) { return pstep.per_process_xs(i); },
         ParticleProcessId{physics.num_particle_processes()},
         pstep.macro_xs())(rng);
     CELER_ASSERT(ppid);

--- a/src/corecel/grid/NonuniformGrid.hh
+++ b/src/corecel/grid/NonuniformGrid.hh
@@ -122,7 +122,7 @@ CELER_FUNCTION size_type NonuniformGrid<T>::find(value_type value) const
         offset_.begin() + 1,
         offset_.end() - 1,
         value,
-        [&v = storage_](T value, ItemId<T> i) { return value < v[i]; });
+        [&v = storage_](T lhs, ItemId<T> rhs_id) { return lhs < v[rhs_id]; });
 
     if (value < storage_[*iter])
     {

--- a/src/corecel/math/HashUtils.hh
+++ b/src/corecel/math/HashUtils.hh
@@ -108,10 +108,10 @@ struct hash<celeritas::Span<T, Extent>>
         else
         {
             std::size_t result{};
-            celeritas::Hasher hash{&result};
+            celeritas::Hasher hash_impl{&result};
             for (auto const& v : s)
             {
-                hash(std::hash<std::remove_cv_t<T>>{}(v));
+                hash_impl(std::hash<std::remove_cv_t<T>>{}(v));
             }
             return result;
         }

--- a/src/corecel/math/IllinoisRootFinder.hh
+++ b/src/corecel/math/IllinoisRootFinder.hh
@@ -74,10 +74,12 @@ IllinoisRootFinder<F>::IllinoisRootFinder(F&& func, real_type tol)
 //---------------------------------------------------------------------------//
 /*!
  * Solve for a root between the two points.
+ *
+ * TODO: rewrite as enum array of size 2
  */
 template<class F>
-CELER_FUNCTION real_type IllinoisRootFinder<F>::operator()(real_type left,
-                                                           real_type right)
+CELER_FUNCTION real_type IllinoisRootFinder<F>::operator()(real_type xl,
+                                                           real_type xr)
 {
     //! Enum defining side of approximated root to true root
     enum class Side
@@ -88,10 +90,10 @@ CELER_FUNCTION real_type IllinoisRootFinder<F>::operator()(real_type left,
     };
 
     // Initialize Iteration parameters
-    real_type f_left = func_(left);
-    real_type f_right = func_(right);
-    real_type f_root = 1;
-    real_type root = 0;
+    real_type fl = func_(xl);
+    real_type fr = func_(xr);
+    real_type fx = 1;
+    real_type x = 0;
     Side side = Side::init;
     int remaining_iters = max_iters_;
 
@@ -99,34 +101,34 @@ CELER_FUNCTION real_type IllinoisRootFinder<F>::operator()(real_type left,
     do
     {
         // Estimate root and update value
-        root = (left * f_right - right * f_left) / (f_right - f_left);
-        f_root = func_(root);
+        x = (xl * fr - xr * fl) / (fr - fl);
+        fx = func_(x);
 
         // Update the bound which produces the same sign as the root
-        if (signum(f_left) == signum(f_root))
+        if (signum(fl) == signum(fx))
         {
-            left = root;
-            f_left = f_root;
+            xl = x;
+            fl = fx;
             if (side == Side::left)
             {
-                f_right *= real_type(0.5);
+                fr *= real_type(0.5);
             }
             side = Side::left;
         }
         else
         {
-            right = root;
-            f_right = f_root;
+            xr = x;
+            fr = fx;
             if (side == Side::right)
             {
-                f_left *= real_type(0.5);
+                fl *= real_type(0.5);
             }
             side = Side::right;
         }
-    } while (std::fabs(f_root) > tol_ && --remaining_iters > 0);
+    } while (std::fabs(fx) > tol_ && --remaining_iters > 0);
 
     CELER_ENSURE(remaining_iters > 0);
-    return root;
+    return x;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/Device.cc
+++ b/src/corecel/sys/Device.cc
@@ -94,7 +94,7 @@ Device& global_device()
  */
 int Device::num_devices()
 {
-    static int const result = [] {
+    static int const num_devices_ = [] {
         if (!CELER_USE_DEVICE)
         {
             CELER_LOG(debug)
@@ -121,7 +121,7 @@ int Device::num_devices()
         CELER_ENSURE(result >= 0);
         return result;
     }();
-    return result;
+    return num_devices_;
 }
 
 //---------------------------------------------------------------------------//
@@ -151,7 +151,7 @@ bool Device::async()
 {
     if constexpr (CELER_STREAM_SUPPORTS_ASYNC)
     {
-        static bool const result = []() -> bool {
+        static bool const async_ = []() -> bool {
             constexpr bool default_val = CELERITAS_USE_CUDA
                                          || !CELER_BUGGY_HIP_ASYNC;
             auto result = getenv_flag("CELER_DEVICE_ASYNC", default_val);
@@ -164,7 +164,7 @@ bool Device::async()
             }
             return result.value;
         }();
-        return result;
+        return async_;
     }
     else
     {

--- a/src/corecel/sys/ScopedProfiling.cc
+++ b/src/corecel/sys/ScopedProfiling.cc
@@ -28,7 +28,7 @@ namespace celeritas
  */
 bool ScopedProfiling::enabled()
 {
-    static bool const result = [] {
+    static bool const enabled_ = [] {
         auto result = celeritas::getenv_flag("CELER_ENABLE_PROFILING", false);
         if (result.value)
         {
@@ -64,7 +64,7 @@ bool ScopedProfiling::enabled()
             << " performance profiling";
         return result.value;
     }();
-    return result;
+    return enabled_;
 }
 
 #if CELERITAS_USE_PERFETTO

--- a/src/geocel/Types.hh
+++ b/src/geocel/Types.hh
@@ -127,16 +127,15 @@ struct Propagation
 CELER_FUNCTION GeoTrackInitializer::GeoTrackInitializer() = default;
 
 //! Construct with an invalid parent ID
-CELER_FUNCTION GeoTrackInitializer::GeoTrackInitializer(Real3 pos, Real3 dir)
-    : GeoTrackInitializer(pos, dir, {})
+CELER_FUNCTION GeoTrackInitializer::GeoTrackInitializer(Real3 p, Real3 d)
+    : GeoTrackInitializer(p, d, {})
 {
 }
 
 //! Construct with position, direction, and parent ID
-CELER_FUNCTION GeoTrackInitializer::GeoTrackInitializer(Real3 pos,
-                                                        Real3 dir,
-                                                        TrackSlotId parent)
-    : pos(pos), dir(dir), parent(parent)
+CELER_FUNCTION
+GeoTrackInitializer::GeoTrackInitializer(Real3 p, Real3 d, TrackSlotId p_id)
+    : pos(p), dir(d), parent(p_id)
 {
 }
 

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -258,12 +258,12 @@ void from_json(nlohmann::json const& j, UnitInput& value)
 
     for (char const* key : {"parent_volumes", "parent_cells"})
     {
-        auto iter = j.find(key);
-        if (iter == j.end())
+        auto parent_iter = j.find(key);
+        if (parent_iter == j.end())
         {
             continue;
         }
-        auto const& parent_vols = iter->get<std::vector<size_type>>();
+        auto const& parent_vols = parent_iter->get<std::vector<size_type>>();
 
         auto const& daughters = j.at("daughters").get<std::vector<size_type>>();
         CELER_VALIDATE(parent_vols.size() == daughters.size(),

--- a/src/orange/orangeinp/CsgTreeUtils.cc
+++ b/src/orange/orangeinp/CsgTreeUtils.cc
@@ -69,14 +69,14 @@ replace_and_simplify(CsgTree* tree, NodeId repl_key, Node repl_value)
         // Replace literals and simplify
         for (auto n : range(CsgTree::false_node_id() + 1, NodeId{tree->size()}))
         {
-            auto repl_value = state[n.get()];
-            if ((repl_value == NodeReplacer::known_true
-                 || repl_value == NodeReplacer::known_false)
+            auto updated = state[n.get()];
+            if ((updated == NodeReplacer::known_true
+                 || updated == NodeReplacer::known_false)
                 && std::holds_alternative<Surface>((*tree)[n]))
             {
                 max_node = std::max(max_node, n);
                 tree->exchange(n,
-                               repl_value == NodeReplacer::known_true
+                               updated == NodeReplacer::known_true
                                    ? Node{True{}}
                                    : Node{False{}});
             }

--- a/src/orange/orangeinp/CsgTypes.cc
+++ b/src/orange/orangeinp/CsgTypes.cc
@@ -58,7 +58,7 @@ std::ostream& operator<<(std::ostream& os, Joined const& n)
        << join(n.nodes.begin(),
                n.nodes.end(),
                ',',
-               [](NodeId n) { return n.unchecked_get(); })
+               [](NodeId jn) { return jn.unchecked_get(); })
        << '}';
     return os;
 }

--- a/src/orange/orangeinp/CsgTypes.hh
+++ b/src/orange/orangeinp/CsgTypes.hh
@@ -212,12 +212,12 @@ struct hash<celeritas::orangeinp::Joined>
         noexcept(!CELERITAS_DEBUG)
     {
         result_type result;
-        celeritas::Hasher hash{&result};
-        hash(static_cast<std::size_t>(val.op));
-        hash(val.nodes.size());
+        celeritas::Hasher hash_impl{&result};
+        hash_impl(static_cast<std::size_t>(val.op));
+        hash_impl(val.nodes.size());
         for (auto& v : val.nodes)
         {
-            hash(std::hash<celeritas::orangeinp::NodeId>{}(v));
+            hash_impl(std::hash<celeritas::orangeinp::NodeId>{}(v));
         }
         return result;
     }

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -852,11 +852,11 @@ GenPrism GenPrism::from_trap(
                    << " [turns]: must be in the range [0, 0.25)");
 
     // Calculate offset of faces from z axis
-    auto [dxdz_hz, dydz_hz] = [&]() -> std::pair<real_type, real_type> {
+    auto [dxdz_hz, dydz_hz] = [&]() {
         real_type cos_phi{}, sin_phi{};
         sincos(phi, &sin_phi, &cos_phi);
         real_type const tan_theta = tan(theta);
-        return {hz * tan_theta * cos_phi, hz * tan_theta * sin_phi};
+        return std::pair{hz * tan_theta * cos_phi, hz * tan_theta * sin_phi};
     }();
 
     // Construct points on faces

--- a/src/orange/orangeinp/detail/VolumeBuilder.cc
+++ b/src/orange/orangeinp/detail/VolumeBuilder.cc
@@ -57,22 +57,22 @@ NodeId VolumeBuilder::insert_region(Metadata&& md, Joined&& j)
         if (j.op == op_and)
         {
             // Shrink an infinite bounding zone
-            BoundingZone bz = BoundingZone::from_infinite();
+            BoundingZone result = BoundingZone::from_infinite();
             for (NodeId d : j.nodes)
             {
-                bz = calc_intersection(bz, ub_->bounds(d));
+                result = calc_intersection(result, ub_->bounds(d));
             }
-            return bz;
+            return result;
         }
         else if (j.op == op_or)
         {
             // Grow a null bounding zone
-            BoundingZone bz;
+            BoundingZone result;
             for (NodeId d : j.nodes)
             {
-                bz = calc_union(bz, ub_->bounds(d));
+                result = calc_union(result, ub_->bounds(d));
             }
-            return bz;
+            return result;
         }
         else
         {

--- a/src/orange/surf/Involute.hh
+++ b/src/orange/surf/Involute.hh
@@ -14,7 +14,6 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/math/Algorithms.hh"
-#include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "orange/OrangeTypes.hh"
 

--- a/src/orange/surf/VariantSurface.hh
+++ b/src/orange/surf/VariantSurface.hh
@@ -6,14 +6,12 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <variant>
-
 #include "corecel/cont/VariantUtils.hh"
 #include "orange/transform/VariantTransform.hh"
 
 #include "SurfaceTypeTraits.hh"
 
-#include "detail/AllSurfaces.hh"
+#include "detail/AllSurfaces.hh"  // IWYU pragma: keep
 
 namespace celeritas
 {

--- a/src/orange/surf/detail/AllSurfaces.hh
+++ b/src/orange/surf/detail/AllSurfaces.hh
@@ -7,13 +7,13 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "../ConeAligned.hh"  // IWYU pragma: export
-#include "../CylAligned.hh"  // IWYU pragma: export
-#include "../CylCentered.hh"  // IWYU pragma: export
-#include "../GeneralQuadric.hh"  // IWYU pragma: export
-#include "../Involute.hh"  // IWYU pragma: export
-#include "../Plane.hh"  // IWYU pragma: export
-#include "../PlaneAligned.hh"  // IWYU pragma: export
-#include "../SimpleQuadric.hh"  // IWYU pragma: export
-#include "../Sphere.hh"  // IWYU pragma: export
-#include "../SphereCentered.hh"  // IWYU pragma: export
+#include "orange/surf/ConeAligned.hh"  // IWYU pragma: export
+#include "orange/surf/CylAligned.hh"  // IWYU pragma: export
+#include "orange/surf/CylCentered.hh"  // IWYU pragma: export
+#include "orange/surf/GeneralQuadric.hh"  // IWYU pragma: export
+#include "orange/surf/Involute.hh"  // IWYU pragma: export
+#include "orange/surf/Plane.hh"  // IWYU pragma: export
+#include "orange/surf/PlaneAligned.hh"  // IWYU pragma: export
+#include "orange/surf/SimpleQuadric.hh"  // IWYU pragma: export
+#include "orange/surf/Sphere.hh"  // IWYU pragma: export
+#include "orange/surf/SphereCentered.hh"  // IWYU pragma: export

--- a/src/orange/surf/detail/InvoluteSolver.hh
+++ b/src/orange/surf/detail/InvoluteSolver.hh
@@ -12,10 +12,7 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/math/Algorithms.hh"
-#include "corecel/math/ArrayOperators.hh"
-#include "corecel/math/BisectionRootFinder.hh"
 #include "corecel/math/IllinoisRootFinder.hh"
-#include "corecel/math/RegulaFalsiRootFinder.hh"
 #include "orange/OrangeTypes.hh"
 
 #include "InvolutePoint.hh"

--- a/src/orange/surf/detail/InvoluteSolver.hh
+++ b/src/orange/surf/detail/InvoluteSolver.hh
@@ -174,13 +174,12 @@ CELER_FUNCTION auto InvoluteSolver::operator()(Real3 const& pos,
     v *= convert;
 
     // Line angle parameter
-
-    real_type beta = line_angle_param(u, v);
+    real_type angle = line_angle_param(u, v);
 
     // Setting first interval bounds, needs to be done to ensure roots are
     // found
     real_type t_lower = 0;
-    real_type t_upper = beta - a_;
+    real_type t_upper = angle - a_;
 
     // Round t_upper to the first positive multiple of pi
     t_upper += max<real_type>(real_type{0}, -std::floor(t_upper / pi)) * pi;


### PR DESCRIPTION
dd4hep turns on `-Wshadowing` for all code downstream; this PR eliminates the ones coming from header files (at least for building a 'minimal' build with Geant4 and tests disabled).