### PR TITLE
Tweak optical problem setup

### DIFF
--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -59,7 +59,7 @@ build_params_refs(CoreParams::Input const& p, CoreScalars const& scalars)
     ref.sim = get_ref<M>(*p.sim);
     ref.surface = get_ref<M>(*p.surface);
     ref.surface_physics = get_ref<M>(*p.surface_physics);
-    ref.detectors = get_ref<M>(*p.detectors);
+    // TODO: Get detectors ref
     if (p.cherenkov)
     {
         ref.cherenkov = get_ref<M>(*p.cherenkov);
@@ -124,7 +124,7 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     CP_VALIDATE_INPUT(sim);
     CP_VALIDATE_INPUT(surface);
     CP_VALIDATE_INPUT(surface_physics);
-    CP_VALIDATE_INPUT(detectors);
+    // TODO: input and validate detectors
     CP_VALIDATE_INPUT(action_reg);
     CP_VALIDATE_INPUT(gen_reg);
     CP_VALIDATE_INPUT(max_streams);

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -20,6 +20,7 @@
 #include "celeritas/optical/OpticalSizes.json.hh"
 #include "celeritas/phys/GeneratorRegistry.hh"
 #include "celeritas/track/SimParams.hh"
+#include "celeritas/user/SDParams.hh"
 
 #include "CoreState.hh"
 #include "MaterialParams.hh"
@@ -124,7 +125,6 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     CP_VALIDATE_INPUT(sim);
     CP_VALIDATE_INPUT(surface);
     CP_VALIDATE_INPUT(surface_physics);
-    // TODO: input and validate detectors
     CP_VALIDATE_INPUT(action_reg);
     CP_VALIDATE_INPUT(gen_reg);
     CP_VALIDATE_INPUT(max_streams);
@@ -132,6 +132,11 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
 
     CELER_EXPECT(input_);
 
+    // TODO: require and validate detectors
+    if (!input_.detectors)
+    {
+        input_.detectors = std::make_shared<SDParams>();
+    }
     if (!input_.aux_reg)
     {
         input_.aux_reg = std::make_shared<AuxParamsRegistry>();

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -55,11 +55,11 @@ build_params_refs(CoreParams::Input const& p, CoreScalars const& scalars)
     ref.geometry = get_ref<M>(*p.geometry);
     ref.material = get_ref<M>(*p.material);
     ref.physics = get_ref<M>(*p.physics);
-    ref.surface = get_ref<M>(*p.surface);
-    ref.surface_physics = get_ref<M>(*p.surface_physics);
     ref.rng = get_ref<M>(*p.rng);
     ref.sim = get_ref<M>(*p.sim);
-    // TODO: Get detectors ref
+    ref.surface = get_ref<M>(*p.surface);
+    ref.surface_physics = get_ref<M>(*p.surface_physics);
+    ref.detectors = get_ref<M>(*p.detectors);
     if (p.cherenkov)
     {
         ref.cherenkov = get_ref<M>(*p.cherenkov);
@@ -124,6 +124,7 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     CP_VALIDATE_INPUT(sim);
     CP_VALIDATE_INPUT(surface);
     CP_VALIDATE_INPUT(surface_physics);
+    CP_VALIDATE_INPUT(detectors);
     CP_VALIDATE_INPUT(action_reg);
     CP_VALIDATE_INPUT(gen_reg);
     CP_VALIDATE_INPUT(max_streams);
@@ -131,12 +132,6 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
 
     CELER_EXPECT(input_);
 
-    // TODO: provide detectors in input, passing from core params
-    detectors_ = input_.detectors;
-    if (!detectors_)
-    {
-        detectors_ = std::make_shared<SDParams>();
-    }
     if (!input_.aux_reg)
     {
         input_.aux_reg = std::make_shared<AuxParamsRegistry>();

--- a/src/celeritas/optical/CoreParams.hh
+++ b/src/celeritas/optical/CoreParams.hh
@@ -6,14 +6,11 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <optional>
-
 #include "corecel/Assert.hh"
 #include "corecel/data/DeviceVector.hh"
 #include "corecel/data/ObserverPtr.hh"
 #include "corecel/data/ParamsDataInterface.hh"
 #include "corecel/random/params/RngParamsFwd.hh"
-#include "corecel/sys/Device.hh"
 #include "celeritas/geo/GeoFwd.hh"
 #include "celeritas/inp/Control.hh"
 #include "celeritas/user/SDParams.hh"
@@ -54,13 +51,15 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
     using SPConstSim = std::shared_ptr<SimParams const>;
     using SPConstSurface = std::shared_ptr<SurfaceParams const>;
     using SPConstSurfacePhysics = std::shared_ptr<SurfacePhysicsParams const>;
-    using SPActionRegistry = std::shared_ptr<ActionRegistry>;
-    using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
-    using SPAuxRegistry = std::shared_ptr<AuxParamsRegistry>;
-    using SPGeneratorRegistry = std::shared_ptr<GeneratorRegistry>;
     using SPConstDetectors = std::shared_ptr<SDParams const>;
+
     using SPConstCherenkov = std::shared_ptr<CherenkovParams const>;
     using SPConstScintillation = std::shared_ptr<ScintillationParams const>;
+
+    using SPActionRegistry = std::shared_ptr<ActionRegistry>;
+    using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
+    using SPGeneratorRegistry = std::shared_ptr<GeneratorRegistry>;
+    using SPAuxRegistry = std::shared_ptr<AuxParamsRegistry>;
 
     template<MemSpace M>
     using ConstRef = CoreParamsData<Ownership::const_reference, M>;
@@ -70,6 +69,13 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
 
     struct Input
     {
+        // Registries
+        SPActionRegistry action_reg;
+        SPOutputRegistry output_reg;
+        SPGeneratorRegistry gen_reg;
+        SPAuxRegistry aux_reg;  //!< Optional, empty default
+
+        // Problem definition and state
         SPConstCoreGeo geometry;
         SPConstMaterial material;
         SPConstPhysics physics;
@@ -78,13 +84,9 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
         SPConstSurface surface;
         SPConstSurfacePhysics surface_physics;
         SPConstDetectors detectors;
+
         SPConstCherenkov cherenkov;  //!< Optional
         SPConstScintillation scintillation;  //!< Optional
-
-        SPActionRegistry action_reg;
-        SPOutputRegistry output_reg;
-        SPGeneratorRegistry gen_reg;
-        SPAuxRegistry aux_reg;  //!< Optional, empty default
 
         //! Maximum number of simultaneous threads/tasks per process
         StreamId::size_type max_streams{1};
@@ -131,7 +133,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
     SPOutputRegistry const& output_reg() const { return input_.output_reg; }
     SPAuxRegistry const& aux_reg() const { return input_.aux_reg; }
     SPGeneratorRegistry const& gen_reg() const { return input_.gen_reg; }
-    SPConstDetectors const& detectors() const { return detectors_; }
+    SPConstDetectors const& detectors() const { return input_.detectors; }
     SPConstCherenkov const& cherenkov() const { return input_.cherenkov; }
     SPConstScintillation const& scintillation() const
     {
@@ -156,8 +158,6 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
 
     // Copy of DeviceRef in device memory
     DeviceVector<DeviceRef> device_ref_vec_;
-
-    SPConstDetectors detectors_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/CoreParams.hh
+++ b/src/celeritas/optical/CoreParams.hh
@@ -13,7 +13,6 @@
 #include "corecel/random/params/RngParamsFwd.hh"
 #include "celeritas/geo/GeoFwd.hh"
 #include "celeritas/inp/Control.hh"
-#include "celeritas/user/SDParams.hh"
 
 #include "CoreTrackData.hh"
 
@@ -27,6 +26,7 @@ class GeneratorRegistry;
 class OutputRegistry;
 class ScintillationParams;
 class SurfaceParams;
+class SDParams;
 
 namespace optical
 {
@@ -44,6 +44,11 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
   public:
     //!@{
     //! \name Type aliases
+    using SPActionRegistry = std::shared_ptr<ActionRegistry>;
+    using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
+    using SPGeneratorRegistry = std::shared_ptr<GeneratorRegistry>;
+    using SPAuxRegistry = std::shared_ptr<AuxParamsRegistry>;
+
     using SPConstCoreGeo = std::shared_ptr<CoreGeoParams const>;
     using SPConstMaterial = std::shared_ptr<MaterialParams const>;
     using SPConstPhysics = std::shared_ptr<PhysicsParams const>;
@@ -55,11 +60,6 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
 
     using SPConstCherenkov = std::shared_ptr<CherenkovParams const>;
     using SPConstScintillation = std::shared_ptr<ScintillationParams const>;
-
-    using SPActionRegistry = std::shared_ptr<ActionRegistry>;
-    using SPOutputRegistry = std::shared_ptr<OutputRegistry>;
-    using SPGeneratorRegistry = std::shared_ptr<GeneratorRegistry>;
-    using SPAuxRegistry = std::shared_ptr<AuxParamsRegistry>;
 
     template<MemSpace M>
     using ConstRef = CoreParamsData<Ownership::const_reference, M>;

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -12,7 +12,6 @@
 #include "geocel/SurfaceData.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/geo/GeoData.hh"
-#include "celeritas/user/SDData.hh"
 
 #include "CoreTrackDataFwd.hh"
 #include "MaterialData.hh"
@@ -56,7 +55,6 @@ struct CoreParamsData
     SimParamsData<W, M> sim;
     SurfaceParamsData<W, M> surface;
     SurfacePhysicsParamsData<W, M> surface_physics;
-    SDParamsData<W, M> detectors;
     CherenkovData<W, M> cherenkov;
     ScintillationData<W, M> scintillation;
 
@@ -81,7 +79,6 @@ struct CoreParamsData
         sim = other.sim;
         surface = other.surface;
         surface_physics = other.surface_physics;
-        detectors = other.detectors;
         cherenkov = other.cherenkov;
         scintillation = other.scintillation;
         scalars = other.scalars;

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -12,6 +12,7 @@
 #include "geocel/SurfaceData.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/geo/GeoData.hh"
+#include "celeritas/user/SDData.hh"
 
 #include "CoreTrackDataFwd.hh"
 #include "MaterialData.hh"
@@ -19,7 +20,6 @@
 #include "PhysicsData.hh"
 #include "SimData.hh"
 #include "TrackInitData.hh"
-#include "Types.hh"
 #include "gen/CherenkovData.hh"
 #include "gen/ScintillationData.hh"
 #include "surface/SurfacePhysicsData.hh"
@@ -56,6 +56,7 @@ struct CoreParamsData
     SimParamsData<W, M> sim;
     SurfaceParamsData<W, M> surface;
     SurfacePhysicsParamsData<W, M> surface_physics;
+    SDParamsData<W, M> detectors;
     CherenkovData<W, M> cherenkov;
     ScintillationData<W, M> scintillation;
 
@@ -80,9 +81,10 @@ struct CoreParamsData
         sim = other.sim;
         surface = other.surface;
         surface_physics = other.surface_physics;
-        scalars = other.scalars;
+        detectors = other.detectors;
         cherenkov = other.cherenkov;
         scintillation = other.scintillation;
+        scalars = other.scalars;
         return *this;
     }
 };
@@ -98,7 +100,6 @@ struct CoreStateData
     using Items = StateCollection<T, W, M>;
 
     GeoStateData<W, M> geometry;
-    // TODO: should we cache the material ID?
     ParticleStateData<W, M> particle;
     PhysicsStateData<W, M> physics;
     RngStateData<W, M> rng;

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -331,7 +331,7 @@ auto build_optical_params(inp::Problem const& p,
     pi.surface = core.surface();
     pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
         pi.action_reg.get(), p.physics.optical.surfaces);
-    pi.detectors = core.detectors();
+    // TODO: copy detectors from core
 
     // Photon generating processes
     if (p.physics.optical.cherenkov)
@@ -388,7 +388,7 @@ auto build_optical_params(inp::OpticalProblem const& p,
     pi.surface = std::move(loaded_model.surface);
     pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
         pi.action_reg.get(), p.physics.surfaces);
-    pi.detectors = std::move(loaded_model.detector);
+    // TODO: save loaded detectors
 
     // Streams and capacities
     pi.max_streams = p.num_streams;
@@ -515,7 +515,7 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
             }
             params.surface = std::make_shared<SurfaceParams>();
         }
-        params.detectors = std::move(loaded_model.detector);
+        // TODO: save detectors to params
     }
 
     // Load materials

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "Problem.hh"
 
+#include <memory>
 #include <optional>
 #include <utility>
 #include <variant>
@@ -297,7 +298,9 @@ auto build_along_step(inp::Field const& var_field,
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct optical parameters.
+ * Construct optical parameters from EM parameters.
+ *
+ * \todo build unique RNG streams for optical loop
  */
 auto build_optical_params(inp::Problem const& p,
                           CoreParams const& core,
@@ -306,49 +309,108 @@ auto build_optical_params(inp::Problem const& p,
     CELER_VALIDATE(!imported.optical_materials.empty(),
                    << "an optical tracking loop was requested but no optical "
                       "materials are present");
+    CELER_EXPECT(p.physics.optical);
+    CELER_EXPECT(p.control.optical_capacity);
 
-    optical::CoreParams::Input params;
-    CELER_ASSERT(p.control.optical_capacity);
-    params.capacity = *p.control.optical_capacity;
-    params.geometry = core.geometry();
-    params.material = optical::MaterialParams::from_import(
+    optical::CoreParams::Input pi;
+
+    // Registries
+    pi.action_reg = std::make_shared<ActionRegistry>();
+    pi.output_reg = core.output_reg();
+    pi.gen_reg = std::make_shared<GeneratorRegistry>();
+    pi.aux_reg = core.aux_reg();
+
+    // Geometry, physics, core
+    pi.geometry = core.geometry();
+    pi.material = optical::MaterialParams::from_import(
         imported, *core.geomaterial(), *core.material());
-    // TODO: unique RNG streams for optical loop
-    params.rng = core.rng();
-    params.sim
-        = std::make_shared<optical::SimParams>(p.tracking.optical_limits);
-    params.surface = core.surface();
-    params.action_reg = std::make_shared<ActionRegistry>();
-    params.gen_reg = std::make_shared<GeneratorRegistry>();
-    params.output_reg = core.output_reg();
-    params.aux_reg = core.aux_reg();
-    params.max_streams = core.max_streams();
+    pi.physics = optical::PhysicsParams::from_import(
+        imported, core.material(), pi.material, pi.action_reg);
+    pi.rng = core.rng();
+    pi.sim = std::make_shared<optical::SimParams>(p.tracking.optical_limits);
+    pi.surface = core.surface();
+    pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
+        pi.action_reg.get(), p.physics.optical.surfaces);
+    pi.detectors = core.detectors();
 
-    // Construct optical physics models
-    params.physics = optical::PhysicsParams::from_import(
-        imported, core.material(), params.material, params.action_reg);
-
-    // Construct optical surface physics models
-    CELER_ASSERT(p.physics.optical);
-    params.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
-        params.action_reg.get(), p.physics.optical.surfaces);
-
-    // Add photon generating processes
+    // Photon generating processes
     if (p.physics.optical.cherenkov)
     {
-        params.cherenkov = std::make_shared<CherenkovParams>(*params.material);
+        pi.cherenkov = std::make_shared<CherenkovParams>(*pi.material);
     }
     if (p.physics.optical.scintillation)
     {
-        params.scintillation
+        pi.scintillation
             = ScintillationParams::from_import(imported, core.particle());
     }
 
-    //! \todo Get sensitive detectors
+    // Streams and capacities
+    pi.max_streams = core.max_streams();
+    pi.capacity = *p.control.optical_capacity;
 
-    CELER_ENSURE(params);
+    CELER_ENSURE(pi);
+    return std::make_shared<optical::CoreParams>(std::move(pi));
+}
 
-    return std::make_shared<optical::CoreParams>(std::move(params));
+//---------------------------------------------------------------------------//
+/*!
+ * Construct optical parameters from optical problem definition.
+ */
+auto build_optical_params(inp::OpticalProblem const& p,
+                          ModelLoaded&& loaded_model,
+                          ImportData const& imported)
+{
+    CELER_VALIDATE(!imported.optical_materials.empty(),
+                   << "an optical tracking loop was requested but no optical "
+                      "materials are present");
+
+    // Create materials and geometry/material coupling
+    auto material = MaterialParams::from_import(imported);
+    auto geomaterial = GeoMaterialParams::from_import(
+        imported, loaded_model.geometry, loaded_model.volume, material);
+
+    optical::CoreParams::Input pi;
+
+    // Registries
+    pi.action_reg = std::make_shared<ActionRegistry>();
+    pi.output_reg = nullptr;
+    pi.gen_reg = std::make_shared<GeneratorRegistry>();
+    pi.aux_reg = std::make_shared<AuxParamsRegistry>();
+
+    // Geometry, materials, physics
+    pi.geometry = std::move(loaded_model.geometry);
+    pi.material = optical::MaterialParams::from_import(
+        imported, *geomaterial, *material);
+    pi.physics = optical::PhysicsParams::from_import(
+        imported, material, pi.material, pi.action_reg);
+    pi.rng = std::make_shared<RngParams>(p.seed);
+    pi.sim = std::make_shared<optical::SimParams>(p.limits);
+    pi.surface = std::move(loaded_model.surface);
+    pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
+        pi.action_reg.get(), p.physics.surfaces);
+    pi.detectors = std::move(loaded_model.detector);
+
+    // Streams and capacities
+    pi.max_streams = p.num_streams;
+    pi.capacity = p.capacity;
+
+    // Photon generating processes
+    // TODO: are these needed for offload-only??
+    if (p.physics.cherenkov)
+    {
+        pi.cherenkov = std::make_shared<CherenkovParams>(*pi.material);
+    }
+    if (p.physics.scintillation)
+    {
+        auto particle = ParticleParams::from_import(imported);
+        pi.scintillation = ScintillationParams::from_import(imported, particle);
+        CELER_ASSERT(pi.scintillation);
+    }
+
+    std::move(loaded_model) = {};
+
+    CELER_ENSURE(pi);
+    return std::make_shared<optical::CoreParams>(std::move(pi));
 }
 
 //---------------------------------------------------------------------------//
@@ -453,6 +515,7 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
             }
             params.surface = std::make_shared<SurfaceParams>();
         }
+        params.detectors = std::move(loaded_model.detector);
     }
 
     // Load materials
@@ -731,15 +794,6 @@ problem(inp::OpticalProblem const& p, ImportData const& imported)
                    << "an optical tracking loop was requested but no optical "
                       "materials are present");
 
-    optical::CoreParams::Input pi;
-
-    // Per-process state sizes
-    pi.capacity = p.capacity;
-
-    // Create action manager and generator registry
-    pi.action_reg = std::make_shared<ActionRegistry>();
-    pi.gen_reg = std::make_shared<GeneratorRegistry>();
-
     // Load geometry and model
     if (auto* filename = std::get_if<std::string>(&p.model.geometry))
     {
@@ -747,65 +801,25 @@ problem(inp::OpticalProblem const& p, ImportData const& imported)
                        << "empty filename in problem.model.geometry");
     }
     auto loaded_model = setup::model(p.model);
-    pi.geometry = std::move(loaded_model.geometry);
-    pi.surface = std::move(loaded_model.surface);
-    CELER_VALIDATE(pi.surface && !pi.surface->disabled(),
+    CELER_VALIDATE(loaded_model.surface && !loaded_model.surface->disabled(),
                    << "surfaces are required for optical physics");
-    if (pi.surface->empty())
+    if (loaded_model.surface->empty())
     {
         CELER_LOG(warning) << "Problem contains optical physics without any "
                               "geometry surface definitions: default physics "
                               "will be used for all surfaces";
     }
 
-    // Create materials and geometry/material coupling
-    auto material = MaterialParams::from_import(imported);
-    auto geomaterial = GeoMaterialParams::from_import(
-        imported, pi.geometry, loaded_model.volume, material);
-
-    // Create optical materials
-    pi.material = optical::MaterialParams::from_import(
-        imported, *geomaterial, *material);
-
-    // Construct RNG params
-    pi.rng = std::make_shared<RngParams>(p.seed);
-
-    // Construct simulation params
-    pi.sim = std::make_shared<optical::SimParams>(p.limits);
-
     // Set up streams
     CELER_VALIDATE(p.num_streams > 0,
                    << "p.num_streams must be manually set before setup");
-    pi.max_streams = p.num_streams;
     if (auto& device = celeritas::device())
     {
-        device.create_streams(pi.max_streams);
+        device.create_streams(p.num_streams);
     }
 
-    // Construct optical bulk physics models
-    pi.physics = optical::PhysicsParams::from_import(
-        imported, material, pi.material, pi.action_reg);
-
-    // Construct optical surface physics models
-    pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
-        pi.action_reg.get(), p.physics.surfaces);
-
-    // Add photon generating processes
-    if (p.physics.cherenkov)
-    {
-        pi.cherenkov = std::make_shared<CherenkovParams>(*pi.material);
-    }
-    if (p.physics.scintillation)
-    {
-        auto particle = ParticleParams::from_import(imported);
-        pi.scintillation = ScintillationParams::from_import(imported, particle);
-        CELER_ASSERT(pi.scintillation);
-    }
-
-    //! \todo Get sensitive detectors
-
-    CELER_ASSERT(pi);
-    auto params = std::make_shared<optical::CoreParams>(std::move(pi));
+    // Build optical params
+    auto params = build_optical_params(p, std::move(loaded_model), imported);
 
     // Construct the optical generator
     std::visit(Overload{

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -375,7 +375,7 @@ auto build_optical_params(inp::OpticalProblem const& p,
     pi.action_reg = std::make_shared<ActionRegistry>();
     pi.output_reg = nullptr;
     pi.gen_reg = std::make_shared<GeneratorRegistry>();
-    pi.aux_reg = std::make_shared<AuxParamsRegistry>();
+    pi.aux_reg = nullptr;  // TODO: require instead of building in CP
 
     // Geometry, materials, physics
     pi.geometry = std::move(loaded_model.geometry);
@@ -394,8 +394,7 @@ auto build_optical_params(inp::OpticalProblem const& p,
     pi.max_streams = p.num_streams;
     pi.capacity = p.capacity;
 
-    // Photon generating processes
-    // TODO: are these needed for offload-only??
+    // Photon generating processes are needed to offload via Geant4 optical
     if (p.physics.cherenkov)
     {
         pi.cherenkov = std::make_shared<CherenkovParams>(*pi.material);
@@ -820,6 +819,7 @@ problem(inp::OpticalProblem const& p, ImportData const& imported)
 
     // Build optical params
     auto params = build_optical_params(p, std::move(loaded_model), imported);
+    CELER_ASSERT(params);
 
     // Construct the optical generator
     std::visit(Overload{


### PR DESCRIPTION
This pulls out some adjustments I'm making to #2077, trying to improve consistency between core/optical functions and between typedefs/member ordering. It moves the two optical core input constructors next to each other for safer addition of new functionality. There should be no observable changes from this PR.