### PR TITLE
Modify ORANGE tracking assertions for production-level problems

### DIFF
--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -572,22 +572,18 @@ SimpleUnitTracker::complex_intersect(LocalState const& state,
     // Current senses should put us inside the volume
     LogicEvaluator is_inside(vol.logic());
 
-    // Return early if the current sense already matches the target sense
-    // (a tracking error)
-    if (is_inside(calc_sense) == (target_sense == Sense::inside))
-    {
+    // Log a warning if the current sense already matches the target sense
 #if !CELER_DEVICE_COMPILE
-        if constexpr (CELERITAS_DEBUG)
+    if constexpr (CELERITAS_DEBUG)
+    {
+        if (is_inside(calc_sense) == (target_sense == Sense::inside))
         {
-            {
-                CELER_LOG_LOCAL(warning)
-                    << "Calculated surface sense at position " << repr(pos)
-                    << " already matches target sense";
-            }
+            CELER_LOG_LOCAL(warning)
+                << "Calculated surface sense at position " << repr(pos)
+                << " already matches target sense";
         }
-#endif
-        return {};
     }
+#endif
 
     // previous isect distance for move delta
     real_type previous_distance{0};

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -23,6 +23,11 @@
 #include "detail/Types.hh"
 #include "detail/Utils.hh"
 
+#if !CELER_DEVICE_COMPILE
+#    include "corecel/io/Logger.hh"
+#    include "corecel/io/Repr.hh"
+#endif
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -566,7 +571,23 @@ SimpleUnitTracker::complex_intersect(LocalState const& state,
     // Calculate local senses, taking current face into account
     // Current senses should put us inside the volume
     LogicEvaluator is_inside(vol.logic());
-    CELER_ASSERT(is_inside(calc_sense) != (target_sense == Sense::inside));
+
+    // Return early if the current sense already matches the target sense
+    // (a tracking error)
+    if (is_inside(calc_sense) == (target_sense == Sense::inside))
+    {
+#if !CELER_DEVICE_COMPILE
+        if constexpr (CELERITAS_DEBUG)
+        {
+            {
+                CELER_LOG_LOCAL(warning)
+                    << "Calculated surface sense at position " << repr(pos)
+                    << " already matches target sense";
+            }
+        }
+#endif
+        return {};
+    }
 
     // previous isect distance for move delta
     real_type previous_distance{0};


### PR DESCRIPTION
This MR relaxes a DBC check in `SimpleUnitTracker::complex_intersect` to become a warning, issued when running a debug build on host. This particular DBC check was being hit at a rate of 1 in 2.2e5 calls when running the ATLAS lower end cap model. This MR will allow transport to proceed on this model, and other production-level models with the same issue (presumably a small overlap).