### PR TITLE
Fix compile error with VecGeom `v2.0.0-rc.8` and Cuda

### DIFF
--- a/src/geocel/vg/detail/VecgeomSetup.cu
+++ b/src/geocel/vg/detail/VecgeomSetup.cu
@@ -50,7 +50,7 @@ struct BvhGetter
 //! Copy the navigation table pointer address to global memory
 struct NavIndexGetter
 {
-    using pointer_type = NavIndex_t const*;
+    using pointer_type = VgNavIndex const*;
     static constexpr char const label[] = "navindex";
 
     pointer_type* dest{nullptr};
@@ -125,9 +125,9 @@ CudaPointers<CudaBVH_t const> bvh_pointers_device()
 /*!
  * Get pointers to the device BVH after setup, for consistency checking.
  */
-CudaPointers<NavIndex_t const> navindex_pointers_device()
+CudaPointers<VgNavIndex const> navindex_pointers_device()
 {
-    CudaPointers<NavIndex_t const> result;
+    CudaPointers<VgNavIndex const> result;
 
     // Copy from kernel using 1-thread launch
     result.kernel = get_device_pointer<NavIndexGetter>();


### PR DESCRIPTION
`NavIndex_t` moved to a new namespace. Use type alias to pick the correct type depending the VecGeom version