### PR TITLE
Add customization of trivial traits to support some GPU types

### DIFF
--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -45,11 +45,10 @@ namespace celeritas
 template<class F>
 class ActionLauncher : public KernelLauncher<F>
 {
-    static_assert((std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
-                   || CELER_COMPILER == CELER_COMPILER_CLANG)
-                      && !std::is_pointer_v<F> && !std::is_reference_v<F>,
-                  "Launched action must be a trivially copyable function "
-                  "object");
+    static_assert(
+        Launchable_v<F>,
+        R"(Launched action must be a trivially copyable function object)");
+
     using StepActionT = CoreStepActionInterface;
 
   public:

--- a/src/celeritas/optical/action/ActionLauncher.device.hh
+++ b/src/celeritas/optical/action/ActionLauncher.device.hh
@@ -48,9 +48,7 @@ template<class F>
 class ActionLauncher : public KernelLauncher<F>
 {
     static_assert(
-        (std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
-         || CELER_COMPILER == CELER_COMPILER_CLANG)
-            && !std::is_pointer_v<F> && !std::is_reference_v<F>,
+        Launchable_v<F>,
         R"(Launched action must be a trivially copyable function object)");
 
   public:

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -125,13 +125,6 @@ using RefPtr = ObserverPtr<S<Ownership::reference, M>, M>;
 //!@{
 //! \name Type trait utilities, used for VecGeom or elsewhere.
 
-//! Switch between host or device type based on memspace
-template<MemSpace M, class HT, class DT>
-using MemSpaceCond_t
-    = std::conditional_t<M == MemSpace::host,
-                         HT,
-                         std::conditional_t<M == MemSpace::device, DT, void>>;
-
 /*!
  * Traits class marking compatibility with Collection and Copier.
  *

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <string>
+#include <type_traits>
 
 #include "corecel/Config.hh"
 
@@ -29,7 +30,7 @@ using size_type = unsigned int;
 using size_type = std::size_t;
 #endif
 
-#if CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
+#if CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE || defined(__DOXYGEN__)
 //! Numerical type for real numbers
 using real_type = double;
 #elif CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_FLOAT
@@ -79,6 +80,8 @@ enum class UnitSystem
 };
 
 //---------------------------------------------------------------------------//
+// TEMPLATE ALIASES
+//---------------------------------------------------------------------------//
 //!@{
 //! \name Convenience typedefs for params and states.
 
@@ -118,6 +121,32 @@ using RefPtr = ObserverPtr<S<Ownership::reference, M>, M>;
 
 //!@}
 
+//---------------------------------------------------------------------------//
+//!@{
+//! \name Type trait utilities, used for VecGeom or elsewhere.
+
+//! Switch between host or device type based on memspace
+template<MemSpace M, class HT, class DT>
+using MemSpaceCond_t
+    = std::conditional_t<M == MemSpace::host,
+                         HT,
+                         std::conditional_t<M == MemSpace::device, DT, void>>;
+
+/*!
+ * Traits class marking compatibility with Collection and Copier.
+ *
+ * This should usually apply only to trivially copyable objects, but there are
+ * \em rare exceptions for external libraries that we know from source
+ * inspection are essentially trivial.
+ */
+template<class T>
+struct TriviallyCopyable : std::is_trivially_copyable<T>
+{
+};
+
+template<class T>
+constexpr inline bool TriviallyCopyable_v = TriviallyCopyable<T>::value;
+//!@}
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS (HOST)
 //---------------------------------------------------------------------------//

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -144,8 +144,17 @@ struct TriviallyCopyable : std::is_trivially_copyable<T>
 {
 };
 
+//! True if a type can be copied from host/device without UB
 template<class T>
 constexpr inline bool TriviallyCopyable_v = TriviallyCopyable<T>::value;
+
+//! True if an object (functor) is compatible with kernel launchers
+template<class F>
+constexpr inline bool Launchable_v
+    = (TriviallyCopyable_v<F> || CELERITAS_USE_HIP
+       || CELER_COMPILER == CELER_COMPILER_CLANG)
+      && !std::is_pointer_v<F> && !std::is_reference_v<F>;
+
 //!@}
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS (HOST)

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -32,8 +32,12 @@ class DedupeCollectionBuilder;
  * The \c Collection manages data allocation and transfer between CPU and GPU.
  * Its primary design goal is facilitating construction of deeply hierarchical
  * data on host at setup time and seamlessly copying to device.
- * The templated \c T must be trivially copyable: either a fundamental data
- * type or a struct of such types.
+ * The templated \c T must be trivially copyable and destructable: either a
+ * fundamental data type or a struct of such types.  (Some classes in external
+ * libraries, such as rocrand's state types and VecGeom's NavTuple types, are
+ * \em essentially trivial, but implement null-op destructors or optimized copy
+ * constructors, so we allow specialization through the
+ * celeritas::TriviallyCopyable class.
  *
  * An individual item in a \c Collection<T> can be accessed with \c ItemId<T>,
  * a contiguous subset of items are accessed with \c ItemRange<T>, and the
@@ -295,11 +299,8 @@ struct AllItems
 template<class T, Ownership W, MemSpace M, class I = ItemId<T>>
 class Collection
 {
-    // rocrand states have nontrivial destructors
     static_assert(TriviallyCopyable_v<T>,
                   "Collection element is not trivially copyable");
-    static_assert(TriviallyCopyable_v<T>,
-                  "Collection element is not trivially destructible");
 
     using CollectionTraitsT = detail::CollectionTraits<T, W, M>;
     using const_value_type = typename CollectionTraitsT::const_type;

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <type_traits>
+
 #include "corecel/Assert.hh"
 #include "corecel/OpaqueId.hh"
 #include "corecel/Types.hh"
@@ -294,9 +296,9 @@ template<class T, Ownership W, MemSpace M, class I = ItemId<T>>
 class Collection
 {
     // rocrand states have nontrivial destructors
-    static_assert(std::is_trivially_copyable<T>::value || CELERITAS_USE_HIP,
+    static_assert(TriviallyCopyable_v<T>,
                   "Collection element is not trivially copyable");
-    static_assert(std::is_trivially_destructible<T>::value || CELERITAS_USE_HIP,
+    static_assert(TriviallyCopyable_v<T>,
                   "Collection element is not trivially destructible");
 
     using CollectionTraitsT = detail::CollectionTraits<T, W, M>;

--- a/src/corecel/data/Copier.hh
+++ b/src/corecel/data/Copier.hh
@@ -32,8 +32,7 @@ namespace celeritas
 template<class T, MemSpace M>
 class Copier
 {
-    static_assert(std::is_trivially_copyable<T>::value,
-                  "Data is not trivially copyable");
+    static_assert(TriviallyCopyable_v<T>, "Data is not trivially copyable");
 
   public:
     //! Construct with the destination and the class's memspace
@@ -59,8 +58,7 @@ class Copier
 template<class T>
 class ItemCopier
 {
-    static_assert(std::is_trivially_copyable<T>::value,
-                  "Data is not trivially copyable");
+    static_assert(TriviallyCopyable_v<T>, "Data is not trivially copyable");
 
   public:
     //! Default constructor

--- a/src/corecel/data/DeviceVector.hh
+++ b/src/corecel/data/DeviceVector.hh
@@ -45,15 +45,8 @@ namespace celeritas
 template<class T>
 class DeviceVector
 {
-#if !CELERITAS_USE_HIP
-    // rocrand states have nontrivial destructors, and some HIP integer types
-    // are not trivially copyable
     static_assert(TriviallyCopyable_v<T>,
                   "DeviceVector element is not trivially copyable");
-
-    static_assert(std::is_trivially_destructible<T>::value,
-                  "DeviceVector element is not trivially destructible");
-#endif
 
   public:
     //!@{

--- a/src/corecel/data/DeviceVector.hh
+++ b/src/corecel/data/DeviceVector.hh
@@ -8,6 +8,7 @@
 
 #include <type_traits>
 
+#include "corecel/Types.hh"
 #include "corecel/cont/InitializedValue.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/sys/ThreadId.hh"
@@ -47,7 +48,7 @@ class DeviceVector
 #if !CELERITAS_USE_HIP
     // rocrand states have nontrivial destructors, and some HIP integer types
     // are not trivially copyable
-    static_assert(std::is_trivially_copyable<T>::value,
+    static_assert(TriviallyCopyable_v<T>,
                   "DeviceVector element is not trivially copyable");
 
     static_assert(std::is_trivially_destructible<T>::value,

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -21,40 +21,6 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-template<class T, class Enable = void>
-struct TrivialInvalidValueTraits
-{
-    static_assert(std::is_trivial<T>::value,
-                  "Cannot legally memset non-trivial types");
-    static T value()
-    {
-        T result;
-        std::memset(&result, 0xd0, sizeof(T));  // 4*b"\xf0\x9f\xa6\xa4".decode()
-        return result;
-    }
-};
-
-//---------------------------------------------------------------------------//
-template<class T>
-struct TrivialInvalidValueTraits<
-    T,
-    typename std::enable_if<std::is_arithmetic<T>::value>::type>
-{
-    static constexpr T value() { return std::numeric_limits<T>::max() / 2; }
-};
-
-template<class T, size_type N>
-struct TrivialInvalidValueTraits<Array<T, N>, void>
-{
-    static Array<T, N> value()
-    {
-        Array<T, N> result;
-        result.fill(TrivialInvalidValueTraits<T>::value());
-        return result;
-    }
-};
-
-//---------------------------------------------------------------------------//
 /*!
  * Return an 'invalid' value.
  *

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -11,8 +11,10 @@
 #include <type_traits>
 
 #include "corecel/OpaqueId.hh"
+#include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/data/Collection.hh"
+#include "celeritas/random/ElementSelector.hh"
 
 namespace celeritas
 {
@@ -64,46 +66,51 @@ struct TrivialInvalidValueTraits<Array<T, N>, void>
  * types, and fill trivial types with garbage values that look like
  * `0xd0d0d0d0`.
  */
-template<class T, class Enable = void>
+template<class T>
 struct InvalidValueTraits
 {
     static T value()
     {
-#if !CELERITAS_USE_HIP
-        static_assert(std::is_trivially_copyable<T>::value,
-                      "Filling can only be done to trivially copyable "
-                      "classes");
-#endif
-        // BAD: we're assigning garbage data to a result with a *non-trivial
-        // type*, such as a struct of OpaqueIds. However, this is in essence
-        // what's going on when we allocate space for nontrivial types on
-        // device: whatever's there (whether memset on NVIDIA or uninitialized
-        // on AMD) is not going to have "placement new" applied since we're not
-        // using thrust or calling Filler to launch initialization kernels on
-        // all our datatypes. Reinterpret the data as bytes and assign garbage
-        // values.
-        T result;
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        std::memset(reinterpret_cast<unsigned char*>(&result), 0xd0, sizeof(T));
-        return result;
+        if constexpr (std::is_trivially_copyable_v<T>)
+        {
+            // Assigning garbage data to a result with a potentially
+            // *non-trivial type*, such as a struct of OpaqueIds, even if it's
+            // trivially copyable. However, this is in essence what's going on
+            // when we allocate space for nontrivial types on device:
+            // whatever's there (whether memset on NVIDIA or uninitialized on
+            // AMD) is not going to have "placement new" applied since we're
+            // not using thrust or calling Filler to launch initialization
+            // kernels on all our datatypes. Reinterpret the data as bytes and
+            // assign garbage values.
+            T v;
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            std::memset(reinterpret_cast<unsigned char*>(&v), 0xd0, sizeof(T));
+            return v;
+        }
+        else if constexpr (TriviallyCopyable_v<T>)
+        {
+            // The type is marked by a developer as being "trivially copyable"
+            // when it's technically not: examples are with the HIP RNG and
+            // VecGeom nav state. Avoid breaking copy constructors.
+            return T{};
+        }
+        else
+        {
+            static_assert(
+                sizeof(T) == 0,
+                R"(Filling can only be done to trivially copyable classes)");
+        }
     }
 };
 
 //---------------------------------------------------------------------------//
 template<class I, class T>
-struct InvalidValueTraits<OpaqueId<I, T>, void>
+struct InvalidValueTraits<OpaqueId<I, T>>
 {
     static constexpr OpaqueId<I, T> value()
     {
         return OpaqueId<I, T>(std::numeric_limits<T>::max() / 2);
     }
-};
-
-//---------------------------------------------------------------------------//
-template<class T>
-struct InvalidValueTraits<T, typename std::enable_if<std::is_trivial<T>::value>::type>
-{
-    static T value() { return TrivialInvalidValueTraits<T>::value(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -54,9 +54,9 @@ struct InvalidValueTraits
         }
         else if constexpr (TriviallyCopyable_v<T>)
         {
-            // The type is marked by a developer as being "trivially copyable"
-            // when it's technically not: examples are with the HIP RNG and
-            // VecGeom nav state. Avoid breaking copy constructors.
+            // The type is specialized by a developer as being "trivially
+            // copyable" when it's technically not: examples are with the HIP
+            // RNG and VecGeom nav state. Avoid breaking copy constructors.
             return T{};
         }
         else

--- a/src/corecel/data/detail/FillInvalid.hh
+++ b/src/corecel/data/detail/FillInvalid.hh
@@ -14,7 +14,6 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/data/Collection.hh"
-#include "celeritas/random/ElementSelector.hh"
 
 namespace celeritas
 {

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -57,9 +57,7 @@ template<class F>
 class KernelLauncher
 {
     static_assert(
-        (std::is_trivially_copyable_v<F> || CELERITAS_USE_HIP
-         || CELER_COMPILER == CELER_COMPILER_CLANG)
-            && !std::is_pointer_v<F> && !std::is_reference_v<F>,
+        Launchable_v<F>,
         R"(Launched action must be a trivially copyable function object)");
 
   public:


### PR DESCRIPTION
Allow fine-tuning of `std::is_trivially_copyable` to allow some essentially-POD objects (e.g., NavStateTuple's underlying container in vecgeom, or the old HIP RNGs)  to be copied to device.