### PR TITLE
Ignore `BUILTIN_X` when `CELERITAS_USE_X` is false

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -55,7 +55,7 @@ jobs:
             geometry: "orange"
             special: "static"
             geant: "11.3"
-          - build_type: "reldebinfo"
+          - build_type: "reldeb"
             geometry: "orange"
             special: "asanlite"
             geant: null
@@ -85,7 +85,7 @@ jobs:
             geant: "11.3"
     env:
       CCACHE_DIR: "${{github.workspace}}/.ccache"
-      CCACHE_MAXSIZE: "${{matrix.build_type == 'reldebinfo' && '500' || '300'}}Mi"
+      CCACHE_MAXSIZE: "${{matrix.build_type == 'reldeb' && '500' || '300'}}Mi"
       CMAKE_PRESET: >-
         ${{format('{0}-{1}{2}{3}',
                   matrix.build_type,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 
 # Optional dependencies
 celeritas_optional_package(covfie "Use Covfie field integrator")
+celeritas_optional_package(DD4hep "Enable DD4hep integration")
 celeritas_optional_package(Geant4 "Enable Geant4 adapter tools")
 celeritas_optional_package(HepMC3 "Enable HepMC3 event record reader")
 celeritas_optional_package(LArSoft "Build LArSoft data interfaces")
@@ -42,7 +43,6 @@ celeritas_optional_package(PNG "Enable PNG output with libpng")
 celeritas_optional_package(Python "Use Python for documentation and testing")
 celeritas_optional_package(ROOT "Enable ROOT I/O")
 celeritas_optional_package(VecGeom "Use VecGeom geometry")
-celeritas_optional_package(DD4hep "Enable DD4hep integration")
 option(CELERITAS_USE_Perfetto "Perfetto tracing library" OFF)
 
 # Components
@@ -86,10 +86,16 @@ if(CELERITAS_BUILD_TESTS)
   mark_as_advanced(CELERITAS_TEST_XML)
 endif()
 
+if(CELERITAS_USE_VecGeom AND CELERITAS_USE_Geant4)
+  set(_needs_g4vg ON)
+else()
+  set(_needs_g4vg OFF)
+endif()
+
 # Automatic options
 celeritas_force_package(CLI11 ${CELERITAS_BUILD_APPS})
 celeritas_force_package(GTest ${CELERITAS_BUILD_TESTS})
-celeritas_force_package(G4VG ${CELERITAS_USE_VecGeom})
+celeritas_force_package(G4VG ${_needs_g4vg})
 celeritas_force_package(nlohmann_json ON)
 
 #----------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 # Automatic options
 celeritas_force_package(CLI11 ${CELERITAS_BUILD_APPS})
 celeritas_force_package(GTest ${CELERITAS_BUILD_TESTS})
+celeritas_force_package(G4VG ${CELERITAS_USE_VecGeom})
 celeritas_force_package(nlohmann_json ON)
 
 #----------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 # Automatic options
 celeritas_force_package(CLI11 ${CELERITAS_BUILD_APPS})
 celeritas_force_package(GTest ${CELERITAS_BUILD_TESTS})
+celeritas_force_package(nlohmann_json ON)
 
 #----------------------------------------------------------------------------#
 # PACKAGE-SPECIFIC OPTIONS

--- a/cmake/CeleritasConfig.cmake.in
+++ b/cmake/CeleritasConfig.cmake.in
@@ -98,6 +98,10 @@ elseif(CELERITAS_USE_HIP)
   find_dependency(hip REQUIRED QUIET)
 endif()
 
+if(CELERITAS_USE_DD4hep)
+  find_dependency(DD4hep REQUIRED)
+endif()
+
 if(CELERITAS_USE_Geant4)
   # Geant4 calls `include_directories` for CLHEP :( which is not what we want!
   # Save and restore include directories around the call -- even though as a
@@ -108,6 +112,10 @@ if(CELERITAS_USE_Geant4)
 
   # Re-establish policy if Geant4 11.1/.2's PTL overwrote it
   cmake_policy(VERSION 3.10...4.0)
+endif()
+
+if(CELERITAS_USE_G4VG AND NOT CELERITAS_BUILTIN_G4VG)
+  find_dependency(G4VG @G4VG_VERSION@ REQUIRED)
 endif()
 
 if(CELERITAS_USE_HepMC3)
@@ -161,14 +169,6 @@ if(CELERITAS_USE_VecGeom)
       "and Celeritas (CELERITAS_USE_CUDA=${CELERITAS_USE_CUDA})"
     )
   endif()
-
-  if(CELERITAS_USE_Geant4 AND NOT CELERITAS_BUILTIN_G4VG)
-    find_dependency(G4VG @G4VG_VERSION@ REQUIRED)
-  endif()
-endif()
-
-if(CELERITAS_USE_DD4hep)
-  find_dependency(DD4hep REQUIRED)
 endif()
 
 cmake_policy(POP)

--- a/cmake/CeleritasOptionUtils.cmake
+++ b/cmake/CeleritasOptionUtils.cmake
@@ -248,6 +248,7 @@ endmacro()
 macro(celeritas_force_package package value)
   set(_var "CELERITAS_USE_${package}")
   set(${_var} ${value})
+  message(VERBOSE "Celeritas: forced ${_var}=${value}")
   # Append to list of components
   _celeritas_append_optional_component(${package} "${value}")
   # Append to list of forced packages for export

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -60,6 +60,7 @@ if(CELERITAS_BUILTIN_covfie)
     "https://github.com/acts-project/covfie/archive/refs/tags/v@VERSION@.tar.gz"
     72da1147c44731caf9163f3931de78d7605a44f056f22a2f6ea024ad02a1ba71
   )
+
   set(COVFIE_PLATFORM_CPU ON)
   set(COVFIE_PLATFORM_CUDA ${CELERITAS_USE_CUDA})
   set(COVFIE_PLATFORM_HIP ${CELERITAS_USE_HIP})

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,26 +3,35 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #-----------------------------------------------------------------------------#
 
-# Print extra information about downloading: hash failures, for example, are
-# silent otherwise
-set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
-
 # Download the package, save version, add to a list
 set(_celer_builtin_packages)
 macro(celer_fetch_external name version url sha)
-  # Save version and annotated string for corecel/Config.cc include
-  set(${name}_VERSION ${version} PARENT_SCOPE)
-  set(${name}_VERSION_STRING "${version}+builtin" PARENT_SCOPE)
+  if(CELERITAS_BUILTIN_${name} AND NOT CELERITAS_USE_${name})
+    message(WARNING "Ignoring CELERITAS_BUILTIN_${name} "
+      "since CELERITAS_USE_${name} is disabled")
+  else()
+    # Save version and annotated string for corecel/Config.cc include
+    # Note that since this a macro, PARENT_SCOPE will be the top-level
+    # celeritas/CMakeLists.txt
+    set(${name}_VERSION ${version} PARENT_SCOPE)
+    set(${name}_VERSION_STRING "${version}+builtin" PARENT_SCOPE)
 
-  string(REGEX REPLACE "@VERSION@" "${version}" _url "${url}")
-  FetchContent_Declare(
-    "${name}"
-    URL "${_url}"
-    URL_HASH SHA256=${sha}
-    DOWNLOAD_NO_PROGRESS TRUE
-  )
-  list(APPEND _celer_builtin_packages "${name}")
+    string(REGEX REPLACE "@VERSION@" "${version}" _url "${url}")
+    FetchContent_Declare(
+      "${name}"
+      URL "${_url}"
+      URL_HASH SHA256=${sha}
+      DOWNLOAD_NO_PROGRESS TRUE
+    )
+    list(APPEND _celer_builtin_packages "${name}")
+  endif()
 endmacro()
+
+#-----------------------------------------------------------------------------#
+
+# Print extra information about downloading: hash failures, for example, are
+# silent otherwise
+set(CMAKE_MESSAGE_LOG_LEVEL VERBOSE)
 
 #-----------------------------------------------------------------------------#
 # CLI11

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -11,8 +11,15 @@
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_covfie": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_G4VG": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_GTest": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_nlohmann_json": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_TEST_VERBOSE":{"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_covfie":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_CUDA":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_DD4hep":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HIP":     {"type": "BOOL", "value": "OFF"},
@@ -24,7 +31,6 @@
         "CELERITAS_USE_Python":  {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_covfie": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_HOSTNAME": "ubuntu-github",
         "CELERITAS_TEST_XML": "$env{GITHUB_WORKSPACE}/test-output/google/",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
@@ -35,53 +41,61 @@
       }
     },
     {
-      "name": "spack",
+      "name": "tool-spack",
       "inherits": ["base", ".spack-base"],
       "displayName": "CONFIG: use full spack toolchain",
       "cacheVariables": {
         "CELERITAS_USE_covfie": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "ON"},
-        "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
-        "CELERITAS_USE_ROOT":    null,
-        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"}
+        "CELERITAS_USE_Geant4": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HepMC3": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_ROOT":    null
       }
     },
     {
-      "name": ".system",
+      "name": "tool-system",
       "inherits": ["base"],
-      "displayName": "CONFIG: build with apt-get dependencies",
+      "displayName": "TOOLCHAIN: build with apt-get dependencies",
       "cacheVariables": {
+        "BUILD_TESTING": {"type": "BOOL", "value": "ON"},
         "CELERITAS_BUILTIN_CLI11": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILTIN_G4VG": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_BUILTIN_GTest": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILTIN_covfie": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILTIN_nlohmann_json": {"type": "BOOL", "value": "OFF"}
+        "CELERITAS_BUILTIN_covfie": {"type": "BOOL", "value": "ON"}
       }
     },
     {
       "name": ".vecgeom",
+      "hidden": true,
       "description": "CONFIG: options to enable VecGeom on Ubuntu",
       "cacheVariables": {
         "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "ON"}
       }
     },
     {
+      "name": ".nogtest",
+      "hidden": true,
+      "description": "CONFIG: disable googletest",
+      "cacheVariables": {
+        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILTIN_GTest": {"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
       "name": "doc",
-      "inherits": [".system"],
+      "inherits": [".nogtest", "tool-system"],
       "displayName": "FINAL: build only documentation",
       "cacheVariables": {
         "BUILD_TESTING": {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_BUILD_APPS":  {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILD_APPS": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_BUILD_DOCS": {"type": "BOOL", "value": "ON"},
+        "CELERITAS_DEBUG": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_DOXYGEN_BUILD_TESTS": {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_covfie":  {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_PNG":     {"type": "BOOL", "value": "OFF"}
+        "CELERITAS_USE_covfie": {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_PNG": {"type": "BOOL", "value": "OFF"}
       }
     },
     {
       "name": "type-reldeb",
+      "hidden": true,
       "description": "TYPE: debug assertions but no debug symbols",
       "cacheVariables": {
         "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
@@ -91,17 +105,16 @@
     },
     {
       "name": "type-ndebug",
-      "description": "TYPE: release build for testing *only* apps",
+      "hidden": true,
+      "description": "TYPE: release build",
       "cacheVariables": {
-        "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
-        "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
-        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "Release"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"}
+        "CELERITAS_DEBUG": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "Release"}
       }
     },
     {
       "name": "fast",
-      "inherits": ["type-reldeb", ".system"],
+      "inherits": ["type-reldeb", "tool-system"],
       "displayName": "FINAL: fast build using apt-get",
       "cacheVariables": {
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"}
@@ -109,36 +122,25 @@
     },
     {
       "name": "ultralite",
-      "inherits": ["type-ndebug", ".system"],
-      "displayName": "FINAL: ultralite build with only app tests",
-      "cacheVariables": {
-        "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_covfie":  {"type": "BOOL", "value": "OFF"}
-      }
+      "inherits": [".nogtest", "type-ndebug", "tool-system"],
+      "displayName": "FINAL: ultralite build with only app tests"
     },
     {
       "name": "ultralite-codecov",
-      "inherits": ["type-ndebug", ".system", ".gcov"],
-      "displayName": "FINAL: ultralite code coverage with only app tests",
-      "cacheVariables": {
-        "BUILD_TESTING":         {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
-        "CELERITAS_USE_covfie":  {"type": "BOOL", "value": "OFF"}
-      }
+      "inherits": [".nogtest", ".gcov", "type-ndebug", "tool-system"],
+      "displayName": "FINAL: ultralite code coverage with only app tests"
     },
     {
       "name": "reldeb-orange",
       "description": "FINAL: ORANGE",
-      "inherits": ["type-reldeb", "spack"]
+      "inherits": ["type-reldeb", "tool-spack"]
     },
     {
       "name": "reldeb-vecgeom-tidy",
       "description": "FINAL: VecGeom and clang-tidy checks",
-      "inherits": ["type-reldeb", ".vecgeom", "spack"],
+      "inherits": [".nogtest", ".vecgeom", "type-reldeb", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "ON"},
-        "CELERITAS_BUILD_TESTS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "ON"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "ON"},
         "CMAKE_CXX_SCAN_FOR_MODULES":  {"type": "BOOL", "value": "OFF"},
@@ -149,7 +151,7 @@
     {
       "name": "reldeb-vecgeom-clhep",
       "description": "FINAL: VecGeom and CLHEP units",
-      "inherits": ["type-reldeb", ".vecgeom", "spack"],
+      "inherits": [".vecgeom", "type-reldeb", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_UNITS": "CLHEP"
       }
@@ -157,17 +159,17 @@
     {
       "name": "reldeb-vecgeom",
       "description": "FINAL: release, assertions, VecGeom",
-      "inherits": ["type-reldeb", ".vecgeom", "spack"]
+      "inherits": [".vecgeom", "type-reldeb", "tool-spack"]
     },
     {
       "name": "reldeb-vecgeom-codecov",
       "description": "FINAL: VecGeom and code coverage",
-      "inherits": ["type-reldeb", ".vecgeom", ".gcov", "spack"]
+      "inherits": [".vecgeom", ".gcov", "type-reldeb", "tool-spack"]
     },
     {
       "name": "reldeb-vgsurf",
       "description": "FINAL: release, assertions, VecGeom 2+surf",
-      "inherits": ["type-reldeb", ".vecgeom", "spack"],
+      "inherits": [".vecgeom", "type-reldeb", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_VecGeom_SURFACE": {"type": "BOOL", "value": "ON"}
       }
@@ -175,7 +177,7 @@
     {
       "name": "reldeb-vecgeom2",
       "description": "FINAL: release, assertions, VecGeom 2~surf",
-      "inherits": ["type-reldeb", ".vecgeom", "spack"],
+      "inherits": [".vecgeom", "type-reldeb", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_VecGeom_SURFACE": {"type": "BOOL", "value": "OFF"}
       }
@@ -183,12 +185,12 @@
     {
       "name": "ndebug-vecgeom",
       "description": "FINAL: vecgeom app only",
-      "inherits": ["type-ndebug", ".vecgeom", "spack"]
+      "inherits": [".vecgeom", ".nogtest", "type-ndebug", "tool-spack"]
     },
     {
       "name": "ndebug-orange-static",
       "description": "FINAL: static libraries and perfetto, no tests",
-      "inherits": ["type-ndebug", "spack"],
+      "inherits": ["type-ndebug", "tool-spack"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Perfetto":{"type": "BOOL", "value": "ON"},
@@ -199,7 +201,7 @@
     {
       "name": "reldeb-geant4",
       "description": "FINAL: Geant4 geometry",
-      "inherits": ["type-reldeb", "spack"],
+      "inherits": ["type-reldeb", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_CORE_GEO": "Geant4",
         "CELERITAS_UNITS": "CLHEP"
@@ -208,7 +210,7 @@
     {
       "name": "reldeb-orange-minimal",
       "description": "FINAL: minimal reasonable dependencies",
-      "inherits": ["type-reldeb", "spack"],
+      "inherits": ["type-reldeb", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
@@ -220,7 +222,7 @@
     {
       "name": "reldeb-orange-asanlite",
       "description": "FINAL: address sanitizer flags and debug symbols",
-      "inherits": ["spack"],
+      "inherits": ["tool-spack"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS":{"type": "BOOL", "value": "ON"},
         "CELERITAS_DEBUG":       {"type": "BOOL", "value": "OFF"},
@@ -234,7 +236,7 @@
     {
       "name": "reldeb-orange-float",
       "description": "FINAL: single-precision arithmetic",
-      "inherits": ["type-reldeb", "spack"],
+      "inherits": ["type-reldeb", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_REAL_TYPE": "float"
       }
@@ -296,12 +298,12 @@
     },
     {
       "name": "spack-unit",
-      "configurePreset": "spack",
+      "configurePreset": "tool-spack",
       "inherits": [".unit", ".base"]
     },
     {
       "name": "spack-app",
-      "configurePreset": "spack",
+      "configurePreset": "tool-spack",
       "inherits": [".app", ".base"]
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -218,7 +218,7 @@
       }
     },
     {
-      "name": "reldebinfo-orange-asanlite",
+      "name": "reldeb-orange-asanlite",
       "description": "FINAL: address sanitizer flags and debug symbols",
       "inherits": ["spack"],
       "cacheVariables": {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -16,6 +16,7 @@
         "CELERITAS_USE_Geant4":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HepMC3":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_HIP":     {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_LarSoft": {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_MPI":     {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "OFF"},
         "CELERITAS_USE_Perfetto":{"type": "BOOL", "value": "OFF"},


### PR DESCRIPTION
This fixes an issue where dependencies such as covfie would be downloaded even when unused. Related to those changes, the github ubuntu cmake presets have been broken apart for an increase in modularity.

Split off #2184.