### PR TITLE
Document and add checks about tracking manager construction

### DIFF
--- a/src/accel/FastSimulationModel.hh
+++ b/src/accel/FastSimulationModel.hh
@@ -23,9 +23,6 @@ class LocalTransporter;
  * `G4VUserDetectorConstruction::ConstructSDandField()`.
  *
  * Note that the argument \c G4Envelope is a type alias to \c G4Region.
- *
- * \todo Maybe need a helper to create a single fast sim model for multiple
- * regions?
  */
 class FastSimulationModel final : public G4VFastSimulationModel
 {

--- a/src/accel/TrackingManager.hh
+++ b/src/accel/TrackingManager.hh
@@ -24,16 +24,23 @@ class LocalTransporter;
 /*!
  * Offload to Celeritas via the per-particle Geant4 "tracking manager".
  *
- * Tracking managers are to be created during worker action initialization and
- * are thus thread-local.  Construction/addition to \c G4ParticleDefinition
- * appears to take place on the master thread, typically
- * in the ConstructProcess method, but the tracking manager pointer is part of
- * the split-class data for the particle. It's observed that different threads
- * have distinct pointers to a LocalTransporter instance, and that these match
- * those of the global thread-local instances in test problems.
+ * Tracking managers are created by \c G4VUserPhysicsList::Construct during
+ * \c G4RunManager::Initialize on each thread. The tracking manager pointer is
+ * a \em thread-local part of the split-class data for a \em global G4Particle.
+ * This thread-local manager points to a corresponding thread-local
+ * transporter.
+ *
+ * Because physics initialization also happens on the master MT thread, where
+ * no events are processed, a custom tracking manager \em also exists for that
+ * thread. In that case, the local transporter should be null.
  *
  * \note As of Geant4 11.3, instances of this class (one per thread) will never
  * be deleted.
+ *
+ * \warning The physics does \em not reconstruct tracking managers on
+ * subsequent runs. Therefore the \c SharedParams and \c LocalTransporter \em
+ * must have lifetimes that span multiple runs (which is the case for using
+ * global/thread-local).
  */
 class TrackingManager final : public G4VTrackingManager
 {

--- a/src/accel/TrackingManagerConstructor.cc
+++ b/src/accel/TrackingManagerConstructor.cc
@@ -53,7 +53,9 @@ TrackingManagerConstructor::TrackingManagerConstructor(
 TrackingManagerConstructor::TrackingManagerConstructor(
     TrackingManagerIntegration* tmi)
     : TrackingManagerConstructor(
-          &detail::IntegrationSingleton::instance().shared_params(), [](int) {
+          &detail::IntegrationSingleton::instance().shared_params(),
+          [](int tid) {
+              CELER_EXPECT(tid >= 0);
               return &detail::IntegrationSingleton::instance()
                           .local_transporter();
           })
@@ -100,8 +102,15 @@ void TrackingManagerConstructor::ConstructProcess()
         shared_ && get_local_,
         << R"(invalid null inputs given to TrackingManagerConstructor)");
 
-    auto* transporter = this->get_local_transporter();
-    CELER_VALIDATE(transporter, << "invalid null local transporter");
+    LocalTransporter* transporter{nullptr};
+
+    if (G4Threading::IsWorkerThread()
+        || !G4Threading::IsMultithreadedApplication())
+    {
+        // Don't create or access local transporter on master thread
+        transporter = this->get_local_(G4Threading::G4GetThreadId());
+        CELER_VALIDATE(transporter, << "invalid null local transporter");
+    }
 
 #if G4VERSION_NUMBER >= 1100
     // Create *thread-local* tracking manager with pointers to *global*
@@ -128,16 +137,6 @@ void TrackingManagerConstructor::ConstructProcess()
     // Constructor should've prevented this
     CELER_ASSERT_UNREACHABLE();
 #endif
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the local transporter associated with the current thread ID.
- */
-LocalTransporter* TrackingManagerConstructor::get_local_transporter() const
-{
-    CELER_EXPECT(get_local_);
-    return this->get_local_(G4Threading::G4GetThreadId());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/accel/TrackingManagerConstructor.cc
+++ b/src/accel/TrackingManagerConstructor.cc
@@ -49,13 +49,19 @@ TrackingManagerConstructor::TrackingManagerConstructor(
  *
  * Since there's only ever one tracking manager integration, we can just use
  * the behind-the-hood objects.
+ *
+ * \note When calling from a serial run manager in a threaded G4 build, the
+ * thread ID is \c G4Threading::MASTER_ID (-1). When calling from the run
+ * manager of a non-threaded G4 build, the thread is \c
+ * G4Threading::SEQUENTIAL_ID (-2).
  */
 TrackingManagerConstructor::TrackingManagerConstructor(
     TrackingManagerIntegration* tmi)
     : TrackingManagerConstructor(
           &detail::IntegrationSingleton::instance().shared_params(),
           [](int tid) {
-              CELER_EXPECT(tid >= 0);
+              CELER_EXPECT(tid >= 0
+                           || !G4Threading::IsMultithreadedApplication());
               return &detail::IntegrationSingleton::instance()
                           .local_transporter();
           })

--- a/src/accel/TrackingManagerConstructor.hh
+++ b/src/accel/TrackingManagerConstructor.hh
@@ -69,14 +69,6 @@ class TrackingManagerConstructor final : public G4VPhysicsConstructor
     // Build and attach tracking manager
     void ConstructProcess() override;
 
-    //// ACCESSORS ////
-
-    //! Get the shared params associated with this TM
-    SharedParams const* shared_params() const { return shared_; }
-
-    // Get the local transporter associated with the current thread ID
-    LocalTransporter* get_local_transporter() const;
-
   private:
     SharedParams const* shared_{nullptr};
     LocalTransporterFromThread get_local_{};

--- a/src/accel/TrackingManagerConstructor.hh
+++ b/src/accel/TrackingManagerConstructor.hh
@@ -7,12 +7,9 @@
 #pragma once
 
 #include <functional>
-#include <G4ParticleDefinition.hh>
 #include <G4VPhysicsConstructor.hh>
 
-#include "corecel/cont/Span.hh"
-
-#include "detail/IntegrationSingleton.hh"
+class G4ParticleDefinition;
 
 namespace celeritas
 {
@@ -52,7 +49,7 @@ class TrackingManagerConstructor final : public G4VPhysicsConstructor
     //!@{
     //! \name Type aliases
     using LocalTransporterFromThread = std::function<LocalTransporter*(int)>;
-    using VecG4PD = SetupOptions::VecG4PD;
+    using VecG4PD = std::vector<G4ParticleDefinition*>;
     //!@}
 
   public:


### PR DESCRIPTION
It's an odd subtlety that a tracking manager gets created for the master thread in an MT run, even though it will never be sent any tracks. A minor change avoids accessing the static `LocalTransporter` on the master thread, and it documents some of the oddities.