### PR TITLE
Fix `GeantOpticalPhysicsOptions` JSON serialization 

### DIFF
--- a/src/celeritas/ext/GeantOpticalPhysicsOptionsIO.json.cc
+++ b/src/celeritas/ext/GeantOpticalPhysicsOptionsIO.json.cc
@@ -215,7 +215,14 @@ void from_json(nlohmann::json const& j, GeantOpticalPhysicsOptions& options)
         return;
     }
 
-#define GOPO_LOAD_OPTION(NAME) CELER_JSON_LOAD_OPTION(j, options, NAME)
+#define GOPO_LOAD_OPTION(NAME)                          \
+    do                                                  \
+    {                                                   \
+        if (auto iter = j.find(#NAME); iter != j.end()) \
+        {                                               \
+            iter->get_to(options.NAME);                 \
+        }                                               \
+    } while (0)
     check_format(j, format_str);
     GOPO_LOAD_OPTION(cherenkov);
     GOPO_LOAD_OPTION(scintillation);

--- a/test/JsonUtils.hh
+++ b/test/JsonUtils.hh
@@ -1,0 +1,31 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file JsonUtils.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "TestMacros.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+//! Verify JSON round-trip serialization.
+template<class T>
+inline void verify_json_round_trip(T const& input, char const* expected)
+{
+    nlohmann::json obj(input);
+    EXPECT_JSON_EQ(expected, obj.dump());
+
+    auto rt_input = obj.get<T>();
+    EXPECT_JSON_EQ(expected, nlohmann::json(rt_input).dump());
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas

--- a/test/celeritas/CMakeLists.txt
+++ b/test/celeritas/CMakeLists.txt
@@ -204,6 +204,9 @@ celeritas_add_test(ext/GeantImporter.test.cc
   FILTER ${_import_filter}
 )
 
+celeritas_add_test(ext/JsonIO.test.cc
+  LINK_LIBRARIES nlohmann_json::nlohmann_json)
+
 celeritas_add_test(ext/RootImporter.test.cc ${_needs_root})
 celeritas_add_test(ext/RootJsonDumper.test.cc ${_needs_root})
 

--- a/test/celeritas/ext/JsonIO.test.cc
+++ b/test/celeritas/ext/JsonIO.test.cc
@@ -1,0 +1,30 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/ext/JsonIO.test.cc
+//---------------------------------------------------------------------------//
+#include "celeritas/ext/GeantOpticalPhysicsOptions.hh"
+#include "celeritas/ext/GeantOpticalPhysicsOptionsIO.json.hh"
+
+#include "JsonUtils.hh"
+#include "celeritas_test.hh"
+
+namespace celeritas
+{
+namespace test
+{
+//---------------------------------------------------------------------------//
+TEST(JsonIOTest, optical)
+{
+    auto input = GeantOpticalPhysicsOptions::deactivated();
+    input.absorption = true;
+
+    char const expected[]
+        = R"json({"_format":"geant4-optical-physics","_version":"0.7.0","absorption":true,"boundary":null,"cherenkov":null,"mie_scattering":false,"rayleigh_scattering":false,"scintillation":null,"verbose":false,"wavelength_shifting":null,"wavelength_shifting2":null})json";
+    verify_json_round_trip(input, expected);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace test
+}  // namespace celeritas


### PR DESCRIPTION
Some of the optical physics options (Cherenkov, scintillation, boundary, WLS) write a null json object if the process is disabled. When loading `GeantOpticalPhysicsOptions` from json, `CELER_JSON_LOAD_OPTION` was used to load the individual processes. However, this macro omits the field if it's null, which meant the default (activated) options were being used instead of the intended null (deactivated) ones.