### PR TITLE
Fix vecgeom 2.x with CUDA

### DIFF
--- a/scripts/cmake-presets/hudson.json
+++ b/scripts/cmake-presets/hudson.json
@@ -15,7 +15,7 @@
         "CELERITAS_USE_HIP":     {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_MPI":     {"type": "BOOL", "value": "OFF"},
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-stringop-overread",
         "CMAKE_CXX_STANDARD": "20",
         "CMAKE_CXX_COMPILER": "/usr/bin/c++",
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
@@ -63,6 +63,26 @@
         "CELERITAS_DEVICE_DEBUG":{"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
       }
+    },
+    {
+      "name": "release-vecgeom2-solid",
+      "displayName": "Build with full optimizations (VecGeom 2 with solid geo)",
+      "inherits": ["release"],
+      "environment": {
+        "CMAKE_PREFIX_PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas-vg2/.spack-env/view"
+      },
+      "cacheVariables": {
+        "CELERITAS_VecGeom_SURFACE": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "release-vecgeom2-surface",
+      "displayName": "Build with full optimizations (VecGeom 2 with surface geo)",
+      "inherits": ["release-vecgeom2-solid"],
+      "cacheVariables": {
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_VecGeom_SURFACE": {"type": "BOOL", "value": "ON"}
+      }
     }
   ],
   "buildPresets": [
@@ -76,7 +96,9 @@
     {"name": "reldeb", "configurePreset": "reldeb", "inherits": ".base"},
     {"name": "release-orange", "configurePreset": "release-orange", "inherits": ".base"},
     {"name": "reldeb-orange", "configurePreset": "reldeb-orange", "inherits": ".base"},
-    {"name": "debug-orange", "configurePreset": "debug-orange", "inherits": ".base"}
+    {"name": "debug-orange", "configurePreset": "debug-orange", "inherits": ".base"},
+    {"name": "release-vecgeom2-solid", "configurePreset": "release-vecgeom2-solid", "inherits": ".base"},
+    {"name": "release-vecgeom2-surface", "configurePreset": "release-vecgeom2-surface", "inherits": ".base"}
   ],
   "testPresets": [
     {
@@ -89,6 +111,8 @@
     {"name": "reldeb", "configurePreset": "reldeb", "inherits": ".base"},
     {"name": "release-orange", "configurePreset": "release-orange", "inherits": ".base"},
     {"name": "reldeb-orange", "configurePreset": "reldeb-orange", "inherits": ".base"},
-    {"name": "debug-orange", "configurePreset": "debug-orange", "inherits": ".base"}
+    {"name": "debug-orange", "configurePreset": "debug-orange", "inherits": ".base"},
+    {"name": "release-vecgeom2-solid", "configurePreset": "release-vecgeom2-solid", "inherits": ".base"},
+    {"name": "release-vecgeom2-surface", "configurePreset": "release-vecgeom2-surface", "inherits": ".base"}
   ]
 }

--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 
 if(CELERITAS_USE_VecGeom)
   list(APPEND SOURCES
+    vg/VecgeomData.cc
     vg/VecgeomParams.cc
     vg/VecgeomParamsOutput.cc
     vg/RaytraceImager.cc

--- a/src/geocel/vg/VecgeomData.cc
+++ b/src/geocel/vg/VecgeomData.cc
@@ -6,6 +6,9 @@
 //---------------------------------------------------------------------------//
 #include "VecgeomData.hh"
 
+#include "corecel/Types.hh"
+#include "geocel/vg/VecgeomTypes.hh"
+
 #if CELER_VGNAV == CELER_VGNAV_TUPLE
 #    include <VecGeom/navigation/NavStateTuple.h>
 #else
@@ -14,11 +17,16 @@
 
 #include "corecel/data/CollectionBuilder.hh"
 
+#include "detail/VecgeomSetup.hh"
+
 namespace celeritas
 {
+
 //---------------------------------------------------------------------------//
 /*!
  * Resize geometry states.
+ *
+ * \todo Add stream ID
  */
 template<MemSpace M>
 void resize(VecgeomStateData<Ownership::value, M>* data,
@@ -32,13 +40,20 @@ void resize(VecgeomStateData<Ownership::value, M>* data,
     resize(&data->pos, size);
     resize(&data->dir, size);
     resize(&data->state, size);
+    resize(&data->next_state, size);
+    if constexpr (M == MemSpace::device)
+    {
+        using AllStates = AllItems<VgNavStateImpl, MemSpace::device>;
+        detail::init_navstate_device(data->state[AllStates{}], StreamId{});
+        detail::init_navstate_device(data->next_state[AllStates{}], StreamId{});
+    }
+
     if constexpr (CELER_VGNAV != CELER_VGNAV_PATH)
     {
         // Unless using the 'path' navigator, boundary data is stored
         // independently
         resize(&data->boundary, size);
     }
-    resize(&data->next_state, size);
     if constexpr (CELER_VGNAV != CELER_VGNAV_PATH)
     {
         // Path navigator stores the boundary, and surface model uses next_surf

--- a/src/geocel/vg/VecgeomData.cc
+++ b/src/geocel/vg/VecgeomData.cc
@@ -43,9 +43,11 @@ void resize(VecgeomStateData<Ownership::value, M>* data,
     resize(&data->next_state, size);
     if constexpr (M == MemSpace::device)
     {
+#if CELER_VGNAV == CELER_VGNAV_TUPLE
         using AllStates = AllItems<VgNavStateImpl, MemSpace::device>;
         detail::init_navstate_device(data->state[AllStates{}], StreamId{});
         detail::init_navstate_device(data->next_state[AllStates{}], StreamId{});
+#endif
     }
 
     if constexpr (CELER_VGNAV != CELER_VGNAV_PATH)

--- a/src/geocel/vg/VecgeomData.hh
+++ b/src/geocel/vg/VecgeomData.hh
@@ -191,42 +191,21 @@ struct VecgeomStateData
 };
 
 //---------------------------------------------------------------------------//
-/*!
- * Resize geometry states.
- *
- * \todo Add stream ID
- */
+// Resize geometry states
 template<MemSpace M>
 void resize(VecgeomStateData<Ownership::value, M>* data,
             HostCRef<VecgeomParamsData> const& params,
-            size_type size)
-{
-    CELER_EXPECT(data);
-    CELER_EXPECT(size > 0);
-    CELER_EXPECT(params);
+            size_type size);
 
-    resize(&data->pos, size);
-    resize(&data->dir, size);
-    resize(&data->state, size);
-    if constexpr (CELER_VGNAV != CELER_VGNAV_PATH)
-    {
-        // Unless using the 'path' navigator, boundary data is stored
-        // independently
-        resize(&data->boundary, size);
-    }
-    resize(&data->next_state, size);
-    if constexpr (CELER_VGNAV != CELER_VGNAV_PATH)
-    {
-        // Path navigator stores the boundary, and surface model uses next_surf
-        resize(&data->next_boundary, size);
-    }
-    if constexpr (CELERITAS_VECGEOM_SURFACE)
-    {
-        resize(&data->next_surf, size);
-    }
+extern template void
+resize<MemSpace::host>(VecgeomStateData<Ownership::value, MemSpace::host>*,
+                       HostCRef<VecgeomParamsData> const&,
+                       size_type);
 
-    CELER_ENSURE(data);
-}
+extern template void
+resize<MemSpace::device>(VecgeomStateData<Ownership::value, MemSpace::device>*,
+                         HostCRef<VecgeomParamsData> const&,
+                         size_type);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/vg/VecgeomData.hh
+++ b/src/geocel/vg/VecgeomData.hh
@@ -19,7 +19,7 @@
 
 #include "VecgeomTypes.hh"
 
-#if CELERITAS_VECGEOM_VERSION >= 0x020000
+#if CELERITAS_VECGEOM_VERSION >= 0x020000 && defined(VECGEOM_ENABLE_CUDA)
 // IWYU errors from navindex/tuple
 #    include <VecGeom/base/Cuda.h>
 #    include <VecGeom/base/Global.h>

--- a/src/geocel/vg/VecgeomData.hh
+++ b/src/geocel/vg/VecgeomData.hh
@@ -19,6 +19,13 @@
 
 #include "VecgeomTypes.hh"
 
+#if CELERITAS_VECGEOM_VERSION >= 0x020000
+// IWYU errors from navindex/tuple
+#    include <VecGeom/base/Cuda.h>
+#    include <VecGeom/base/Global.h>
+#    include <VecGeom/management/CudaManager.h>
+#endif
+
 #if CELER_VGNAV == CELER_VGNAV_PATH
 #    include "detail/VecgeomNavCollection.hh"
 #elif CELER_VGNAV == CELER_VGNAV_TUPLE

--- a/src/geocel/vg/detail/VecgeomSetup.hh
+++ b/src/geocel/vg/detail/VecgeomSetup.hh
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "corecel/Assert.hh"
+#include "corecel/cont/Span.hh"
+#include "corecel/sys/ThreadId.hh"
 #include "geocel/vg/VecgeomTypes.hh"
 
 #if CELERITAS_VECGEOM_SURFACE && !defined(__NVCC__)
@@ -49,6 +51,10 @@ CudaPointers<detail::CudaBVH_t const> bvh_pointers_device();
 CudaPointers<unsigned int const> navindex_pointers_device();
 
 //---------------------------------------------------------------------------//
+// Default-initialize navigation state because DeviceVector doesn't
+void init_navstate_device(Span<VgNavStateImpl> nav, StreamId);
+
+//---------------------------------------------------------------------------//
 #if CELERITAS_VECGEOM_SURFACE && !defined(__NVCC__)
 // Set up surface tracking
 void setup_surface_tracking_device(vgbrep::SurfData<vecgeom::Precision> const&);
@@ -84,6 +90,14 @@ inline void teardown_surface_tracking_device()
 }
 #    endif
 #endif
+
+#if !defined(VECGEOM_ENABLE_CUDA) || CELER_VGNAV != CELER_VGNAV_TUPLE
+inline void init_navstate_device(Span<VgNavStateImpl>, StreamId)
+{
+    // Null-op: not navtuple or CUDA not enabled
+}
+#endif
+
 //---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/test/geocel/vg/Vecgeom.test.cu
+++ b/test/geocel/vg/Vecgeom.test.cu
@@ -12,6 +12,7 @@
 
 #include "corecel/sys/KernelParamCalculator.device.hh"
 #include "geocel/vg/VecgeomTrackView.hh"
+#include "geocel/vg/VecgeomTypes.hh"
 
 using thrust::raw_pointer_cast;
 


### PR DESCRIPTION
This fixes two issues introduced by #2116 with vecgeom 2 when CUDA is enabled:
1. The VecGeom nav states reference inline global device data declared in CudaManager, which isn't included
2. The NavTuple initializer *must* be called to reset the level to zero to avoid an uninitialized read error due to an "optimized" assignment operator