### PR TITLE
CudaRdcUtils v13 --no-undefined fix, add missing cudart

### DIFF
--- a/cmake/external/CudaRdcUtils.cmake
+++ b/cmake/external/CudaRdcUtils.cmake
@@ -812,7 +812,7 @@ function(cuda_rdc_use_middle_lib_in_property target property)
   set(_new_values)
   foreach(_lib IN LISTS _target_libs)
     set(_newlib ${_lib})
-    # Simplistic treatement of `$<LINK_ONLY:...>`
+    # Simplistic treatment of `$<LINK_ONLY:...>`
     string(REGEX REPLACE "\\\$<LINK_ONLY:(.*)>" "\\1" _stripped_lib ${_lib})
     if(_stripped_lib STREQUAL _lib)
       set(_stripped_lib)
@@ -921,7 +921,7 @@ function(cuda_rdc_check_cuda_runtime OUTVAR library)
     #   You have used file(GET_RUNTIME_DEPENDENCIES) in project mode.  This is
     #     probably not what you intended to do.
     # On the other hand, if the library is using (relocatable) CUDA code and
-    # the shared run-time library and we don't have the scafolding libraries
+    # the shared run-time library and we don't have the scaffolding libraries
     # (shared/static/final) then this won't work well. i.e. if we were to detect this
     # case we probably need to 'error out'.
     get_target_property(_cuda_middle_library ${library} CUDA_RDC_MIDDLE_LIBRARY)

--- a/cmake/external/CudaRdcUtils.cmake
+++ b/cmake/external/CudaRdcUtils.cmake
@@ -528,13 +528,11 @@ function(cuda_rdc_add_library target)
     EXPORT_PROPERTIES "CUDA_RUNTIME_LIBRARY;CUDA_RDC_LIBRARY_TYPE;CUDA_RDC_FINAL_LIBRARY;CUDA_RDC_MIDDLE_LIBRARY;CUDA_RDC_STATIC_LIBRARY"
   )
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if(CUDA_RDC_LINKER_SUPPORTS_ALLOW_SHLIB_UNDEFINED)
-      target_link_options(${target} PRIVATE LINKER:--allow-shlib-undefined)
-    endif()
-    if(CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)
-      target_link_options(${target} PRIVATE LINKER:-z,undefs)
-    endif()
+  if(CUDA_RDC_LINKER_SUPPORTS_ALLOW_SHLIB_UNDEFINED)
+    target_link_options(${target} PRIVATE LINKER:--allow-shlib-undefined)
+  endif()
+  if(CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)
+    target_link_options(${target} PRIVATE LINKER:-z,undefs)
   endif()
 
   ## STATIC ##

--- a/cmake/external/CudaRdcUtils.cmake
+++ b/cmake/external/CudaRdcUtils.cmake
@@ -137,7 +137,7 @@ relocatable device code and most importantly linking against those libraries.
 
 #]=======================================================================]
 
-set(_CUDA_RDC_VERSION 12)
+set(_CUDA_RDC_VERSION 13)
 if(CUDA_RDC_VERSION GREATER _CUDA_RDC_VERSION)
   # A newer version has already been loaded
   message(VERBOSE "Ignoring CUDA_RDC_VERSION ${_CUDA_RDC_VERSION}: "
@@ -202,6 +202,69 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 else()
   set(CMAKE_CXX_LINK_LIBRARY_USING_no_as_needed_SUPPORTED FALSE)
 endif()
+
+# Check if the compiler/linker supports -Wl,-z,undefs flag
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  include(CheckLinkerFlag)
+  check_linker_flag(CXX "LINKER:-z,undefs" CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)
+  if(CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)
+    message(VERBOSE "Linker supports \"-z undefs\" flag")
+  else()
+    message(VERBOSE "Linker does not support \"-z undefs\" flag")
+  endif()
+  check_linker_flag(CXX "LINKER:--allow-shlib-undefined" CUDA_RDC_LINKER_SUPPORTS_ALLOW_SHLIB_UNDEFINED)
+  if(CUDA_RDC_LINKER_SUPPORTS_ALLOW_SHLIB_UNDEFINED)
+    message(VERBOSE "Linker supports \"--allow-shlib-undefined\" flag")
+  else()
+    message(VERBOSE "Linker does not support \"--allow-shlib-undefined\" flag")
+  endif()
+endif()
+
+# On Linux, sanitize global shared linker flags to avoid enforcing no-undefined, which
+# conflicts with CUDA RDC split libraries (middle). This keeps builds compatible
+# when toolchains or parent projects inject these flags.
+
+# Helper macro to sanitize a linker flags variable
+# Remove common forms of no-undefined
+macro(_cuda_rdc_sanitize_linker_flags _var_name)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(DEFINED ${_var_name} AND NOT ${_var_name} STREQUAL "")
+      # Store original value in a backup variable for potential restoration
+      set(_CUDA_RDC_ORIG_${_var_name} "${${_var_name}}")
+      set(_filtered_flags "${${_var_name}}")
+      # Remove common forms of no-undefined
+      string(REGEX REPLACE "(^|[ \t])-Wl,--no-undefined([ \t]|$)" " " _filtered_flags "${_filtered_flags}")
+      string(REGEX REPLACE "(^|[ \t])--no-undefined([ \t]|$)" " " _filtered_flags "${_filtered_flags}")
+      string(REGEX REPLACE "(^|[ \t])-Wl,-z,defs([ \t]|$)" " " _filtered_flags "${_filtered_flags}")
+      string(REGEX REPLACE "(^|[ \t])-z[ ,]defs([ \t]|$)" " " _filtered_flags "${_filtered_flags}")
+      # Also tolerate the misspelled form sometimes used (no-defined)
+      string(REGEX REPLACE "(^|[ \t])-Wl,--no-defined([ \t]|$)" " " _filtered_flags "${_filtered_flags}")
+      string(REGEX REPLACE "(^|[ \t])--no-defined([ \t]|$)" " " _filtered_flags "${_filtered_flags}")
+      # Normalize whitespace
+      string(REGEX REPLACE "[ \t]+" " " _filtered_flags "${_filtered_flags}")
+      string(STRIP "${_filtered_flags}" _filtered_flags)
+      if(NOT _filtered_flags STREQUAL "${_CUDA_RDC_ORIG_${_var_name}}")
+        # Update cache so the change persists if the flag was provided via cache/toolchain
+        set(${_var_name} "${_filtered_flags}" CACHE STRING "Linker flags updated by cuda_rdc function" FORCE)
+        message(WARNING "Sanitized ${_var_name}: '${_CUDA_RDC_ORIG_${_var_name}}' -> '${_filtered_flags}'")
+      endif()
+    endif()
+  endif()
+endmacro()
+
+# Function to sanitize all relevant shared linker flags
+function(cuda_rdc_sanitize_shared_linker_flags)
+  # Sanitize base shared linker flags
+  _cuda_rdc_sanitize_linker_flags(CMAKE_SHARED_LINKER_FLAGS)
+
+  # Sanitize current build type flags if defined
+  if(DEFINED CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE STREQUAL "")
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type_upper)
+    _cuda_rdc_sanitize_linker_flags(CMAKE_SHARED_LINKER_FLAGS_${_build_type_upper})
+  endif()
+endfunction()
+
+
 
 ##############################################################################
 # Separate the OPTIONS out from the sources
@@ -442,6 +505,11 @@ function(cuda_rdc_add_library target)
 
   ## MIDDLE (main library) ##
 
+  # Remove no-undefined from shared linker flags
+  if(NOT CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)
+    cuda_rdc_sanitize_shared_linker_flags()
+  endif()
+
   add_library(${target} ${_lib_requested_type}
     $<TARGET_OBJECTS:${target}_objects>
   )
@@ -459,6 +527,15 @@ function(cuda_rdc_add_library target)
     CUDA_RESOLVE_DEVICE_SYMBOLS OFF # We really don't want nvlink called.
     EXPORT_PROPERTIES "CUDA_RUNTIME_LIBRARY;CUDA_RDC_LIBRARY_TYPE;CUDA_RDC_FINAL_LIBRARY;CUDA_RDC_MIDDLE_LIBRARY;CUDA_RDC_STATIC_LIBRARY"
   )
+
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(CUDA_RDC_LINKER_SUPPORTS_ALLOW_SHLIB_UNDEFINED)
+      target_link_options(${target} PRIVATE LINKER:--allow-shlib-undefined)
+    endif()
+    if(CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)
+      target_link_options(${target} PRIVATE LINKER:-z,undefs)
+    endif()
+  endif()
 
   ## STATIC ##
 
@@ -735,7 +812,7 @@ function(cuda_rdc_use_middle_lib_in_property target property)
   set(_new_values)
   foreach(_lib IN LISTS _target_libs)
     set(_newlib ${_lib})
-    # Simplistic treatment of `$<LINK_ONLY:...>`
+    # Simplistic treatement of `$<LINK_ONLY:...>`
     string(REGEX REPLACE "\\\$<LINK_ONLY:(.*)>" "\\1" _stripped_lib ${_lib})
     if(_stripped_lib STREQUAL _lib)
       set(_stripped_lib)
@@ -844,7 +921,7 @@ function(cuda_rdc_check_cuda_runtime OUTVAR library)
     #   You have used file(GET_RUNTIME_DEPENDENCIES) in project mode.  This is
     #     probably not what you intended to do.
     # On the other hand, if the library is using (relocatable) CUDA code and
-    # the shared run-time library and we don't have the scaffolding libraries
+    # the shared run-time library and we don't have the scafolding libraries
     # (shared/static/final) then this won't work well. i.e. if we were to detect this
     # case we probably need to 'error out'.
     get_target_property(_cuda_middle_library ${library} CUDA_RDC_MIDDLE_LIBRARY)
@@ -1096,6 +1173,7 @@ function(cuda_rdc_target_link_libraries target)
         # and the current one is Shared.
         if(${_need_to_use_shared_runtime})
           set_target_properties(${target} PROPERTIES CUDA_RUNTIME_LIBRARY "Shared")
+          target_link_libraries(${target} PRIVATE CUDA::cudart)
         endif()
       endif()
     endif()


### PR DESCRIPTION
Add missing cudart for non-cuda library that depends on a cuda library.

Avoid no-undefined flag when constructing middle library

Also explicitly allow undefined symbols for rdc library (in case `—no-undefined` becomes the default for linker)

The cuda_rdc middle library has by definition many unresolved symbols. Those symbols are generated by nvlink whose result is only included in the final library.

If the user request `-Wl,--no-undefined` to be applied/used when generating a shared library, we must remove it for the middle library generation (we could not find a flag that took priority/reverted the `no-undefined` if/when it is passed to the linker).

This is required for building within the LHCb context where we have:

 ```
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "-Wl,--as-needed -Wl,--no-undefined")
 ```

This patch means that for CMake project that create any RDC libraries, and relies on setting `--no-undefined` via `CMAKE_SHARED_LINKER_FLAGS[_INIT]` then `--no-undefined` will be disabled globally (as opposed to 'just' for the CUDA rdc
 middle library).

Instead of modifying `CMAKE_SHARED_LINKER_FLAGS`, when it is available we can use `-z undefs`

