### PR TITLE
Link against development LArSim

### DIFF
--- a/doc/usage/installation.rst
+++ b/doc/usage/installation.rst
@@ -233,7 +233,7 @@ It includes environment files for quickly getting started on systems including N
    $ cd celeritas
    $ ./scripts/build.sh base
 
-You can, of course, manually build as a
+You can, of course, build manually:
 
 .. code-block:: console
 
@@ -245,7 +245,7 @@ You can, of course, manually build as a
 
 .. _zip file: https://github.com/celeritas-project/celeritas/archive/refs/heads/develop.zip
 .. _Perlmutter: https://docs.nersc.gov/systems/perlmutter/
-.. _ExCL: https://docs.olcf.ornl.gov/systems/excl_user_guide.html
+.. _ExCL: https://docs.excl.ornl.gov
 .. _Frontier: https://docs.olcf.ornl.gov/systems/frontier_user_guide.html
 .. _JLSE: https://www.jlse.anl.gov/
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -105,8 +105,8 @@ ln_presets() {
     else
       log warning "${dst} points to ${actual}, not ${src}: overwriting"
     fi
-  elif [ -e "${src}" ]; then
-    log warning "${dst} already exists but is not a symlink to ${src}"
+  elif [ -e "${dst}" ]; then
+    log warning "${PWD}/${dst} already exists but is not a symlink (should link to ${src})"
     return
   fi
 
@@ -277,7 +277,7 @@ setup_ccache
 # Check arguments and give presets if missing
 if [ $# -eq 0 ] ; then
   printf '%s\n' "Usage: $0 PRESET [config_args...]" >&2
-  if [ -n "${CMAKE}" ]; then
+  if [ -z "${CMAKE}" ]; then
     log error "cmake unavailable: cannot call --list-presets"
     exit 1
   fi

--- a/scripts/env/scisoftbuild01.sh
+++ b/scripts/env/scisoftbuild01.sh
@@ -114,25 +114,31 @@ if [ -n "$CELER_SOURCE_DIR" ]; then
   _clangd="$CELER_SOURCE_DIR/.clangd"
   if [ ! -e "${_clangd}" ]; then
     # Create clangd compatible with the system and build config
-    _gcc_version=$(gcc -dumpversion | cut -d. -f1)
-    celerlog info "Creating clangd config using GCC ${_gcc_version}: ${_clangd}"
-    cat > "${_clangd}" << EOF
+    _cxx=$GCC_FQ_DIR/bin/g++
+    if [ ! -x "${_cxx}" ]; then
+      celerlog info "GCC isn't loaded as expected at \$GCC_FQ_DIR/bin/g++ = ${_cxx}"
+    else
+      celerlog info "Creating clangd config using ${_cxx}: ${_clangd}"
+
+      # Extract include paths from GCC
+      _gcc_includes=$("${_cxx}" -E -x c++ - -v < /dev/null 2>&1 | \
+        sed -n '/^#include <...> search starts here:/,/^End of search list\./p' | \
+        grep '^ ' | sed 's/^ *//' | \
+        awk '{printf "      -isystem,\n      %s,\n", $0}' | \
+        sed '$s/,$//')
+
+      cat > "${_clangd}" << EOF
 CompileFlags:
   CompilationDatabase: ${SCRATCHDIR}/build/celeritas-reldeb-orange
   Add:
     [
-      -isystem,
-      /usr/include/c++/${_gcc_version},
-      -isystem,
-      /usr/local/include,
-      -isystem,
-      /usr/include,
-      -isystem,
-      /usr/include/x86_64-linux-gnu/c++/${_gcc_version},
+${_gcc_includes}
     ]
 EOF
+      unset _gcc_includes
+    fi
+    unset _clangd
   fi
-  unset _clangd
 fi
 
 export XDG_CACHE_HOME="${SCRATCHDIR}/cache"

--- a/scripts/env/scisoftbuild01.sh
+++ b/scripts/env/scisoftbuild01.sh
@@ -48,12 +48,16 @@ if [ -n "${APPTAINER_CONTAINER}" ]; then
   export MRB_PROJECT_VERSION=v10_14_01
   export MRB_QUALS=e26:prof
   celerlog info "Running in apptainer ${APPTAINER_CONTAINER}"
-  if [ -z "${UPS_DIR}" ]; then
+  if [ -n "${UPS_DIR}" ]; then
+    celerlog debug "Dune UPS already set up: ${UPS_DIR}"
+  else
     celerlog info "Setting up DUNE UPS"
     . /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
     celerlog debug "Using UPS_OVERRIDE=${UPS_OVERRIDE}, MRB_PROJECT=${MRB_PROJECT}"
   fi
-  if [ -z "${SETUP_LARCORE}" ]; then
+  if [ -n "${SETUP_LARCORE}" ]; then
+    celerlog debug "LARCORE is already set up"
+  else
     # Set up larsoft build defaults with UPS
     celerlog info "Setting up ${MRB_PROJECT} ${MRB_PROJECT_VERSION} with qualifiers '${MRB_QUALS}'"
     setup ${MRB_PROJECT} ${MRB_PROJECT_VERSION} -q ${MRB_QUALS} || return $?
@@ -76,18 +80,20 @@ done
 # Set up larsoft if running inside an apptainer
 if [ -n "${MRB_PROJECT}" ]; then
   LARSCRATCHDIR="${SCRATCHDIR}/${MRB_PROJECT}"
-  if ! [ -d "${LARSCRATCHDIR}" ]; then
-    celerlog info "Creating MRB dev area in ${LARSCRATCHDIR}..."
+  if [ -d "${LARSCRATCHDIR}" ]; then
+    celerlog debug "MRB dev area already exists at ${LARSCRATCHDIR}"
+  else
+    celerlog info "Creating MRB dev area in ${LARSCRATCHDIR}"
     mkdir -p "${LARSCRATCHDIR}" || return $?
     (
       cd "${LARSCRATCHDIR}"
       mrb newDev
-    )
+    ) || return 1
     celerlog debug "MRB environment created"
   fi
   _setup_filename="${LARSCRATCHDIR}/localProducts_${MRB_PROJECT}_${MRB_PROJECT_VERSION}_${MRB_QUALS//:/_}/setup"
   if ! [ -f "${_setup_filename}" ]; then
-    celerlog warn "Expected setup file at ${_setup_filename}: MRB may not have been set up correctly"
+    celerlog warning "Expected setup file at ${_setup_filename}: MRB may not have been set up correctly"
     _setup_filename=$(printf %s "${LARSCRATCHDIR}/localProducts_${MRB_PROJECT}"*/setup)
     if [ -f "${_setup_filename}" ]; then
       celerlog info "Found setup file ${_setup_filename}"
@@ -100,17 +106,19 @@ fi
 if [ -n "${MRB_SOURCE}" ]; then
   _pkg=larsim
   if ! [ -d "${MRB_SOURCE}/${_pkg}" ]; then
-    celerlog info "Installing ${_pkg}"
-    mrb g ${_pkg}
+    _tag=LARSOFT_SUITE_${MRB_PROJECT_VERSION}
+    celerlog info "Installing ${_pkg} @${_tag}"
+    mrb g -t ${_tag} ${_pkg}
   fi
 
   # Now that a package exists in MRB source, cmake and dependencies can load
   celerlog info "Activating MRB environment"
-  if ! mrbsetenv; then
-    celerlog error "Failed to set up MRB"
-    return 1
+  # Note that this may be a shell script
+  if ! command -v mrbsetenv >/dev/null 2>&1 ; then
+    celerlog warning "mrbsetenv is not defined: run manually in shell"
+  else
+    celerlog debug "MRB setup complete"
   fi
-  celerlog debug "MRB setup complete"
 fi
 
 if [ -n "$CELER_SOURCE_DIR" ]; then

--- a/scripts/env/scisoftbuild01.sh
+++ b/scripts/env/scisoftbuild01.sh
@@ -88,7 +88,7 @@ if [ -n "${MRB_PROJECT}" ]; then
   _setup_filename="${LARSCRATCHDIR}/localProducts_${MRB_PROJECT}_${MRB_PROJECT_VERSION}_${MRB_QUALS//:/_}/setup"
   if ! [ -f "${_setup_filename}" ]; then
     celerlog warn "Expected setup file at ${_setup_filename}: MRB may not have been set up correctly"
-    _setup_filename=$(print %s"${LARSCRATCHDIR}/localProducts_${MRB_PROJECT}*/setup")
+    _setup_filename=$(printf %s "${LARSCRATCHDIR}/localProducts_${MRB_PROJECT}"*/setup)
     if [ -f "${_setup_filename}" ]; then
       celerlog info "Found setup file ${_setup_filename}"
     fi
@@ -106,7 +106,10 @@ if [ -n "${MRB_SOURCE}" ]; then
 
   # Now that a package exists in MRB source, cmake and dependencies can load
   celerlog info "Activating MRB environment"
-  mrbsetenv
+  if ! mrbsetenv; then
+    celerlog error "Failed to set up MRB"
+    return 1
+  fi
   celerlog debug "MRB setup complete"
 fi
 

--- a/src/larceler/CMakeLists.txt
+++ b/src/larceler/CMakeLists.txt
@@ -15,10 +15,19 @@ set(PUBLIC_DEPS
   Celeritas::BuildFlags
 )
 
-if(TARGET larsim::OpticalPropagationTools)
-  message(SEND_ERROR "This version of Celeritas is meant for testing larsim "
-    "before https://github.com/nuRiceLab/larsim/pull/1 : please implement or "
-    "update Celeritas")
+set(_larsoft_tool_target larsim::OpticalPropagationTools)
+if(NOT TARGET ${_larsoft_tool_target})
+  message(WARNING "LArSoft version is too old for integrated Celeritas support: "
+    "defining fake plugin target for local testing "
+    "(missing target ${_larsoft_tool_target})"
+  )
+  celeritas_add_interface_library(OpticalPropagationTools)
+  celeritas_target_include_directories(OpticalPropagationTools
+    SYSTEM INTERFACE
+      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/larceler/larsim-future>"
+      "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/larceler/larsim-future>"
+  )
+  set(_larsoft_tool_target Celeritas::OpticalPropagationTools)
 endif()
 
 #-----------------------------------------------------------------------------#
@@ -34,6 +43,7 @@ celeritas_target_link_libraries(larceler
   PUBLIC ${PUBLIC_DEPS}
 )
 
+
 #-----------------------------------------------------------------------------#
 # Create plugin
 #-----------------------------------------------------------------------------#
@@ -48,6 +58,7 @@ celeritas_target_link_libraries(${_plugin_name}
     cetlib_except::cetlib_except
     larcoreobj::SimpleTypesAndConstants # Implicit dependency needed by MCBase
     lardataobj::MCBase
+    ${_larsoft_tool_target}
   PUBLIC ${PUBLIC_DEPS}
 )
 

--- a/src/larceler/CMakeLists.txt
+++ b/src/larceler/CMakeLists.txt
@@ -15,6 +15,10 @@ set(PUBLIC_DEPS
   Celeritas::BuildFlags
 )
 
+#-----------------------------------------------------------------------------#
+# Create mock upstream library for building against official LArSoft
+#-----------------------------------------------------------------------------#
+
 set(_larsoft_tool_target larsim::OpticalPropagationTools)
 if(NOT TARGET ${_larsoft_tool_target})
   message(WARNING "LArSoft version is too old for integrated Celeritas support: "
@@ -42,7 +46,6 @@ celeritas_target_link_libraries(larceler
   PRIVATE ${PRIVATE_DEPS}
   PUBLIC ${PUBLIC_DEPS}
 )
-
 
 #-----------------------------------------------------------------------------#
 # Create plugin

--- a/src/larceler/LarCelerStandalone.cc
+++ b/src/larceler/LarCelerStandalone.cc
@@ -47,6 +47,8 @@ auto LarCelerStandalone::executeEvent(VecSED const& edeps) -> UPVecBTR
     CELER_EXPECT(runner_);
     CELER_EXPECT(!edeps.empty());
 
+    using VecBTR = LarStandaloneRunner::VecBTR;
+
     // Calculate detector responsors for the input steps
     auto& run = *runner_;
     VecBTR result = run(edeps);

--- a/src/larceler/LarCelerStandalone.cc
+++ b/src/larceler/LarCelerStandalone.cc
@@ -14,8 +14,8 @@
 
 #include "corecel/Assert.hh"
 
-#include "larceler/LarStandaloneRunner.hh"
-#include "larceler/inp/LarStandaloneRunner.hh"
+#include "LarStandaloneRunner.hh"
+#include "inp/LarStandaloneRunner.hh"
 
 namespace celeritas
 {

--- a/src/larceler/LarCelerStandalone.hh
+++ b/src/larceler/LarCelerStandalone.hh
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 #include <art/Utilities/ToolConfigTable.h>
+#include <larsim/PhotonPropagation/OpticalPropagationTools/IOpticalPropagation.h>
 
 #include "LarStandaloneRunner.hh"
 
@@ -20,34 +20,6 @@ namespace sim
 class SimEnergyDeposit;
 class OpDetBacktrackerRecord;
 }  // namespace sim
-
-// TODO: This will be defined upstream:
-// see https://github.com/nuRiceLab/larsim/pull/1
-namespace phot
-{
-class OpticalSimInterface
-{
-  public:
-    //!@{
-    //! \name Type aliases
-    using VecSED = std::vector<sim::SimEnergyDeposit>;
-    using VecBTR = std::vector<sim::OpDetBacktrackerRecord>;
-    using UPVecBTR = std::unique_ptr<VecBTR>;
-    ///@}
-
-    // Enable polymorphic deletion
-    virtual ~OpticalSimInterface() = 0;
-
-    // Set up execution
-    virtual void beginJob() = 0;
-
-    // Process a single event, returning detector hits
-    virtual UPVecBTR executeEvent(VecSED const& edeps) = 0;
-
-    // Tear down execution
-    virtual void endJob() = 0;
-};
-}  // namespace phot
 
 namespace celeritas
 {
@@ -75,7 +47,7 @@ namespace celeritas
  *
  * See \c celeritas::detail::LarCelerStandaloneConfig .
  */
-class LarCelerStandalone final : public phot::OpticalSimInterface
+class LarCelerStandalone final : public phot::IOpticalPropagation
 {
   public:
     //!@{

--- a/src/larceler/LarCelerStandalone.hh
+++ b/src/larceler/LarCelerStandalone.hh
@@ -56,11 +56,11 @@ namespace celeritas
  * Run optical photons in a standalone simulation.
  *
  * This plugin implements a replacement for LArSim's \c phot::PDFastSimPAR
- * class, taking a vector of energy-depositing steps and returning a vector
- * is instantiated by a FHiCL workflow file with a set of
- * parameters. It is executed after the detector simulation step (ionization,
- * recombination, scintillation, etc.) with a vector of steps that contain
- * energy deposition, and it returns a vector of detector responses.
+ * class. It is instantiated by a FHiCL workflow file with a set of
+ * parameters. It takes a vector of energy-depositing steps and returns a
+ * vector of detector responses. It is executed after the detector simulation
+ * module (ionization, recombination, scintillation, etc.) with a vector of
+ * steps that contain local energy deposition.
  *
  * The execution happens \em after LArG4 is complete, so it is completely
  * independent of the Geant4 run manager and execution. It requires an input

--- a/src/larceler/inp/LarStandaloneRunner.cc
+++ b/src/larceler/inp/LarStandaloneRunner.cc
@@ -6,8 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "LarStandaloneRunner.hh"
 
-#include "corecel/io/Logger.hh"
-
 #include "larceler/detail/LarCelerConfig.hh"
 
 namespace celeritas

--- a/src/larceler/inp/LarStandaloneRunner.cc
+++ b/src/larceler/inp/LarStandaloneRunner.cc
@@ -34,11 +34,9 @@ from_config(detail::LarCelerStandaloneConfig const& cfg)
 #endif
 
     out.geometry = cfg.geometry();
-    out.optical_step_iters = cfg.optical_step_iters();
-    if (out.optical_step_iters == 0)
+    if (auto step_iters = cfg.optical_step_iters())
     {
-        CELER_LOG(debug) << "Using unlimited optical step iters";
-        out.optical_step_iters = out.unlimited;
+        out.tracking_limits.step_iters = step_iters;
     }
 
     // Optical capacities

--- a/src/larceler/inp/LarStandaloneRunner.hh
+++ b/src/larceler/inp/LarStandaloneRunner.hh
@@ -12,6 +12,7 @@
 
 #include "corecel/Types.hh"
 #include "celeritas/inp/Control.hh"
+#include "celeritas/inp/Tracking.hh"
 
 namespace celeritas
 {
@@ -36,10 +37,6 @@ namespace inp
  */
 struct LarStandaloneRunner
 {
-    //! Don't limit the number of steps (from TrackingLimits)
-    static constexpr size_type unlimited
-        = std::numeric_limits<size_type>::max();
-
     //// DATA ////
 
     //! Environment variables used for program setup/diagnostic
@@ -49,7 +46,7 @@ struct LarStandaloneRunner
     std::string geometry;
 
     //! Step iterations before aborting the optical stepping loop
-    size_type optical_step_iters{unlimited};
+    OpticalTrackingLimits tracking_limits;
 
     //! Optical buffer sizes
     OpticalStateCapacity optical_capacity;

--- a/src/larceler/inp/LarStandaloneRunner.hh
+++ b/src/larceler/inp/LarStandaloneRunner.hh
@@ -6,11 +6,9 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <limits>
 #include <map>
 #include <string>
 
-#include "corecel/Types.hh"
 #include "celeritas/inp/Control.hh"
 #include "celeritas/inp/Tracking.hh"
 

--- a/src/larceler/larsim-future/larsim/PhotonPropagation/OpticalPropagationTools/IOpticalPropagation.h
+++ b/src/larceler/larsim-future/larsim/PhotonPropagation/OpticalPropagationTools/IOpticalPropagation.h
@@ -1,0 +1,54 @@
+//---------------------------------------------------------------------------//
+//! \file IOpticalPropagation.h
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - //
+//! \brief Abstract interface for optical simulation libraries
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <lardataobj/Simulation/OpDetBacktrackerRecord.h>
+#include <lardataobj/Simulation/SimEnergyDeposit.h>
+
+namespace phot
+{
+class IOpticalPropagation;
+}
+
+//-------------------------------------------------------------------------//
+/*!
+ * Abstract interface for optical propagation.
+ *
+ * This interface allows the addition of different optical photon propagation
+ * tools. As an \c art::tool, the \c executeEvent function is called *once*
+ * during a \c art::EDProducer::produce module execution, and uses all \c
+ * sim::SimEnergyDeposits from an \c art::Event found by the \c art::Handle .
+ *
+ * I.e. a single \c executeEvent function call propagates all resulting
+ * optical photons from the existing batch of energy depositions on an
+ * event-by-event basis. It is currently expected to manage 3 methods:
+ * - \c PDFastSimPAR : already available in larsim
+ * - \c Celeritas : Full optical particle transport on CPU and GPU
+ * - \c Opticks : Full optical particle transport on Nvidia GPUs
+ *
+ * The interfaces takes a vector of \c sim::SimEnergyDeposit as input and
+ * produces a vector of \c sim::OpDetBacktrackerRecord from detector hits.
+ */
+class phot::IOpticalPropagation
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using VecSED = std::vector<sim::SimEnergyDeposit>;
+    using UPVecBTR = std::unique_ptr<std::vector<sim::OpDetBacktrackerRecord>>;
+    ///@}
+
+    // Initialize tool
+    virtual void beginJob() = 0;
+
+    // Execute is called for every art::Event
+    virtual UPVecBTR executeEvent(VecSED const& edeps) = 0;
+
+    // Bring tool back to invalid state
+    virtual void endJob() = 0;
+};

--- a/test/larceler/LarStandaloneRunner.test.cc
+++ b/test/larceler/LarStandaloneRunner.test.cc
@@ -68,7 +68,7 @@ auto LarSphereTest::make_input() const -> Input
 {
     Input result;
     result.geometry = this->test_data_path("geocel", "lar-sphere.gdml");
-    result.optical_step_iters = 10;
+    result.tracking_limits.steps = 10;
     result.optical_capacity.tracks = 16;
     return result;
 }
@@ -103,6 +103,7 @@ TEST_F(LarSphereTest, single_photon)
         /* origTrackID = */ 123);
 
     auto response = run({sed});
+    EXPECT_EQ(0, response.size());
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This adds a copy of the `IOpticalPropagation` file from https://github.com/nuRiceLab/larsim/pull/1 for testing against the release version of larsoft as an independent CMake build, while supporting linking against the nuRiceLab development version as part of `mrb`. It also addresses fixes from #2154.

I've verified that it builds inside MRB, but there's probably a few steps before it's fully "integrated": whereas larsim installs to `localProducts.../larsim/v10_09_01/slf7.x86_64.e26.prof/lib/`, the celeritas-as-mrb installs to `localProducts.../lib/`. We may need an mrb expert to tide us over till the new spack-based workflow is in place.