### PR TITLE
Warn and replace unphysical values in MFP grid

### DIFF
--- a/src/celeritas/optical/PhysicsTrackView.hh
+++ b/src/celeritas/optical/PhysicsTrackView.hh
@@ -191,10 +191,10 @@ CELER_FUNCTION real_type PhysicsTrackView::calc_xs(ModelId model,
     }
 
     // Calculate the MFP using the grid, then return its inverse (xs)
-    NonuniformGridCalculator calc{grid, params_.reals};
-    real_type result = calc(value_as<Energy>(energy));
-    CELER_ENSURE(result > 0);
-    return 1 / result;
+    NonuniformGridCalculator calc_mfp{grid, params_.reals};
+    real_type mfp = calc_mfp(value_as<Energy>(energy));
+    CELER_ENSURE(mfp > 0);
+    return 1 / mfp;
 }
 
 //---------------------------------------------------------------------------//

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -626,7 +626,7 @@ auto OpticalSurfaces::make_primary_input() const -> PrimaryInput
     result.shape
         = inp::PointDistribution{array_cast<double>(from_cm({30, 0, 0}))};
     result.angle = inp::MonodirectionalDistribution{{-1, 0, 0}};
-    result.energy = inp::MonoenergeticDistribution{10};  // [MeV]
+    result.energy = inp::MonoenergeticDistribution{100};  // [MeV]
     result.primaries_per_event = 1;
     result.num_events = 4;  // Overridden with BeamOn
     return result;


### PR DESCRIPTION
In the optical surface integration test I ran into some cases where the photon's mean free path (and step length) was zero. This occurred because the user-provided absorption MFP was zero at the last energy grid point and the photon energy was outside the grid. To avoid this without introducing special-case logic in the stepping loop, this change warns if the MFP grid contains nonpositive values and replaces them with epsilon.