### PR TITLE
Reduce ORANGE state size for models with background volumes

### DIFF
--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -839,7 +839,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","scalars":{"logic":"postfix","num_univ_levels":1,"max_faces":3,"max_intersections":6,"max_csg_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"inner_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"fast_real3s":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4}})json",
+        R"json({"_category":"internal","_label":"orange","scalars":{"logic":"postfix","num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"inner_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"fast_real3s":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4}})json",
         to_string(out));
 }
 


### PR DESCRIPTION
This MR fixes a bug that causes `OrangeStateData` to allocate significantly more runtime scratch space than necessary, which has been observed to cause perfectly doable simulations to run out of memory.

`OrangeStateData` stores, among other things, three fields that serve as scratch space during intersection operations: `temp_face`, `temp_distance`, and `temp_isect`, which are sized to be `max_intersections`*`num_tracks`.  This sizing allows for intersection checks to store all potential intersections with a volume, i.e., intersections with all constituent surfaces. The distance to intersection is then found by sorting these intersections by distance and finding the first one that results in a volume sense change upon crossing.

Because any track could encounter an intersection operation with any volume, `max_intersections` must be the global maximum over all volumes. However, prior to this MR, "background" volumes were erroneously included in this maximum. "Background" volumes are volumes that are implicitly defined as any space that does not exist within another volume within a given universe. This is useful in cases where a universe contains, for example, many complex components surrounded by air. Technically, the background volume has the outer boundaries of all of its daughters as constituent surfaces, which causes `max_intersections` within background volumes to be high---potentially orders of magnitude higher than any other volume in the geometry. However, intersection operations within background volumes *do not* check for intersections with all of these constituent surfaces at once. Instead, a Bounding Interval Hierarchy (BIH) is used to test for intersections with daughter volumes one at a time (with acceleration). Thus, `max_intersections` only needs to be as large as the `max_intersections` of the largest non-background volume.

This is accomplished by simply setting `max_intersections` to zero for background volumes. This approach is appropriate because `max_intersections` is only used as a global quantity for allocating data. While `max_intersections` is stored on each `VolumeRecord`, this is only used for DBC checks. A value of zero means that DBC checks will fail when erroneously trying to use the standard (non-BIH) intersection algorithm on a background volume.