### PR TITLE
Fix uninitialized hit counter in `HitProcessor`

### DIFF
--- a/src/celeritas/ext/detail/HitProcessor.hh
+++ b/src/celeritas/ext/detail/HitProcessor.hh
@@ -137,7 +137,7 @@ class HitProcessor
     bool step_post_status_{false};
 
     //! Accumulated number of hits
-    size_type num_hits_;
+    size_type num_hits_{0};
 
     void update_track(G4Track&) const;
 };


### PR DESCRIPTION
Likely why @rahmans1 was seeing an unexpectedly large number of hits compared to the number of steps.