### PR TITLE
Fix edge cases with optical setup and runtime

### DIFF
--- a/src/celeritas/optical/PhysicsStepUtils.hh
+++ b/src/celeritas/optical/PhysicsStepUtils.hh
@@ -33,12 +33,16 @@ inline CELER_FUNCTION StepLimit calc_physics_step_limit(
         total_xs += physics.calc_xs(model, particle.energy());
     }
     physics.macro_xs(total_xs);
-
-    CELER_ASSERT(physics.macro_xs() > 0);
+    CELER_ASSERT(physics.macro_xs() >= 0);
 
     StepLimit limit;
     limit.action = physics.discrete_action();
     limit.step = physics.interaction_mfp() / total_xs;
+
+    if (CELER_UNLIKELY(total_xs == 0))
+    {
+        limit.action = {};
+    }
 
     return limit;
 }

--- a/test/accel/CMakeLists.txt
+++ b/test/accel/CMakeLists.txt
@@ -102,13 +102,16 @@ celeritas_add_integration_tests(
   RMTYPE serial mt
 )
 
+#-----------------------------------------------------------------------------#
+# Disable MT Geant4 geometry for optical physics
+#-----------------------------------------------------------------------------#
+
 set(_optical_rm_type "serial")
 if(NOT (CELERITAS_CORE_GEO STREQUAL "Geant4"))
   list(APPEND _optical_rm_type "mt")
 endif()
 
-# Test with optical physics, except that currently trying to use Geant4
-# navigation for the optical tracks wreaks havoc
+# Test optical
 celeritas_add_integration_tests(
   TrackingManagerIntegration LarSphereOptical run
   OFFLOAD cpu gpu g4
@@ -118,6 +121,13 @@ celeritas_add_integration_tests(
 # Test with optical physics offloading distributions
 celeritas_add_integration_tests(
   UserActionIntegration LarSphereOpticalOffload run
+  OFFLOAD cpu gpu g4
+  RMTYPE ${_optical_rm_type}
+)
+
+# Test optical surface physics
+celeritas_add_integration_tests(
+  TrackingManagerIntegration OpticalSurfaces run
   OFFLOAD cpu gpu g4
   RMTYPE ${_optical_rm_type}
 )

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -383,6 +383,26 @@ auto IntegrationTestBase::make_sens_det(std::string const&) -> UPSensDet
 }
 
 //---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+void enable_optical_physics(IntegrationTestBase::PhysicsInput& phys_inp)
+{
+    // Set default optical physics
+    auto& optical = phys_inp.optical;
+    optical = {};
+    EXPECT_TRUE(optical);
+    EXPECT_TRUE(optical.cherenkov);
+    EXPECT_TRUE(optical.scintillation);
+
+    // Disable WLS which isn't yet working (reemission) in Celeritas
+    using WLSO = WavelengthShiftingOptions;
+    optical.wavelength_shifting = WLSO::deactivated();
+    optical.wavelength_shifting2 = WLSO::deactivated();
+}
+
+//---------------------------------------------------------------------------//
+// TEST PROBLEM MIXINS
+//---------------------------------------------------------------------------//
 /*!
  * Create physics list: default is EM only using make_physics_input.
  */

--- a/test/accel/IntegrationTestBase.hh
+++ b/test/accel/IntegrationTestBase.hh
@@ -110,6 +110,14 @@ class IntegrationTestBase : public ::celeritas::test::Test
 };
 
 //---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+
+void enable_optical_physics(IntegrationTestBase::PhysicsInput&);
+
+//---------------------------------------------------------------------------//
+// TEST PROBLEM MIXINS
+//---------------------------------------------------------------------------//
 //! Generate LAr sphere geometry with 10 MeV electrons and functional hit call
 class LarSphereIntegrationMixin : virtual public IntegrationTestBase
 {

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -14,11 +14,13 @@
 #include <G4UserTrackingAction.hh>
 #include <G4VModularPhysicsList.hh>
 
+#include "corecel/cont/Array.hh"
 #include "corecel/io/Logger.hh"
 #include "geocel/GeantUtils.hh"
 #include "geocel/UnitUtils.hh"
 #include "celeritas/ext/GeantParticleView.hh"
 #include "celeritas/global/CoreState.hh"
+#include "celeritas/inp/Events.hh"
 #include "celeritas/optical/CoreState.hh"
 #include "celeritas/optical/OpticalCollector.hh"
 #include "celeritas/phys/PDGNumber.hh"
@@ -49,6 +51,39 @@ bool is_running_events()
 constexpr bool using_surface_vg = CELERITAS_VECGEOM_SURFACE
                                   && CELERITAS_CORE_GEO
                                          == CELERITAS_CORE_GEO_VECGEOM;
+
+/*!
+ * Count particle types.
+ */
+class CounterTrackingAction final : public G4UserTrackingAction
+{
+  public:
+    void PreUserTrackingAction(G4Track const* t) final
+    {
+        GeantParticleView particle{*t->GetParticleDefinition()};
+
+        if (particle.pdg() == pdg::electron())
+        {
+            ++num_electrons_;
+        }
+        if (particle.pdg() == pdg::positron())
+        {
+            ++num_positrons_;
+        }
+        else if (particle.is_optical_photon())
+        {
+            ++num_photons_;
+        }
+    }
+    std::size_t num_photons() const { return num_photons_; }
+    std::size_t num_electrons() const { return num_electrons_; }
+    std::size_t num_positrons() const { return num_positrons_; }
+
+  private:
+    std::size_t num_photons_{};
+    std::size_t num_electrons_{};
+    std::size_t num_positrons_{};
+};
 
 }  // namespace
 
@@ -101,6 +136,8 @@ class TMITestBase : virtual public IntegrationTestBase
     std::function<void()> check_during_run_;
 };
 
+//---------------------------------------------------------------------------//
+// LAR SPHERE
 //---------------------------------------------------------------------------//
 class LarSphere : public LarSphereIntegrationMixin, public TMITestBase
 {
@@ -215,54 +252,36 @@ TEST_F(LarSphere, run_ui)
 // LAR SPHERE WITH OPTICAL
 //---------------------------------------------------------------------------//
 /*!
- * Count particle types.
- *
- * \todo This is redundant with (but more "Geant4-like" than)
- * \c GeantStepDiagnostic .
- */
-class TrackingAction : public G4UserTrackingAction
-{
-  public:
-    void PreUserTrackingAction(G4Track const* t)
-    {
-        GeantParticleView particle{*t->GetParticleDefinition()};
-
-        if (particle.pdg() == pdg::electron())
-        {
-            ++num_electrons_;
-        }
-        if (particle.pdg() == pdg::positron())
-        {
-            ++num_positrons_;
-        }
-        else if (particle.is_optical_photon())
-        {
-            ++num_photons_;
-        }
-    }
-    std::size_t num_photons() const { return num_photons_; }
-    std::size_t num_electrons() const { return num_electrons_; }
-    std::size_t num_positrons() const { return num_positrons_; }
-
-  private:
-    std::size_t num_photons_{};
-    std::size_t num_electrons_{};
-    std::size_t num_positrons_{};
-};
-
-/*!
  * Test the LarSphere, offloading both EM tracks *and* optical photons.
  */
 class LarSphereOptical : public LarSphere
 {
   public:
-    PhysicsInput make_physics_input() const override;
-    PrimaryInput make_primary_input() const override;
+    PhysicsInput make_physics_input() const override
+    {
+        auto result = LarSphere::make_physics_input();
+        enable_optical_physics(result);
+        return result;
+    }
+
+    PrimaryInput make_primary_input() const override
+    {
+        auto result = LarSphereIntegrationMixin::make_primary_input();
+
+        result.shape = inp::PointDistribution{
+            array_cast<double>(from_cm({0.1, 0.1, 0}))};
+        result.primaries_per_event = 1;
+        result.energy = inp::MonoenergeticDistribution{2};  // [MeV]
+        return result;
+    }
+
     SetupOptions make_setup_options() override;
+
     void EndOfRunAction(G4Run const* run) override;
+
     UPTrackAction make_tracking_action() override
     {
-        auto result = std::make_unique<TrackingAction>();
+        auto result = std::make_unique<CounterTrackingAction>();
         {
             // Store the raw pointer in the tracking_ vector using a static
             // mutex
@@ -274,42 +293,8 @@ class LarSphereOptical : public LarSphere
     }
 
   private:
-    std::vector<TrackingAction*> tracking_;
+    std::vector<CounterTrackingAction*> tracking_;
 };
-
-//---------------------------------------------------------------------------//
-/*!
- * Enable optical physics.
- */
-auto LarSphereOptical::make_physics_input() const -> PhysicsInput
-{
-    auto result = LarSphereIntegrationMixin::make_physics_input();
-
-    // Set default optical physics
-    auto& optical = result.optical;
-    optical = {};
-    EXPECT_TRUE(optical);
-    EXPECT_TRUE(optical.cherenkov);
-    EXPECT_TRUE(optical.scintillation);
-
-    // Disable WLS which isn't yet working (reemission) in Celeritas
-    using WLSO = WavelengthShiftingOptions;
-    optical.wavelength_shifting = WLSO::deactivated();
-    optical.wavelength_shifting2 = WLSO::deactivated();
-
-    return result;
-}
-
-auto LarSphereOptical::make_primary_input() const -> PrimaryInput
-{
-    auto result = LarSphereIntegrationMixin::make_primary_input();
-
-    result.shape
-        = inp::PointDistribution{array_cast<double>(from_cm({0.1, 0.1, 0}))};
-    result.primaries_per_event = 1;
-    result.energy = inp::MonoenergeticDistribution{2};  // [MeV]
-    return result;
-}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -416,6 +401,9 @@ TEST_F(LarSphereOptical, run)
     rm.BeamOn(2);
 }
 
+//---------------------------------------------------------------------------//
+// OPNOVICE
+//---------------------------------------------------------------------------//
 /*!
  * Test the Op-Novice example, offloading optical photons.
  */
@@ -425,7 +413,7 @@ class OpNoviceOptical : public OpNoviceIntegrationMixin, public TMITestBase
     void EndOfRunAction(G4Run const* run) override;
     UPTrackAction make_tracking_action() override
     {
-        auto result = std::make_unique<TrackingAction>();
+        auto result = std::make_unique<CounterTrackingAction>();
         {
             // Store the raw pointer in the tracking_ vector using a static
             // mutex
@@ -437,7 +425,7 @@ class OpNoviceOptical : public OpNoviceIntegrationMixin, public TMITestBase
     }
 
   private:
-    std::vector<TrackingAction*> tracking_;
+    std::vector<CounterTrackingAction*> tracking_;
 };
 
 //---------------------------------------------------------------------------//
@@ -524,6 +512,127 @@ TEST_F(OpNoviceOptical, run)
     rm.Initialize();
     CELER_LOG(status) << "Run two events";
     rm.BeamOn(10);
+}
+
+//---------------------------------------------------------------------------//
+// OPTICAL SURFACES
+//---------------------------------------------------------------------------//
+/*!
+ * Test the LarSphere, offloading both EM tracks *and* optical photons.
+ */
+class OpticalSurfaces : public TMITestBase
+{
+  public:
+    std::string_view gdml_basename() const final { return "optical-surfaces"; }
+    PhysicsInput make_physics_input() const override
+    {
+        auto result = TMITestBase::make_physics_input();
+        enable_optical_physics(result);
+        return result;
+    }
+
+    PrimaryInput make_primary_input() const override;
+    SetupOptions make_setup_options() override;
+    void EndOfRunAction(G4Run const* run) override;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Fire positrons through the liquid argon toward the detectors.
+ */
+auto OpticalSurfaces::make_primary_input() const -> PrimaryInput
+{
+    PrimaryInput result;
+    result.pdg = {pdg::positron()};
+    result.shape
+        = inp::PointDistribution{array_cast<double>(from_cm({30, 0, 0}))};
+    result.angle = inp::MonodirectionalDistribution{{-1, 0, 0}};
+    result.energy = inp::MonoenergeticDistribution{10};  // [MeV]
+    result.primaries_per_event = 1;
+    result.num_events = 4;  // Overridden with BeamOn
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Enable optical tracking.
+ */
+auto OpticalSurfaces::make_setup_options() -> SetupOptions
+{
+    auto result = TMITestBase::make_setup_options();
+
+    result.sd.enabled = false;
+    result.optical = [] {
+        OpticalSetupOptions opt;
+        opt.capacity.tracks = 32768;
+        opt.capacity.generators = 32768 * 8;
+        opt.capacity.primaries = opt.capacity.generators;
+        return opt;
+    }();
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Test that the optical tracking loop completed correctly.
+ *
+ * - Generator counters show whether any photons are queued but not run
+ * - Accumulated stats show whether the state has run some photons
+ */
+void OpticalSurfaces::EndOfRunAction(G4Run const* run)
+{
+    auto& integration = detail::IntegrationSingleton::instance();
+    if (integration.mode() == OffloadMode::enabled)
+    {
+        auto& local_transporter = integration.local_transporter();
+        auto const& shared_params = integration.shared_params();
+
+        // Check that local/shared data is available before end of run
+        EXPECT_EQ(is_running_events(), static_cast<bool>(local_transporter));
+        EXPECT_TRUE(shared_params) << "Celeritas was not enabled";
+
+        auto const& optical_collector = shared_params.optical_collector();
+        EXPECT_TRUE(optical_collector) << "optical offloading was not enabled";
+        if (local_transporter && optical_collector)
+        {
+            // Use diagnostic methods to check counters
+            auto const& accum_stats
+                = optical_collector->optical_state(local_transporter.GetState())
+                      .accum();
+            CELER_LOG_LOCAL(info)
+                << "Ran " << accum_stats.steps << " over "
+                << accum_stats.step_iters << " step iterations from "
+                << accum_stats.flushes << " flushes";
+            EXPECT_GT(accum_stats.steps, 0);
+            EXPECT_GT(accum_stats.step_iters, 0);
+            EXPECT_GT(accum_stats.flushes, 0);
+
+            auto& aux_state = local_transporter.GetState().aux();
+            auto counts = optical_collector->buffer_counts(aux_state);
+            EXPECT_EQ(0, counts.buffer_size);  //!< Pending generators
+            EXPECT_EQ(0, counts.num_pending);  //!< Photons pending generation
+            EXPECT_EQ(0, counts.num_generated);  //!< Photons generated
+        }
+    }
+
+    // Continue cleanup and other checks at end of run
+    TMITestBase::EndOfRunAction(run);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Check that the test runs.
+ */
+TEST_F(OpticalSurfaces, run)
+{
+    auto& rm = this->run_manager();
+    TMI::Instance().SetOptions(this->make_setup_options());
+
+    CELER_LOG(status) << "Run initialization";
+    rm.Initialize();
+    CELER_LOG(status) << "Run two events";
+    rm.BeamOn(2);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This adds a high-level coverage test for optical physics with surfaces, originally targeting #1928 , but using a test input that discovered two edge cases we didn't account for:

- Total cross section can be exactly zero in vacuum
- Not all optical materials have to be used in the geometry (we could turn this into a warning instead of a subtle informational message)