### PR TITLE
Add JSON serialization for distribution inputs

### DIFF
--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -81,6 +81,7 @@ list(APPEND SOURCES
   grid/TwodGridBuilder.cc
   grid/UniformGridInserter.cc
   grid/XsGridInserter.cc
+  inp/EventsIO.json.cc
   inp/MucfPhysics.cc
   io/AtomicRelaxationReader.cc
   io/GammaNuclearXsReader.cc

--- a/src/celeritas/inp/EventsIO.json.cc
+++ b/src/celeritas/inp/EventsIO.json.cc
@@ -38,7 +38,7 @@ void from_json(nlohmann::json const& j, EnergyDistribution& v)
 {
     EIO_LOAD_VARIANT(delta, MonoenergeticDistribution);
     EIO_LOAD_VARIANT(normal, NormalDistribution);
-    CELER_ASSERT_UNREACHABLE();
+    CELER_VALIDATE(false, << "invalid EnergyDistribution input");
 }
 
 void to_json(nlohmann::json& j, ShapeDistribution const& v)
@@ -50,7 +50,7 @@ void from_json(nlohmann::json const& j, ShapeDistribution& v)
 {
     EIO_LOAD_VARIANT(delta, PointDistribution);
     EIO_LOAD_VARIANT(uniform_box, UniformBoxDistribution);
-    CELER_ASSERT_UNREACHABLE();
+    CELER_VALIDATE(false, << "invalid ShapeDistribution input");
 }
 
 void to_json(nlohmann::json& j, AngleDistribution const& v)
@@ -62,7 +62,7 @@ void from_json(nlohmann::json const& j, AngleDistribution& v)
 {
     EIO_LOAD_VARIANT(delta, MonodirectionalDistribution);
     EIO_LOAD_VARIANT(isotropic, IsotropicDistribution);
-    CELER_ASSERT_UNREACHABLE();
+    CELER_VALIDATE(false, << "invalid AngleDistribution input");
 }
 
 void to_json(nlohmann::json& j, OpticalPrimaryGenerator const& v)

--- a/src/celeritas/inp/EventsIO.json.cc
+++ b/src/celeritas/inp/EventsIO.json.cc
@@ -19,14 +19,14 @@ namespace inp
 //!@{
 //! I/O routines for JSON
 
-#define EIO_LOAD_VARIANT(NAME, TYPE)                    \
-    do                                                  \
-    {                                                   \
-        if (auto iter = j.find(#NAME); iter != j.end()) \
-        {                                               \
-            v = j.get<TYPE>();                          \
-            return;                                     \
-        }                                               \
+#define EIO_LOAD_VARIANT(NAME, TYPE) \
+    do                               \
+    {                                \
+        if (j.at("_type") == #NAME)  \
+        {                            \
+            v = j.get<TYPE>();       \
+            return;                  \
+        }                            \
     } while (0)
 
 void to_json(nlohmann::json& j, EnergyDistribution const& v)

--- a/src/celeritas/inp/EventsIO.json.cc
+++ b/src/celeritas/inp/EventsIO.json.cc
@@ -1,0 +1,92 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/inp/EventsIO.json.cc
+//---------------------------------------------------------------------------//
+#include "EventsIO.json.hh"
+
+#include <variant>
+
+#include "corecel/inp/DistributionsIO.json.hh"
+#include "corecel/io/JsonUtils.json.hh"
+
+namespace celeritas
+{
+namespace inp
+{
+//---------------------------------------------------------------------------//
+//!@{
+//! I/O routines for JSON
+
+#define EIO_LOAD_VARIANT(NAME, TYPE)                    \
+    do                                                  \
+    {                                                   \
+        if (auto iter = j.find(#NAME); iter != j.end()) \
+        {                                               \
+            v = j.get<TYPE>();                          \
+            return;                                     \
+        }                                               \
+    } while (0)
+
+void to_json(nlohmann::json& j, EnergyDistribution const& v)
+{
+    j = std::visit([](auto const& d) { return nlohmann::json(d); }, v);
+}
+
+void from_json(nlohmann::json const& j, EnergyDistribution& v)
+{
+    EIO_LOAD_VARIANT(delta, MonoenergeticDistribution);
+    EIO_LOAD_VARIANT(normal, NormalDistribution);
+    CELER_ASSERT_UNREACHABLE();
+}
+
+void to_json(nlohmann::json& j, ShapeDistribution const& v)
+{
+    j = std::visit([](auto const& d) { return nlohmann::json(d); }, v);
+}
+
+void from_json(nlohmann::json const& j, ShapeDistribution& v)
+{
+    EIO_LOAD_VARIANT(delta, PointDistribution);
+    EIO_LOAD_VARIANT(uniform_box, UniformBoxDistribution);
+    CELER_ASSERT_UNREACHABLE();
+}
+
+void to_json(nlohmann::json& j, AngleDistribution const& v)
+{
+    j = std::visit([](auto const& d) { return nlohmann::json(d); }, v);
+}
+
+void from_json(nlohmann::json const& j, AngleDistribution& v)
+{
+    EIO_LOAD_VARIANT(delta, MonodirectionalDistribution);
+    EIO_LOAD_VARIANT(isotropic, IsotropicDistribution);
+    CELER_ASSERT_UNREACHABLE();
+}
+
+void to_json(nlohmann::json& j, OpticalPrimaryGenerator const& v)
+{
+    j = nlohmann::json{
+        CELER_JSON_PAIR(v, shape),
+        CELER_JSON_PAIR(v, angle),
+        CELER_JSON_PAIR(v, energy),
+        CELER_JSON_PAIR(v, primaries),
+    };
+}
+
+void from_json(nlohmann::json const& j, OpticalPrimaryGenerator& v)
+{
+    CELER_JSON_LOAD_REQUIRED(j, v, shape);
+    CELER_JSON_LOAD_REQUIRED(j, v, angle);
+    CELER_JSON_LOAD_REQUIRED(j, v, energy);
+    CELER_JSON_LOAD_REQUIRED(j, v, primaries);
+}
+
+#undef EIO_LOAD_VARIANT
+
+//!@}
+
+//---------------------------------------------------------------------------//
+}  // namespace inp
+}  // namespace celeritas

--- a/src/celeritas/inp/EventsIO.json.hh
+++ b/src/celeritas/inp/EventsIO.json.hh
@@ -1,0 +1,33 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/inp/EventsIO.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "Events.hh"
+
+namespace celeritas
+{
+namespace inp
+{
+//---------------------------------------------------------------------------//
+
+void to_json(nlohmann::json& j, EnergyDistribution const&);
+void from_json(nlohmann::json const& j, EnergyDistribution&);
+
+void to_json(nlohmann::json& j, ShapeDistribution const&);
+void from_json(nlohmann::json const& j, ShapeDistribution&);
+
+void to_json(nlohmann::json& j, AngleDistribution const&);
+void from_json(nlohmann::json const& j, AngleDistribution&);
+
+void to_json(nlohmann::json& j, OpticalPrimaryGenerator const&);
+void from_json(nlohmann::json const& j, OpticalPrimaryGenerator&);
+
+//---------------------------------------------------------------------------//
+}  // namespace inp
+}  // namespace celeritas

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -209,6 +209,7 @@ list(APPEND SOURCES
   grid/GridTypesIO.json.cc
   grid/SplineDerivCalculator.cc
   grid/VectorUtils.cc
+  inp/DistributionsIO.json.cc
   io/BuildOutput.cc
   io/ColorUtils.cc
   io/ExceptionOutput.cc

--- a/src/corecel/inp/DistributionsIO.json.cc
+++ b/src/corecel/inp/DistributionsIO.json.cc
@@ -20,48 +20,50 @@ namespace inp
 template<class T>
 void to_json(nlohmann::json& j, DeltaDistribution<T> const& v)
 {
-    j = nlohmann::json{{"delta", v.value}};
+    j = {json_type_pair("delta"), CELER_JSON_PAIR(v, value)};
 }
 
 template<class T>
 void from_json(nlohmann::json const& j, DeltaDistribution<T>& v)
 {
-    j.at("delta").get_to(v.value);
+    CELER_JSON_LOAD_REQUIRED(j, v, value);
 }
 
 void to_json(nlohmann::json& j, NormalDistribution const& v)
 {
-    j = nlohmann::json{
-        {"normal", {{"mean", v.mean}, {"stddev", v.stddev}}},
+    j = {
+        json_type_pair("normal"),
+        CELER_JSON_PAIR(v, mean),
+        CELER_JSON_PAIR(v, stddev),
     };
 }
 
 void from_json(nlohmann::json const& j, NormalDistribution& v)
 {
-    auto const& params = j.at("normal");
-    params.at("mean").get_to(v.mean);
-    params.at("stddev").get_to(v.stddev);
+    CELER_JSON_LOAD_REQUIRED(j, v, mean);
+    CELER_JSON_LOAD_REQUIRED(j, v, stddev);
 }
 
 void to_json(nlohmann::json& j, IsotropicDistribution const&)
 {
-    j = nlohmann::json{{"isotropic", nlohmann::json::object()}};
+    j = {json_type_pair("isotropic")};
 }
 
 void from_json(nlohmann::json const&, IsotropicDistribution&) {}
 
 void to_json(nlohmann::json& j, UniformBoxDistribution const& v)
 {
-    j = nlohmann::json{
-        {"uniform_box", {{"lower", v.lower}, {"upper", v.upper}}},
+    j = {
+        json_type_pair("uniform_box"),
+        CELER_JSON_PAIR(v, lower),
+        CELER_JSON_PAIR(v, upper),
     };
 }
 
 void from_json(nlohmann::json const& j, UniformBoxDistribution& v)
 {
-    auto const& params = j.at("uniform_box");
-    params.at("lower").get_to(v.lower);
-    params.at("upper").get_to(v.upper);
+    CELER_JSON_LOAD_REQUIRED(j, v, lower);
+    CELER_JSON_LOAD_REQUIRED(j, v, upper);
 }
 
 //!@}

--- a/src/corecel/inp/DistributionsIO.json.cc
+++ b/src/corecel/inp/DistributionsIO.json.cc
@@ -1,0 +1,82 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/inp/DistributionsIO.json.cc
+//---------------------------------------------------------------------------//
+#include "DistributionsIO.json.hh"
+
+#include "corecel/cont/ArrayIO.json.hh"
+#include "corecel/io/JsonUtils.json.hh"
+
+namespace celeritas
+{
+namespace inp
+{
+//---------------------------------------------------------------------------//
+//!@{
+//! I/O routines for JSON
+
+template<class T>
+void to_json(nlohmann::json& j, DeltaDistribution<T> const& v)
+{
+    j = nlohmann::json{{"delta", v.value}};
+}
+
+template<class T>
+void from_json(nlohmann::json const& j, DeltaDistribution<T>& v)
+{
+    j.at("delta").get_to(v.value);
+}
+
+void to_json(nlohmann::json& j, NormalDistribution const& v)
+{
+    j = nlohmann::json{
+        {"normal", {{"mean", v.mean}, {"stddev", v.stddev}}},
+    };
+}
+
+void from_json(nlohmann::json const& j, NormalDistribution& v)
+{
+    auto const& params = j.at("normal");
+    params.at("mean").get_to(v.mean);
+    params.at("stddev").get_to(v.stddev);
+}
+
+void to_json(nlohmann::json& j, IsotropicDistribution const&)
+{
+    j = nlohmann::json{{"isotropic", nlohmann::json::object()}};
+}
+
+void from_json(nlohmann::json const&, IsotropicDistribution&) {}
+
+void to_json(nlohmann::json& j, UniformBoxDistribution const& v)
+{
+    j = nlohmann::json{
+        {"uniform_box", {{"lower", v.lower}, {"upper", v.upper}}},
+    };
+}
+
+void from_json(nlohmann::json const& j, UniformBoxDistribution& v)
+{
+    auto const& params = j.at("uniform_box");
+    params.at("lower").get_to(v.lower);
+    params.at("upper").get_to(v.upper);
+}
+
+//!@}
+
+//---------------------------------------------------------------------------//
+// EXPLICIT TEMPLATE INSTANTIATION
+//---------------------------------------------------------------------------//
+
+template void from_json(nlohmann::json const&, DeltaDistribution<double>&);
+template void to_json(nlohmann::json&, DeltaDistribution<double> const&);
+template void
+from_json(nlohmann::json const&, DeltaDistribution<Array<double, 3>>&);
+template void
+to_json(nlohmann::json&, DeltaDistribution<Array<double, 3>> const&);
+
+//---------------------------------------------------------------------------//
+}  // namespace inp
+}  // namespace celeritas

--- a/src/corecel/inp/DistributionsIO.json.hh
+++ b/src/corecel/inp/DistributionsIO.json.hh
@@ -1,0 +1,35 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/inp/DistributionsIO.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "Distributions.hh"
+
+namespace celeritas
+{
+namespace inp
+{
+//---------------------------------------------------------------------------//
+
+template<class T>
+void to_json(nlohmann::json& j, DeltaDistribution<T> const&);
+template<class T>
+void from_json(nlohmann::json const& j, DeltaDistribution<T>&);
+
+void to_json(nlohmann::json& j, NormalDistribution const&);
+void from_json(nlohmann::json const& j, NormalDistribution&);
+
+void to_json(nlohmann::json& j, IsotropicDistribution const&);
+void from_json(nlohmann::json const& j, IsotropicDistribution&);
+
+void to_json(nlohmann::json& j, UniformBoxDistribution const&);
+void from_json(nlohmann::json const& j, UniformBoxDistribution&);
+
+//---------------------------------------------------------------------------//
+}  // namespace inp
+}  // namespace celeritas

--- a/src/corecel/io/JsonUtils.json.hh
+++ b/src/corecel/io/JsonUtils.json.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string_view>
+#include <utility>
 #include <variant>
 #include <nlohmann/json.hpp>
 
@@ -132,6 +133,15 @@ void check_format(nlohmann::json const& j, std::string_view format);
 
 // Check units for consistency
 void check_units(nlohmann::json const& j, std::string_view format);
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a key/value pair for JSON polymorphism.
+ */
+inline std::pair<std::string, std::string> json_type_pair(std::string&& s)
+{
+    return {"_type", std::move(s)};
+}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -380,6 +380,11 @@ celeritas_add_test(io/RootEventIO.test.cc ${_needs_root})
 celeritas_add_test(io/SeltzerBergerReader.test.cc ${_needs_geant4})
 
 #-----------------------------------------------------------------------------#
+# Inp
+celeritas_add_test(inp/JsonIO.test.cc
+  LINK_LIBRARIES nlohmann_json::nlohmann_json)
+
+#-----------------------------------------------------------------------------#
 # Optical
 
 function(celeritas_standalone_add_tests basename suite test backend)

--- a/test/celeritas/inp/JsonIO.test.cc
+++ b/test/celeritas/inp/JsonIO.test.cc
@@ -27,7 +27,7 @@ TEST(JsonIOTest, events)
     input.shape = UniformBoxDistribution{{0, 0, 0}, {1, 1, 1}};
 
     char const expected[]
-        = R"json({"angle":{"delta":[0.0,0.0,1.0]},"energy":{"normal":{"mean":1.0,"stddev":0.0}},"primaries":512,"shape":{"uniform_box":{"lower":[0.0,0.0,0.0],"upper":[1.0,1.0,1.0]}}})json";
+        = R"json({"angle":{"_type":"delta","value":[0.0,0.0,1.0]},"energy":{"_type":"normal","mean":1.0,"stddev":0.0},"primaries":512,"shape":{"_type":"uniform_box","lower":[0.0,0.0,0.0],"upper":[1.0,1.0,1.0]}})json";
     nlohmann::json obj(input);
     EXPECT_JSON_EQ(expected, obj.dump());
 

--- a/test/celeritas/inp/JsonIO.test.cc
+++ b/test/celeritas/inp/JsonIO.test.cc
@@ -1,0 +1,54 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/inp/JsonIO.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/inp/EventsIO.json.hh"
+
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace inp
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+TEST(JsonIOTest, events)
+{
+    using Real3 = Array<double, 3>;
+
+    // Test optical primary generator round trip
+    OpticalPrimaryGenerator input;
+    input.primaries = 512;
+    input.energy = NormalDistribution{1, 0};
+    input.angle = MonodirectionalDistribution{{0, 0, 1}};
+    input.shape = UniformBoxDistribution{{0, 0, 0}, {1, 1, 1}};
+
+    char const expected[]
+        = R"json({"angle":{"delta":[0.0,0.0,1.0]},"energy":{"normal":{"mean":1.0,"stddev":0.0}},"primaries":512,"shape":{"uniform_box":{"lower":[0.0,0.0,0.0],"upper":[1.0,1.0,1.0]}}})json";
+    nlohmann::json obj(input);
+    EXPECT_JSON_EQ(expected, obj.dump());
+
+    auto rt_input = obj.get<OpticalPrimaryGenerator>();
+    EXPECT_JSON_EQ(expected, nlohmann::json(rt_input).dump());
+
+    EXPECT_EQ(input.primaries, rt_input.primaries);
+
+    auto const& energy = std::get<NormalDistribution>(rt_input.energy);
+    EXPECT_EQ(1.0, energy.mean);
+    EXPECT_EQ(0.0, energy.stddev);
+
+    auto const& angle = std::get<MonodirectionalDistribution>(rt_input.angle);
+    EXPECT_EQ(Real3({0, 0, 1}), angle.value);
+
+    auto const& shape = std::get<UniformBoxDistribution>(rt_input.shape);
+    EXPECT_EQ(Real3({0, 0, 0}), shape.lower);
+    EXPECT_EQ(Real3({1, 1, 1}), shape.upper);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace inp
+}  // namespace celeritas


### PR DESCRIPTION
This add `to_json` and `from_json` functions for the distribution and optical primary generator inputs.