### PR TITLE
Support RANLUX++ as core RNG

### DIFF
--- a/scripts/cmake-presets/executor.json
+++ b/scripts/cmake-presets/executor.json
@@ -77,15 +77,6 @@
       }
     },
     {
-      "name": "clhep",
-      "displayName": "With CLHEP units",
-      "inherits": [".base", ".debug", "default"],
-      "cacheVariables": {
-        "CELERITAS_UNITS": "CLHEP",
-        "CELERITAS_USE_VecGeom": {"type": "BOOL",   "value": "ON"}
-      }
-    },
-    {
       "name": "mini",
       "displayName": "Minimal deps",
       "inherits": ["minimal", ".base", ".debug"]
@@ -172,7 +163,7 @@
     {
       "name": "ndebug",
       "displayName": "With ORANGE in optimized mode",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".ccache", ".ndebug", ".base"],
       "cacheVariables": {
         "CELERITAS_USE_ROOT": {"type": "BOOL",   "value": "OFF"}
       }
@@ -180,7 +171,7 @@
     {
       "name": "ndebug-vecgeom",
       "displayName": "With vecgeom, clhep, dev g4 in optimized mode",
-      "inherits": [".base", ".ndebug", "vecgeom"],
+      "inherits": [".ccache", ".base", ".ndebug", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},

--- a/src/corecel/random/engine/RanluxppRngEngine.hh
+++ b/src/corecel/random/engine/RanluxppRngEngine.hh
@@ -14,8 +14,11 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/random/data/RanluxppRngData.hh"
-#include "corecel/random/engine/detail/RanluxppImpl.hh"
+#include "corecel/random/distribution/GenerateCanonical.hh"
+#include "corecel/random/distribution/detail/GenerateCanonical32.hh"
 #include "corecel/sys/ThreadId.hh"
+
+#include "detail/RanluxppImpl.hh"
 
 namespace celeritas
 {
@@ -100,6 +103,29 @@ class RanluxppRngEngine
     static constexpr int offset_ = 48;
     ParamsRef const& params_;
     RanluxppRngState* state_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Specialization of GenerateCanonical for XorwowRngEngine.
+ */
+template<class RealType>
+struct GenerateCanonical<RanluxppRngEngine, RealType>
+{
+    //!@{
+    //! \name Type aliases
+    using real_type = RealType;
+    using result_type = RealType;
+    //!@}
+
+    //! Declare that we use the 32-bit canonical generator
+    static constexpr auto policy = GenerateCanonicalPolicy::builtin32;
+
+    //! Sample a random number on [0, 1)
+    CELER_FORCEINLINE_FUNCTION result_type operator()(RanluxppRngEngine& rng)
+    {
+        return detail::GenerateCanonical32<RealType>()(rng);
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/random/engine/RanluxppRngEngine.hh
+++ b/src/corecel/random/engine/RanluxppRngEngine.hh
@@ -87,10 +87,10 @@ class RanluxppRngEngine
     inline CELER_FUNCTION RanluxppRngEngine&
     operator=(Initializer_t const& init);
 
-    // Generate a double-precision random number
+    // Generate a 32-bit random integer
     inline CELER_FUNCTION result_type operator()();
 
-    //! Advance the state \c count times.
+    // Advance the state \c count times.
     inline CELER_FUNCTION void discard(RanluxppUInt count);
 
   private:
@@ -107,7 +107,7 @@ class RanluxppRngEngine
 
 //---------------------------------------------------------------------------//
 /*!
- * Specialization of GenerateCanonical for XorwowRngEngine.
+ * Specialization of GenerateCanonical for RanluxppRngEngine.
  */
 template<class RealType>
 struct GenerateCanonical<RanluxppRngEngine, RealType>
@@ -132,7 +132,7 @@ struct GenerateCanonical<RanluxppRngEngine, RealType>
 // INLINE FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
- * Initialize state for the given seed and subsequence
+ * Initialize state for the given seed and subsequence.
  */
 inline CELER_FUNCTION RanluxppRngEngine&
 RanluxppRngEngine::operator=(Initializer_t const& init)
@@ -195,7 +195,7 @@ CELER_FUNCTION void RanluxppRngEngine::discard(RanluxppUInt n)
 
 //---------------------------------------------------------------------------//
 /*!
- * Return the next random bits, generate a new block if necessary.
+ * Return the next random bits, generating a new block if necessary.
  */
 CELER_FUNCTION auto RanluxppRngEngine::operator()() -> result_type
 {
@@ -224,7 +224,7 @@ CELER_FUNCTION auto RanluxppRngEngine::operator()() -> result_type
 
 //---------------------------------------------------------------------------//
 /*!
- * Produce the next block of random bits.
+ * Advance to the next state (block of random bits).
  */
 CELER_FUNCTION void RanluxppRngEngine::advance()
 {

--- a/src/corecel/random/engine/RanluxppRngEngine.hh
+++ b/src/corecel/random/engine/RanluxppRngEngine.hh
@@ -41,21 +41,20 @@ namespace celeritas
  * The underlying RCARRY algorithm used an array of 24 24-bit integer words,
  * which with today's large integer sizes can be written as 9 64-bit integers.
  * A given state is used to extract 12 samples, and the lower 32
- * bits of each is used as entropy. Two of those are concatenated to form a
- * 64-bit sample.
+ * bits of each is used as entropy.
  *
  * \todo The decision to discard the high bits rather than the low bits from
  * each word is likely undesirable at least for the last number in the state,
  * since it is known that LCG integers have highly correlated sequential LSBs.
- * Additionally, the class should be adapted to provide 32-bit samples, which
- * the GenerateCanonical32 will map to 64-bit reals as needed.
+ * Also instead, the class could be adapted to provide 18 32-bit samples
+ * instead of discarding 16 out of every 48 bits.
  */
 class RanluxppRngEngine
 {
   public:
     //@{
     //! Public types.
-    using result_type = RanluxppUInt;
+    using result_type = std::uint32_t;
     using Initializer_t = RanluxppInitializer;
     using ParamsRef = NativeCRef<RanluxppRngParamsData>;
     using StateRef = NativeRef<RanluxppRngStateData>;
@@ -78,7 +77,7 @@ class RanluxppRngEngine
     //! Highest value potentially generated.
     static CELER_CONSTEXPR_FUNCTION result_type max()
     {
-        return celeritas::numeric_limits<RanluxppUInt>::max();
+        return celeritas::numeric_limits<result_type>::max();
     }
 
     // Initialize state with the given seed.
@@ -86,24 +85,13 @@ class RanluxppRngEngine
     operator=(Initializer_t const& init);
 
     // Generate a double-precision random number
-    inline CELER_FUNCTION RanluxppUInt operator()();
+    inline CELER_FUNCTION result_type operator()();
 
     //! Advance the state \c count times.
-    inline CELER_FUNCTION void discard(RanluxppUInt count)
-    {
-        // Have to discard twice because 64-bit random numbers are composed of
-        // *two* calls to nextRandomBits
-        this->skip(2 * count);
-    }
+    inline CELER_FUNCTION void discard(RanluxppUInt count);
 
   private:
     /// IMPLEMENTATION ///
-
-    // Skip 'n' random numbers without generating them
-    inline CELER_FUNCTION void skip(RanluxppUInt n);
-
-    // Return the next random bits, generate a new block if necessary
-    inline CELER_FUNCTION RanluxppUInt next_random_bits();
 
     // Produce the next block of random bits.
     inline CELER_FUNCTION void advance();
@@ -141,21 +129,9 @@ RanluxppRngEngine::operator=(Initializer_t const& init)
 
 //---------------------------------------------------------------------------//
 /*!
- * Generate a double-precision random number
- */
-CELER_FUNCTION RanluxppUInt RanluxppRngEngine::operator()()
-{
-    // draw two 48-bit words, but take only their low 32 bits each
-    RanluxppUInt lo = this->next_random_bits() & 0xFFFFFFFFu;
-    RanluxppUInt hi = this->next_random_bits() & 0xFFFFFFFFu;
-    return (lo << 32) | hi;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Skip `n` random numbers without generating them.
  */
-CELER_FUNCTION void RanluxppRngEngine::skip(RanluxppUInt n)
+CELER_FUNCTION void RanluxppRngEngine::discard(RanluxppUInt n)
 {
     CELER_EXPECT(n > 0);
     CELER_ASSERT(params_.max_position > 0);
@@ -195,13 +171,14 @@ CELER_FUNCTION void RanluxppRngEngine::skip(RanluxppUInt n)
 /*!
  * Return the next random bits, generate a new block if necessary.
  */
-CELER_FUNCTION RanluxppUInt RanluxppRngEngine::next_random_bits()
+CELER_FUNCTION auto RanluxppRngEngine::operator()() -> result_type
 {
     if (state_->position + offset_ > params_.max_position)
     {
         this->advance();
     }
 
+    // Extract the Nth word from the state
     int idx = state_->position / 64;
     int offset = state_->position % 64;
     int num_bits = 64 - offset;
@@ -216,7 +193,7 @@ CELER_FUNCTION RanluxppUInt RanluxppRngEngine::next_random_bits()
     state_->position += offset_;
 
     CELER_ENSURE(state_->position <= params_.max_position);
-    return bits;
+    return bits & 0xffffffffu;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -52,8 +52,8 @@ bool GeantTestBase::is_ci_build()
 {
     if (!(CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE
           && CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_GEANT4
-          && CELERITAS_UNITS == CELERITAS_UNITS_CGS)
-        && cstring_equal(cmake::core_rng, "xorwow"))
+          && CELERITAS_UNITS == CELERITAS_UNITS_CGS
+          && cstring_equal(cmake::core_rng, "xorwow")))
     {
         // Config options are different
         return false;

--- a/test/celeritas/geo/HeuristicGeoTestBase.cc
+++ b/test/celeritas/geo/HeuristicGeoTestBase.cc
@@ -67,6 +67,8 @@ void HeuristicGeoTestBase::run(size_type num_states,
 
     if (celeritas::device())
     {
+        device().create_streams(1);
+
         auto dvc_path = this->run_impl<MemSpace::device>(num_states, num_steps);
         EXPECT_VEC_SOFT_EQ(host_path, dvc_path)
             << R"(GPU and CPU produced different results)";

--- a/test/celeritas/global/AlongStep.test.cc
+++ b/test/celeritas/global/AlongStep.test.cc
@@ -577,6 +577,11 @@ TEST_F(SimpleCmsFieldVolAlongStepTest, msc_field)
         // Without a field the electron has the same step length but a larger
         // displacement
         auto result = this->run(inp, num_tracks);
+        if (CELERITAS_CORE_RNG != CELERITAS_CORE_RNG_XORWOW)
+        {
+            GTEST_SKIP() << "Not using reference RNG";
+        }
+
         EXPECT_SOFT_NEAR(0.28064807889290933, result.displacement, tol);
         EXPECT_SOFT_NEAR(0.68629076604678063, result.angle, tol);
         EXPECT_SOFT_NEAR(0.33775753626703175, result.step, tol);
@@ -639,6 +644,10 @@ TEST_F(SimpleCmsAlongStepTest, msc_field)
         inp.direction = {0, -1, 0};
 
         auto result = this->run(inp, num_tracks);
+        if (CELERITAS_CORE_RNG != CELERITAS_CORE_RNG_XORWOW)
+        {
+            GTEST_SKIP() << "Not using reference RNG";
+        }
         EXPECT_SOFT_NEAR(0.28057298212898418, result.displacement, tol);
         EXPECT_SOFT_NEAR(0.6882027184831665, result.angle, tol);
         EXPECT_SOFT_NEAR(0.33775753626703175, result.step, tol);

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -122,6 +122,11 @@ TEST_F(KernelContextExceptionTest, typical)
         simplified_str = std::regex_replace(
             simplified_str, std::regex("@(global|world)"), "");
 
+        if (CELERITAS_CORE_RNG != CELERITAS_CORE_RNG_XORWOW)
+        {
+            GTEST_SKIP() << "Reference results only apply to reference RNG";
+        }
+
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             EXPECT_EQ(

--- a/test/celeritas/optical/Generator.test.cc
+++ b/test/celeritas/optical/Generator.test.cc
@@ -38,7 +38,8 @@ namespace test
 constexpr bool reference_configuration
     = ((CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
        && (CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_VECGEOM
-           || !CELERITAS_VECGEOM_SURFACE));
+           || !CELERITAS_VECGEOM_SURFACE)
+       && CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW);
 
 //---------------------------------------------------------------------------//
 // TEST FIXTURES

--- a/test/celeritas/optical/SurfacePhysicsIntegration.test.cc
+++ b/test/celeritas/optical/SurfacePhysicsIntegration.test.cc
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #include <memory>
 
+#include "corecel/Config.hh"
+
 #include "corecel/cont/ArrayIO.hh"
 #include "corecel/data/AuxInterface.hh"
 #include "corecel/data/AuxParamsRegistry.hh"
@@ -39,13 +41,16 @@ namespace optical
 {
 namespace test
 {
-// Reference results:
-// - Double precision
-// - Orange geometry (requires valid surface normals and relocation on
-// boundary)
+/*!
+ * Reference results:
+ * - Double precision
+ * - Orange geometry (requires valid surface normals and relocation on
+ *   boundary)
+ */
 constexpr bool reference_configuration
     = ((CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
-       && (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE));
+       && (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+       && (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW));
 
 using namespace ::celeritas::test;
 //---------------------------------------------------------------------------//

--- a/test/celeritas/random/RngReseed.test.cc
+++ b/test/celeritas/random/RngReseed.test.cc
@@ -64,34 +64,40 @@ TEST_F(RngReseedTest, reseed)
         values.push_back(rng());
     }
 #if CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_CURAND
-    static unsigned int const expected_values[] = {65145249u,
-                                                   4154590960u,
-                                                   2216085262u,
-                                                   241608182u,
-                                                   2278993841u,
-                                                   1643630301u,
-                                                   2759037535u,
-                                                   3550652068u};
+    static unsigned int const expected_values[] = {
+        65145249u,
+        4154590960u,
+        2216085262u,
+        241608182u,
+        2278993841u,
+        1643630301u,
+        2759037535u,
+        3550652068u,
+    };
 #elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW
-    static unsigned int const expected_values[] = {3522223652u,
-                                                   296995412u,
-                                                   1414776235u,
-                                                   1609101469u,
-                                                   363980503u,
-                                                   2861073075u,
-                                                   1771581540u,
-                                                   3600889717u};
+    static unsigned int const expected_values[] = {
+        3522223652u,
+        296995412u,
+        1414776235u,
+        1609101469u,
+        363980503u,
+        2861073075u,
+        1771581540u,
+        3600889717u,
+    };
 #elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_RANLUXPP
-    static unsigned int const expected_values[] = {1506987910u,
-                                                   289122019u,
-                                                   3660744945u,
-                                                   46319873u,
-                                                   2718473539u,
-                                                   1739478500u,
-                                                   3043999655u,
-                                                   2441727977u};
+    static unsigned int const expected_values[] = {
+        2625581829u,
+        4017657946u,
+        1657869191u,
+        2557868954u,
+        14578066u,
+        819209073u,
+        72409102u,
+        537563558u,
+    };
 #endif
-    EXPECT_VEC_EQ(values, expected_values);
+    EXPECT_VEC_EQ(expected_values, values) << repr(values);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/user/SlotDiagnostic.test.cc
+++ b/test/celeritas/user/SlotDiagnostic.test.cc
@@ -183,6 +183,11 @@ TEST_F(TestEm3SlotTest, host)
 {
     auto result = this->run<MemSpace::host>(32, 64);
 
+    if (CELERITAS_CORE_RNG != CELERITAS_CORE_RNG_XORWOW)
+    {
+        GTEST_SKIP() << "Reference results only apply to reference RNG";
+    }
+
     static char const* const expected_labels[] = {"gamma", "e-", "e+"};
     EXPECT_VEC_EQ(expected_labels, result.labels);
     std::vector<std::string> expected_slots = {

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -256,13 +256,13 @@ TEST_F(KnMctruthTest, two_step)
     EXPECT_VEC_EQ(expected_track, result.track);
     static int const expected_step[] = {1, 2, 1, 2, 1, 2, 1, 2};
     EXPECT_VEC_EQ(expected_step, result.step);
-    if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
-    {
-        static int const expected_volume[] = {1, 1, 1, 1, 1, 2, 1, 2};
-        EXPECT_VEC_EQ(expected_volume, result.volume);
-    }
     if (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
     {
+        if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
+        {
+            static int const expected_volume[] = {1, 1, 1, 1, 1, 2, 1, 2};
+            EXPECT_VEC_EQ(expected_volume, result.volume);
+        }
         // clang-format off
         static const double expected_pos[] = {0, 0, 0, 2.6999255778482, 0, 0, 0, 0, 0, 3.5717683161497, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 5, 0, 0};
         EXPECT_VEC_SOFT_EQ(expected_pos, result.pos);

--- a/test/corecel/random/RanluxppRngEngine.test.cc
+++ b/test/corecel/random/RanluxppRngEngine.test.cc
@@ -295,12 +295,12 @@ TEST_F(RanluxppRngEngineTest, generate_canonical)
     {
         RanluxppRngEngine rng(host_ref, states.ref(), TrackSlotId{0});
         EXPECT_FLOAT_EQ(0.59196556f, generate_canonical<float>(rng));
-        EXPECT_FLOAT_EQ(0.64862144f, generate_canonical<float>(rng));
+        EXPECT_FLOAT_EQ(0.23885389f, generate_canonical<float>(rng));
     }
     {
         RanluxppRngEngine rng(host_ref, states.ref(), TrackSlotId{1});
-        EXPECT_DOUBLE_EQ(0.4976657511624521, generate_canonical<double>(rng));
-        EXPECT_DOUBLE_EQ(0.84101992374240664, generate_canonical<double>(rng));
+        EXPECT_DOUBLE_EQ(0.49766548977877423, generate_canonical<double>(rng));
+        EXPECT_DOUBLE_EQ(0.84101980819525746, generate_canonical<double>(rng));
     }
 }
 

--- a/test/corecel/random/RanluxppRngEngine.test.cc
+++ b/test/corecel/random/RanluxppRngEngine.test.cc
@@ -16,6 +16,7 @@
 #include "corecel/random/distribution/GenerateCanonical.hh"
 #include "corecel/random/engine/detail/RanluxppImpl.hh"
 #include "corecel/random/params/RanluxppRngParams.hh"
+#include "corecel/sys/ThreadId.hh"
 
 #include "RngTally.hh"
 #include "celeritas_test.hh"
@@ -268,22 +269,39 @@ TEST_F(RanluxppRngEngineTest, host)
 
 TEST_F(RanluxppRngEngineTest, moments)
 {
-    unsigned int num_samples = 1 << 13;
-    unsigned int num_seeds = 1 << 8;
+    unsigned int num_samples = 4000;
+    TrackSlotId::size_type num_states = 256;
 
-    HostStore states(params_->host_ref(), StreamId{0}, num_seeds);
+    auto const& host_ref = params_->host_ref();
+    HostStore states(host_ref, StreamId{0}, num_states);
     RngTally tally;
 
-    for (unsigned int i = 0; i < num_seeds; ++i)
+    for (auto tid : range(TrackSlotId{num_states}))
     {
-        RanluxppRngEngine rng(
-            params_->host_ref(), states.ref(), TrackSlotId{i});
+        RanluxppRngEngine rng(host_ref, states.ref(), tid);
         for (unsigned int j = 0; j < num_samples; ++j)
         {
             tally(generate_canonical(rng));
         }
     }
-    tally.check(num_samples * num_seeds, 1e-3);
+    tally.check(num_samples * num_states, 1e-3);
+}
+
+TEST_F(RanluxppRngEngineTest, generate_canonical)
+{
+    auto const& host_ref = params_->host_ref();
+    HostStore states(host_ref, StreamId{0}, 2);
+
+    {
+        RanluxppRngEngine rng(host_ref, states.ref(), TrackSlotId{0});
+        EXPECT_FLOAT_EQ(0.59196556f, generate_canonical<float>(rng));
+        EXPECT_FLOAT_EQ(0.64862144f, generate_canonical<float>(rng));
+    }
+    {
+        RanluxppRngEngine rng(host_ref, states.ref(), TrackSlotId{1});
+        EXPECT_DOUBLE_EQ(0.4976657511624521, generate_canonical<double>(rng));
+        EXPECT_DOUBLE_EQ(0.84101992374240664, generate_canonical<double>(rng));
+    }
 }
 
 TEST_F(RanluxppRngEngineTest, jump)

--- a/test/corecel/random/RanluxppRngEngine.test.cc
+++ b/test/corecel/random/RanluxppRngEngine.test.cc
@@ -284,7 +284,7 @@ TEST_F(RanluxppRngEngineTest, moments)
             tally(generate_canonical(rng));
         }
     }
-    tally.check(num_samples * num_states, 1e-3);
+    tally.check(static_cast<double>(num_samples * num_states), 1e-3);
 }
 
 TEST_F(RanluxppRngEngineTest, generate_canonical)

--- a/test/corecel/random/RngEngine.test.cc
+++ b/test/corecel/random/RngEngine.test.cc
@@ -173,6 +173,8 @@ class DeviceRngEngineTest : public Test
 
 TEST_F(DeviceRngEngineTest, TEST_IF_CELER_DEVICE(device))
 {
+    device().create_streams(1);
+
     // Create and initialize states
     RngDeviceStore rng_store(params->host_ref(), StreamId{0}, 1024);
 
@@ -187,40 +189,65 @@ TEST_F(DeviceRngEngineTest, TEST_IF_CELER_DEVICE(device))
         test_values.push_back(values[i]);
     }
 
-#if CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_CURAND
-    static unsigned int const expected_test_values[] = {165860337u,
-                                                        3006138920u,
-                                                        2161337536u,
-                                                        390101068u,
-                                                        2347834113u,
-                                                        100129048u,
-                                                        4122784086u,
-                                                        473544901u,
-                                                        2822849608u};
-#elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_HIPRAND
-    static unsigned int const expected_test_values[] = {2191810108u,
-                                                        1563840703u,
-                                                        1491406143u,
-                                                        2960567511u,
-                                                        2495908560u,
-                                                        3320024263u,
-                                                        1303634785u,
-                                                        964015610u,
-                                                        4033624067u};
-#elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW
-    static unsigned int const expected_test_values[] = {492039014u,
-                                                        3443467310u,
-                                                        2732308719u,
-                                                        1725881526u,
-                                                        3375752591u,
-                                                        2072392377u,
-                                                        1525078619u,
-                                                        2145729803u,
-                                                        3489021697u};
-#else
-    PRINT_EXPECTED(test_values);
-    static unsigned int const expected_test_values[] = {0};
-#endif
+    std::vector<unsigned int> expected_test_values;
+
+    if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_CURAND)
+    {
+        expected_test_values = {
+            165860337u,
+            3006138920u,
+            2161337536u,
+            390101068u,
+            2347834113u,
+            100129048u,
+            4122784086u,
+            473544901u,
+            2822849608u,
+        };
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_HIPRAND)
+    {
+        expected_test_values = {
+            2191810108u,
+            1563840703u,
+            1491406143u,
+            2960567511u,
+            2495908560u,
+            3320024263u,
+            1303634785u,
+            964015610u,
+            4033624067u,
+        };
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        expected_test_values = {
+            492039014u,
+            3443467310u,
+            2732308719u,
+            1725881526u,
+            3375752591u,
+            2072392377u,
+            1525078619u,
+            2145729803u,
+            3489021697u,
+        };
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_RANLUXPP)
+    {
+        expected_test_values = {
+            2542472709u,
+            2309767698u,
+            1214867291u,
+            2137002303u,
+            3924296658u,
+            2242409071u,
+            1227608165u,
+            1258085756u,
+            3380639425u,
+        };
+    }
+
     EXPECT_VEC_EQ(test_values, expected_test_values);
 }
 
@@ -235,36 +262,58 @@ class DeviceRngEngineFloatTest : public DeviceRngEngineTest
 
 void check_expected_float_samples(std::vector<float> const& v)
 {
+    std::vector<float> expected = {0, 0};
+    if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_CURAND)
+    {
+        expected = {0.038617369f, 0.411269426f};
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_HIPRAND)
+    {
+        expected = {0.51032054f, 0.22727294f};
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        expected = {0.11456176f, 0.71564859f};
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_RANLUXPP)
+    {
+        expected = {0.5919656f, 0.4976658f};
+    }
+    else
+    {
+        FAIL() << "Unexpected RNG";
+    }
     ASSERT_LE(2, v.size());
-#if CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_CURAND
-    EXPECT_FLOAT_EQ(0.038617369f, v[0]);
-    EXPECT_FLOAT_EQ(0.411269426f, v[1]);
-#elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_HIPRAND
-    EXPECT_FLOAT_EQ(0.51032054f, v[0]);
-    EXPECT_FLOAT_EQ(0.22727294f, v[1]);
-#elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW
-    EXPECT_FLOAT_EQ(0.11456176f, v[0]);
-    EXPECT_FLOAT_EQ(0.71564859f, v[1]);
-#else
-    FAIL() << "Unexpected RNG";
-#endif
+    EXPECT_FLOAT_EQ(expected[0], v[0]);
+    EXPECT_FLOAT_EQ(expected[1], v[1]);
 }
 
 void check_expected_float_samples(std::vector<double> const& v)
 {
+    std::vector<double> expected = {0, 0};
+    if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_CURAND)
+    {
+        expected = {0.283318433931184, 0.653335242131673};
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_HIPRAND)
+    {
+        expected = {0.22503638759639666, 0.73006306995055248};
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW)
+    {
+        expected = {0.11456196141430341, 0.71564819382390976};
+    }
+    else if constexpr (CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_RANLUXPP)
+    {
+        expected = {0.5919656707376143, 0.49766548977877423};
+    }
+    else
+    {
+        FAIL() << "Unexpected RNG";
+    }
     ASSERT_LE(2, v.size());
-#if CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_CURAND
-    EXPECT_REAL_EQ(0.283318433931184, v[0]);
-    EXPECT_REAL_EQ(0.653335242131673, v[1]);
-#elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_HIPRAND
-    EXPECT_REAL_EQ(0.22503638759639666, v[0]);
-    EXPECT_REAL_EQ(0.73006306995055248, v[1]);
-#elif CELERITAS_CORE_RNG == CELERITAS_CORE_RNG_XORWOW
-    EXPECT_REAL_EQ(0.11456196141430341, v[0]);
-    EXPECT_REAL_EQ(0.71564819382390976, v[1]);
-#else
-    FAIL() << "Unexpected RNG";
-#endif
+    EXPECT_DOUBLE_EQ(expected[0], v[0]);
+    EXPECT_DOUBLE_EQ(expected[1], v[1]);
 }
 
 using FloatTypes = ::testing::Types<float, double>;


### PR DESCRIPTION
This reduces the sample size of the ranlux++ generator to 32 bits and uses the Celeritas `GenerateCanonical` (rather than the host-only `std` version) to concatenate the samples for 64-bit sampling requirements.