### PR TITLE
Use Vecgeom2 solids in CI job

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -129,7 +129,6 @@ jobs:
             spack -e . add vecgeom@1.2.11:1+gdml
           elif ${{matrix.geometry == 'vecgeom2'}}; then
             spack -e . add vecgeom@2.0.0-rc.7+gdml
-          fi
           elif ${{matrix.geometry == 'vgsurf'}}; then
             spack -e . add vecgeom@2.0.0-rc.7+surface+gdml
           fi

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -127,6 +127,9 @@ jobs:
             scripts/ci/spack.yaml > spack.yaml
           if ${{matrix.geometry == 'vecgeom'}}; then
             spack -e . add vecgeom@1.2.11:1+gdml
+          elif ${{matrix.geometry == 'vecgeom2'}}; then
+            spack -e . add vecgeom@2.0.0-rc.7+gdml
+          fi
           elif ${{matrix.geometry == 'vgsurf'}}; then
             spack -e . add vecgeom@2.0.0-rc.7+surface+gdml
           fi

--- a/test/celeritas/geo/Geometry.test.cc
+++ b/test/celeritas/geo/Geometry.test.cc
@@ -198,9 +198,9 @@ auto SimpleCmsTest::reference_avg_path() const -> SpanConstReal
         if (using_solids_vg && CELERITAS_VECGEOM_VERSION >= 0x020000)
         {
             // TODO: try to fix any discrepancies from vg2.x-solids
-            paths[4] = 487.651955842282;
-            paths[5] = 869.116923540767;
-            paths[6] = 2199.33144744229;
+            paths[4] = 454.195842538179;
+            paths[5] = 1148.46821493334;
+            paths[6] = 1871.43143781146;
         }
         return make_span(paths);
     }
@@ -256,8 +256,8 @@ auto ThreeSpheresTest::reference_avg_path() const -> SpanConstReal
     if (using_solids_vg && CELERITAS_VECGEOM_VERSION >= 0x020000)
     {
         // TODO: try to fix any discrepancies from vg2.x-solids
-        paths[0] = 0.174520372497482;
-        paths[2] = 4.97131837547155;
+        paths[0] = 0.193968509125204;
+        paths[2] = 6.63492117919102;
     }
     return make_span(paths);
 }


### PR DESCRIPTION
We're using `vecgeom` 1.X in the vecgeom2 CI job, never testing VecGeom2 solids model. I'm getting two failing tests locally:

```
The following tests FAILED:
        233 - celeritas/geo/Geometry:SimpleCms* (Failed)        unit
        235 - celeritas/geo/Geometry:ThreeSpheres* (Failed)     unit
```