### PR TITLE
Extract splitmix64 rng

### DIFF
--- a/src/corecel/random/engine/SplitMix64.hh
+++ b/src/corecel/random/engine/SplitMix64.hh
@@ -39,7 +39,7 @@ class SplitMix64
 /*!
  * Construct the SplitMix64 engine with the given seed.
  */
-SplitMix64::SplitMix64(std::uint64_t seed) : state_(seed)
+CELER_FUNCTION SplitMix64::SplitMix64(std::uint64_t seed) : state_(seed)
 {
     /* * */
 }

--- a/src/corecel/random/engine/SplitMix64.hh
+++ b/src/corecel/random/engine/SplitMix64.hh
@@ -23,7 +23,7 @@ class SplitMix64
 {
   public:
     // Construct the SplitMix64 class with the given seed
-    inline explicit SplitMix64(std::uint64_t seed);
+    inline CELER_FUNCTION explicit SplitMix64(std::uint64_t seed);
 
     // Produce a random number
     inline CELER_FUNCTION std::uint64_t operator()();
@@ -37,7 +37,7 @@ class SplitMix64
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct the SplitMix64 engine with the given seed
+ * Construct the SplitMix64 engine with the given seed.
  */
 SplitMix64::SplitMix64(std::uint64_t seed) : state_(seed)
 {

--- a/src/corecel/random/engine/SplitMix64.hh
+++ b/src/corecel/random/engine/SplitMix64.hh
@@ -1,0 +1,62 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/random/engine/SplitMix64.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cstdint>
+
+#include "corecel/Macros.hh"
+
+namespace celeritas
+{
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief RNG for initializing the state for other RNGs
+ *
+ * See https://prng.di.unimi.it for a details of the SplitMix64 engine
+ */
+class SplitMix64
+{
+  public:
+    // Construct the SplitMix64 class with the given seed
+    inline explicit SplitMix64(std::uint64_t seed);
+
+    // Produce a random number
+    inline CELER_FUNCTION std::uint64_t operator()();
+
+  private:
+    // SplitMix64 State
+    std::uint64_t state_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct the SplitMix64 engine with the given seed
+ */
+SplitMix64::SplitMix64(std::uint64_t seed) : state_(seed)
+{
+    /* * */
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Generate a 64-bit pseudorandom number using the SplitMix64 engine.
+ *
+ * See https://prng.di.unimi.it for a description of the method.
+ */
+CELER_FUNCTION std::uint64_t SplitMix64::operator()()
+{
+    std::uint64_t z = (state_ += 0x9e3779b97f4a7c15ull);
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+    return z ^ (z >> 31);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/random/engine/XorwowRngEngine.hh
+++ b/src/corecel/random/engine/XorwowRngEngine.hh
@@ -12,6 +12,7 @@
 #include "corecel/random/data/XorwowRngData.hh"
 #include "corecel/random/distribution/GenerateCanonical.hh"
 #include "corecel/random/distribution/detail/GenerateCanonical32.hh"
+#include "corecel/random/engine/SplitMix64.hh"
 #include "corecel/sys/ThreadId.hh"
 
 namespace celeritas
@@ -110,13 +111,6 @@ class XorwowRngEngine
     inline CELER_FUNCTION void
     jump(ull_int, ArrayJumpPoly const&, XorwowState&);
     inline CELER_FUNCTION void jump(JumpPoly const&, XorwowState&);
-
-    // Helper RNG for initializing the state
-    struct SplitMix64
-    {
-        std::uint64_t state;
-        inline CELER_FUNCTION std::uint64_t operator()();
-    };
 };
 
 //---------------------------------------------------------------------------//
@@ -358,20 +352,6 @@ XorwowRngEngine::jump(JumpPoly const& jump_poly, XorwowState& state)
         }
     }
     state.xorstate = s;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Generate a 64-bit pseudorandom number using the SplitMix64 engine.
- *
- * This is used to initialize the XORWOW state. See https://prng.di.unimi.it.
- */
-CELER_FUNCTION std::uint64_t XorwowRngEngine::SplitMix64::operator()()
-{
-    std::uint64_t z = (state += 0x9e3779b97f4a7c15ull);
-    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
-    z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
-    return z ^ (z >> 31);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -101,11 +101,12 @@ celeritas_add_test(math/TridiagonalSolver.test.cc)
 
 celeritas_add_test(random/CachedRngEngine.test.cc)
 celeritas_add_test(random/Histogram.test.cc)
+celeritas_add_test(random/RanluxppRngEngine.test.cc GPU)
 celeritas_add_device_test(random/RngEngine
   LINK_LIBRARIES Celeritas::ExtThrust)
 celeritas_add_test(random/Selector.test.cc)
+celeritas_add_test(random/SplitMix64.test.cc GPU)
 celeritas_add_test(random/XorwowRngEngine.test.cc GPU)
-celeritas_add_test(random/RanluxppRngEngine.test.cc GPU)
 
 celeritas_add_test(random/distribution/BernoulliDistribution.test.cc)
 celeritas_add_test(random/distribution/ExponentialDistribution.test.cc)

--- a/test/corecel/random/SplitMix64.test.cc
+++ b/test/corecel/random/SplitMix64.test.cc
@@ -25,17 +25,6 @@ TEST(SplitMix64Test, host)
     EXPECT_EQ(9350289611492784363ul, sm());
 }
 
-TEST(SplitMix64Test, TEST_IF_CELER_DEVICE(device))
-{
-    celeritas::SplitMix64 sm(12345);
-
-    EXPECT_EQ(2454886589211414944ul, sm());
-    EXPECT_EQ(3778200017661327597ul, sm());
-    EXPECT_EQ(2205171434679333405ul, sm());
-    EXPECT_EQ(3248800117070709450ul, sm());
-    EXPECT_EQ(9350289611492784363ul, sm());
-}
-
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/random/SplitMix64.test.cc
+++ b/test/corecel/random/SplitMix64.test.cc
@@ -1,0 +1,41 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/random/SplitMix64.test.cc
+//---------------------------------------------------------------------------//
+#include "corecel/random/engine/SplitMix64.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+
+TEST(SplitMix64Test, host)
+{
+    celeritas::SplitMix64 sm(12345);
+
+    EXPECT_EQ(2454886589211414944ul, sm());
+    EXPECT_EQ(3778200017661327597ul, sm());
+    EXPECT_EQ(2205171434679333405ul, sm());
+    EXPECT_EQ(3248800117070709450ul, sm());
+    EXPECT_EQ(9350289611492784363ul, sm());
+}
+
+TEST(SplitMix64Test, TEST_IF_CELER_DEVICE(device))
+{
+    celeritas::SplitMix64 sm(12345);
+
+    EXPECT_EQ(2454886589211414944ul, sm());
+    EXPECT_EQ(3778200017661327597ul, sm());
+    EXPECT_EQ(2205171434679333405ul, sm());
+    EXPECT_EQ(3248800117070709450ul, sm());
+    EXPECT_EQ(9350289611492784363ul, sm());
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
In preparation for reseeding an RNG every time a track is created, this PR extracts the SplitMix64 RNG from within the Xorwow RNG to make it an independent class.
