### PR TITLE
Update build script with best practices

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,7 +43,7 @@ log() {
 fancy_hostname() {
   sys=${LMOD_SYSTEM_NAME}
   if [ -z "${sys}" ]; then
-    sys=$(uname -n)
+    sys="$(uname -n)"
     # Trim login/compute from head of string
     case "${sys}" in
       login[0-9]*.*|compute[0-9]*.*) sys=${sys#*.} ;;
@@ -62,7 +62,7 @@ ln_presets() {
 
   # Return early if it exists
   if [ -L "${dst}" ]; then
-    src=$(readlink "${dst}" 2>/dev/null || printf "<unknown>")
+    src="$(readlink "${dst}" 2>/dev/null || printf "<unknown>")"
     log debug "CMake preset already exists: ${dst} -> ${src}"
     return
   elif [ -e "${dst}" ]; then
@@ -145,12 +145,12 @@ OLD_CMAKE="$(command -v cmake 2>/dev/null || printf '')"
 OLD_PRE_COMMIT="$(command -v pre-commit 2>/dev/null || printf '')"
 
 # Load environment paths
-_env_script="scripts/env/${SYSTEM_NAME}.sh"
-if [ -f "${_env_script}" ]; then
-  log info "Sourcing environment script at ${_env_script}"
-  . "${_env_script}"
+ENV_SCRIPT="scripts/env/${SYSTEM_NAME}.sh"
+if [ -f "${ENV_SCRIPT}" ]; then
+  log info "Sourcing environment script at ${ENV_SCRIPT}"
+  . "${ENV_SCRIPT}"
 else
-  log debug "No environment script exists at ${_env_script}"
+  log debug "No environment script exists at ${ENV_SCRIPT}"
 fi
 
 NEW_CMAKE="$(command -v cmake 2>/dev/null || printf 'cmake unavailable')"
@@ -194,13 +194,13 @@ if cmake --build --preset="${CMAKE_PRESET}"; then
 
   install_precommit_if_git
   if [ "${NEW_PRE_COMMIT}" != "${OLD_PRE_COMMIT}" ]; then
-    log warning "Local environment script uses a different pre-commit than your \${PATH}:"
-    log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"
+    log warning "Local environment script uses a different pre-commit than your \$PATH:"
+    log info "Recommend adding '. ${PWD}/${ENV_SCRIPT}' to your shell rc"
   fi
 
   if [ "${NEW_CMAKE}" != "${OLD_CMAKE}" ]; then
-    log warning "Local environment script uses a different CMake than your \${PATH}:"
-    log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"
+    log warning "Local environment script uses a different CMake than your \$PATH:"
+    log info "Recommend adding '. ${PWD}/${ENV_SCRIPT}' to your shell rc"
   fi
 else
   log error "build failed: check configuration and build errors above"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 #-------------------------------- -*- sh -*- ---------------------------------#
 # Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -17,30 +17,37 @@
 #
 #-----------------------------------------------------------------------------#
 
+set -e
+
+die() {
+  log error "$1"
+  exit 1
+}
+
 # Print a colorful message to stderr
 log() {
   level=$1
   message=$2
 
   case "$level" in
-    "debug")
+    debug)
       color="2;37;40"
-      printf "\033[${color}m%s\033[0m\n" "$message" >&2
+      printf "\033[%sm%s\033[0m\n" "$color" "$message" >&2
       return
       ;;
-    "info") color="32;40"; level="INFO" ;;
-    "warning") color="33;40"; level="WARNING" ;;
-    "error") color="31;40"; level="ERROR" ;;
+    info) color="32;40"; level="INFO" ;;
+    warning) color="33;40"; level="WARNING" ;;
+    error) color="31;40"; level="ERROR" ;;
     *) color="37;40" ;;
   esac
 
-  printf "\033[${color}m%s:\033[0m %s\n" "$level" "$message" >&2
+  printf "\033[%sm%s:\033[0m %s\n" "$color" "$level" "$message" >&2
 }
 
 # Get the hostname, trying to account for being on a compute node or cluster
 fancy_hostname() {
   sys=${LMOD_SYSTEM_NAME}
-  if [ -z "${sys}" ]; then
+  if [ -z "$sys" ]; then
     sys=${HOSTNAME}
     # Trim login/compute from head of string
     case "$sys" in
@@ -50,7 +57,7 @@ fancy_hostname() {
     sys=${sys%%.*}
   fi
   log debug "Determined system name: ${sys} (override with LMOD_SYSTEM_NAME)"
-  echo "${sys}"
+  printf '%s\n' "$sys"
 }
 
 # Link the presets file
@@ -58,34 +65,39 @@ ln_presets() {
   src="scripts/cmake-presets/$1.json"
   dst="CMakeUserPresets.json"
 
-  # Return early if they exist
-  if [ -e "${dst}" ]; then
-    src=$(readlink ${dst} || echo "<not a symlink>")
-    log debug "CMake preset already exists: ${dst} -> ${src}"
+  # Return early if it exists
+  if [ -e "$dst" ]; then
+    if [ -L "$dst" ]; then
+      log debug "CMake preset already exists: $dst (symlink)"
+    else
+      log debug "CMake preset already exists: $dst"
+    fi
     return
   fi
 
-  # Create if preset file doesn't exist
-  if [ ! -f "${src}" ]; then
-    log info "Creating user presets at ${src} . Please update this file for future configurations."
-    cp "scripts/cmake-presets/_dev_.json" "${src}"
-    git add "${src}" || error "Could not stage presets"
+  # Create preset if it doesn't exist
+  if [ ! -f "$src" ]; then
+    log info "Creating user presets at $src . Please update this file for future configurations."
+    cp "scripts/cmake-presets/_dev_.json" "$src"
+    git add "$src" || die "Could not stage presets"
   fi
-  log info "Linking presets to ${dst}"
-  ln -s "${src}" "${dst}"
+  log info "Linking presets to $dst"
+  ln -s "$src" "$dst"
 }
 
 # Check if ccache is full and warn user
 check_ccache_usage() {
-  cache_stats=$(ccache --print-stats)
-  current_kb=$(echo "$cache_stats" | grep "^cache_size_kibibyte" | cut -f2)
-  max_kb=$(echo "$cache_stats" | grep "^max_cache_size_kibibyte" | cut -f2)
+  cache_stats=$(ccache --print-stats 2>/dev/null || printf '')
+  current_kb=$(printf '%s\n' "$cache_stats" | grep "^cache_size_kibibyte" | cut -f2)
+  max_kb=$(printf '%s\n' "$cache_stats" | grep "^max_cache_size_kibibyte" | cut -f2)
 
-  if [ -n "$current_kb" ] && [ -n "$max_kb" ] && [ "$max_kb" -gt 0 ] 2>/dev/null; then
+  # Ensure numeric
+  case $current_kb in (""|*[!0-9]*) current_kb= ;; esac
+  case $max_kb in (""|*[!0-9]*) max_kb= ;; esac
+
+  if [ -n "$current_kb" ] && [ -n "$max_kb" ] && [ "$max_kb" -gt 0 ]; then
     usage_percent=$((current_kb * 100 / max_kb))
-
-    if [ "$usage_percent" -gt 90 ] 2>/dev/null; then
-      # Convert to human-readable sizes (GiB)
+    if [ "$usage_percent" -gt 90 ]; then
       current_gb=$((current_kb / 1024 / 1024))
       max_gb=$((max_kb / 1024 / 1024))
       log warning "ccache is ${usage_percent}% full (${current_gb}/${max_gb} GiB)"
@@ -96,22 +108,23 @@ check_ccache_usage() {
 
 # Auto-detect and configure ccache if available
 setup_ccache() {
-  if CCACHE_PROGRAM="$(which ccache 2>/dev/null)"; then
+  if CCACHE_PROGRAM="$(command -v ccache 2>/dev/null)"; then
     log info "Using ccache: ${CCACHE_PROGRAM}"
     check_ccache_usage
+    [ -n "$CCACHE_PROGRAM" ] && export CCACHE_PROGRAM
   fi
-  export CCACHE_PROGRAM=${CCACHE_PROGRAM}
 }
 
 # Check if pre-commit hook is installed and install if missing
 install_precommit_if_git() {
-  git_dir=$(git rev-parse --git-dir 2>/dev/null)
-  if [ $? -ne 0 ]; then
+  if git_dir=$(git rev-parse --git-dir 2>/dev/null); then
+    :
+  else
     log debug "Not in a git repository, skipping pre-commit check"
     return 1
   fi
 
-  if [ ! -f "${git_dir}/hooks/pre-commit" ]; then
+  if [ ! -f "$git_dir/hooks/pre-commit" ]; then
     log info "Pre-commit hook not found, installing commit hooks"
     ./scripts/dev/install-commit-hooks.sh
   fi
@@ -120,44 +133,43 @@ install_precommit_if_git() {
 
 #-----------------------------------------------------------------------------#
 
-# Run everything from the parent directory of this script (i.e. the Celeritas
-# source dir)
-cd "$(dirname $0)"/..
+# Run everything from the parent directory of this script (i.e. the Celeritas source dir)
+cd "$(dirname "$0")"/..
 
 # Determine system name, failing on an empty string
 SYSTEM_NAME=$(fancy_hostname)
-if [ -z "${SYSTEM_NAME}" ]; then
+if [ -z "$SYSTEM_NAME" ]; then
   log warning "Could not determine SYSTEM_NAME from LMOD_SYSTEM_NAME or HOSTNAME"
   log error "Empty SYSTEM_NAME"
   exit 1
 fi
 
-# Check whether cmake changes from environment
-OLD_CMAKE=$(which cmake 2>/dev/null || echo "")
-OLD_PRE_COMMIT=$(which pre-commit 2>/dev/null || echo "")
+# Check whether cmake/pre-commit change from environment
+OLD_CMAKE="$(command -v cmake 2>/dev/null || printf '')"
+OLD_PRE_COMMIT="$(command -v pre-commit 2>/dev/null || printf '')"
 
 # Load environment paths
 _env_script="scripts/env/${SYSTEM_NAME}.sh"
-if [ -f "${_env_script}" ]; then
+if [ -f "$_env_script" ]; then
   log info "Sourcing environment script at ${_env_script}"
-  . "${_env_script}"
+  . "$_env_script"
 else
   log debug "No environment script exists at ${_env_script}"
 fi
 
-NEW_CMAKE=$(which cmake 2>/dev/null || echo "cmake unavailable")
-NEW_PRE_COMMIT=$(which pre-commit 2>/dev/null || echo "")
+NEW_CMAKE="$(command -v cmake 2>/dev/null || printf 'cmake unavailable')"
+NEW_PRE_COMMIT="$(command -v pre-commit 2>/dev/null || printf '')"
 
 # Link preset file
-ln_presets "${SYSTEM_NAME}"
+ln_presets "$SYSTEM_NAME"
 
 # Search for and probe ccache
 setup_ccache
 
 # Check arguments and give presets if missing
 if [ $# -eq 0 ]; then
-  echo "Usage: $0 PRESET [config_args...]" >&2
-  if hash cmake 2>/dev/null ; then
+  printf '%s\n' "Usage: $0 PRESET [config_args...]" >&2
+  if command -v cmake >/dev/null 2>&1; then
     if cmake --list-presets >&2 ; then
       log info "Try using the '${SYSTEM_NAME}' or 'dev' presets ('base'), or 'default' if not"
     else
@@ -171,14 +183,13 @@ fi
 CMAKE_PRESET=$1
 shift
 
-
 # Configure, build, and test
 log info "Configuring with verbosity"
-cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE "$@"
+cmake --preset="$CMAKE_PRESET" --log-level=VERBOSE "$@"
 log info "Building"
-if cmake --build --preset=${CMAKE_PRESET}; then
+if cmake --build --preset="$CMAKE_PRESET"; then
   log info "Testing"
-  if ctest --preset=${CMAKE_PRESET} --timeout 15; then
+  if ctest --preset="$CMAKE_PRESET" --timeout 15; then
     log info "Celeritas was successfully built and tested for development!"
   else
     log warning "Celeritas built but some tests failed"
@@ -186,12 +197,12 @@ if cmake --build --preset=${CMAKE_PRESET}; then
   fi
 
   install_precommit_if_git
-  if [ "${NEW_PRE_COMMIT}" != "${OLD_PRE_COMMIT}" ]; then
+  if [ "$NEW_PRE_COMMIT" != "$OLD_PRE_COMMIT" ]; then
     log warning "Local environment script uses a different pre-commit than your \$PATH:"
     log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"
   fi
 
-  if [ "${NEW_CMAKE}" != "${OLD_CMAKE}" ]; then
+  if [ "$NEW_CMAKE" != "$OLD_CMAKE" ]; then
     log warning "Local environment script uses a different CMake than your \$PATH:"
     log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"
   fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,10 +24,10 @@ log() {
   level=$1
   message=$2
 
-  case "$level" in
+  case "${level}" in
     debug)
       color="2;37;40"
-      printf "\033[%sm%s\033[0m\n" "$color" "$message" >&2
+      printf "\033[%sm%s\033[0m\n" "${color}" "${message}" >&2
       return
       ;;
     info) color="32;40"; level="INFO" ;;
@@ -36,23 +36,23 @@ log() {
     *) color="37;40" ;;
   esac
 
-  printf "\033[%sm%s:\033[0m %s\n" "$color" "$level" "$message" >&2
+  printf "\033[%sm%s:\033[0m %s\n" "${color}" "${level}" "${message}" >&2
 }
 
 # Get the hostname, trying to account for being on a compute node or cluster
 fancy_hostname() {
-  sys=$LMOD_SYSTEM_NAME
-  if [ -z "$sys" ]; then
+  sys=${LMOD_SYSTEM_NAME}
+  if [ -z "${sys}" ]; then
     sys=$(uname -n)
     # Trim login/compute from head of string
-    case "$sys" in
+    case "${sys}" in
       login[0-9]*.*|compute[0-9]*.*) sys=${sys#*.} ;;
     esac
     # Trim all but the first component
     sys=${sys%%.*}
   fi
   log debug "Determined system name: ${sys} (override with LMOD_SYSTEM_NAME)"
-  printf '%s\n' "$sys"
+  printf '%s\n' "${sys}"
 }
 
 # Link the presets file
@@ -61,38 +61,38 @@ ln_presets() {
   dst="CMakeUserPresets.json"
 
   # Return early if it exists
-  if [ -L "$dst" ]; then
-    src=$(readlink "$dst" 2>/dev/null || printf "<unknown>")
-    log debug "CMake preset already exists: $dst -> $src"
+  if [ -L "${dst}" ]; then
+    src=$(readlink "${dst}" 2>/dev/null || printf "<unknown>")
+    log debug "CMake preset already exists: ${dst} -> ${src}"
     return
-  elif [ -e "$dst" ]; then
-    log debug "CMake preset already exists: $dst"
+  elif [ -e "${dst}" ]; then
+    log debug "CMake preset already exists: ${dst}"
     return
   fi
 
   # Create preset if it doesn't exist
-  if [ ! -f "$src" ]; then
-    log info "Creating user presets at $src . Please update this file for future configurations."
-    cp "scripts/cmake-presets/_dev_.json" "$src"
-    git add "$src" || log error "Could not stage presets"
+  if [ ! -f "${src}" ]; then
+    log info "Creating user presets at ${src} . Please update this file for future configurations."
+    cp "scripts/cmake-presets/_dev_.json" "${src}"
+    git add "${src}" || log error "Could not stage presets"
   fi
-  log info "Linking presets to $dst"
-  ln -s "$src" "$dst"
+  log info "Linking presets to ${dst}"
+  ln -s "${src}" "${dst}"
 }
 
 # Check if ccache is full and warn user
 check_ccache_usage() {
   cache_stats=$(ccache --print-stats 2>/dev/null || printf '')
-  current_kb=$(printf '%s\n' "$cache_stats" | grep "^cache_size_kibibyte" | cut -f2)
-  max_kb=$(printf '%s\n' "$cache_stats" | grep "^max_cache_size_kibibyte" | cut -f2)
+  current_kb=$(printf '%s\n' "${cache_stats}" | grep "^cache_size_kibibyte" | cut -f2)
+  max_kb=$(printf '%s\n' "${cache_stats}" | grep "^max_cache_size_kibibyte" | cut -f2)
 
   # Ensure numeric
-  case $current_kb in (""|*[!0-9]*) current_kb= ;; esac
-  case $max_kb in (""|*[!0-9]*) max_kb= ;; esac
+  case ${current_kb} in (""|*[!0-9]*) current_kb= ;; esac
+  case ${max_kb} in (""|*[!0-9]*) max_kb= ;; esac
 
-  if [ -n "$current_kb" ] && [ -n "$max_kb" ] && [ "$max_kb" -gt 0 ]; then
+  if [ -n "${current_kb}" ] && [ -n "${max_kb}" ] && [ "${max_kb}" -gt 0 ]; then
     usage_percent=$((current_kb * 100 / max_kb))
-    if [ "$usage_percent" -gt 90 ]; then
+    if [ "${usage_percent}" -gt 90 ]; then
       current_gb=$((current_kb / 1024 / 1024))
       max_gb=$((max_kb / 1024 / 1024))
       log warning "ccache is ${usage_percent}% full (${current_gb}/${max_gb} GiB)"
@@ -106,7 +106,7 @@ setup_ccache() {
   if CCACHE_PROGRAM="$(command -v ccache 2>/dev/null)"; then
     log info "Using ccache: ${CCACHE_PROGRAM}"
     check_ccache_usage
-    [ -n "$CCACHE_PROGRAM" ] && export CCACHE_PROGRAM
+    [ -n "${CCACHE_PROGRAM}" ] && export CCACHE_PROGRAM
   fi
 }
 
@@ -119,7 +119,7 @@ install_precommit_if_git() {
     return 1
   fi
 
-  if [ ! -f "$git_dir/hooks/pre-commit" ]; then
+  if [ ! -f "${git_dir}/hooks/pre-commit" ]; then
     log info "Pre-commit hook not found, installing commit hooks"
     ./scripts/dev/install-commit-hooks.sh
   fi
@@ -134,7 +134,7 @@ cd "$(dirname "$0")"/..
 
 # Determine system name, failing on an empty string
 SYSTEM_NAME=$(fancy_hostname)
-if [ -z "$SYSTEM_NAME" ]; then
+if [ -z "${SYSTEM_NAME}" ]; then
   log warning "Could not determine SYSTEM_NAME from LMOD_SYSTEM_NAME or HOSTNAME"
   log error "Empty SYSTEM_NAME, needed to load environment and presets"
   exit 1
@@ -146,9 +146,9 @@ OLD_PRE_COMMIT="$(command -v pre-commit 2>/dev/null || printf '')"
 
 # Load environment paths
 _env_script="scripts/env/${SYSTEM_NAME}.sh"
-if [ -f "$_env_script" ]; then
+if [ -f "${_env_script}" ]; then
   log info "Sourcing environment script at ${_env_script}"
-  . "$_env_script"
+  . "${_env_script}"
 else
   log debug "No environment script exists at ${_env_script}"
 fi
@@ -157,7 +157,7 @@ NEW_CMAKE="$(command -v cmake 2>/dev/null || printf 'cmake unavailable')"
 NEW_PRE_COMMIT="$(command -v pre-commit 2>/dev/null || printf '')"
 
 # Link preset file
-ln_presets "$SYSTEM_NAME"
+ln_presets "${SYSTEM_NAME}"
 
 # Search for and probe ccache
 setup_ccache
@@ -181,11 +181,11 @@ shift
 
 # Configure, build, and test
 log info "Configuring with verbosity"
-cmake --preset="$CMAKE_PRESET" --log-level=VERBOSE "$@"
+cmake --preset="${CMAKE_PRESET}" --log-level=VERBOSE "$@"
 log info "Building"
-if cmake --build --preset="$CMAKE_PRESET"; then
+if cmake --build --preset="${CMAKE_PRESET}"; then
   log info "Testing"
-  if ctest --preset="$CMAKE_PRESET" --timeout 15; then
+  if ctest --preset="${CMAKE_PRESET}" --timeout 15; then
     log info "Celeritas was successfully built and tested for development!"
   else
     log warning "Celeritas built but some tests failed"
@@ -193,13 +193,13 @@ if cmake --build --preset="$CMAKE_PRESET"; then
   fi
 
   install_precommit_if_git
-  if [ "$NEW_PRE_COMMIT" != "$OLD_PRE_COMMIT" ]; then
-    log warning "Local environment script uses a different pre-commit than your \$PATH:"
+  if [ "${NEW_PRE_COMMIT}" != "${OLD_PRE_COMMIT}" ]; then
+    log warning "Local environment script uses a different pre-commit than your \${PATH}:"
     log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"
   fi
 
-  if [ "$NEW_CMAKE" != "$OLD_CMAKE" ]; then
-    log warning "Local environment script uses a different CMake than your \$PATH:"
+  if [ "${NEW_CMAKE}" != "${OLD_CMAKE}" ]; then
+    log warning "Local environment script uses a different CMake than your \${PATH}:"
     log info "Recommend adding '. ${PWD}/${_env_script}' to your shell rc"
   fi
 else

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,9 +41,9 @@ log() {
 
 # Get the hostname, trying to account for being on a compute node or cluster
 fancy_hostname() {
-  sys=${LMOD_SYSTEM_NAME}
+  sys=$LMOD_SYSTEM_NAME
   if [ -z "$sys" ]; then
-    sys=${HOSTNAME}
+    sys=$(uname -n)
     # Trim login/compute from head of string
     case "$sys" in
       login[0-9]*.*|compute[0-9]*.*) sys=${sys#*.} ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -66,12 +66,12 @@ ln_presets() {
   dst="CMakeUserPresets.json"
 
   # Return early if it exists
-  if [ -e "$dst" ]; then
-    if [ -L "$dst" ]; then
-      log debug "CMake preset already exists: $dst (symlink)"
-    else
-      log debug "CMake preset already exists: $dst"
-    fi
+  if [ -L "$dst" ]; then
+    src=$(readlink "$dst" 2>/dev/null || printf "<unknown>")
+    log debug "CMake preset already exists: $dst -> $src"
+    return
+  elif [ -e "$dst" ]; then
+    log debug "CMake preset already exists: $dst"
     return
   fi
 
@@ -133,7 +133,8 @@ install_precommit_if_git() {
 
 #-----------------------------------------------------------------------------#
 
-# Run everything from the parent directory of this script (i.e. the Celeritas source dir)
+# Run everything from the parent directory of this script (i.e. the Celeritas
+# source dir)
 cd "$(dirname "$0")"/..
 
 # Determine system name, failing on an empty string

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,11 +19,6 @@
 
 set -e
 
-die() {
-  log error "$1"
-  exit 1
-}
-
 # Print a colorful message to stderr
 log() {
   level=$1
@@ -79,7 +74,7 @@ ln_presets() {
   if [ ! -f "$src" ]; then
     log info "Creating user presets at $src . Please update this file for future configurations."
     cp "scripts/cmake-presets/_dev_.json" "$src"
-    git add "$src" || die "Could not stage presets"
+    git add "$src" || log error "Could not stage presets"
   fi
   log info "Linking presets to $dst"
   ln -s "$src" "$dst"
@@ -141,7 +136,7 @@ cd "$(dirname "$0")"/..
 SYSTEM_NAME=$(fancy_hostname)
 if [ -z "$SYSTEM_NAME" ]; then
   log warning "Could not determine SYSTEM_NAME from LMOD_SYSTEM_NAME or HOSTNAME"
-  log error "Empty SYSTEM_NAME"
+  log error "Empty SYSTEM_NAME, needed to load environment and presets"
   exit 1
 fi
 


### PR DESCRIPTION
This applies some fixes via chatgpt that I recognized were necessary after discussions with @pcanal on #2035 .

## Shebang and shell options
Changed `#!/bin/sh -e` to a plain shebang with an explicit `set -e` for full POSIX compliance.  
Many systems ignore or misinterpret flags after `#!/bin/sh`.

## Quoting and pathname safety
Quoted all variable expansions (`"$0"`, `"$src"`, `"$dst"`, etc.) in command arguments and messages to prevent breakage on spaces, glob characters, or special symbols.

## Safe handling of set -e
Rewrote command substitutions (e.g., `git_dir=$(...)`) so they do not cause the script to exit under `set -e` when commands fail.  
Used `if var=$(command)` style instead of checking `$?` afterward.

## Use of command -v instead of which
Replaced all uses of `which` and `hash` with the POSIX-compliant `command -v` for command existence and path lookup.

## Numeric validation in ccache usage
Added validation of numeric fields before performing arithmetic to prevent runtime errors and extraneous stderr output if `ccache --print-stats` fails or returns malformed data.

## Argument quoting in cmake and ctest calls
Quoted `$CMAKE_PRESET` and argument lists (`"$@"`) to handle presets or paths containing spaces safely.

## Consistent output formatting
Replaced non-portable `echo` usage with `printf '%s\n' ...` for predictable, POSIX-standard output behavior across different shells.

## Removed readlink dependency
~Eliminated non-POSIX use of `readlink`.~
Use a POSIX test for symlink, but print the target with `readlink`

## Fix HOSTNAME

The HOSTNAME variable isn't always exported to secondary processes; so `uname -n` is used instead.