### PR TITLE
Fix ExCL env script

### DIFF
--- a/scripts/env/excl.sh
+++ b/scripts/env/excl.sh
@@ -14,7 +14,7 @@ if ! command -v celerlog >/dev/null 2>&1; then
   }
 fi
 if test -z "${SYSTEM_NAME}"; then
-  SYSTEM_NAME=$(uname -s)
+  SYSTEM_NAME=$(hostname -s)
   celerlog debug "Set SYSTEM_NAME=${SYSTEM_NAME}"
 fi
 


### PR DESCRIPTION
This MR fixes a small bug that prevented environment scripts from loading the correct, node-specific spack environment.