### PR TITLE
Rename min_split_size to max_leaf_size

### DIFF
--- a/doc/usage/execution/environment.rst
+++ b/doc/usage/execution/environment.rst
@@ -18,36 +18,36 @@ has a default value but can be overridden with any boolean value.
 
 .. table:: Environment variables used by Celeritas.
 
- ========================= ========= ==========================================
- Variable                  Component Brief description
- ========================= ========= ==========================================
- CELER_COLOR               corecel   Flag: log with ANSI colors
- CELER_DEBUG_DEVICE        corecel   Flag: check device ID consistency
- CELER_DISABLE_DEVICE      corecel   Flag: disable CUDA/HIP support
- CELER_DISABLE_PARALLEL    corecel   Flag: disable MPI support
- CELER_DISABLE_REDIRECT    corecel   Flag: disable stream->logger redirection
- CELER_DISABLE_ROOT        corecel   Flag: disable ROOT I/O calls
- CELER_DISABLE_SIGNALS     corecel   Flag: disable signal handling
- CELER_DEVICE_ASYNC        corecel   Flag: allocate memory asynchronously
- CELER_ENABLE_PROFILING    corecel   Flag: use NVTX/ROCTX profiling [#pr]_
- CELER_LOG                 corecel   Set "global" logger verbosity [#lg]_
- CELER_LOG_LOCAL           corecel   Set "local" logger verbosity [#lg]_
- CELER_MEMPOOL... [#mp]_   corecel   Set ``cudaMemPoolAttrReleaseThreshold``
- CELER_PERFETT... [#bs]_   corecel   Set in-process tracing buffer size
- CELER_PROFILE_DEVICE      corecel   Flag: record kernel launch counts
- CUDA_HEAP_SIZE            geocel    Set ``cudaLimitMallocHeapSize`` (VG)
- CUDA_STACK_SIZE           geocel    Set ``cudaLimitStackSize`` for VecGeom
- G4ORG_OPTIONS             orange    JSON filename for G4-to-ORANGE conversion
- G4VG_COMPARE_VOLUMES      geocel    Check G4VG volume capacity when converting
- HEPMC3_VERBOSE            celeritas HepMC3 debug level integer
- VECGEOM_VERBOSE           celeritas VecGeom CUDA verbosity integer
- CELER_DISABLE             accel     Flag: disable Celeritas offloading entirely
- CELER_LOG_ALL_LOCAL       accel     Flag: log more messages from all threads
- CELER_KILL_OFFLOAD        accel     Flag: kill offloaded tracks [#ko]_
- CELER_NONFATAL_FLUSH      accel     Flag: print and continue on failure [#nf]_
- CELER_STRIP_SOURCEDIR     accel     Flag: clean exception output
- ORANGE_BIH_MIN_SPLIT_SIZE orange    Set BIH ``min_split_size``
- ========================= ========= ==========================================
+ ======================== ========= ==========================================
+ Variable                 Component Brief description
+ ======================== ========= ==========================================
+ CELER_COLOR              corecel   Flag: log with ANSI colors
+ CELER_DEBUG_DEVICE       corecel   Flag: check device ID consistency
+ CELER_DISABLE_DEVICE     corecel   Flag: disable CUDA/HIP support
+ CELER_DISABLE_PARALLEL   corecel   Flag: disable MPI support
+ CELER_DISABLE_REDIRECT   corecel   Flag: disable stream->logger redirection
+ CELER_DISABLE_ROOT       corecel   Flag: disable ROOT I/O calls
+ CELER_DISABLE_SIGNALS    corecel   Flag: disable signal handling
+ CELER_DEVICE_ASYNC       corecel   Flag: allocate memory asynchronously
+ CELER_ENABLE_PROFILING   corecel   Flag: use NVTX/ROCTX profiling [#pr]_
+ CELER_LOG                corecel   Set "global" logger verbosity [#lg]_
+ CELER_LOG_LOCAL          corecel   Set "local" logger verbosity [#lg]_
+ CELER_MEMPOOL... [#mp]_  corecel   Set ``cudaMemPoolAttrReleaseThreshold``
+ CELER_PERFETT... [#bs]_  corecel   Set in-process tracing buffer size
+ CELER_PROFILE_DEVICE     corecel   Flag: record kernel launch counts
+ CUDA_HEAP_SIZE           geocel    Set ``cudaLimitMallocHeapSize`` (VG)
+ CUDA_STACK_SIZE          geocel    Set ``cudaLimitStackSize`` for VecGeom
+ G4ORG_OPTIONS            orange    JSON filename for G4-to-ORANGE conversion
+ G4VG_COMPARE_VOLUMES     geocel    Check G4VG volume capacity when converting
+ HEPMC3_VERBOSE           celeritas HepMC3 debug level integer
+ VECGEOM_VERBOSE          celeritas VecGeom CUDA verbosity integer
+ CELER_DISABLE            accel     Flag: disable Celeritas offloading entirely
+ CELER_LOG_ALL_LOCAL      accel     Flag: log more messages from all threads
+ CELER_KILL_OFFLOAD       accel     Flag: kill offloaded tracks [#ko]_
+ CELER_NONFATAL_FLUSH     accel     Flag: print and continue on failure [#nf]_
+ CELER_STRIP_SOURCEDIR    accel     Flag: clean exception output
+ ORANGE_BIH_MAX_LEAF_SIZE orange    Set BIH ``max_leaf_size``
+ ======================== ========= ==========================================
 
 .. [#pr] See :ref:`profiling`
 .. [#lg] See :ref:`logging`

--- a/doc/usage/execution/environment.rst
+++ b/doc/usage/execution/environment.rst
@@ -18,36 +18,36 @@ has a default value but can be overridden with any boolean value.
 
 .. table:: Environment variables used by Celeritas.
 
- ======================== ========= ==========================================
- Variable                 Component Brief description
- ======================== ========= ==========================================
- CELER_COLOR              corecel   Flag: log with ANSI colors
- CELER_DEBUG_DEVICE       corecel   Flag: check device ID consistency
- CELER_DISABLE_DEVICE     corecel   Flag: disable CUDA/HIP support
- CELER_DISABLE_PARALLEL   corecel   Flag: disable MPI support
- CELER_DISABLE_REDIRECT   corecel   Flag: disable stream->logger redirection
- CELER_DISABLE_ROOT       corecel   Flag: disable ROOT I/O calls
- CELER_DISABLE_SIGNALS    corecel   Flag: disable signal handling
- CELER_DEVICE_ASYNC       corecel   Flag: allocate memory asynchronously
- CELER_ENABLE_PROFILING   corecel   Flag: use NVTX/ROCTX profiling [#pr]_
- CELER_LOG                corecel   Set "global" logger verbosity [#lg]_
- CELER_LOG_LOCAL          corecel   Set "local" logger verbosity [#lg]_
- CELER_MEMPOOL... [#mp]_  corecel   Set ``cudaMemPoolAttrReleaseThreshold``
- CELER_PERFETT... [#bs]_  corecel   Set in-process tracing buffer size
- CELER_PROFILE_DEVICE     corecel   Flag: record kernel launch counts
- CUDA_HEAP_SIZE           geocel    Set ``cudaLimitMallocHeapSize`` (VG)
- CUDA_STACK_SIZE          geocel    Set ``cudaLimitStackSize`` for VecGeom
- G4ORG_OPTIONS            orange    JSON filename for G4-to-ORANGE conversion
- G4VG_COMPARE_VOLUMES     geocel    Check G4VG volume capacity when converting
- HEPMC3_VERBOSE           celeritas HepMC3 debug level integer
- VECGEOM_VERBOSE          celeritas VecGeom CUDA verbosity integer
- CELER_DISABLE            accel     Flag: disable Celeritas offloading entirely
- CELER_LOG_ALL_LOCAL      accel     Flag: log more messages from all threads
- CELER_KILL_OFFLOAD       accel     Flag: kill offloaded tracks [#ko]_
- CELER_NONFATAL_FLUSH     accel     Flag: print and continue on failure [#nf]_
- CELER_STRIP_SOURCEDIR    accel     Flag: clean exception output
- ORANGE_BIH_MAX_LEAF_SIZE orange    Set BIH ``max_leaf_size``
- ======================== ========= ==========================================
+ ========================= ========= ==========================================
+ Variable                  Component Brief description
+ ========================= ========= ==========================================
+ CELER_COLOR               corecel   Flag: log with ANSI colors
+ CELER_DEBUG_DEVICE        corecel   Flag: check device ID consistency
+ CELER_DISABLE_DEVICE      corecel   Flag: disable CUDA/HIP support
+ CELER_DISABLE_PARALLEL    corecel   Flag: disable MPI support
+ CELER_DISABLE_REDIRECT    corecel   Flag: disable stream->logger redirection
+ CELER_DISABLE_ROOT        corecel   Flag: disable ROOT I/O calls
+ CELER_DISABLE_SIGNALS     corecel   Flag: disable signal handling
+ CELER_DEVICE_ASYNC        corecel   Flag: allocate memory asynchronously
+ CELER_ENABLE_PROFILING    corecel   Flag: use NVTX/ROCTX profiling [#pr]_
+ CELER_LOG                 corecel   Set "global" logger verbosity [#lg]_
+ CELER_LOG_LOCAL           corecel   Set "local" logger verbosity [#lg]_
+ CELER_MEMPOOL... [#mp]_   corecel   Set ``cudaMemPoolAttrReleaseThreshold``
+ CELER_PERFETT... [#bs]_   corecel   Set in-process tracing buffer size
+ CELER_PROFILE_DEVICE      corecel   Flag: record kernel launch counts
+ CUDA_HEAP_SIZE            geocel    Set ``cudaLimitMallocHeapSize`` (VG)
+ CUDA_STACK_SIZE           geocel    Set ``cudaLimitStackSize`` for VecGeom
+ G4ORG_OPTIONS             orange    JSON filename for G4-to-ORANGE conversion
+ G4VG_COMPARE_VOLUMES      geocel    Check G4VG volume capacity when converting
+ HEPMC3_VERBOSE            celeritas HepMC3 debug level integer
+ VECGEOM_VERBOSE           celeritas VecGeom CUDA verbosity integer
+ CELER_DISABLE             accel     Flag: disable Celeritas offloading entirely
+ CELER_LOG_ALL_LOCAL       accel     Flag: log more messages from all threads
+ CELER_KILL_OFFLOAD        accel     Flag: kill offloaded tracks [#ko]_
+ CELER_NONFATAL_FLUSH      accel     Flag: print and continue on failure [#nf]_
+ CELER_STRIP_SOURCEDIR     accel     Flag: clean exception output
+ ORANGE_BIH_MAX_LEAF_SIZE  orange    Set BIH ``max_leaf_size``
+ ========================= ========= ==========================================
 
 .. [#pr] See :ref:`profiling`
 .. [#lg] See :ref:`logging`

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -27,7 +27,7 @@ BIHBuilder::BIHBuilder(Storage* storage, Input inp)
     , inp_{inp}
 {
     CELER_EXPECT(storage);
-    CELER_EXPECT(inp_.min_split_size > 1);
+    CELER_EXPECT(inp_.max_leaf_size > 0);
 }
 
 //---------------------------------------------------------------------------//
@@ -138,7 +138,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
         (*nodes)[current_index] = node;
     };
 
-    if (indices.size() < inp_.min_split_size)
+    if (indices.size() <= inp_.max_leaf_size)
     {
         // All bboxes fit on a single leaf; make it and exit early
         make_leaf();

--- a/src/orange/inp/Bih.hh
+++ b/src/orange/inp/Bih.hh
@@ -18,11 +18,12 @@ namespace inp
  */
 struct BIHBuilder
 {
-    //! Minimum number of bboxes needed to trigger a partitioning attempt
-    size_type min_split_size = 2;
+    //! Maximum number of bboxes that can reside on a leaf node without
+    //! triggering a partitioning attempt
+    size_type max_leaf_size = 1;
 
     //! Whether the options are valid
-    explicit operator bool() const { return min_split_size >= 2; }
+    explicit operator bool() const { return max_leaf_size >= 1; }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/InputBuilder.cc
+++ b/src/orange/orangeinp/InputBuilder.cc
@@ -149,12 +149,12 @@ auto InputBuilder::operator()(ProtoInterface const& global) const -> result_type
         csg_outp.write(opts_.csg_output_file);
     }
 
-    if (std::string var = celeritas::getenv("ORANGE_BIH_MIN_SPLIT_SIZE");
+    if (std::string var = celeritas::getenv("ORANGE_BIH_MAX_LEAF_SIZE");
         !var.empty())
     {
-        size_type mss = std::stoul(var);
-        CELER_EXPECT(mss > 1);
-        result.construction_opts.bih_options.min_split_size = mss;
+        size_type mls = std::stoul(var);
+        CELER_EXPECT(mls > 0);
+        result.construction_opts.bih_options.max_leaf_size = mls;
     }
 
     CELER_ENSURE(result);

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -89,7 +89,7 @@ TEST_F(BIHBuilderTest, basic)
         {{0, -1, 0}, {5, 0, 100}},
     };
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{2});
+    BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
@@ -278,7 +278,7 @@ TEST_F(BIHBuilderTest, grid)
         }
     }
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{2});
+    BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
     ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0},
@@ -534,7 +534,7 @@ TEST_F(BIHBuilderTest, grid_less_split)
         }
     }
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{5});
+    BIHBuilder build(&storage_, BIHBuilder::Input{4});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
     ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0},
@@ -667,7 +667,7 @@ TEST_F(BIHBuilderTest, single_finite_volume)
 {
     VecFastBbox bboxes = {{{0, 0, 0}, {1, 1, 1}}};
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{2});
+    BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
@@ -687,7 +687,7 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
         {{0, 0, 0}, {1, 1, 1}},
     };
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{2});
+    BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
@@ -705,7 +705,7 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
 {
     VecFastBbox bboxes = {FastBBox::from_infinite()};
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{2});
+    BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
@@ -723,7 +723,7 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
         FastBBox::from_infinite(),
     };
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{2});
+    BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inner_nodes.size());
@@ -749,7 +749,7 @@ TEST_F(BIHBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))
         {{-inff, 0, 0}, {inff, 1, 1}},
     };
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{2});
+    BIHBuilder build(&storage_, BIHBuilder::Input{1});
     EXPECT_THROW(build(std::move(bboxes), implicit_vol_ids_), DebugError);
 }
 

--- a/test/orange/detail/BIHEnclosingVolFinder.test.cc
+++ b/test/orange/detail/BIHEnclosingVolFinder.test.cc
@@ -65,7 +65,7 @@ class BIHEnclosingVolFinderTest : public Test
  */
 TEST_F(BIHEnclosingVolFinderTest, basic)
 {
-    auto run_test = [&](size_type min_split_size) {
+    auto run_test = [&](size_type max_leaf_size) {
         VecFastBbox bboxes = {
             FastBBox::from_infinite(),
             {{0, 0, 0}, {1.6f, 1, 100}},
@@ -75,7 +75,7 @@ TEST_F(BIHEnclosingVolFinderTest, basic)
             {{0, -1, 0}, {5, 0, 100}},
         };
 
-        BIHBuilder build(&storage_, BIHBuilder::Input{min_split_size});
+        BIHBuilder build(&storage_, BIHBuilder::Input{max_leaf_size});
         auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
         ref_storage_ = storage_;
@@ -91,9 +91,9 @@ TEST_F(BIHEnclosingVolFinderTest, basic)
         EXPECT_EQ(LocalVolumeId{5}, find_volume({2.9, -0.7, 50}, odd_vol_id_));
     };
 
-    for (auto min_split_size : range(2, 5))
+    for (auto max_leaf_size : range(1, 4))
     {
-        run_test(min_split_size);
+        run_test(max_leaf_size);
     }
 }
 
@@ -116,7 +116,7 @@ TEST_F(BIHEnclosingVolFinderTest, basic)
  */
 TEST_F(BIHEnclosingVolFinderTest, grid)
 {
-    auto run_test = [&](size_type min_split_size) {
+    auto run_test = [&](size_type max_leaf_size) {
         VecFastBbox bboxes = {FastBBox::from_infinite()};
         for (auto i : range(3))
         {
@@ -128,7 +128,7 @@ TEST_F(BIHEnclosingVolFinderTest, grid)
             }
         }
 
-        BIHBuilder build(&storage_, BIHBuilder::Input{min_split_size});
+        BIHBuilder build(&storage_, BIHBuilder::Input{max_leaf_size});
         auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
         ref_storage_ = storage_;
@@ -149,9 +149,9 @@ TEST_F(BIHEnclosingVolFinderTest, grid)
         }
     };
 
-    for (auto min_split_size : range(2, 5))
+    for (auto max_leaf_size : range(1, 4))
     {
-        run_test(min_split_size);
+        run_test(max_leaf_size);
     }
 }
 

--- a/test/orange/detail/BIHIntersectingVolFinder.test.cc
+++ b/test/orange/detail/BIHIntersectingVolFinder.test.cc
@@ -47,7 +47,7 @@ class BIHIntersectingVolFinderTest : public Test
     using DistMap = std::map<LocalVolumeId, real_type>;
 
   protected:
-    void setup(size_type min_split_size)
+    void setup(size_type max_leaf_size)
     {
         BIHBuilder::VecBBox bboxes = {
             FastBBox::from_infinite(),
@@ -58,7 +58,7 @@ class BIHIntersectingVolFinderTest : public Test
             {{0, -1, 0}, {5, 0, 100}},
         };
 
-        BIHBuilder build(&storage_, BIHBuilder::Input{min_split_size});
+        BIHBuilder build(&storage_, BIHBuilder::Input{max_leaf_size});
         BIHBuilder::SetLocalVolId implicit_vol_ids_;
         bih_tree_ = build(std::move(bboxes), implicit_vol_ids_);
         ref_storage_ = storage_;
@@ -126,8 +126,8 @@ class BIHIntersectingVolFinderTest : public Test
 // intersection yields the first volume intersection.
 TEST_F(BIHIntersectingVolFinderTest, outside_first)
 {
-    auto run_test = [&](size_type min_split_size) {
-        this->setup(min_split_size);
+    auto run_test = [&](size_type max_leaf_size) {
+        this->setup(max_leaf_size);
         Real3 pos, dir;
         DistMap dist_map;
 
@@ -209,9 +209,9 @@ TEST_F(BIHIntersectingVolFinderTest, outside_first)
         this->check_result({pos, dir}, dist_map, LocalVolumeId{5}, 1.3, 1.2);
     };
 
-    for (auto min_split_size : range(2, 5))
+    for (auto max_leaf_size : range(1, 4))
     {
-        run_test(min_split_size);
+        run_test(max_leaf_size);
     }
 }
 
@@ -219,8 +219,8 @@ TEST_F(BIHIntersectingVolFinderTest, outside_first)
 // contains first intersecting volume.
 TEST_F(BIHIntersectingVolFinderTest, inside_first)
 {
-    auto run_test = [&](size_type min_split_size) {
-        this->setup(min_split_size);
+    auto run_test = [&](size_type max_leaf_size) {
+        this->setup(max_leaf_size);
         Real3 pos, dir;
         DistMap dist_map;
 
@@ -313,9 +313,9 @@ TEST_F(BIHIntersectingVolFinderTest, inside_first)
         this->check_result({pos, dir}, dist_map, LocalVolumeId{5}, 1.6, 1.2);
     };
 
-    for (auto min_split_size : range(2, 5))
+    for (auto max_leaf_size : range(1, 4))
     {
-        run_test(min_split_size);
+        run_test(max_leaf_size);
     }
 }
 
@@ -323,8 +323,8 @@ TEST_F(BIHIntersectingVolFinderTest, inside_first)
 // collision
 TEST_F(BIHIntersectingVolFinderTest, not_first)
 {
-    auto run_test = [&](size_type min_split_size) {
-        this->setup(min_split_size);
+    auto run_test = [&](size_type max_leaf_size) {
+        this->setup(max_leaf_size);
         Real3 pos, dir;
         DistMap dist_map;
 
@@ -386,9 +386,9 @@ TEST_F(BIHIntersectingVolFinderTest, not_first)
         this->check_result({pos, dir}, dist_map, LocalVolumeId{2}, 2.1, 1.5);
     };
 
-    for (auto min_split_size : range(2, 5))
+    for (auto max_leaf_size : range(1, 4))
     {
-        run_test(min_split_size);
+        run_test(max_leaf_size);
     }
 }
 


### PR DESCRIPTION
This MR renamed the BIH parameter `min_split_size` to `max_leaf_size`. In addition to being easier to explain, it also has the more natural default value of 1, rather than 2.