### PR TITLE
Fix spurious warning when loading scintillation properties and update device tests

### DIFF
--- a/test/celeritas/optical/Generator.test.cc
+++ b/test/celeritas/optical/Generator.test.cc
@@ -300,7 +300,7 @@ TEST_F(LArSphereGeneratorTest, TEST_IF_CELER_DEVICE(device_generator))
     if (reference_configuration)
     {
         EXPECT_EQ(409643, gen.num_generated);
-        EXPECT_EQ(434165, result.steps);
+        EXPECT_EQ(427544, result.steps);
         EXPECT_EQ(28, result.step_iters);
     }
 }

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -535,7 +535,7 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        constexpr int ref_steps = using_surface_vg ? 55 : 60;
+        constexpr int ref_steps = using_surface_vg ? 55 : 59;
         EXPECT_EQ(ref_steps, result.accum.step_iters);
         EXPECT_EQ(1, result.accum.flushes);
         ASSERT_EQ(1, result.accum.generators.size());


### PR DESCRIPTION
- Fixes the warning emitted even when the correct prefix was used:
```console
src/celeritas/ext/GeantImporter.cc:280: warning: Deprecated property prefix SCINTILLATIONLAMBDA: use CELER_SCINTILLATION
src/celeritas/ext/GeantImporter.cc:280: warning: Deprecated property prefix SCINTILLATIONLAMBDA: use CELER_SCINTILLATION
```
- Validates that either both or neither of the mean and sigma are present
- Updates the device tests for #2100 (which we always forget to do :))