### PR TITLE
Tweak optical offload settings and construction

### DIFF
--- a/src/accel/LocalOpticalOffload.cc
+++ b/src/accel/LocalOpticalOffload.cc
@@ -55,10 +55,18 @@ LocalOpticalOffload::LocalOpticalOffload(SetupOptions const& options,
     auto const& optical_params = *transport_->params();
 
     // Save a pointer to the generator action
-    CELER_ASSERT(optical_params.gen_reg()->size() == 1);
-    generate_ = std::dynamic_pointer_cast<optical::GeneratorAction const>(
-        optical_params.gen_reg()->at(GeneratorId(0)));
-    CELER_ASSERT(generate_);
+    auto const& gen_reg = *optical_params.gen_reg();
+    for (auto gen_id : range(GeneratorId(gen_reg.size())))
+    {
+        if (auto gen = std::dynamic_pointer_cast<optical::GeneratorAction const>(
+                gen_reg.at(gen_id)))
+        {
+            CELER_VALIDATE(!generate_,
+                           << "more than one optical GeneratorAction found");
+            generate_ = gen;
+        }
+    }
+    CELER_VALIDATE(generate_, << "no optical GeneratorAction found");
 
     // Number of optical photons to buffer before offloading
     auto const& capacity = options.optical->capacity;

--- a/src/accel/LocalOpticalOffload.cc
+++ b/src/accel/LocalOpticalOffload.cc
@@ -35,29 +35,33 @@ namespace celeritas
 LocalOpticalOffload::LocalOpticalOffload(SetupOptions const& options,
                                          SharedParams& params)
 {
-    CELER_EXPECT(options.optical_capacity);
-    CELER_EXPECT(params.optical_params());
-
     CELER_VALIDATE(params.mode() == SharedParams::Mode::enabled,
                    << "cannot create local optical offload when Celeritas "
                       "offloading is disabled");
-    CELER_VALIDATE(options.optical_generator
+    CELER_VALIDATE(options.optical
                        && std::holds_alternative<inp::OpticalOffloadGenerator>(
-                           *options.optical_generator),
+                           options.optical->generator),
                    << "invalid optical photon generation mechanism for local "
                       "optical offload");
 
     // Check the thread ID and MT model
     validate_geant_threading(params.Params()->max_streams());
 
+    // Save a pointer to the optical transporter
+    transport_ = params.optical_transporter();
+    CELER_ASSERT(transport_);
+
+    CELER_ASSERT(transport_->params());
+    auto const& optical_params = *transport_->params();
+
     // Save a pointer to the generator action
-    CELER_ASSERT(params.optical_params()->gen_reg()->size() == 1);
+    CELER_ASSERT(optical_params.gen_reg()->size() == 1);
     generate_ = std::dynamic_pointer_cast<optical::GeneratorAction const>(
-        params.optical_params()->gen_reg()->at(GeneratorId(0)));
+        optical_params.gen_reg()->at(GeneratorId(0)));
     CELER_ASSERT(generate_);
 
     // Number of optical photons to buffer before offloading
-    auto const& capacity = *options.optical_capacity;
+    auto const& capacity = options.optical->capacity;
     auto_flush_ = capacity.primaries;
 
     auto stream_id = id_cast<StreamId>(get_geant_thread_id());
@@ -67,12 +71,12 @@ LocalOpticalOffload::LocalOpticalOffload(SetupOptions const& options,
     if (memspace == MemSpace::device)
     {
         state_ = std::make_shared<optical::CoreState<MemSpace::device>>(
-            *params.optical_params(), stream_id, capacity.tracks);
+            optical_params, stream_id, capacity.tracks);
     }
     else
     {
         state_ = std::make_shared<optical::CoreState<MemSpace::host>>(
-            *params.optical_params(), stream_id, capacity.tracks);
+            optical_params, stream_id, capacity.tracks);
     }
 
     // Allocate auxiliary data
@@ -81,12 +85,6 @@ LocalOpticalOffload::LocalOpticalOffload(SetupOptions const& options,
         state_->aux() = std::make_shared<AuxStateVec>(
             *params.Params()->aux_reg(), memspace, stream_id, capacity.tracks);
     }
-
-    // Build the optical transporter
-    optical::Transporter::Input inp;
-    inp.params = params.optical_params();
-    inp.max_step_iters = options.max_optical_step_iters;
-    transport_ = std::make_shared<optical::Transporter>(std::move(inp));
 
     CELER_ENSURE(*this);
 }

--- a/src/accel/LocalOpticalOffload.cc
+++ b/src/accel/LocalOpticalOffload.cc
@@ -206,10 +206,27 @@ void LocalOpticalOffload::Finalize()
     CELER_EXPECT(*this);
 
     CELER_VALIDATE(buffer_.empty(),
-                   << "offloaded photons (" << num_photons_
-                   << " in buffer) were not flushed");
+                   << "offloaded photons (" << num_photons_ << " in buffer of "
+                   << buffer_.size() << " distributions) were not flushed");
 
-    //! \todo Output optical stats
+    auto const& accum = state_->accum();
+    CELER_ASSERT(state_->aux());
+    auto const& gen = generate_->counters(*state_->aux());
+    CELER_LOG_LOCAL(info)
+        << "Finalizing Celeritas after " << accum.steps
+        << " optical steps (over " << accum.step_iters << " step iterations)"
+        << " from " << gen.accum.num_generated
+        << " optical photons generated from " << gen.accum.buffer_size
+        << " distributions";
+
+    if (!gen.counters.empty())
+    {
+        CELER_LOG_LOCAL(warning)
+            << "Not all optical photons were tracked "
+               "at the end of the stepping loop: "
+            << gen.counters.num_pending << " queued photons from "
+            << gen.counters.buffer_size << " distributions";
+    }
 
     // Reset all data
     *this = {};

--- a/src/accel/LocalOpticalOffload.hh
+++ b/src/accel/LocalOpticalOffload.hh
@@ -77,17 +77,17 @@ class LocalOpticalOffload final : public LocalOffloadInterface
     explicit operator bool() const { return this->Initialized(); }
 
   private:
-    // Thread-local state data
-    std::shared_ptr<optical::CoreStateBase> state_;
-
     // Transport pending optical tracks
     std::shared_ptr<optical::Transporter> transport_;
 
-    // Buffered distributions for offloading
-    std::vector<DistributionData> buffer_;
-
     // Action for generating optical photons from distribution data
     std::shared_ptr<optical::GeneratorAction const> generate_;
+
+    // Thread-local state data
+    std::shared_ptr<optical::CoreStateBase> state_;
+
+    // Buffered distributions for offloading
+    std::vector<DistributionData> buffer_;
 
     // Accumulated number of buffered photons
     size_type num_photons_{};

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -158,9 +158,9 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
     CELER_VALIDATE(params.mode() == SharedParams::Mode::enabled,
                    << "cannot create local transporter when Celeritas "
                       "offloading is disabled");
-    CELER_VALIDATE(!options.optical_generator
+    CELER_VALIDATE(!options.optical
                        || std::holds_alternative<inp::OpticalEmGenerator>(
-                           *options.optical_generator),
+                           options.optical->generator),
                    << "invalid optical photon generation mechanism for local "
                       "transporter");
 
@@ -198,7 +198,7 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
     params.set_state(stream_id.get(), step_->sp_state());
 
     // Save optical pointers if available, for diagnostics
-    optical_ = params.optical();
+    optical_ = params.optical_collector();
 
     CELER_ENSURE(*this);
 }

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -100,16 +100,10 @@ void ProblemSetup::operator()(inp::Problem& p) const
             = static_cast<size_type>(so.secondary_stack_factor * c.tracks);
         return c;
     }();
-    p.control.optical_capacity = so.optical_capacity;
     if (so.max_num_events)
     {
         CELER_LOG(warning) << "Ignoring removed option 'max_num_events': will "
                               "be an error in v0.7";
-    }
-
-    if (so.optical_generator)
-    {
-        p.physics.optical_generator = *so.optical_generator;
     }
 
     p.tracking.limits = [this] {
@@ -119,6 +113,13 @@ void ProblemSetup::operator()(inp::Problem& p) const
         tl.field_substeps = so.max_field_substeps;
         return tl;
     }();
+
+    if (so.optical)
+    {
+        p.control.optical_capacity = so.optical->capacity;
+        p.physics.optical_generator = so.optical->generator;
+        p.tracking.limits.optical_step_iters = so.optical->max_step_iters;
+    }
 
     if (so.track_order != TrackOrder::size_)
     {

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -17,6 +17,7 @@
 #include "celeritas/global/ActionInterface.hh"
 #include "celeritas/inp/Control.hh"
 #include "celeritas/inp/Physics.hh"
+#include "celeritas/inp/Tracking.hh"
 
 class G4LogicalVolume;
 class G4ParticleDefinition;
@@ -116,6 +117,20 @@ struct SDSetupOptions
 
 //---------------------------------------------------------------------------//
 /*!
+ * Control options for initializing optical photon transport in Celeritas.
+ */
+struct OpticalSetupOptions
+{
+    //! Capacity for storing optical photon state
+    inp::OpticalStateCapacity capacity;
+    //! Optical photon generation mechanism
+    inp::OpticalGenerator generator;
+    //! Limit on number of optical step iterations before aborting
+    size_type max_step_iters{inp::TrackingLimits::unlimited};
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Control options for initializing Celeritas.
  *
  * The interface for the "along-step factory" (input parameters and output) is
@@ -132,7 +147,7 @@ struct SDSetupOptions
  *
  * Note that the Celeritas core capacity values (\c max_num_tracks, \c
  * initializer_capacity and \c auto_flush) are per \em stream while the \c
- * optical_capacity values are per \em process.
+ * capacity values in \c OpticalSetupOptions are per \em process.
  *
  * \note This class will be replaced in v1.0
  *       by \c celeritas::inp::FrameworkInput .
@@ -177,12 +192,7 @@ struct SetupOptions
     //!@{
     //! \name Optical photon options
 
-    //! Capacity for storing optical photon state
-    std::optional<inp::OpticalStateCapacity> optical_capacity;
-    //! Optical photon generation mechanism
-    std::optional<inp::OpticalGenerator> optical_generator;
-    //! Limit on number of optical step iterations before aborting
-    size_type max_optical_step_iters = no_max_steps();
+    std::optional<OpticalSetupOptions> optical;
     //!@}
 
     //!@{

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -28,7 +28,7 @@ class OffloadWriter;
 
 namespace optical
 {
-class CoreParams;
+class Transporter;
 }  // namespace optical
 
 class CoreParams;
@@ -139,8 +139,8 @@ class SharedParams
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
     using SPTimeOutput = std::shared_ptr<TimeOutput>;
     using SPState = std::shared_ptr<CoreStateInterface>;
-    using SPOptical = std::shared_ptr<OpticalCollector>;
-    using SPOpticalParams = std::shared_ptr<optical::CoreParams>;
+    using SPOpticalCollector = std::shared_ptr<OpticalCollector>;
+    using SPOpticalTransporter = std::shared_ptr<optical::Transporter>;
     using SPConstGeantGeoParams = std::shared_ptr<GeantGeoParams const>;
     using BBox = BoundingBox<double>;
 
@@ -148,10 +148,10 @@ class SharedParams
     Mode mode() const { return mode_; }
 
     // Optical properties (only if using optical physics)
-    inline SPOptical const& optical() const;
+    inline SPOpticalCollector const& optical_collector() const;
 
     // Optical params (only if using optical physics)
-    inline SPOpticalParams const& optical_params() const;
+    inline SPOpticalTransporter const& optical_transporter() const;
 
     // Hit manager, to be used only by LocalTransporter
     inline SPGeantSd const& hit_manager() const;
@@ -182,8 +182,8 @@ class SharedParams
     Mode mode_{Mode::uninitialized};
     SPConstGeantGeoParams geant_geo_;
     std::shared_ptr<CoreParams> params_;
-    std::shared_ptr<OpticalCollector> optical_;
-    SPOpticalParams optical_params_;
+    SPOpticalCollector optical_collector_;
+    SPOpticalTransporter optical_transporter_;
     std::shared_ptr<GeantSd> geant_sd_;
     std::shared_ptr<StepCollector> step_collector_;
     VecG4PD offload_particles_;
@@ -247,22 +247,22 @@ auto SharedParams::OffloadParticles() const -> VecG4PD const&
 
 //---------------------------------------------------------------------------//
 /*!
- * Optical params: null if Celeritas optical physics is disabled.
+ * Optical transporter: null if Celeritas optical physics is disabled.
  */
-auto SharedParams::optical_params() const -> SPOpticalParams const&
+auto SharedParams::optical_transporter() const -> SPOpticalTransporter const&
 {
     CELER_EXPECT(*this);
-    return optical_params_;
+    return optical_transporter_;
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Optical data: null if Celeritas optical physics is disabled.
  */
-auto SharedParams::optical() const -> SPOptical const&
+auto SharedParams::optical_collector() const -> SPOpticalCollector const&
 {
     CELER_EXPECT(*this);
-    return optical_;
+    return optical_collector_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/detail/IntegrationSingleton.cc
+++ b/src/accel/detail/IntegrationSingleton.cc
@@ -363,9 +363,9 @@ auto IntegrationSingleton::local_offload_ptr() -> UPOffload&
  */
 bool IntegrationSingleton::optical_offload() const
 {
-    return options_.optical_generator
+    return options_.optical
            && std::holds_alternative<inp::OpticalOffloadGenerator>(
-               *options_.optical_generator);
+               options_.optical->generator);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/setup/Problem.hh
+++ b/src/celeritas/setup/Problem.hh
@@ -19,7 +19,7 @@ struct Problem;
 
 namespace optical
 {
-class CoreParams;
+class Transporter;
 }  // namespace optical
 
 class CoreParams;
@@ -43,9 +43,9 @@ struct ProblemLoaded
 
     //! Step collector
     std::shared_ptr<StepCollector> step_collector;
-    //! Optical data
-    std::shared_ptr<optical::CoreParams> optical_params;
-    //! Optical offload management
+    //! Optical-only offload management
+    std::shared_ptr<optical::Transporter> optical_transporter;
+    //! Combined EM and optical offload management
     std::shared_ptr<OpticalCollector> optical_collector;
     //! Geant4 SD interface
     std::shared_ptr<GeantSd> geant_sd;

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -552,12 +552,12 @@ SetupOptions OpNoviceIntegrationMixin::make_setup_options()
 {
     auto result = Base::make_setup_options();
     result.sd.enabled = false;
-    result.optical_capacity = [] {
-        inp::OpticalStateCapacity cap;
-        cap.tracks = 32768;
-        cap.generators = 32768 * 8;
-        cap.primaries = cap.generators;
-        return cap;
+    result.optical = [] {
+        OpticalSetupOptions opt;
+        opt.capacity.tracks = 32768;
+        opt.capacity.generators = 32768 * 8;
+        opt.capacity.primaries = opt.capacity.generators;
+        return opt;
     }();
     return result;
 }

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -552,13 +552,13 @@ SetupOptions OpNoviceIntegrationMixin::make_setup_options()
 {
     auto result = Base::make_setup_options();
     result.sd.enabled = false;
-    result.optical.emplace([] {
-        inp::OpticalStateCapacity cap;
-        cap.tracks = 32768;
-        cap.generators = 32768 * 8;
-        cap.primaries = cap.generators;
-        return cap;
-    }());
+    result.optical = [] {
+        OpticalSetupOptions opt;
+        opt.capacity.tracks = 32768;
+        opt.capacity.generators = 32768 * 8;
+        opt.capacity.primaries = opt.capacity.generators;
+        return opt;
+    }();
     return result;
 }
 

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -552,13 +552,13 @@ SetupOptions OpNoviceIntegrationMixin::make_setup_options()
 {
     auto result = Base::make_setup_options();
     result.sd.enabled = false;
-    result.optical = [] {
-        OpticalSetupOptions opt;
-        opt.capacity.tracks = 32768;
-        opt.capacity.generators = 32768 * 8;
-        opt.capacity.primaries = opt.capacity.generators;
-        return opt;
-    }();
+    result.optical.emplace([] {
+        inp::OpticalStateCapacity cap;
+        cap.tracks = 32768;
+        cap.generators = 32768 * 8;
+        cap.primaries = cap.generators;
+        return cap;
+    }());
     return result;
 }
 

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -311,12 +311,12 @@ auto LarSphereOptical::make_setup_options() -> SetupOptions
 {
     auto result = LarSphereIntegrationMixin::make_setup_options();
 
-    result.optical_capacity = [] {
-        inp::OpticalStateCapacity cap;
-        cap.tracks = 32768;
-        cap.generators = 32768 * 8;
-        cap.primaries = cap.generators;
-        return cap;
+    result.optical = [] {
+        OpticalSetupOptions opt;
+        opt.capacity.tracks = 32768;
+        opt.capacity.generators = 32768 * 8;
+        opt.capacity.primaries = opt.capacity.generators;
+        return opt;
     }();
 
     return result;
@@ -341,7 +341,7 @@ void LarSphereOptical::EndOfRunAction(G4Run const* run)
         EXPECT_EQ(is_running_events(), static_cast<bool>(local_transporter));
         EXPECT_TRUE(shared_params) << "Celeritas was not enabled";
 
-        auto const& optical_collector = shared_params.optical();
+        auto const& optical_collector = shared_params.optical_collector();
         EXPECT_TRUE(optical_collector) << "optical offloading was not enabled";
         if (local_transporter && optical_collector)
         {
@@ -458,7 +458,7 @@ void OpNoviceOptical::EndOfRunAction(G4Run const* run)
         EXPECT_EQ(is_running_events(), static_cast<bool>(local_transporter));
         EXPECT_TRUE(shared_params) << "Celeritas was not enabled";
 
-        auto const& optical_collector = shared_params.optical();
+        auto const& optical_collector = shared_params.optical_collector();
         EXPECT_TRUE(optical_collector) << "optical offloading was not enabled";
         if (local_transporter && optical_collector)
         {

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -311,13 +311,13 @@ auto LarSphereOptical::make_setup_options() -> SetupOptions
 {
     auto result = LarSphereIntegrationMixin::make_setup_options();
 
-    result.optical.emplace([] {
-        inp::OpticalStateCapacity cap;
-        cap.tracks = 32768;
-        cap.generators = 32768 * 8;
-        cap.primaries = cap.generators;
-        return cap;
-    }());
+    result.optical = [] {
+        OpticalSetupOptions opt;
+        opt.capacity.tracks = 32768;
+        opt.capacity.generators = 32768 * 8;
+        opt.capacity.primaries = opt.capacity.generators;
+        return opt;
+    }();
 
     return result;
 }

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -311,13 +311,13 @@ auto LarSphereOptical::make_setup_options() -> SetupOptions
 {
     auto result = LarSphereIntegrationMixin::make_setup_options();
 
-    result.optical = [] {
-        OpticalSetupOptions opt;
-        opt.capacity.tracks = 32768;
-        opt.capacity.generators = 32768 * 8;
-        opt.capacity.primaries = opt.capacity.generators;
-        return opt;
-    }();
+    result.optical.emplace([] {
+        inp::OpticalStateCapacity cap;
+        cap.tracks = 32768;
+        cap.generators = 32768 * 8;
+        cap.primaries = cap.generators;
+        return cap;
+    }());
 
     return result;
 }

--- a/test/accel/UserActionIntegration.test.cc
+++ b/test/accel/UserActionIntegration.test.cc
@@ -165,16 +165,17 @@ auto LarSphereOpticalOffload::make_setup_options() -> SetupOptions
 {
     auto result = LarSphereIntegrationMixin::make_setup_options();
 
-    result.optical_capacity = [] {
-        inp::OpticalStateCapacity cap;
-        cap.tracks = 32768;
-        cap.generators = cap.tracks * 8;
-        cap.primaries = cap.tracks * 16;
-        return cap;
-    }();
+    result.optical = [] {
+        OpticalSetupOptions opt;
+        opt.capacity.tracks = 32768;
+        opt.capacity.generators = opt.capacity.tracks * 8;
+        opt.capacity.primaries = opt.capacity.tracks * 16;
 
-    // Enable optical distribution offloading
-    result.optical_generator = inp::OpticalOffloadGenerator{};
+        // Enable optical distribution offloading
+        opt.generator = inp::OpticalOffloadGenerator{};
+
+        return opt;
+    }();
 
     // Don't offload any particles
     result.offload_particles = SetupOptions::VecG4PD{};


### PR DESCRIPTION
A few small changes following on to #2092:
- Construct a single `optical::Transporter` (and `ActionGroups`)  per params instead of per stream for `LocalOpticalOffload`
- Move the optical setup options to a separate struct
- Log accumulated optical loop stats in `LocalOpticalOffload::Finalize()`
- Save optical `max_step_iters` to `inp::Problem`