### PR TITLE
Centralize default capacity values

### DIFF
--- a/app/celer-g4/RunInput.hh
+++ b/app/celer-g4/RunInput.hh
@@ -78,10 +78,10 @@ struct RunInput
     PrimaryGeneratorOptions primary_options;
 
     // Control
-    size_type num_track_slots{};  //!< Defaults to 2^18 on device, 2^10 on host
+    size_type num_track_slots{};
     size_type max_steps{unspecified};
-    size_type initializer_capacity{};  //!< Defaults to 8 * num_track_slots
-    real_type secondary_stack_factor{2};
+    size_type initializer_capacity{};
+    real_type secondary_stack_factor{};
     size_type auto_flush{};  //!< Defaults to num_track_slots
 
     bool action_times{false};

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -101,6 +101,7 @@ void from_json(nlohmann::json const& j, RunInput& v)
     RI_LOAD_DEFAULT(num_track_slots, capacity.tracks / num_streams);
     RI_LOAD_OPTION(max_steps);
     RI_LOAD_DEFAULT(initializer_capacity, capacity.initializers / num_streams);
+    CELER_ASSERT(capacity.secondaries);
     RI_LOAD_DEFAULT(
         secondary_stack_factor,
         static_cast<real_type>(*capacity.secondaries) / capacity.tracks);

--- a/app/celer-g4/RunInputIO.json.cc
+++ b/app/celer-g4/RunInputIO.json.cc
@@ -13,9 +13,11 @@
 #include "corecel/io/StringEnumMapper.hh"
 #include "corecel/sys/Environment.hh"
 #include "corecel/sys/EnvironmentIO.json.hh"
+#include "geocel/GeantUtils.hh"
 #include "celeritas/TypesIO.json.hh"
 #include "celeritas/ext/GeantPhysicsOptionsIO.json.hh"
 #include "celeritas/field/FieldDriverOptionsIO.json.hh"
+#include "celeritas/inp/Control.hh"
 #include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
 
 namespace celeritas
@@ -88,19 +90,27 @@ void from_json(nlohmann::json const& j, RunInput& v)
     // DEPRECATED: remove in v1.0
     RI_LOAD_DEPRECATED(sync, action_times);
 
+    // Get default capacities *integrated* over streams
+    auto capacity = inp::CoreStateCapacity::from_default(
+        celeritas::Device::num_devices());
+
+    // celer-g4 input capacities are *per-stream*
+    size_type num_streams = get_geant_num_threads();
+
     RI_LOAD_OPTION(num_track_slots);
-    RI_LOAD_DEFAULT(num_track_slots,
-                    celeritas::Device::num_devices() ? 262144 : 1024);
+    RI_LOAD_DEFAULT(num_track_slots, capacity.tracks / num_streams);
     RI_LOAD_OPTION(max_steps);
-    RI_LOAD_DEFAULT(initializer_capacity, 8 * v.num_track_slots);
-    RI_LOAD_OPTION(secondary_stack_factor);
+    RI_LOAD_DEFAULT(initializer_capacity, capacity.initializers / num_streams);
+    RI_LOAD_DEFAULT(
+        secondary_stack_factor,
+        static_cast<real_type>(*capacity.secondaries) / capacity.tracks);
     RI_LOAD_OPTION(action_times);
     if (j.count("default_stream"))
     {
         // DEPRECATED: remove in v1.0
         CELER_LOG(warning) << "Ignoring removed option 'default_stream'";
     }
-    RI_LOAD_DEFAULT(auto_flush, v.num_track_slots);
+    RI_LOAD_DEFAULT(auto_flush, capacity.primaries / num_streams);
 
     RI_LOAD_OPTION(track_order);
 

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -60,7 +60,7 @@ struct RunnerInput
 
     struct OpticalOptions
     {
-        // Sizes are divided among streams
+        // *Per-process* capacities
         size_type num_track_slots{};  //!< Number of optical loop tracks slots
         size_type buffer_capacity{};  //!< Number of steps that created photons
         size_type auto_flush{};  //!< Threshold number of primaries for
@@ -114,14 +114,12 @@ struct RunnerInput
 
     // Control
     unsigned int seed{};
-    size_type num_track_slots{};  //!< Divided among streams. Defaults to 2^20
-                                  //!< on device, 2^12 on host
-    size_type initializer_capacity{};  //!< Divided among streams. Defaults to
-                                       //!< 8 * num_track_slots
+    size_type num_track_slots{};  //!< Per-process track slots
+    size_type initializer_capacity{};  //!< Per-process initializer buffer size
+    real_type secondary_stack_factor{};
     size_type max_steps = static_cast<size_type>(-1);  //!< Step *iterations*
     InterpolationType interpolation{InterpolationType::linear};
     size_type poly_spline_order{1};
-    real_type secondary_stack_factor{2};
     bool use_device{};
     bool action_times{};
     bool merge_events{false};  //!< Run all events at once on a single stream

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -98,6 +98,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
     LDIO_LOAD_DEFAULT(num_track_slots, capacity.tracks);
     LDIO_LOAD_OPTION(max_steps);
     LDIO_LOAD_DEFAULT(initializer_capacity, capacity.initializers);
+    CELER_ASSERT(capacity.secondaries);
     LDIO_LOAD_DEFAULT(
         secondary_stack_factor,
         static_cast<real_type>(*capacity.secondaries) / capacity.tracks);

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -21,6 +21,7 @@
 #include "celeritas/TypesIO.json.hh"
 #include "celeritas/ext/GeantPhysicsOptionsIO.json.hh"
 #include "celeritas/field/FieldDriverOptionsIO.json.hh"
+#include "celeritas/inp/Control.hh"
 #include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
 #include "celeritas/user/RootStepWriterIO.json.hh"
 
@@ -90,10 +91,16 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
 
     LDIO_LOAD_OPTION(seed);
     LDIO_LOAD_REQUIRED(use_device);
-    LDIO_LOAD_DEFAULT(num_track_slots, v.use_device ? 1048576 : 4096);
+
+    // Get default capacities *integrated* over streams
+    auto capacity = inp::CoreStateCapacity::from_default(v.use_device);
+
+    LDIO_LOAD_DEFAULT(num_track_slots, capacity.tracks);
     LDIO_LOAD_OPTION(max_steps);
-    LDIO_LOAD_DEFAULT(initializer_capacity, 16 * v.num_track_slots);
-    LDIO_LOAD_OPTION(secondary_stack_factor);
+    LDIO_LOAD_DEFAULT(initializer_capacity, capacity.initializers);
+    LDIO_LOAD_DEFAULT(
+        secondary_stack_factor,
+        static_cast<real_type>(*capacity.secondaries) / capacity.tracks);
     LDIO_LOAD_OPTION(interpolation);
     LDIO_LOAD_OPTION(poly_spline_order);
     LDIO_LOAD_OPTION(action_times);

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -91,13 +91,27 @@ void ProblemSetup::operator()(inp::Problem& p) const
     // NOTE: old SetupOptions input *per stream*, but inp::Problem needs
     // *integrated* over streams
     p.control.capacity = [this, num_streams = p.control.num_streams] {
-        auto capacity = get_default(so, num_streams);
-        inp::CoreStateCapacity c;
-        c.tracks = capacity.tracks;
-        c.initializers = capacity.initializers;
-        c.primaries = capacity.primaries;
-        c.secondaries
-            = static_cast<size_type>(so.secondary_stack_factor * c.tracks);
+        auto c = inp::CoreStateCapacity::from_default(
+            celeritas::Device::num_devices());
+
+        // Override default values if capacities were specified
+        if (so.max_num_tracks)
+        {
+            c.tracks = so.max_num_tracks * num_streams;
+        }
+        if (so.initializer_capacity)
+        {
+            c.initializers = so.initializer_capacity * num_streams;
+        }
+        if (so.auto_flush)
+        {
+            c.primaries = so.auto_flush * num_streams;
+        }
+        if (so.secondary_stack_factor)
+        {
+            c.secondaries
+                = static_cast<size_type>(so.secondary_stack_factor * c.tracks);
+        }
         return c;
     }();
 
@@ -283,37 +297,6 @@ inp::FrameworkInput to_inp(SetupOptions const& so)
     result.physics_import.data_selection.processes = selection;
 
     result.adjust = ProblemSetup{so};
-    return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get runtime-dependent default capacity values.
- *
- * \note This must be called after CUDA/MPI have been initialized.
- */
-inp::CoreStateCapacity
-get_default(SetupOptions const& so, size_type num_streams)
-{
-    inp::CoreStateCapacity result;
-    result.tracks = num_streams * [&so] {
-        if (so.max_num_tracks)
-        {
-            return static_cast<size_type>(so.max_num_tracks);
-        }
-        if (celeritas::Device::num_devices())
-        {
-            constexpr size_type device_default = 262144;
-            return device_default;
-        }
-        constexpr size_type host_default = 1024;
-        return host_default;
-    }();
-    result.initializers = so.initializer_capacity
-                              ? num_streams * so.initializer_capacity
-                              : 8 * result.tracks;
-    result.primaries = so.auto_flush ? so.auto_flush
-                                     : result.tracks / num_streams;
     return result;
 }
 

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -209,7 +209,7 @@ struct SetupOptions
     //! Maximum number of track initializers (primaries+secondaries)
     size_type initializer_capacity{};
     //! At least the average number of secondaries per track slot
-    real_type secondary_stack_factor{2.0};
+    real_type secondary_stack_factor{};
     //! Number of tracks to buffer before offloading (if unset: max num tracks)
     size_type auto_flush{};
     //!@}
@@ -290,10 +290,6 @@ inp::GeantSd to_inp(SDSetupOptions const& so);
 
 // Construct a framework input
 inp::FrameworkInput to_inp(SetupOptions const& so);
-
-// Get runtime-dependent default capacity values
-inp::CoreStateCapacity
-get_default(SetupOptions const& so, size_type num_streams);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/inp/Control.hh
+++ b/src/celeritas/inp/Control.hh
@@ -75,10 +75,19 @@ struct CoreStateCapacity : StateCapacity
     size_type initializers{};
     //! Maximum number of secondaries created per step
     std::optional<size_type> secondaries;
-
-    //! Maximum number of simultaneous events (zero for doing one event at a
-    //! time)
+    //! Maximum number of simultaneous events (zero for one event at a time)
     std::optional<size_type> events;
+
+    //! Return default values
+    static CoreStateCapacity from_default(bool use_device)
+    {
+        CoreStateCapacity result;
+        result.tracks = use_device ? 1048576 : 4096;
+        result.primaries = result.tracks;
+        result.initializers = 8 * result.tracks;
+        result.secondaries = 2 * result.tracks;
+        return result;
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -91,6 +100,16 @@ struct OpticalStateCapacity : StateCapacity
 {
     //! Maximum number of queued photon-generating steps
     size_type generators{};
+
+    //! Return default values
+    static OpticalStateCapacity from_default(bool use_device)
+    {
+        OpticalStateCapacity result;
+        result.tracks = use_device ? 1048576 : 4096;
+        result.primaries = 128 * result.tracks;
+        result.generators = 2 * result.tracks;
+        return result;
+    }
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This moves the default capacity values, which were previously defined in accel/celer-sim/celer-g4, to `inp::StateCapacity`. 