### PR TITLE
Fix VgNavIndex narrowing conversion

### DIFF
--- a/src/geocel/vg/VecgeomData.hh
+++ b/src/geocel/vg/VecgeomData.hh
@@ -41,10 +41,10 @@ namespace celeritas
 inline constexpr VgSurfaceInt vg_null_surface{-1};
 inline constexpr VgNavIndex vg_outside_nav_index{0};
 inline constexpr VgNavIndex vg_world_nav_index{
-    VECGEOM_VERSION < 0x020000         ? 1
-    : CELER_VGNAV == CELER_VGNAV_INDEX ? 3
-    : CELER_VGNAV == CELER_VGNAV_TUPLE ? 2
-                                       : -1};
+    static_cast<VgNavIndex>(VECGEOM_VERSION < 0x020000         ? 1
+                            : CELER_VGNAV == CELER_VGNAV_INDEX ? 3
+                            : CELER_VGNAV == CELER_VGNAV_TUPLE ? 2
+                                                               : -1)};
 
 //---------------------------------------------------------------------------//
 // PARAMS

--- a/src/geocel/vg/VecgeomData.hh
+++ b/src/geocel/vg/VecgeomData.hh
@@ -40,11 +40,6 @@ namespace celeritas
 
 inline constexpr VgSurfaceInt vg_null_surface{-1};
 inline constexpr VgNavIndex vg_outside_nav_index{0};
-inline constexpr VgNavIndex vg_world_nav_index{
-    static_cast<VgNavIndex>(VECGEOM_VERSION < 0x020000         ? 1
-                            : CELER_VGNAV == CELER_VGNAV_INDEX ? 3
-                            : CELER_VGNAV == CELER_VGNAV_TUPLE ? 2
-                                                               : -1)};
 
 //---------------------------------------------------------------------------//
 // PARAMS


### PR DESCRIPTION
The narrowing conversion shows up when trying to build AtlasExternals

```
In file included from /builds/atlas/atlasexternals/ci_build/src/Celeritas/src/geocel/vg/VecgeomParams.hh:24,
                 from /builds/atlas/atlasexternals/ci_build/src/Celeritas/src/geocel/vg/VecgeomParams.cc:7:
/builds/atlas/atlasexternals/ci_build/src/Celeritas/src/geocel/vg/VecgeomData.hh:44:40: error: narrowing conversion of '-1' from 'int' to 'celeritas::VgNavIndex' {aka 'unsigned int'} [-Wnarrowing]
   44 |     VECGEOM_VERSION < 0x020000         ? 1
```

