### PR TITLE
Fix document warnings related CI infrastructure

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           echo "::group::Install"
           cmake --install .
-          echo "::endgroup::
+          echo "::endgroup::"
           cmake --build . --target clean
       - name: Check installation
         if: >-

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -96,7 +96,7 @@ jobs:
           echo "::group::Build verbosely"
           ninja -v -k0
           echo "::endgroup::"
-          echo "::notice title=build-size::$(du -hs . | awk '{print $1}')"
+          echo "::notice title=build-size::Build size is $(du -hs . | awk '{print $1}')"
 
       ### TEST ###
 
@@ -135,7 +135,9 @@ jobs:
         id: install
         working-directory: build
         run: |
+          echo "::group::Install"
           cmake --install .
+          echo "::endgroup::
           cmake --build . --target clean
       - name: Check installation
         if: >-

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -75,7 +75,7 @@ jobs:
       # NOTE: checkout must occur *after* setting up environment for git tags to work
       # NOTE: depth must be enough to include the previous tag
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
         with:
           fetch-depth: 383
           fetch-tags: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -93,7 +93,10 @@ jobs:
       - name: Build Celeritas
         working-directory: build
         run: |
-          ninja
+          echo "::group::Build verbosely"
+          ninja -v -k0
+          echo "::endgroup::"
+          echo "::notice title=build-size::$(du -hs . | awk '{print $1}')"
 
       ### TEST ###
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -129,10 +129,17 @@ jobs:
       ### INSTALL ###
 
       - name: Install Celeritas
+        id: install
         working-directory: build
         run: |
           cmake --install .
+          cmake --build . --target clean
       - name: Check installation
+        if: >-
+          ${{
+            !cancelled()
+            && steps.install.outcome == 'success'
+          }}
         working-directory: install
         run: |
           for exe in orange-update celer-export-geant \
@@ -144,7 +151,8 @@ jobs:
         # TODO: rocm+ndebug fails to propagate HIP library link
         if: >-
           ${{
-            !(matrix.image == 'ubuntu-rocm' && matrix.buildtype == 'ndebug')
+            steps.install.outcome == 'success'
+            && !(matrix.image == 'ubuntu-rocm' && matrix.buildtype == 'ndebug')
           }}
         run: |
           . /etc/profile

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -58,7 +58,7 @@ jobs:
       }}
     steps:
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
 
       ### ENVIRONMENT ###
 
@@ -162,7 +162,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
 
       ### ENVIRONMENT ###
 

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -122,6 +122,7 @@ jobs:
           path: spack-src
       - name: Initialize spack environment
         run: |
+          echo "::notice title=spack-arch::Spack architecture is $(spack arch)"
           sed -e 's/cxxstd=default/cxxstd=${{env.CXXSTD}}/' \
             scripts/ci/spack.yaml > spack.yaml
           if ${{matrix.geometry == 'vecgeom'}}; then
@@ -161,7 +162,6 @@ jobs:
         run: |
           spack -e . -v concretize || (
             ERR=$?
-            spack arch
             cat spack.yaml
             exit $ERR
           )

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -242,7 +242,10 @@ jobs:
         working-directory: build
         run: |
           ccache -z
+          echo "::group::Build verbosely"
           ninja -v -k0
+          echo "::endgroup::"
+          echo "::notice title=build-size::$(du -hs . | awk '{print $1}')"
       - name: Show ccache stats
         if: ${{!cancelled() && steps.installdeps.outcome == 'success'}}
         run: |

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -144,7 +144,9 @@ jobs:
                 && matrix.geant != ''}}; then
             spack -e . add g4vg@1.0.5
           fi
+          echo "::group::Find compilers"
           spack -vd -e . compiler find --mixed-toolchain
+          echo "::endgroup::
           # Add the spack ref so that updating spack will reconcretize
           echo "# Concretized with ${{env.SPACK_REF}}" >> spack.yaml
       - name: Cache concretization
@@ -245,7 +247,7 @@ jobs:
           echo "::group::Build verbosely"
           ninja -v -k0
           echo "::endgroup::"
-          echo "::notice title=build-size::$(du -hs . | awk '{print $1}')"
+          echo "::notice title=build-size::Build size is $(du -hs . | awk '{print $1}')"
       - name: Show ccache stats
         if: ${{!cancelled() && steps.installdeps.outcome == 'success'}}
         run: |
@@ -357,7 +359,9 @@ jobs:
           }}
         working-directory: build
         run: |
-          ninja install
+          echo "::group::Install"
+          cmake --install .
+          echo "::endgroup::
           ninja clean
       - name: Check installation
         if: >-

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -355,6 +355,7 @@ jobs:
         working-directory: build
         run: |
           ninja install
+          ninja clean
       - name: Check installation
         if: >-
           ${{
@@ -370,13 +371,12 @@ jobs:
           ./bin/celer-sim --config
       - name: Build examples
         env:
-          CELER_DISABLE_G4_EXAMPLES: >-
-            ${{(!matrix.geant) && '1' || ''}}
-        # Special clang features require downstream flags that don't propagate
+          CELER_DISABLE_G4_EXAMPLES: ${{(!matrix.geant) && '1' || ''}}
+        # `asanlite` requires downstream flags that don't propagate
         if: >-
           ${{
-            matrix.special != 'asanlite'
-            && matrix.special != 'tidy'
+            steps.install.outcome == 'success'
+            && matrix.special != 'asanlite'
           }}
         run: |
           . ${SPACK_VIEW}/rc

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -105,7 +105,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
         with:
           fetch-depth: ${{format('{0}', matrix.special != 'tidy' && 383 || 0)}}
           fetch-tags: true # to get version information
@@ -188,8 +188,6 @@ jobs:
 
       - name: Configure Celeritas
         run: |
-          # NOTE: tags have issues, see https://github.com/actions/checkout/issues/2041
-          git fetch --tags
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
           if ${{matrix.geant == '11.0'}}; then
             # Test overriding of Geant4 environment variables

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -146,7 +146,7 @@ jobs:
           fi
           echo "::group::Find compilers"
           spack -vd -e . compiler find --mixed-toolchain
-          echo "::endgroup::
+          echo "::endgroup::"
           # Add the spack ref so that updating spack will reconcretize
           echo "# Concretized with ${{env.SPACK_REF}}" >> spack.yaml
       - name: Cache concretization
@@ -361,7 +361,7 @@ jobs:
         run: |
           echo "::group::Install"
           cmake --install .
-          echo "::endgroup::
+          echo "::endgroup::"
           ninja clean
       - name: Check installation
         if: >-

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
 
       ### ENVIRONMENT ###
 
@@ -121,7 +121,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
 
       ### ENVIRONMENT ###
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,7 +30,7 @@ jobs:
     needs: build-docs
     steps:
       - name: Check out Celeritas doc base
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
         with:
           ref: doc/gh-pages-base
       - uses: actions/setup-python@v5

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -94,7 +94,7 @@ jobs:
           mkdir build && cd build
           cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE \
             ${{ github.workflow == 'pull_request'
-             && '-DDOXYGEN_WARN_AS_ERROR="YES" -DCELERITAS_SPHINX_USER_HTML_ARGS="-W;--keep-going"'
+             && '-DDOXYGEN_WARN_AS_ERROR="YES" -DCELERITAS_SPHINX_ARGS="-W;--keep-going"'
              || ''}} \
             ..
       - name: Build documentation

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,7 +36,7 @@ jobs:
             sudo apt-get -y install \
                 cmake graphviz ninja-build doxygen nlohmann-json3-dev
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
         with:
           fetch-depth: 383
           fetch-tags: true
@@ -44,8 +44,6 @@ jobs:
         # Turn warnings into errors only for PRs
         # Disable expensive graphs for PRs also
         run: |
-          # NOTE: tags have issues, see https://github.com/actions/checkout/issues/2041
-          git fetch --tags
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
           mkdir build && cd build
           cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE \
@@ -79,7 +77,7 @@ jobs:
             sudo apt-get -y install \
                 cmake graphviz ninja-build doxygen nlohmann-json3-dev
       - name: Check out Celeritas
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1 (2 Dec 2025)
         with:
           fetch-depth: 383
           fetch-tags: true
@@ -92,8 +90,6 @@ jobs:
             pip install -r scripts/doc-requirements.txt
       - name: Configure celeritas
         run: |
-          # NOTE: tags have issues, see https://github.com/actions/checkout/issues/2041
-          git fetch --tags
           ln -fs scripts/cmake-presets/ci-ubuntu-github.json CMakeUserPresets.json
           mkdir build && cd build
           cmake --preset=${CMAKE_PRESET} --log-level=VERBOSE \

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -110,6 +110,7 @@ if(CELERITAS_PYTHONPATH_RERUN)
   unset(CELERITAS_PYTHONPATH_RERUN CACHE)
 endif()
 
+
 if(NOT Sphinx_FOUND)
   function(celeritas_build_sphinx type output depends)
     add_custom_command(
@@ -125,6 +126,10 @@ if(NOT Sphinx_FOUND)
     )
   endfunction()
 else()
+  set(CELERITAS_SPHINX_ARGS "" CACHE STRING
+    "Additional arguments to pass to Sphinx to build user docs")
+  mark_as_advanced(CELERITAS_SPHINX_ARGS)
+
   celeritas_get_pyenv(CELER_PYTHONENV)
   function(celeritas_build_sphinx type output depends)
     if(NOT type STREQUAL "dummy")
@@ -139,7 +144,7 @@ else()
         "$<TARGET_FILE:Python::Interpreter>" -m sphinx.cmd.build -q
           -d "${CMAKE_CURRENT_BINARY_DIR}/doctrees"
           -b ${type}
-          ${ARGN}
+          ${CELERITAS_SPHINX_ARGS}
           "${CMAKE_CURRENT_SOURCE_DIR}"
           "${CMAKE_CURRENT_BINARY_DIR}/${type}"
       COMMENT "${_comment}"
@@ -272,7 +277,7 @@ doxygen_add_docs(doxygen_xml
 )
 
 #-----------------------------------------------------------------------------#
-# MMD PROCESSING
+# GRAPHICS PROCESSING
 
 # Note that *all* dot files must be present at the same time to prevent
 # errors when doing separate HTML/PDF builds: the doctrees directory caches the
@@ -338,12 +343,8 @@ add_custom_target(doc_preprocess DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${_doctree
 
 #-----------------------------------------------------------------------------#
 # HTML
-set(CELERITAS_SPHINX_USER_HTML_ARGS "" CACHE STRING
-  "Additional arguments to pass to Sphinx to build HTML user docs")
-mark_as_advanced(CELERITAS_SPHINX_USER_HTML_ARGS)
-
 set(_doc_html "html/index.html")
-celeritas_build_sphinx(html "${_doc_html}" "${_doctree_env}" ${CELERITAS_SPHINX_USER_HTML_ARGS})
+celeritas_build_sphinx(html "${_doc_html}" "${_doctree_env}")
 add_custom_target(doc DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${_doc_html}")
 
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html/"

--- a/doc/implementation/mucf-physics.rst
+++ b/doc/implementation/mucf-physics.rst
@@ -101,7 +101,7 @@ muonic atom spin flip. The muon-catalyzed fusion process is activated by
 enabling the ``mucf_physics`` option in
 :cpp:class:`celeritas::ext::GeantPhysicsOptions`.
 
-.. doxygenclass:: celeritas::inp::MucfPhysics
+.. celerstruct:: inp::MucfPhysics
 
 .. todo:: Expand description when hardcoded data is finalized.
 

--- a/doc/usage/input/problem.rst
+++ b/doc/usage/input/problem.rst
@@ -53,16 +53,16 @@ structures:
 The primary generator, similar to Geant4's "particle gun", has different
 configuration options:
 
-.. doxygentypedef:: celeritas::inp::Events
-.. doxygentypedef:: celeritas::inp::ShapeDistribution
 .. doxygentypedef:: celeritas::inp::AngleDistribution
 .. doxygentypedef:: celeritas::inp::EnergyDistribution
+.. doxygentypedef:: celeritas::inp::Events
+.. doxygentypedef:: celeritas::inp::MonodirectionalDistribution
+.. doxygentypedef:: celeritas::inp::MonoenergeticDistribution
+.. doxygentypedef:: celeritas::inp::PointDistribution
+.. doxygentypedef:: celeritas::inp::ShapeDistribution
 
-.. celerstruct:: inp::PointDistribution
 .. celerstruct:: inp::UniformBoxDistribution
 .. celerstruct:: inp::IsotropicDistribution
-.. celerstruct:: inp::MonodirectionalDistribution
-.. celerstruct:: inp::MonoenergeticDistribution
 
 
 .. _inp_system:

--- a/scripts/ci/spack.yaml
+++ b/scripts/ci/spack.yaml
@@ -4,9 +4,9 @@
 spack:
   view: /opt/spack-view
   specs:
-  - ccache
+  - "ccache@4.10:"
   - cli11 +pic ~ipo
-  - cmake
+  - "cmake ^curl tls=openssl"
   - covfie
   - googletest
   - hepmc3

--- a/scripts/cmake-presets/ci-rocky-cuda.json
+++ b/scripts/cmake-presets/ci-rocky-cuda.json
@@ -5,13 +5,14 @@
     {
       "name": "base",
       "displayName": "Ubuntu/nvidia-docker default options for GCC",
-      "inherits": [".cuda-volta", "default"],
+      "inherits": ["default"],
       "binaryDir": "${sourceDir}/build",
       "generator": "Ninja",
       "cacheVariables": {
         "BUILD_SHARED_LIBS":     {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_CUDA":    {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_covfie":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
@@ -25,6 +26,7 @@
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations",
         "CMAKE_CUDA_FLAGS": "-Werror all-warnings",
+        "CMAKE_CUDA_ARCHITECTURES": {"type": "STRING", "value": "80"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install"
       }
     },
@@ -70,7 +72,7 @@
       "cacheVariables": {
         "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_DEBUG": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"}
+        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "OFF"}
       }
     },
     {
@@ -78,7 +80,8 @@
       "description": "Build with RelWithDebInfo, assertions, and VecGeom",
       "inherits": [".reldeb", ".vecgeom", "base"],
       "cacheVariables": {
-        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"}
+        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"},
+        "CMAKE_CUDA_ARCHITECTURES": "80-virtual"
       }
     },
     {

--- a/scripts/cmake-presets/ci-rocky-cuda.json
+++ b/scripts/cmake-presets/ci-rocky-cuda.json
@@ -5,14 +5,13 @@
     {
       "name": "base",
       "displayName": "Ubuntu/nvidia-docker default options for GCC",
-      "inherits": ["default"],
+      "inherits": [".cuda-volta", "default"],
       "binaryDir": "${sourceDir}/build",
       "generator": "Ninja",
       "cacheVariables": {
         "BUILD_SHARED_LIBS":     {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_CUDA":    {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_covfie":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
@@ -26,7 +25,6 @@
         "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
         "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-error=deprecated-declarations",
         "CMAKE_CUDA_FLAGS": "-Werror all-warnings",
-        "CMAKE_CUDA_ARCHITECTURES": {"type": "STRING", "value": "80"},
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install"
       }
     },
@@ -72,7 +70,7 @@
       "cacheVariables": {
         "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_DEBUG": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "OFF"}
+        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"}
       }
     },
     {
@@ -80,8 +78,7 @@
       "description": "Build with RelWithDebInfo, assertions, and VecGeom",
       "inherits": [".reldeb", ".vecgeom", "base"],
       "cacheVariables": {
-        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"},
-        "CMAKE_CUDA_ARCHITECTURES": "80-virtual"
+        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"}
       }
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -69,9 +69,13 @@
       "inherits": [".system"],
       "displayName": "FINAL: build only documentation",
       "cacheVariables": {
+        "BUILD_TESTING": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILD_APPS":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
         "CELERITAS_DOXYGEN_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_covfie":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_PNG":     {"type": "BOOL", "value": "OFF"}
       }
     },

--- a/scripts/cmake-presets/executor.json
+++ b/scripts/cmake-presets/executor.json
@@ -62,7 +62,7 @@
       "cacheVariables": {
         "CELERITAS_BUILD_DOCS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_PYTHONWARNINGS": "ignore:::urllib3,ignore:::breathe.project,ignore::UserWarning:pybtex.plugin",
-        "CELERITAS_SPHINX_USER_HTML_ARGS": "-W;--keep-going",
+        "CELERITAS_SPHINX_ARGS": "-W;--keep-going",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/install",
         "DOXYGEN_WARN_AS_ERROR":  "YES"
       }


### PR DESCRIPTION
Warnings in the sphinx documentation were accidentally disabled in (I think) #1988 because warnings are now shown during doctree generation rather than html construction. I fixed the couple errors in the docs that have accumulated during that time.

Related, I've removed a now-unnecessary workaround for https://github.com/actions/checkout/issues/2041 , and I've added code to get the build size and clean the build directory after it's last used, since we now seem to see intermittent failures on the CUDA builds https://github.com/celeritas-project/celeritas/actions/runs/19948559972/job/57204118695 .

To fix the size overrun errors (nearly 5GB for the debug/reldeb) I've disabled CUBIN compilation for the reldeb case and turned off DEVICE_DEBUG for the debug case.