### PR TITLE
cuda rdc: Check for -z undefs only when CUDA enabled

### DIFF
--- a/cmake/external/CudaRdcUtils.cmake
+++ b/cmake/external/CudaRdcUtils.cmake
@@ -204,7 +204,7 @@ else()
 endif()
 
 # Check if the compiler/linker supports -Wl,-z,undefs flag
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CUDA_COMPILER)
   include(CheckLinkerFlag)
   check_linker_flag(CXX "LINKER:-z,undefs" CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)
   if(CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS)


### PR DESCRIPTION
Avoid printing at CMake configuration time:
```
-- Performing Test CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS
-- Performing Test CUDA_RDC_LINKER_SUPPORTS_Z_UNDEFS - Success
-- Performing Test CUDA_RDC_LINKER_SUPPORTS_ALLOW_SHLIB_UNDEFINED
-- Performing Test CUDA_RDC_LINKER_SUPPORTS_ALLOW_SHLIB_UNDEFINED - Success
```
when CUDA is not even enabled.