### PR TITLE
Only include CUDA RDC utils when using CUDA-enabled VecGeom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,7 +614,10 @@ endif()
 # Load our local copy in case a dependency hasn't loaded a newer one
 # and install it alongside CeleritasConfig (see further below)
 set(_LOCAL_RDCUTILS_FILENAME "${PROJECT_SOURCE_DIR}/cmake/external/CudaRdcUtils.cmake")
-include("${_LOCAL_RDCUTILS_FILENAME}")
+if(VecGeom_CUDA_FOUND)
+  # RDC hacks are only needed and desired when VecGeom is enabled and compiled with CUDA support
+  include("${_LOCAL_RDCUTILS_FILENAME}")
+endif()
 
 # NOTE: include library utils after RDC
 include(CeleritasLibrary)

--- a/cmake/CeleritasConfig.cmake.in
+++ b/cmake/CeleritasConfig.cmake.in
@@ -170,11 +170,11 @@ cmake_policy(POP)
 #-----------------------------------------------------------------------------#
 
 if(NOT TARGET celeritas)
-  # Load Celeritas-distributed RDC utils after potential older version
-  # in dependencies
-  # TODO: in the future, rely on its inclusion via upstream VecGeom, and only
-  # include here if VecGeom+CUDA are enabled.
-  include("${CELERITAS_CMAKE_DIR}/CudaRdcUtils.cmake" OPTIONAL)
+  # Load Celeritas-distributed RDC utils after dependencies to override
+  # potential older versions
+  if(VecGeom_CUDA_FOUND)
+    include("${CELERITAS_CMAKE_DIR}/CudaRdcUtils.cmake")
+  endif()
 
   # Load Celeritas library wrappers
   include("${CELERITAS_CMAKE_DIR}/CeleritasLibrary.cmake")

--- a/cmake/CeleritasLibrary.cmake
+++ b/cmake/CeleritasLibrary.cmake
@@ -49,7 +49,12 @@ if(NOT DEFINED CELERITAS_USE_VecGeom)
   )
 endif()
 
-if(NOT (CELERITAS_USE_VecGeom AND CELERITAS_USE_CUDA))
+if(CELERITAS_USE_VecGeom AND CELERITAS_USE_CUDA AND NOT COMMAND cuda_rdc_add_library)
+  message(FATAL_ERROR "CudaRdcUtils is required but missing")
+endif()
+
+
+if(NOT COMMAND cuda_rdc_add_library)
   # Forward all arguments directly to CMake builtins
   macro(celeritas_add_library)
     add_library(${ARGV})
@@ -70,10 +75,6 @@ if(NOT (CELERITAS_USE_VecGeom AND CELERITAS_USE_CUDA))
     target_compile_options(${ARGV})
   endmacro()
 else()
-  if(NOT COMMAND cuda_rdc_add_library)
-    message(FATAL_ERROR "This file MUST be used with CudaRdcUtils")
-  endif()
-
   # Forward all arguments to RDC utility wrappers
   macro(celeritas_add_library)
     cuda_rdc_add_library(${ARGV})


### PR DESCRIPTION
Avoid potentially confusing configuration messages and cache variables by only including and distributing the CUDA RDC macros when VecGeom CUDA is available.