### PR TITLE
Use a single `ActionSequence` across all states

### DIFF
--- a/app/celer-sim/Runner.cc
+++ b/app/celer-sim/Runner.cc
@@ -74,7 +74,7 @@ Runner::Runner(RunnerInput const& old_inp)
     transporter_input_->max_steps = old_inp.max_steps;
     transporter_input_->store_track_counts = old_inp.write_track_counts;
     transporter_input_->store_step_times = old_inp.write_step_times;
-    transporter_input_->action_times = old_inp.action_times;
+    transporter_input_->actions = std::move(loaded.problem.actions);
     transporter_input_->log_progress = old_inp.log_progress;
 
     transporters_.resize(this->num_streams());

--- a/app/celer-sim/Transporter.hh
+++ b/app/celer-sim/Transporter.hh
@@ -21,6 +21,7 @@
 
 namespace celeritas
 {
+class ActionSequence;
 struct Primary;
 template<MemSpace M>
 class Stepper;
@@ -38,9 +39,7 @@ struct TransporterInput
 {
     // Stepper input
     std::shared_ptr<CoreParams const> params;
-    std::shared_ptr<OpticalCollector const> optical;
-    bool action_times{false};  //!< Whether to synchronize device between
-                               //!< actions for timing
+    std::shared_ptr<ActionSequence> actions;
 
     // Loop control
     size_type max_steps{};
@@ -50,10 +49,12 @@ struct TransporterInput
 
     StreamId stream_id{0};
 
+    std::shared_ptr<OpticalCollector const> optical;
+
     //! True if all params are assigned
     explicit operator bool() const
     {
-        return params && max_steps > 0 && log_progress > 0;
+        return params && actions && max_steps > 0 && log_progress > 0;
     }
 };
 

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -349,6 +349,10 @@ SharedParams::SharedParams(SetupOptions const& options)
         }
     }
 
+    // Save action sequence
+    actions_ = std::move(loaded.problem.actions);
+    CELER_ASSERT(actions_);
+
     // Load geant4 geometry adapter and save as "global"
     CELER_ASSERT(loaded.geo);
     geant_geo_ = std::move(loaded.geo);

--- a/src/accel/SharedParams.hh
+++ b/src/accel/SharedParams.hh
@@ -31,6 +31,7 @@ namespace optical
 class Transporter;
 }  // namespace optical
 
+class ActionSequence;
 class CoreParams;
 class CoreStateInterface;
 class GeantGeoParams;
@@ -134,6 +135,7 @@ class SharedParams
     //!@{
     //! \name Internal use only
 
+    using SPActionSequence = std::shared_ptr<ActionSequence>;
     using SPGeantSd = std::shared_ptr<GeantSd>;
     using SPOffloadWriter = std::shared_ptr<detail::OffloadWriter>;
     using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
@@ -152,6 +154,9 @@ class SharedParams
 
     // Optical params (only if using optical physics)
     inline SPOpticalTransporter const& optical_transporter() const;
+
+    // Action sequence
+    inline SPActionSequence const& actions() const;
 
     // Hit manager, to be used only by LocalTransporter
     inline SPGeantSd const& hit_manager() const;
@@ -184,6 +189,7 @@ class SharedParams
     std::shared_ptr<CoreParams> params_;
     SPOpticalCollector optical_collector_;
     SPOpticalTransporter optical_transporter_;
+    SPActionSequence actions_;
     std::shared_ptr<GeantSd> geant_sd_;
     std::shared_ptr<StepCollector> step_collector_;
     VecG4PD offload_particles_;
@@ -275,6 +281,16 @@ auto SharedParams::hit_manager() const -> SPGeantSd const&
 {
     CELER_EXPECT(*this);
     return geant_sd_;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Action sequence for the stepper.
+ */
+auto SharedParams::actions() const -> SPActionSequence const&
+{
+    CELER_EXPECT(*this);
+    return actions_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/ActionSequence.cc
+++ b/src/celeritas/global/ActionSequence.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "corecel/DeviceRuntimeApi.hh"
 
@@ -36,9 +37,6 @@ namespace celeritas
 ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
     : actions_{reg}, options_{std::move(options)}
 {
-    // Initialize timing
-    accum_time_.resize(actions_.step().size());
-
     // Get status checker if available
     for (auto const& brun_sp : actions_.begin_run())
     {
@@ -51,8 +49,6 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
             break;
         }
     }
-
-    CELER_ENSURE(actions_.step().size() == accum_time_.size());
 }
 
 //---------------------------------------------------------------------------//
@@ -76,13 +72,19 @@ void ActionSequence::begin_run(CoreParams const& params, CoreState<M>& state)
 template<MemSpace M>
 void ActionSequence::step(CoreParams const& params, CoreState<M>& state)
 {
-    // Save the stream for synchronizing after each step for timing
-    // NOTE: instead of synchronizing the stream we could add
-    // device timers to reduce the performance
+    // Save a pointer to aux data and the stream for synchronizing after each
+    // step for timing
+    // NOTE: instead of synchronizing the stream we could add device timers to
+    // reduce the performance
     Stream* stream = nullptr;
-    if (M == MemSpace::device && options_.action_times)
+    std::vector<double>* accum_time = nullptr;
+    if (options_.action_times)
     {
-        stream = &device().stream(state.stream_id());
+        accum_time = &options_.action_times->state(state.aux()).accum_time;
+        if (M == MemSpace::device)
+        {
+            stream = &device().stream(state.stream_id());
+        }
     }
 
     // When running a single track slot on host, we can preemptively skip
@@ -113,7 +115,7 @@ void ActionSequence::step(CoreParams const& params, CoreState<M>& state)
                 {
                     stream->sync();
                 }
-                accum_time_[i] += get_time();
+                (*accum_time)[action.action_id().get()] += get_time();
                 if (CELER_UNLIKELY(status_checker_))
                 {
                     status_checker_->step(action.action_id(), params, state);
@@ -137,6 +139,19 @@ void ActionSequence::step(CoreParams const& params, CoreState<M>& state)
             }
         }
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the accumulated action times.
+ */
+auto ActionSequence::get_action_times(AuxStateVec const& aux) const -> MapStrDbl
+{
+    if (options_.action_times)
+    {
+        return options_.action_times->get_action_times(aux);
+    }
+    return {};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/global/ActionSequence.cc
+++ b/src/celeritas/global/ActionSequence.cc
@@ -35,7 +35,9 @@ namespace celeritas
  * Construct from an action registry and sequence options.
  */
 ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
-    : actions_{reg}, options_{std::move(options)}
+    : actions_{reg}
+    , options_{std::move(options)}
+    , num_actions_(reg.num_actions())
 {
     // Get status checker if available
     for (auto const& brun_sp : actions_.begin_run())
@@ -58,6 +60,9 @@ ActionSequence::ActionSequence(ActionRegistry const& reg, Options options)
 template<MemSpace M>
 void ActionSequence::begin_run(CoreParams const& params, CoreState<M>& state)
 {
+    CELER_VALIDATE(params.action_reg()->num_actions() == num_actions_,
+                   << "Number of actions changed since setup completed");
+
     for (auto const& sp_action : actions_.begin_run())
     {
         ScopedProfiling profile_this{sp_action->label()};
@@ -75,7 +80,7 @@ void ActionSequence::step(CoreParams const& params, CoreState<M>& state)
     // Save a pointer to aux data and the stream for synchronizing after each
     // step for timing
     // NOTE: instead of synchronizing the stream we could add device timers to
-    // reduce the performance
+    // reduce the performance impact
     Stream* stream = nullptr;
     std::vector<double>* accum_time = nullptr;
     if (options_.action_times)

--- a/src/celeritas/global/ActionSequence.hh
+++ b/src/celeritas/global/ActionSequence.hh
@@ -8,9 +8,9 @@
 
 #include <memory>
 #include <type_traits>
-#include <vector>
 
 #include "corecel/Types.hh"
+#include "celeritas/user/ActionTimes.hh"
 
 #include "ActionGroups.hh"
 #include "ActionInterface.hh"
@@ -28,9 +28,8 @@ class StatusChecker;
  * TODO accessors here are used by diagnostic output from celer-sim etc.;
  * perhaps make this public or add a diagnostic output for it?
  *
- * \todo Refactor action times as "aux data" and as an end-gather action so
- * that this class can merge across states. Currently there's one sequence per
- * stepper which isn't right.
+ * \note This class must be constructed \em after all actions have been added
+ * to the action registry.
  */
 class ActionSequence
 {
@@ -38,14 +37,15 @@ class ActionSequence
     //!@{
     //! \name Type aliases
     using ActionGroupsT = ActionGroups<CoreParams, CoreState>;
-    using VecDouble = std::vector<double>;
+    using SPActionTimes = std::shared_ptr<ActionTimes>;
+    using MapStrDbl = ActionTimes::MapStrDbl;
     //!@}
 
   public:
     //! Construction/execution options
     struct Options
     {
-        bool action_times{false};  //!< Call DeviceSynchronize and add timer
+        SPActionTimes action_times;  //!< Call DeviceSynchronize and add timer
     };
 
   public:
@@ -62,21 +62,17 @@ class ActionSequence
     template<MemSpace M>
     void step(CoreParams const&, CoreState<M>& state);
 
-    //// ACCESSORS ////
+    // Get the accumulated action times
+    MapStrDbl get_action_times(AuxStateVec const&) const;
 
-    //! Whether synchronization is taking place
-    bool action_times() const { return options_.action_times; }
+    //// ACCESSORS ////
 
     //! Get the ordered vector of actions in the sequence
     ActionGroupsT const& actions() const { return actions_; }
 
-    //! Get the corresponding accumulated time, if 'sync' or host called
-    VecDouble const& accum_time() const { return accum_time_; }
-
   private:
     ActionGroupsT actions_;
     Options options_;
-    VecDouble accum_time_;
     std::shared_ptr<StatusChecker const> status_checker_;
 };
 

--- a/src/celeritas/global/ActionSequence.hh
+++ b/src/celeritas/global/ActionSequence.hh
@@ -73,6 +73,7 @@ class ActionSequence
   private:
     ActionGroupsT actions_;
     Options options_;
+    size_type num_actions_;
     std::shared_ptr<StatusChecker const> status_checker_;
 };
 

--- a/src/celeritas/global/Stepper.cc
+++ b/src/celeritas/global/Stepper.cc
@@ -19,7 +19,6 @@
 #include "celeritas/track/ExtendFromPrimariesAction.hh"
 #include "celeritas/track/TrackInitParams.hh"
 
-#include "ActionSequence.hh"
 #include "CoreParams.hh"
 
 #include "detail/KillActive.hh"
@@ -63,12 +62,11 @@ StepperInterface::~StepperInterface() = default;
  */
 template<MemSpace M>
 Stepper<M>::Stepper(Input input)
-    : params_(std::move(input.params)), actions_{[&] {
-        ActionSequenceT::Options opts;
-        opts.action_times = input.action_times;
-        return std::make_shared<ActionSequenceT>(*params_->action_reg(), opts);
-    }()}
+    : params_(std::move(input.params)), actions_(std::move(input.actions))
 {
+    CELER_EXPECT(params_);
+    CELER_EXPECT(actions_);
+
     // Save primary action: TODO this is a hack and should be refactored so
     // that we pass generators into the stepper and eliminate the call
     // signature with primaries

--- a/src/celeritas/setup/Problem.hh
+++ b/src/celeritas/setup/Problem.hh
@@ -22,6 +22,7 @@ namespace optical
 class Transporter;
 }  // namespace optical
 
+class ActionSequence;
 class CoreParams;
 class GeantSd;
 class OpticalCollector;
@@ -51,6 +52,8 @@ struct ProblemLoaded
     std::shared_ptr<GeantSd> geant_sd;
     //! ROOT file manager
     std::shared_ptr<RootFileManager> root_manager;
+    //! Action sequence
+    std::shared_ptr<ActionSequence> actions;
 
     //!@}
 

--- a/src/celeritas/user/ActionTimes.hh
+++ b/src/celeritas/user/ActionTimes.hh
@@ -29,6 +29,8 @@ class AuxParamsRegistry;
  * that invokes the sequence of step actions should be shared across threads,
  * the action times are stored as auxiliary data rather than locally in that
  * class.
+ *
+ * \todo Add an end-gather action to merge across states?
  */
 class ActionTimes : public AuxParamsInterface
 {

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -139,6 +139,8 @@ class BadGeometryTest : public InvalidOrangeTestBase
         result.params = this->core();
         result.stream_id = StreamId{0};
         result.num_track_slots = 1;
+        result.actions = std::make_shared<ActionSequence>(
+            *this->action_reg(), ActionSequence::Options{});
         return result;
     }
 

--- a/test/celeritas/global/StepperTestBase.cc
+++ b/test/celeritas/global/StepperTestBase.cc
@@ -43,6 +43,8 @@ StepperInput StepperTestBase::make_stepper_input(size_type tracks)
     result.params = this->core();
     result.stream_id = StreamId{0};
     result.num_track_slots = tracks;
+    result.actions = std::make_shared<ActionSequence>(
+        *this->action_reg(), ActionSequence::Options{});
 
     if (auto& d = device())
     {

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -184,6 +184,8 @@ auto LArSphereOffloadTest::run(size_type num_primaries,
     step_inp.params = this->core();
     step_inp.stream_id = StreamId{0};
     step_inp.num_track_slots = num_track_slots;
+    step_inp.actions = std::make_shared<ActionSequence>(
+        *this->action_reg(), ActionSequence::Options{});
     Stepper<M> step(step_inp);
     LogContextException log_context{this->output_reg().get()};
 

--- a/test/celeritas/track/TrackSort.test.cc
+++ b/test/celeritas/track/TrackSort.test.cc
@@ -50,6 +50,8 @@ class TrackSortTestBase : virtual public GlobalTestBase
         result.params = this->core();
         result.stream_id = StreamId{0};
         result.num_track_slots = tracks;
+        result.actions = std::make_shared<ActionSequence>(
+            *this->action_reg(), ActionSequence::Options{});
 
         if constexpr (M == MemSpace::device)
         {

--- a/test/celeritas/user/SimpleLoopTestBase.cc
+++ b/test/celeritas/user/SimpleLoopTestBase.cc
@@ -36,6 +36,8 @@ void SimpleLoopTestBase::run_impl(size_type num_tracks, size_type num_steps)
     step_inp.params = this->core();
     step_inp.stream_id = StreamId{0};
     step_inp.num_track_slots = num_tracks;
+    step_inp.actions = std::make_shared<ActionSequence>(
+        *this->action_reg(), ActionSequence::Options{});
 
     if constexpr (M == MemSpace::device)
     {

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -205,6 +205,8 @@ TEST_F(KnSimpleLoopTestBase, multiple_interfaces)
         step_inp.params = this->core();
         step_inp.stream_id = StreamId{0};
         step_inp.num_track_slots = 2;
+        step_inp.actions = std::make_shared<ActionSequence>(
+            *this->action_reg(), ActionSequence::Options{});
 
         Stepper<MemSpace::host> step(step_inp);
 


### PR DESCRIPTION
The updates the `ActionSequence` to use aux data for accumulating action times and moves to a single `ActionSequence` per params rather than one per `Stepper` (part of #1556).