### PR TITLE
Clamp out-of-bound indices in `CartMapField`

### DIFF
--- a/src/celeritas/field/CartMapField.covfie.hh
+++ b/src/celeritas/field/CartMapField.covfie.hh
@@ -64,9 +64,9 @@ CartMapField::CartMapField(ParamsRef const& shared) : field_{shared.get_view()}
 /*!
  * Calculate the magnetic field vector for the given position.
  *
- * This does a 3-D interpolation on the input grid and reconstructs the
- * magnetic field vector from the stored X, Y, Z components of the field.
- * The result is in the native Celeritas unit system.
+ * \warning Accessing values outside the grid clamps to boundary values.
+ * This behavior differs from other field maps, where values outside the map
+ * are assumed zero.
  */
 CELER_FUNCTION auto CartMapField::operator()(Real3 const& pos) const -> Real3
 {

--- a/src/celeritas/field/CartMapField.covfie.hh
+++ b/src/celeritas/field/CartMapField.covfie.hh
@@ -21,10 +21,9 @@ namespace celeritas
 /*!
  * Interpolate a magnetic field vector on an x/y/z grid.
  *
- * \warning Accessing values outside the grid has different behavior depending
- * on the platform: CUDA clamps via texture memory; HIP and CPU clamp on the
- * low side but assert on the high side. This behavior also differs from other
- * field maps, where values outside the map are assumed zero.
+ * \warning Accessing values outside the grid clamps to boundary values.
+ * This behavior differs from other field maps, where values outside the map
+ * are assumed zero.
  */
 class CartMapField
 {
@@ -64,9 +63,9 @@ CartMapField::CartMapField(ParamsRef const& shared) : field_{shared.get_view()}
 /*!
  * Calculate the magnetic field vector for the given position.
  *
- * \warning Accessing values outside the grid clamps to boundary values.
- * This behavior differs from other field maps, where values outside the map
- * are assumed zero.
+ * This does a 3-D interpolation on the input grid and reconstructs the
+ * magnetic field vector from the stored X, Y, Z components of the field.
+ * The result is in the native Celeritas unit system.
  */
 CELER_FUNCTION auto CartMapField::operator()(Real3 const& pos) const -> Real3
 {

--- a/src/celeritas/field/CartMapFieldData.covfie.hh
+++ b/src/celeritas/field/CartMapFieldData.covfie.hh
@@ -85,9 +85,11 @@ struct CartMapFieldParamsData<Ownership::value, MemSpace::device>
             }
             else
             {
+                auto const& host_backend = other.field->backend();
+                auto const& strided_backend
+                    = host_backend.get_backend().get_backend().get_backend();
                 field = std::make_unique<field_t>(covfie::make_parameter_pack(
-                    other.field->backend().get_configuration(),
-                    other.field->backend().get_backend().get_backend()));
+                    host_backend.get_configuration(), strided_backend));
             }
             field_view = DeviceVector<view_t>{1};
             field_view.copy_to_device(make_span<view_t const>({{*field}}));

--- a/src/celeritas/field/detail/CovfieFieldTraits.hh
+++ b/src/celeritas/field/detail/CovfieFieldTraits.hh
@@ -8,9 +8,11 @@
 
 #include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
 #include <covfie/core/backend/transformer/linear.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
 
 #include "corecel/Config.hh"
 #include "corecel/DeviceRuntimeApi.hh"  // IWYU pragma: keep
@@ -41,7 +43,8 @@ struct CovfieFieldTraits<MemSpace::host>
     using dimensioned_t
         = covfie::backend::strided<covfie::vector::size3, storage_t>;
     using interp_t = covfie::backend::linear<dimensioned_t>;
-    using transformed_t = covfie::backend::affine<interp_t>;
+    using clamped_t = covfie::backend::clamp<interp_t>;
+    using transformed_t = covfie::backend::affine<clamped_t>;
     using field_t = covfie::field<transformed_t>;
     using builder_t = covfie::field<dimensioned_t>;
 
@@ -69,7 +72,8 @@ struct CovfieFieldTraits<MemSpace::device>
     using dimensioned_t
         = covfie::backend::strided<covfie::vector::size3, storage_t>;
     using interp_t = covfie::backend::linear<dimensioned_t>;
-    using transformed_t = covfie::backend::affine<interp_t>;
+    using clamped_t = covfie::backend::clamp<interp_t>;
+    using transformed_t = covfie::backend::affine<clamped_t>;
 #endif
 
     using field_t = covfie::field<transformed_t>;

--- a/test/accel/CartMapMagneticField.test.cc
+++ b/test/accel/CartMapMagneticField.test.cc
@@ -120,17 +120,12 @@ TEST_F(CartMapMagneticFieldTest, geant_calculation)
     pos = {0.5 * cm, 0.11 * cm, -3.9 * cm};
     this->check_field(cart_field, pos, tol);
 
-    if (false)
-    {
-        // TODO: Checking outside the field's domain clamps to a nearby grid
-        // point or triggers a C assert that terminates the program
-        pos = {-1 * cm, 0.1 * cm, -0.1 * cm};
-        EXPECT_VEC_NEAR(
-            (Dbl3{0, 0, 0}), this->calc_field(cart_field, pos), tol);
-        pos = {1 * cm, 0.1 * cm, -0.1 * cm};
-        EXPECT_VEC_NEAR(
-            (Dbl3{0, 0, 0}), this->calc_field(cart_field, pos), tol);
-    }
+    pos = {-1 * cm, 0.1 * cm, -0.1 * cm};
+    EXPECT_VEC_NEAR(
+        (Dbl3{-1.05, -1.5, 3.6}), this->calc_field(cart_field, pos), tol);
+    pos = {1 * cm, 0.1 * cm, -0.1 * cm};
+    EXPECT_VEC_NEAR(
+        (Dbl3{0.45, -1.5, 3.6}), this->calc_field(cart_field, pos), tol);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Follow-up to #2222. This add a `covfie::clamp` layer to host `CartMapField` to clamp out-of-bound access. 

The clamp layer is placed before linear interpolation because covfie’s linear backend [casts](https://github.com/acts-project/covfie/blob/4447a6076c3d5d486ab9a4492196db4877363c36/lib/core/covfie/core/backend/transformer/linear.hpp#L234-L236) the interpolation coordinate to an unsigned index. The [affine transform](https://github.com/celeritas-project/celeritas/blob/3331decb02742422a8268dc938ad8f842659ab64/src/celeritas/field/CartMapFieldParams.covfie.cc#L69-L83) only guarantees valid index coordinates for positions inside the field’s world bounds. For negative out-of-bounds positions, the cast would wrap to a positive index and trigger invalid access. Clamping first keeps the coordinate in-range and prevents that wraparound.

This makes the GPU/behavior consistent with each other.