### PR TITLE
Support different CODATA measured constants with `CELERITAS_CODATA` config option

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,13 +37,12 @@ jobs:
         image: ["rocky-cuda", "ubuntu-rocm"]
         exclude:
           - geometry: "vecgeom"
+            buildtype: "debug" # Build is too large
+          - geometry: "vecgeom"
             image: "ubuntu-rocm" # VecGeom not installed on HIP
           - buildtype: "debug"
-            image: "ubuntu-rocm" # Debug builds don't work with HIP
+            image: "ubuntu-rocm" # Debug device code breaks HIP optimizer
         include:
-          - geometry: "vecgeom"
-            buildtype: "reldeb"
-            image: "rocky-cuda"
           - buildtype: "reldeb"
             geometry: "vecgeom"
             special: "codecov"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,8 +185,10 @@ celeritas_define_options(CELERITAS_UNITS
 # CELERITAS_CODATA
 # Experimentally measured physical constants
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+celeritas_setup_option(CELERITAS_CODATA 2006) # Used by CLHEP
 celeritas_setup_option(CELERITAS_CODATA 2018)
 celeritas_setup_option(CELERITAS_CODATA 2022)
+set(CELERITAS_CODATA_OPTION_DEFAULT 2018)
 celeritas_define_options(CELERITAS_CODATA
   "Experimentally measured physical constants revision")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,15 @@ celeritas_define_options(CELERITAS_UNITS
   "Native unit system for Celeritas")
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# CELERITAS_CODATA
+# Experimentally measured physical constants
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+celeritas_setup_option(CELERITAS_CODATA 2018)
+celeritas_setup_option(CELERITAS_CODATA 2022)
+celeritas_define_options(CELERITAS_CODATA
+  "Experimentally measured physical constants revision")
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # CELERITAS_REAL_TYPE
 # Precision for real numbers
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cmake/CeleritasOptionUtils.cmake
+++ b/cmake/CeleritasOptionUtils.cmake
@@ -353,7 +353,11 @@ function(celeritas_define_options var doc)
 
   if(_val STREQUAL "")
     # Dynamic default option: set as core variable in parent scope
-    list(GET ${var}_OPTIONS 0 _default)
+    if(DEFINED ${var}_OPTION_DEFAULT)
+      set(_default ${${var}_OPTION_DEFAULT})
+    else()
+      list(GET ${var}_OPTIONS 0 _default)
+    endif()
     set(${var} "${_default}" PARENT_SCOPE)
     set(_val "${_default}")
     if(NOT "${_val}" STREQUAL "${${_last_var}}")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -47,6 +47,12 @@ else()
   set(_DOXYGEN_TEST_SOURCE)
 endif()
 
+# Include paths must be used for macro preprocessing to function correctly...
+set(DOXYGEN_INCLUDE_PATH
+  "${PROJECT_BINARY_DIR}/include/"
+  "${PROJECT_SOURCE_DIR}/src/"
+)
+
 # Documentation usage
 set(DOXYGEN_DISTRIBUTE_GROUP_DOC YES)
 set(DOXYGEN_ENABLED_SECTIONS "CELERITAS_DOC_DEV")

--- a/doc/implementation/units-constants.rst
+++ b/doc/implementation/units-constants.rst
@@ -19,11 +19,12 @@ physical constants such as the speed of light, Planck's constant, and the
 electron charge, have exact numerical values as specified by the SI unit system
 :cite:`si-2019`. Other physical constants such as the atomic mass unit and electron
 radius are derived from experimental measurements in CODATA 2018
-:cite:`codata-2018`. Because the
+:cite:`codata-2018` or CODATA 2022.
+Because the
 reported constants are derived from regression fits to experimental data
 points, some exactly defined physical relationships (such as the fine structure
 constant
-:math:`\alpha = \frac{e^2}{2 \epsilon_0 h c}`) are only approximate.
+:math:`\alpha = \frac{e^2}{2 \epsilon_0 h c}` ) are only approximate.
 
 Unlike Geant4 and the CLHEP unit systems :cite:`clhep`, Celeritas avoids using "natural"
 units in its definitions. Although a natural unit system makes some
@@ -35,7 +36,6 @@ stores quantities in another unit system with a compile-time constant that
 allows their conversion back to native units. This allows, for example,
 particles to represent their energy as MeV and charge as fractions of *e* but
 work seamlessly with a field definition in native (macro-scale quantity) units.
-
 
 .. _api_quantity:
 

--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -154,6 +154,10 @@ easy way to toggle through all the valid options.
   Choose the native Celeritas unit system: see :ref:`the unit
   documentation <api_units>`.
 
+``CELERITAS_CODATA``
+  Choose the default set of experimentally measured CODATA constants:
+  see :ref:`the constants documentation <api_constants>`.
+
 Celeritas libraries (generally) use CMake-provided default properties. These
 can be changed with standard `CMake variables`_ such as ``BUILD_SHARED_LIBS`` to
 enable shared libraries, ``CMAKE_POSITION_INDEPENDENT_CODE``, etc.

--- a/scripts/cmake-presets/ci-rocky-cuda.json
+++ b/scripts/cmake-presets/ci-rocky-cuda.json
@@ -64,24 +64,6 @@
       }
     },
     {
-      "name": "debug-vecgeom",
-      "description": "Build tests with vecgeom and assertions enabled",
-      "inherits": [".ndebug", ".vecgeom", "base"],
-      "cacheVariables": {
-        "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_DEBUG": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"}
-      }
-    },
-    {
-      "name": "reldeb-vecgeom",
-      "description": "Build with RelWithDebInfo, assertions, and VecGeom",
-      "inherits": [".reldeb", ".vecgeom", "base"],
-      "cacheVariables": {
-        "CELERITAS_DEVICE_DEBUG": {"type": "BOOL", "value": "ON"}
-      }
-    },
-    {
       "name": "ndebug-vecgeom",
       "description": "Build release with vecgeom for testing *only* demos",
       "inherits": [".ndebug", ".vecgeom", "base"],
@@ -110,8 +92,6 @@
     },
     {"name": "debug-orange"       , "configurePreset": "debug-orange"       , "inherits": "base"},
     {"name": "ndebug-orange", "configurePreset": "ndebug-orange", "inherits": "base", "targets": ["all", "install"]},
-    {"name": "reldeb-vecgeom"  , "configurePreset": "reldeb-vecgeom"  , "inherits": "base", "targets": ["all", "install"]},
-    {"name": "debug-vecgeom"   , "configurePreset": "debug-vecgeom"   , "inherits": "base", "jobs": 8},
     {"name": "ndebug-vecgeom"   , "configurePreset": "ndebug-vecgeom"   , "inherits": "base", "jobs": 8, "targets": ["app/all", "install"]}
   ],
   "testPresets": [
@@ -133,8 +113,6 @@
     },
     {"name": "debug-orange"       , "configurePreset": "debug-orange"       , "inherits": "base"},
     {"name": "ndebug-orange", "configurePreset": "ndebug-orange", "inherits": "base"},
-    {"name": "reldeb-vecgeom"  , "configurePreset": "reldeb-vecgeom"  , "inherits": "base"},
-    {"name": "debug-vecgeom"   , "configurePreset": "debug-vecgeom"   , "inherits": "base"},
     {"name": "ndebug-vecgeom"   , "configurePreset": "ndebug-vecgeom"   , "inherits": "base"}
   ]
 }

--- a/src/celeritas/Constants.hh
+++ b/src/celeritas/Constants.hh
@@ -77,7 +77,7 @@ CELER_ICC kcd_luminous{683};
 #if CELERITAS_UNITS == CELERITAS_UNITS_CLHEP
 //!@{
 //! \name Special cases for CLHEP
-//! Electron charged is unity by definition
+//! Electron charge is unity by definition
 CELER_ICC e_electron{1};
 //!@}
 #endif

--- a/src/celeritas/Constants.hh
+++ b/src/celeritas/Constants.hh
@@ -87,8 +87,29 @@ CELER_ICC e_electron{1};
 CELER_ICC hbar_planck{h_planck / (2 * pi)};
 //!@}
 
+//! Experimental physical constants from CODATA 2006
+#if CELERITAS_CODATA == CELERITAS_CODATA_2006
+inline
+#endif
+    namespace codata2006
+{
+CELER_ICC a0_bohr = Constant{5.2917720859e-11} * units::meter;
+CELER_ICC alpha_fine_structure = Constant{7.2973525376e-3};
+CELER_ICC atomic_mass = Constant{1.660538782e-24} * units::gram;
+CELER_ICC electron_mass = Constant{9.10938215e-28} * units::gram;
+CELER_ICC proton_mass = Constant{1.672621637e-24} * units::gram;
+CELER_ICC eps_electric = Constant{8.854187817e-12} * units::farad
+                         / units::meter;
+CELER_ICC mu_magnetic = Constant{1.2566370614e-6} * units::newton
+                        / (units::ampere * units::ampere);
+CELER_ICC r_electron = Constant{2.8179402894e-15} * units::meter;
+CELER_ICC rinf_rydberg = Constant{10973731.568527} / units::meter;
+CELER_ICC eh_hartree = Constant{4.35974394e-18} / units::meter;
+CELER_ICC lambdabar_electron = Constant{3.8615926459e-13} * units::meter;
+}
+
 //! Experimental physical constants from CODATA 2018
-#if CELERITAS_CODATA == CELERITAS_CODATA_2018 && !defined(__DOXYGEN__)
+#if CELERITAS_CODATA == CELERITAS_CODATA_2018
 inline
 #endif
     namespace codata2018
@@ -109,7 +130,7 @@ CELER_ICC lambdabar_electron = Constant{3.8615926796e-13} * units::meter;
 }
 
 //! Experimental physical constants from CODATA 2022
-#if CELERITAS_CODATA == CELERITAS_CODATA_2022 && !defined(__DOXYGEN__)
+#if CELERITAS_CODATA == CELERITAS_CODATA_2022
 inline
 #endif
     namespace codata2022
@@ -130,7 +151,7 @@ CELER_ICC lambdabar_electron = Constant{3.8615926744e-13} * units::meter;
 }
 
 //!@{
-//! \name Other constants
+//! \name Other constants with physical meaning
 inline constexpr int stable_decay_constant{0};
 //!@}
 

--- a/src/celeritas/Constants.hh
+++ b/src/celeritas/Constants.hh
@@ -10,7 +10,6 @@
 #include "corecel/Config.hh"
 
 #include "corecel/Constants.hh"
-#include "corecel/Types.hh"
 
 #include "Units.hh"
 
@@ -47,7 +46,11 @@ namespace celeritas
  *
  * Some experimental physical constants are derived from the other physical
  * constants, but for consistency and clarity they are presented numerically
- * with the units provided in the CODATA 2018 dataset. The \c Constants.test.cc
+ * with the units provided in the CODATA 2018 or 2022 datasets. The
+ * \c CELERITAS_CODATA cmake variable determines which of the two datasets is
+ * "inlined" into the \c celeritas namespace, allowing fine-grain transition
+ * for classes that require it.
+ * The \c Constants.test.cc
  * unit tests compare the numerical value against the derivative values inside
  * the celeritas unit system. All experimental values include the final
  * (usually two) imprecise digits; their precision is usually on the order of
@@ -72,8 +75,11 @@ CELER_ICC kcd_luminous{683};
 //!@}
 
 #if CELERITAS_UNITS == CELERITAS_UNITS_CLHEP
-//! Special case for CLHEP: electron charged is unity by definition
+//!@{
+//! \name Special cases for CLHEP
+//! Electron charged is unity by definition
 CELER_ICC e_electron{1};
+//!@}
 #endif
 
 //!@{
@@ -81,8 +87,12 @@ CELER_ICC e_electron{1};
 CELER_ICC hbar_planck{h_planck / (2 * pi)};
 //!@}
 
-//!@{
-//! \name Experimental physical constants from CODATA 2018
+//! Experimental physical constants from CODATA 2018
+#if CELERITAS_CODATA == CELERITAS_CODATA_2018 && !defined(__DOXYGEN__)
+inline
+#endif
+    namespace codata2018
+{
 CELER_ICC a0_bohr = Constant{5.29177210903e-11} * units::meter;
 CELER_ICC alpha_fine_structure = Constant{7.2973525693e-3};
 CELER_ICC atomic_mass = Constant{1.66053906660e-24} * units::gram;
@@ -96,7 +106,28 @@ CELER_ICC r_electron = Constant{2.8179403262e-15} * units::meter;
 CELER_ICC rinf_rydberg = Constant{10973731.568160} / units::meter;
 CELER_ICC eh_hartree = Constant{4.3597447222071e-18} / units::meter;
 CELER_ICC lambdabar_electron = Constant{3.8615926796e-13} * units::meter;
-//!@}
+}
+
+//! Experimental physical constants from CODATA 2022
+#if CELERITAS_CODATA == CELERITAS_CODATA_2022 && !defined(__DOXYGEN__)
+inline
+#endif
+    namespace codata2022
+{
+CELER_ICC a0_bohr = Constant{5.29177210544e-11} * units::meter;
+CELER_ICC alpha_fine_structure = Constant{7.2973525643e-3};
+CELER_ICC atomic_mass = Constant{1.66053906892e-24} * units::gram;
+CELER_ICC electron_mass = Constant{9.1093837139e-28} * units::gram;
+CELER_ICC proton_mass = Constant{1.67262192595e-24} * units::gram;
+CELER_ICC eps_electric = Constant{8.8541878188e-12} * units::farad
+                         / units::meter;
+CELER_ICC mu_magnetic = Constant{1.25663706127e-6} * units::newton
+                        / (units::ampere * units::ampere);
+CELER_ICC r_electron = Constant{2.8179403205e-15} * units::meter;
+CELER_ICC rinf_rydberg = Constant{10973731.568157} / units::meter;
+CELER_ICC eh_hartree = Constant{4.3597447222060e-18} / units::meter;
+CELER_ICC lambdabar_electron = Constant{3.8615926744e-13} * units::meter;
+}
 
 //!@{
 //! \name Other constants

--- a/src/celeritas/Quantities.hh
+++ b/src/celeritas/Quantities.hh
@@ -7,7 +7,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Macros.hh"
 #include "corecel/math/Quantity.hh"  // IWYU pragma: export
 
 #include "UnitTypes.hh"  // IWYU pragma: export

--- a/src/celeritas/UnitTypes.hh
+++ b/src/celeritas/UnitTypes.hh
@@ -11,6 +11,7 @@
 
 #include "corecel/Config.hh"
 
+#include "corecel/Macros.hh"
 #include "corecel/math/Constant.hh"
 #include "corecel/math/UnitUtils.hh"
 

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CELERITAS_USE_VECGEOM ${CELERITAS_USE_VecGeom})
 # Start counter from 1 because undefined config have the implicit value of 0 in
 # the C preprocessor, so any unavailable options (e.g. CELERITAS_USE_CURAND
 # when HIP is in use) will implicitly be zero.
+celeritas_generate_option_config(CELERITAS_CODATA)
 celeritas_generate_option_config(CELERITAS_CORE_GEO)
 celeritas_generate_option_config(CELERITAS_CORE_RNG)
 celeritas_generate_option_config(CELERITAS_OPENMP)
@@ -74,7 +75,7 @@ else()
     string(APPEND CELERITAS_BUILD_TYPE ",pic")
   endif()
 endif()
-foreach(_var BUILD_TYPE HOSTNAME REAL_TYPE UNITS OPENMP CORE_GEO CORE_RNG)
+foreach(_var BUILD_TYPE HOSTNAME REAL_TYPE UNITS CONSTANTS OPENMP CORE_GEO CORE_RNG)
   string(TOLOWER "${_var}" _lower)
   celeritas_append_cmake_string("${_lower}" "${CELERITAS_${_var}}")
 endforeach()

--- a/src/corecel/Config.hh.in
+++ b/src/corecel/Config.hh.in
@@ -48,6 +48,8 @@
 // Core configuration
 //---------------------------------------------------------------------------//
 
+@CELERITAS_CODATA_CONFIG@
+
 @CELERITAS_REAL_TYPE_CONFIG@
 
 @CELERITAS_UNITS_CONFIG@

--- a/test/celeritas/Constants.test.cc
+++ b/test/celeritas/Constants.test.cc
@@ -10,6 +10,8 @@
 
 #include "corecel/Config.hh"
 
+#include "corecel/math/Quantity.hh"
+#include "celeritas/Quantities.hh"
 #include "celeritas/Units.hh"
 
 #include "celeritas_test.hh"
@@ -64,6 +66,26 @@ TEST(ConstantsTest, formulas)
         a0_bohr);
     EXPECT_SOFT_EQ(alpha_fine_structure * alpha_fine_structure * a0_bohr,
                    r_electron);
+}
+
+TEST(ConstantsTest, clhep_codata)
+{
+    // Values differ from the CLHEP constants (CODATA 2006) by ~1e-7 due to
+    // the 2019 change in SI using e- charge as an exact definition
+    // rather than a measured constant
+    constexpr Constant old_e_electron{1.602176487e-19 * units::coulomb};
+
+    using MevMass = Quantity<units::MevPerCsq, double>;
+
+    // Like other CODATA constants, derivative values seem to be accurate only
+    // to ~1e-10 due to propagation of uncertainty
+    EXPECT_SOFT_NEAR(
+        native_value_to<MevMass>(codata2006::electron_mass).value(),
+        0.510998910 * old_e_electron / e_electron,
+        5e-10);
+    EXPECT_SOFT_NEAR(native_value_to<MevMass>(codata2006::proton_mass).value(),
+                     938.272013 * old_e_electron / e_electron,
+                     5e-10);
 }
 
 TEST(ConstantsTest, clhep)


### PR DESCRIPTION
A new cmake option allows us to choose between the 2018 value (existing, default) of the CODATA experimental constants, the new 2022 values, or the 2006 (used by CLHEP, see https://github.com/celeritas-project/celeritas/pull/1309#discussion_r1672818600) values. An `inline` namespace allows us to just use `celeritas::constants::foo` in the regular case but specifically choose a sub-namespace if a certain class wants to use it for reproducibility.

This also fixes the documentation for units and constants: a weird doxygen bug meant that omitting the `INCLUDE_PATH` prevented preprocessing from affecting the content of the files, leading to the electron constant showing up as 1 (for CLHEP) rather than `1.602176634e-19 C`.