### PR TITLE
Fix VecGeom 2 solids behavior by clearing last exited state

### DIFF
--- a/src/geocel/vg/detail/SolidsNavigator.hh
+++ b/src/geocel/vg/detail/SolidsNavigator.hh
@@ -77,6 +77,7 @@ class SolidsNavigator
         real_type step = navigator->ComputeStepAndPropagatedState(
             glpos, gldir, step_limit, curr, next);
         curr.SetLastExited({});
+        next.SetLastExited({});
 
         return step;
     }

--- a/src/geocel/vg/detail/SolidsNavigator.hh
+++ b/src/geocel/vg/detail/SolidsNavigator.hh
@@ -76,6 +76,7 @@ class SolidsNavigator
         auto* navigator = curr_volume->GetNavigator();
         real_type step = navigator->ComputeStepAndPropagatedState(
             glpos, gldir, step_limit, curr, next);
+        curr.SetLastExited({});
 
         return step;
     }

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1595,11 +1595,11 @@ TEST_F(CmseTest, coarse)
         else
         {
             // FIXME: version 1.x needs much more steps -> taking much longer!
-            expected_num_boundary = {20, 101, 60, 24};
-            expected_num_step = {53, 6462, 3236, 428};
-            expected_num_intercept = {204, 19551, 16170, 3176};
-            expected_num_integration = {475, 58282, 41914, 8362};
-            EXPECT_EQ(scoped_log_.messages().size(), 62);
+            expected_num_boundary = {258, 101, 60, 304};
+            expected_num_step = {10001, 6462, 3236, 1396};
+            expected_num_intercept = {30807, 19551, 16170, 11419};
+            expected_num_integration = {81030, 58282, 41914, 29021};
+            EXPECT_EQ(scoped_log_.messages().size(), 4);
         }
     }
     else if (!scoped_log_.empty())

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -1091,19 +1091,6 @@ TEST_F(TwoBoxesTest,
         "world",
     };
 
-    if (using_solids_vg && CELERITAS_VECGEOM_VERSION >= 0x020000)
-    {
-        expected_boundary[1] = 0;
-        expected_substeps[1] = 1;
-        expected_distances[1] = 0.00785398163397448;
-        expected_volumes[1] = "world";
-
-        expected_boundary[3] = 0;
-        expected_substeps[3] = 1;
-        expected_distances[3] = 0.00448798950512828;
-        expected_volumes[3] = "world";
-    }
-
     EXPECT_VEC_EQ(expected_boundary, boundary);
     EXPECT_VEC_NEAR(expected_distances, distances, real_type{.1} * coarse_eps);
     EXPECT_VEC_EQ(expected_substeps, substeps);
@@ -1584,31 +1571,11 @@ TEST_F(CmseTest, coarse)
     }
     else if (using_solids_vg)
     {
-        if (CELERITAS_VECGEOM_VERSION < 0x020000)
-        {
-            expected_num_boundary = {134, 101, 60, 40};
-            expected_num_step = {10001, 6462, 3236, 1303};
-            expected_num_intercept = {30419, 19551, 16170, 9956};
-            expected_num_integration = {80659, 58282, 41914, 26114};
-            EXPECT_EQ(scoped_log_.messages().size(), 1);
-        }
-        else
-        {
-            // FIXME: version 1.x needs much more steps -> taking much longer!
-            expected_num_boundary = {258, 101, 60, 304};
-            expected_num_step = {10001, 6462, 3236, 1396};
-            expected_num_intercept = {30807, 19551, 16170, 11419};
-            expected_num_integration = {81030, 58282, 41914, 29021};
-            EXPECT_EQ(scoped_log_.messages().size(), 4);
-        }
-    }
-    else if (!scoped_log_.empty())
-    {
         // Bumped (platform-dependent!): counts change a bit
-        expected_num_boundary = {134, 101, 60, 40};
-        expected_num_step = {10001, 6462, 3236, 1303};
-        expected_num_intercept = {30419, 19551, 16170, 9956};
-        expected_num_integration = {80659, 58282, 41914, 26114};
+        expected_num_boundary[1] = 101;
+        expected_num_step[1] = 6462;
+        expected_num_intercept[1] = 19551;
+        expected_num_integration[1] = 58282;
         static char const* const expected_log_messages[] = {
             R"(Moved internally from boundary but safety didn't increase: volume 18 from {10.32, -6.565, 796.9} to {10.32, -6.565, 796.9} (distance: 1.000e-4))"};
         EXPECT_VEC_EQ(expected_log_messages, scoped_log_.messages())

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -2348,13 +2348,6 @@ void TwoBoxesGeoTest::test_detailed_tracking() const
     geo.set_dir({-1, 0, 0});
     next = geo.find_next_step(from_cm(1000));
     EXPECT_TRUE(next.boundary);
-    if (test_->geometry_type() == "VecGeom" && using_solids_vg
-        && vecgeom_version >= Version{2, 0})
-    {
-        // VecGeom 2.x-solid totally misses the inner boundary
-        EXPECT_SOFT_NEAR(505 + 2 * dx, to_cm(next.distance), 1e-4);
-        GTEST_SKIP() << "VecGeom 2.x misses inner boundary";
-    }
     EXPECT_SOFT_NEAR(2 * dx, to_cm(next.distance), 1e-4);
     geo.move_to_boundary();
     EXPECT_TRUE(geo.is_on_boundary());


### PR DESCRIPTION
This is the core change of #2116 to fix discrepancies between VecGeom 1 and 2 for the solids model. I think the way we query and move across boundaries is different enough to AdePT's that the recent VecGeom changes broke our existing method by preventing "reentry" into a volume recently queried.

@agheata I think it could improve the consistency and usage of the navigation "state" to split out the two embedded states and the boundary state, and *just* have a single nav tuple/index represent the state. (This is what I've partly done in #2116.) There's also an increasing amount of unused code in VecGeom's master, perhaps a description of what's intended to be used and what's to be discarded would help? We can discuss at the next vecgeom meeting if needed.