### PR TITLE
Fix InitializedValue semantics

### DIFF
--- a/src/corecel/cont/InitializedValue.hh
+++ b/src/corecel/cont/InitializedValue.hh
@@ -9,6 +9,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "corecel/Macros.hh"
+
 namespace celeritas
 {
 namespace detail
@@ -17,7 +19,7 @@ namespace detail
 template<class T>
 struct DefaultFinalize
 {
-    void operator()(T&) const noexcept {}
+    CELER_FORCEINLINE void operator()(T&) const noexcept {}
 };
 //---------------------------------------------------------------------------//
 }  // namespace detail
@@ -30,14 +32,14 @@ struct DefaultFinalize
  * to treat one member data specially but can use default assign/construct for
  * the other elements. The default behavior is just to default-initialize when
  * assigning and clearing the RHS when moving; this is useful for handling
- * managed memory. The *finalizer* is useful when the type has a
- * destructor-type method that has to be called before clearing it.
+ * managed memory. The \em finalizer is called every time a value is lost by
+ * assignment or destruction.
  */
 template<class T, class Finalizer = detail::DefaultFinalize<T>>
 class InitializedValue
 {
   private:
-    static constexpr bool ne_finalize_
+    static constexpr bool noexcept_finalize_
         = noexcept(std::declval<Finalizer>()(std::declval<T&>()));
 
   public:
@@ -48,18 +50,8 @@ class InitializedValue
     InitializedValue() = default;
     //! Implicit construct from lvalue
     InitializedValue(T const& value) : value_(value) {}
-    //! Implicit construct from lvalue and finalizer
-    InitializedValue(T const& value, Finalizer fin)
-        : value_(value), fin_(std::move(fin))
-    {
-    }
     //! Implicit construct from rvalue
     InitializedValue(T&& value) : value_(std::move(value)) {}
-    //! Implicit construct from value type and finalizer
-    InitializedValue(T&& value, Finalizer fin)
-        : value_(std::move(value)), fin_(std::move(fin))
-    {
-    }
 
     //! Default copy constructor
     InitializedValue(InitializedValue const&) noexcept(
@@ -73,7 +65,13 @@ class InitializedValue
     {
     }
 
-    ~InitializedValue() = default;
+    ~InitializedValue() noexcept(noexcept_finalize_)
+    {
+        if (value_ != T{})
+        {
+            Finalizer{}(value_);
+        }
+    }
 
     //!@}
     //!@{
@@ -81,40 +79,26 @@ class InitializedValue
 
     //! Finalize our value when assigning
     InitializedValue& operator=(InitializedValue const& other) noexcept(
-        ne_finalize_ && std::is_nothrow_copy_assignable_v<T>)
+        noexcept_finalize_ && std::is_nothrow_copy_assignable_v<T>)
     {
-        fin_(value_);
+        if (value_ != T{})
+        {
+            Finalizer{}(value_);
+        }
         value_ = other.value_;
-        fin_ = other.fin_;
         return *this;
     }
 
     //! Clear other value on move assign
     InitializedValue& operator=(InitializedValue&& other) noexcept(
-        ne_finalize_ && std::is_nothrow_move_assignable_v<T>)
+        noexcept_finalize_ && std::is_nothrow_move_assignable_v<T>)
     {
-        fin_(value_);
-        value_ = std::exchange(other.value_, {});
-        fin_ = std::exchange(other.fin_, {});
+        if (value_ != T{})
+        {
+            Finalizer{}(value_);
+        }
+        value_ = std::exchange(other.value_, T{});
         return *this;
-    }
-
-    //! Implicit assign from type
-    InitializedValue&
-    operator=(T const& value) noexcept(ne_finalize_
-                                       && std::is_nothrow_copy_assignable_v<T>)
-    {
-        fin_(value_);
-        value_ = value;
-        return *this;
-    }
-
-    //! Swap with another value
-    void swap(InitializedValue& other) noexcept
-    {
-        using std::swap;
-        swap(other.value_, value_);
-        swap(other.fin_, fin_);
     }
 
     //!@}
@@ -128,19 +112,11 @@ class InitializedValue
     //! Explicit reference to stored value
     T const& value() const& { return value_; }
     T& value() & { return value_; }
-    T&& value() && { return value_; }
 
-    //!@}
-
-    //!@{
-    //! Access finalizer
-    Finalizer const& finalizer() const { return fin_; }
-    void finalizer(Finalizer fin) { fin_ = std::move(fin); }
     //!@}
 
   private:
     T value_{};
-    Finalizer fin_{};  // TODO: if C++20, [[no_unique_address]]
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/cont/InitializedValue.hh
+++ b/src/corecel/cont/InitializedValue.hh
@@ -26,19 +26,20 @@ struct DefaultFinalize
 
 //---------------------------------------------------------------------------//
 /*!
- * Clear the value of the object on initialization and moving.
+ * Clear and finalize default values when moving and destroying.
  *
  * This helper class is used to simplify the "rule of 5" for classes that have
  * to treat one member data specially but can use default assign/construct for
  * the other elements. The default behavior is just to default-initialize when
  * assigning and clearing the RHS when moving; this is useful for handling
- * managed memory. The \em finalizer is called every time a value is lost by
- * assignment or destruction.
+ * managed memory. The \em finalizer is called every time a \em non-default
+ * value is lost by assignment or destruction.
  */
 template<class T, class Finalizer = detail::DefaultFinalize<T>>
 class InitializedValue
 {
-  private:
+    static_assert(std::is_default_constructible_v<T>);
+    static_assert(std::is_default_constructible_v<Finalizer>);
     static constexpr bool noexcept_finalize_
         = noexcept(std::declval<Finalizer>()(std::declval<T&>()));
 
@@ -58,13 +59,14 @@ class InitializedValue
         std::is_nothrow_copy_constructible_v<T>)
         = default;
 
-    //! Clear other value on move construct
+    //! Exchange with other value on move construct
     InitializedValue(InitializedValue&& other) noexcept(
         std::is_nothrow_move_constructible_v<T>)
         : value_(std::exchange(other.value_, {}))
     {
     }
 
+    //! Call finalizer on destruct
     ~InitializedValue() noexcept(noexcept_finalize_)
     {
         if (value_ != T{})

--- a/src/corecel/cont/InitializedValue.hh
+++ b/src/corecel/cont/InitializedValue.hh
@@ -59,51 +59,25 @@ class InitializedValue
         std::is_nothrow_copy_constructible_v<T>)
         = default;
 
-    //! Exchange with other value on move construct
+    // Move constructor
     InitializedValue(InitializedValue&& other) noexcept(
-        std::is_nothrow_move_constructible_v<T>)
-        : value_(std::exchange(other.value_, {}))
-    {
-    }
+        std::is_nothrow_move_constructible_v<T>);
 
-    //! Call finalizer on destruct
-    ~InitializedValue() noexcept(noexcept_finalize_)
-    {
-        if (value_ != T{})
-        {
-            Finalizer{}(value_);
-        }
-    }
+    // Destructor
+    ~InitializedValue() noexcept(noexcept_finalize_);
 
     //!@}
+
     //!@{
     //! \name Assignment
-
-    //! Finalize our value when assigning
+    // Copy assignment
     InitializedValue& operator=(InitializedValue const& other) noexcept(
-        noexcept_finalize_ && std::is_nothrow_copy_assignable_v<T>)
-    {
-        if (value_ != T{})
-        {
-            Finalizer{}(value_);
-        }
-        value_ = other.value_;
-        return *this;
-    }
-
-    //! Clear other value on move assign
+        noexcept_finalize_ && std::is_nothrow_copy_assignable_v<T>);
+    // Move assignment
     InitializedValue& operator=(InitializedValue&& other) noexcept(
-        noexcept_finalize_ && std::is_nothrow_move_assignable_v<T>)
-    {
-        if (value_ != T{})
-        {
-            Finalizer{}(value_);
-        }
-        value_ = std::exchange(other.value_, T{});
-        return *this;
-    }
-
+        noexcept_finalize_ && std::is_nothrow_move_assignable_v<T>);
     //!@}
+
     //!@{
     //! \name Conversion
 
@@ -120,6 +94,58 @@ class InitializedValue
   private:
     T value_{};
 };
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+//! Exchange with other value on move construct
+template<class T, class Finalizer>
+InitializedValue<T, Finalizer>::InitializedValue(
+    InitializedValue&& other) noexcept(std::is_nothrow_move_constructible_v<T>)
+    : value_(std::exchange(other.value_, {}))
+{
+}
+
+//---------------------------------------------------------------------------//
+//! Call finalizer on destruct
+template<class T, class Finalizer>
+InitializedValue<T, Finalizer>::~InitializedValue() noexcept(noexcept_finalize_)
+{
+    if (value_ != T{})
+    {
+        Finalizer{}(value_);
+    }
+}
+
+//---------------------------------------------------------------------------//
+//! Finalize our value when assigning
+template<class T, class Finalizer>
+InitializedValue<T, Finalizer>&
+InitializedValue<T, Finalizer>::operator=(InitializedValue const& other) noexcept(
+    noexcept_finalize_ && std::is_nothrow_copy_assignable_v<T>)
+{
+    if (value_ != T{})
+    {
+        Finalizer{}(value_);
+    }
+    value_ = other.value_;
+    return *this;
+}
+
+//---------------------------------------------------------------------------//
+//! Clear other value on move assign
+template<class T, class Finalizer>
+InitializedValue<T, Finalizer>&
+InitializedValue<T, Finalizer>::operator=(InitializedValue&& other) noexcept(
+    noexcept_finalize_ && std::is_nothrow_move_assignable_v<T>)
+{
+    if (value_ != T{})
+    {
+        Finalizer{}(value_);
+    }
+    value_ = std::exchange(other.value_, T{});
+    return *this;
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/test/corecel/cont/InitializedValue.test.cc
+++ b/test/corecel/cont/InitializedValue.test.cc
@@ -102,10 +102,25 @@ TEST(InitializedValue, finalizer)
     EXPECT_EQ(0, ival);
     EXPECT_EQ(std::nullopt, get_last_finalized());
 
+    {
+        InitValueInt temp{2};
+        ival = std::move(temp);
+        EXPECT_EQ(std::nullopt, get_last_finalized());
+        EXPECT_EQ(0, temp);
+        EXPECT_EQ(2, ival);
+    }
+    EXPECT_EQ(std::nullopt, get_last_finalized());
+    ival = {};
+    EXPECT_EQ(2, get_last_finalized());
+
     InitValueInt other{345};
     EXPECT_EQ(345, other);
     ival = other;
     EXPECT_EQ(std::nullopt, get_last_finalized());
+    EXPECT_EQ(345, ival);
+    EXPECT_EQ(345, other);
+    other = ival;
+    EXPECT_EQ(345, get_last_finalized());
     EXPECT_EQ(345, ival);
     EXPECT_EQ(345, other);
 

--- a/test/corecel/cont/InitializedValue.test.cc
+++ b/test/corecel/cont/InitializedValue.test.cc
@@ -17,8 +17,7 @@ namespace test
 TEST(InitializedValue, no_finalizer)
 {
     using InitValueInt = InitializedValue<int>;
-    // TODO: in C++20 use [[no_unique_address]] and restore this assertion
-    // static_assert(sizeof(InitValueInt) == sizeof(int), "Bad size");
+    static_assert(sizeof(InitValueInt) == sizeof(int), "Bad size");
 
     // Use operator new to test that the int is being initialized properly by
     // constructing into data space that's been set to a different value
@@ -66,61 +65,72 @@ TEST(InitializedValue, no_finalizer)
 }
 
 //---------------------------------------------------------------------------//
+using OptionalInt = std::optional<int>;
 struct Finalizer
 {
-    static std::vector<int>& finalized_values()
+    static OptionalInt& last_finalized()
     {
-        static std::vector<int> result;
+        static OptionalInt result;
         return result;
     }
 
-    void operator()(int val) const { finalized_values().push_back(val); }
+    void operator()(int val) const { last_finalized() = val; }
 };
+
+OptionalInt get_last_finalized()
+{
+    return std::exchange(Finalizer::last_finalized(), {});
+}
 
 TEST(InitializedValue, finalizer)
 {
-    std::vector<int> expected;
-    std::vector<int>& actual = Finalizer::finalized_values();
-    actual.clear();
-
     using InitValueInt = InitializedValue<int, Finalizer>;
+
+    // Test default value
+    InitValueInt{};
+    EXPECT_EQ(std::nullopt, get_last_finalized());
+
+    {
+        // Test nondefault value
+        InitValueInt derp{1};
+        EXPECT_EQ(1, derp);
+        EXPECT_EQ(std::nullopt, get_last_finalized());
+    }
+    EXPECT_EQ(1, get_last_finalized());
 
     InitValueInt ival{};
     EXPECT_EQ(0, ival);
-    EXPECT_VEC_EQ(expected, actual);
+    EXPECT_EQ(std::nullopt, get_last_finalized());
 
     InitValueInt other{345};
     EXPECT_EQ(345, other);
     ival = other;
-    expected.push_back(0);
-    EXPECT_VEC_EQ(expected, actual);
+    EXPECT_EQ(std::nullopt, get_last_finalized());
     EXPECT_EQ(345, ival);
     EXPECT_EQ(345, other);
 
     other = 1000;
-    expected.push_back(345);
-    EXPECT_VEC_EQ(expected, actual);
+    EXPECT_EQ(345, get_last_finalized());
     ival = std::move(other);
-    expected.push_back(345);
-    EXPECT_VEC_EQ(expected, actual);
+    EXPECT_EQ(345, get_last_finalized());
     EXPECT_EQ(1000, ival);
     EXPECT_EQ(0, other);
 
     InitValueInt third(std::move(ival));
     EXPECT_EQ(0, ival);
     EXPECT_EQ(1000, third);
+    EXPECT_EQ(std::nullopt, get_last_finalized());
 
     // Test const T& constructor
     int const cint = 1234;
-    other = InitValueInt(cint);
-    expected.push_back(0);
-    EXPECT_VEC_EQ(expected, actual);
-    EXPECT_EQ(1234, other);
+    third = InitValueInt(cint);
+    EXPECT_EQ(1000, get_last_finalized());
+    EXPECT_EQ(1234, third);
 
     // Test implicit conversion
     int tempint;
     tempint = third;
-    EXPECT_EQ(1000, tempint);
+    EXPECT_EQ(1234, tempint);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/data/DeviceAllocation.test.cc
+++ b/test/corecel/data/DeviceAllocation.test.cc
@@ -23,7 +23,14 @@ TEST(ConstructionTest, should_work_always)
 {
     DeviceAllocation alloc;
     EXPECT_EQ(0, alloc.size());
+    EXPECT_EQ(nullptr, alloc.data());
     EXPECT_TRUE(alloc.empty());
+    EXPECT_EQ(StreamId{}, alloc.stream_id());
+
+    DeviceAllocation alloc2;
+    swap(alloc, alloc2);
+    EXPECT_TRUE(alloc.empty());
+    EXPECT_TRUE(alloc.device_ref().empty());
 }
 
 #if !CELER_USE_DEVICE


### PR DESCRIPTION
It wasn't actually used in the main codebase but will be as part of the inp refactor (#2030) but the finalizer stuff for `InitializedValue` was inconsistent. With this change, the finalizer will be called on every non-default value that gets overwritten or destroyed, which is what one would expect for MPI finalize, memory allocation, etc.