### PR TITLE
Remove use of G4Backtrace

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -99,7 +99,6 @@ void run(std::string_view filename, std::shared_ptr<SharedParams> params)
 
     // Disable external error handlers
     ScopedRootErrorHandler scoped_root_errors;
-    disable_geant_signal_handler();
 
     // Set the random seed *before* the run manager is instantiated
     // (G4MTRunManager constructor uses the RNG)

--- a/src/celeritas/ext/GeantSetup.cc
+++ b/src/celeritas/ext/GeantSetup.cc
@@ -18,9 +18,6 @@
 #include <G4RunManager.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4VUserDetectorConstruction.hh>
-#if G4VERSION_NUMBER >= 1070
-#    include <G4Backtrace.hh>
-#endif
 #if G4VERSION_NUMBER >= 1100
 #    include <G4RunManagerFactory.hh>
 #endif
@@ -90,9 +87,6 @@ GeantSetup::GeantSetup(std::string const& gdml_filename, Options options)
                        << "Geant4 cannot be 'run' more than once per "
                           "execution");
         ++geant_launch_count;
-
-        // Disable signal handling
-        disable_geant_signal_handler();
 
 #if G4VERSION_NUMBER >= 1100
         run_manager_.reset(

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -27,20 +27,16 @@
 #include <G4Version.hh>
 #include <G4VisExtent.hh>
 
-#include "corecel/Assert.hh"
-#include "geocel/inp/Model.hh"
-#if G4VERSION_NUMBER >= 1070
-#    include <G4Backtrace.hh>
-#endif
-
 #include "corecel/Config.hh"
 
+#include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedProfiling.hh"
+#include "geocel/inp/Model.hh"
 
 #include "GeantGdmlLoader.hh"
 #include "GeantGeoUtils.hh"
@@ -673,8 +669,6 @@ GeantGeoParams::from_gdml(std::string const& filename)
 
     ScopedGeantLogger logger(celeritas::world_logger());
     ScopedGeantExceptionHandler exception_handler;
-
-    disable_geant_signal_handler();
 
     if (!ends_with(filename, ".gdml"))
     {

--- a/src/geocel/GeantUtils.cc
+++ b/src/geocel/GeantUtils.cc
@@ -15,9 +15,6 @@
 #if G4VERSION_NUMBER < 1070
 #    include <G4MTRunManager.hh>
 #endif
-#if G4VERSION_NUMBER >= 1070
-#    include <G4Backtrace.hh>
-#endif
 
 #ifdef _OPENMP
 #    include <omp.h>
@@ -30,21 +27,6 @@
 
 namespace celeritas
 {
-//---------------------------------------------------------------------------//
-/*!
- * Clear Geant4's signal handlers that get installed on startup/activation.
- *
- * This should be called before instantiating a run manager.
- */
-void disable_geant_signal_handler()
-{
-#if G4VERSION_NUMBER >= 1070
-    CELER_LOG(debug) << "Disabling Geant4 signal handlers";
-    // Disable geant4 signal interception
-    G4Backtrace::DefaultSignals() = {};
-#endif
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Get the number of threads in a version-portable way.

--- a/src/geocel/GeantUtils.hh
+++ b/src/geocel/GeantUtils.hh
@@ -17,10 +17,6 @@ class G4RunManager;
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-// Clear Geant4's signal handlers that get installed when linking 11+
-void disable_geant_signal_handler();
-
-//---------------------------------------------------------------------------//
 // Get the number of threads in a version-portable way
 int get_geant_num_threads(G4RunManager const&);
 
@@ -50,8 +46,6 @@ std::ostream& operator<<(std::ostream& os, StreamablePD const& pd);
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 #if !CELERITAS_USE_GEANT4
-inline void disable_geant_signal_handler() {}
-
 inline int get_geant_num_threads(G4RunManager const&)
 {
     CELER_NOT_CONFIGURED("Geant4");

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -294,9 +294,6 @@ G4RunManager& IntegrationTestBase::run_manager()
         };
         CELER_ASSERT(rm);
 
-        // Disable signal handling
-        disable_geant_signal_handler();
-
         // Set up detector
         rm->SetUserInitialization(new DetectorConstruction{
             this->test_data_path("geocel", basename + ".gdml"),


### PR DESCRIPTION
This was only enabled temporarily in geant4 10.7 (15 May 2021) and disabled subsequently by @drbenmorgan for Geant4 11.0.3 (2022-03-18). Since all its code is inlined, including the file means activating some of its components. Instead of touching the signals ourselves, rely on upstream users to set `GEANT4_BUILD_BUILTIN_BACKTRACE=OFF`.