### PR TITLE
Fix device linking of downstream applications with Covfie+CUDA

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -177,10 +177,32 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
 endif()
 
 if(CELERITAS_USE_covfie)
-  list(APPEND SOURCES field/CartMapFieldParams.covfie.cc)
-  celeritas_polysource_append(SOURCES
+  set(_celer_covfie_src
+    field/CartMapFieldParams.covfie.cc
+  )
+  celeritas_polysource_append(_celer_covfie_src
     alongstep/AlongStepCartMapFieldMscAction)
-  list(APPEND PRIVATE_DEPS Celeritas::BuildFlags Celeritas::geocel ${_core_geo_deps} Celeritas::Extcovfie)
+  # object libraries do not work properly with RDC builds
+  if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
+    list(APPEND SOURCES ${_celer_covfie_src})
+    list(APPEND PRIVATE_DEPS
+      Celeritas::BuildFlags
+      Celeritas::geocel
+      ${_core_geo_deps}
+      Celeritas::Extcovfie
+    )
+  else()
+    celeritas_add_object_library(celeritas_covfie ${_celer_covfie_src})
+    celeritas_target_link_libraries(celeritas_covfie
+      PRIVATE
+        Celeritas::BuildFlags
+        Celeritas::geocel
+        ${_core_geo_deps}
+        Celeritas::Extcovfie
+    )
+    list(APPEND SOURCES $<TARGET_OBJECTS:celeritas_covfie>)
+    list(APPEND PRIVATE_DEPS celeritas_covfie)
+  endif()
 else()
   celeritas_polysource_append(SOURCES
     alongstep/AlongStepCartMapFieldMscAction)

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -177,25 +177,13 @@ if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
 endif()
 
 if(CELERITAS_USE_covfie)
-  set(_celer_covfie_src
-    field/CartMapFieldParams.covfie.cc
-  )
-  celeritas_polysource_append(_celer_covfie_src
+  list(APPEND SOURCES field/CartMapFieldParams.covfie.cc)
+  celeritas_polysource_append(SOURCES
     alongstep/AlongStepCartMapFieldMscAction)
-
-  celeritas_add_object_library(celeritas_covfie ${_celer_covfie_src})
-  celeritas_target_link_libraries(celeritas_covfie
-    PRIVATE
-      Celeritas::BuildFlags
-      Celeritas::geocel
-      ${_core_geo_deps}
-      Celeritas::Extcovfie
-  )
-  list(APPEND SOURCES $<TARGET_OBJECTS:celeritas_covfie>)
-  list(APPEND PRIVATE_DEPS celeritas_covfie)
+  list(APPEND PRIVATE_DEPS Celeritas::BuildFlags Celeritas::geocel ${_core_geo_deps} Celeritas::Extcovfie)
 else()
   celeritas_polysource_append(SOURCES
-  alongstep/AlongStepCartMapFieldMscAction)
+    alongstep/AlongStepCartMapFieldMscAction)
 endif()
 
 if(CELERITAS_USE_Geant4)


### PR DESCRIPTION
I was trying to debug the source of this error in Athena when using covfie propagation kernel:

```
21:53:30 /pscratch/sd/e/esseivaj/celer-athena/externals_build/x86_64-el9-gcc13-opt/include/VecGeom/navigation/NavStateTuple.h:286: static const unsigned int *vecgeom::NavStateTuple::NavIndAddr(unsigned int): block: [2054,0,0], thread: [224,0,0] Assertion `false && sizeof("internal" ": " "vecgeom::globaldevicegeomdata::gNavIndex != nullptr")` failed.
```

It turns out that we were using `celeritas_add_object_library` to create an internal CMake library to link covfie (cuda) code with our main lib. This was causing an issue in downstream executables/libraries as this internal was being picked up and linked into the final executable, probably shadowing the global device symbols.... 

```
cuobjdump ../athsim_build/x86_64-el9-gcc13-opt/lib/libAtlasGeant4Lib.so -lelf
ELF file    1: libAtlasGeant4.1.sm_61.cubin
ELF file    2: libAtlasGeant4.2.sm_75.cubin
ELF file    3: libAtlasGeant4.3.sm_80.cubin
ELF file    4: libAtlasGeant4.4.sm_89.cubin
ELF file    5: AlongStepCartMapFieldMscAction.sm_80.cubin
```