### PR TITLE
Use User-defined literals

### DIFF
--- a/src/celeritas/Units.hh
+++ b/src/celeritas/Units.hh
@@ -188,24 +188,24 @@ CELER_ICC barn = Constant{1e-24} * centimeter * centimeter;
 namespace literals
 {
 
-#define CELER_DEFINE_UNIT_UDL(SUFFIX, NAME)                                 \
-    CELER_CONSTEXPR_FUNCTION long double operator""_##SUFFIX(long double v) \
-    {                                                                       \
-        return v * units::NAME;                                             \
-    }                                                                       \
-    CELER_CONSTEXPR_FUNCTION Constant operator""_##SUFFIX(                  \
-        unsigned long long int v)                                           \
-    {                                                                       \
-        return v * units::NAME;                                             \
-    }                                                                       \
-    CELER_CONSTEXPR_FUNCTION long double operator""_##NAME(long double v)   \
-    {                                                                       \
-        return v * units::NAME;                                             \
-    }                                                                       \
-    CELER_CONSTEXPR_FUNCTION Constant operator""_##NAME(                    \
-        unsigned long long int v)                                           \
-    {                                                                       \
-        return v * units::NAME;                                             \
+#define CELER_DEFINE_UNIT_UDL(SUFFIX, NAME)                            \
+    CELER_CONSTEXPR_FUNCTION double operator""_##SUFFIX(long double v) \
+    {                                                                  \
+        return v * units::NAME;                                        \
+    }                                                                  \
+    CELER_CONSTEXPR_FUNCTION Constant operator""_##SUFFIX(             \
+        unsigned long long int v)                                      \
+    {                                                                  \
+        return v * units::NAME;                                        \
+    }                                                                  \
+    CELER_CONSTEXPR_FUNCTION double operator""_##NAME(long double v)   \
+    {                                                                  \
+        return v * units::NAME;                                        \
+    }                                                                  \
+    CELER_CONSTEXPR_FUNCTION Constant operator""_##NAME(               \
+        unsigned long long int v)                                      \
+    {                                                                  \
+        return v * units::NAME;                                        \
     }
 
 CELER_DEFINE_UNIT_UDL(cm, centimeter)

--- a/src/celeritas/Units.hh
+++ b/src/celeritas/Units.hh
@@ -181,7 +181,7 @@ CELER_ICC barn = Constant{1e-24} * centimeter * centimeter;
  * units::centimeter) or bring in only the needed literal operator inside a
  * function scope:
  * \code
- * using celeritas::units::literals::operator"" _centimeter;
+ * using celeritas::units::literals::operator""_centimeter;
  * return 2.5_centimeter;
  * \endcode
  */

--- a/src/celeritas/Units.hh
+++ b/src/celeritas/Units.hh
@@ -188,24 +188,24 @@ CELER_ICC barn = Constant{1e-24} * centimeter * centimeter;
 namespace literals
 {
 
-#define CELER_DEFINE_UNIT_UDL(SUFFIX, NAME)                            \
-    CELER_CONSTEXPR_FUNCTION double operator""_##SUFFIX(long double v) \
-    {                                                                  \
-        return v * units::NAME;                                        \
-    }                                                                  \
-    CELER_CONSTEXPR_FUNCTION Constant operator""_##SUFFIX(             \
-        unsigned long long int v)                                      \
-    {                                                                  \
-        return v * units::NAME;                                        \
-    }                                                                  \
-    CELER_CONSTEXPR_FUNCTION double operator""_##NAME(long double v)   \
-    {                                                                  \
-        return v * units::NAME;                                        \
-    }                                                                  \
-    CELER_CONSTEXPR_FUNCTION Constant operator""_##NAME(               \
-        unsigned long long int v)                                      \
-    {                                                                  \
-        return v * units::NAME;                                        \
+#define CELER_DEFINE_UNIT_UDL(SUFFIX, NAME)                                 \
+    CELER_CONSTEXPR_FUNCTION long double operator""_##SUFFIX(long double v) \
+    {                                                                       \
+        return v * units::NAME;                                             \
+    }                                                                       \
+    CELER_CONSTEXPR_FUNCTION Constant operator""_##SUFFIX(                  \
+        unsigned long long int v)                                           \
+    {                                                                       \
+        return v * units::NAME;                                             \
+    }                                                                       \
+    CELER_CONSTEXPR_FUNCTION long double operator""_##NAME(long double v)   \
+    {                                                                       \
+        return v * units::NAME;                                             \
+    }                                                                       \
+    CELER_CONSTEXPR_FUNCTION Constant operator""_##NAME(                    \
+        unsigned long long int v)                                           \
+    {                                                                       \
+        return v * units::NAME;                                             \
     }
 
 CELER_DEFINE_UNIT_UDL(cm, centimeter)

--- a/src/celeritas/Units.hh
+++ b/src/celeritas/Units.hh
@@ -188,24 +188,24 @@ CELER_ICC barn = Constant{1e-24} * centimeter * centimeter;
 namespace literals
 {
 
-#define CELER_DEFINE_UNIT_UDL(SUFFIX, NAME)                               \
-    CELER_CONSTEXPR_FUNCTION real_type operator""_##SUFFIX(long double v) \
-    {                                                                     \
-        return static_cast<real_type>(v) * units::NAME;                   \
-    }                                                                     \
-    CELER_CONSTEXPR_FUNCTION Constant operator""_##SUFFIX(                \
-        unsigned long long int v)                                         \
-    {                                                                     \
-        return v * units::NAME;                                           \
-    }                                                                     \
-    CELER_CONSTEXPR_FUNCTION real_type operator""_##NAME(long double v)   \
-    {                                                                     \
-        return static_cast<real_type>(v) * units::NAME;                   \
-    }                                                                     \
-    CELER_CONSTEXPR_FUNCTION Constant operator""_##NAME(                  \
-        unsigned long long int v)                                         \
-    {                                                                     \
-        return v * units::NAME;                                           \
+#define CELER_DEFINE_UNIT_UDL(SUFFIX, NAME)                            \
+    CELER_CONSTEXPR_FUNCTION double operator""_##SUFFIX(long double v) \
+    {                                                                  \
+        return v * units::NAME;                                        \
+    }                                                                  \
+    CELER_CONSTEXPR_FUNCTION Constant operator""_##SUFFIX(             \
+        unsigned long long int v)                                      \
+    {                                                                  \
+        return v * units::NAME;                                        \
+    }                                                                  \
+    CELER_CONSTEXPR_FUNCTION double operator""_##NAME(long double v)   \
+    {                                                                  \
+        return v * units::NAME;                                        \
+    }                                                                  \
+    CELER_CONSTEXPR_FUNCTION Constant operator""_##NAME(               \
+        unsigned long long int v)                                      \
+    {                                                                  \
+        return v * units::NAME;                                        \
     }
 
 CELER_DEFINE_UNIT_UDL(cm, centimeter)

--- a/src/celeritas/Units.hh
+++ b/src/celeritas/Units.hh
@@ -178,10 +178,9 @@ CELER_ICC barn = Constant{1e-24} * centimeter * centimeter;
  * \endcode
  *
  * \note In headers, prefer explicit multiplication (e.g., \c 2.5 *
- * units::centimeter) or bring in only the needed literal operator inside a
- * function scope:
+ * units::centimeter) or bring the namespace inside a function scope:
  * \code
- * using celeritas::units::literals::operator""_centimeter;
+ * using namespace celeritas::units::literals;
  * return 2.5_centimeter;
  * \endcode
  */

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -271,7 +271,7 @@ CELER_FUNCTION real_type WentzelDistribution::flat_form_factor(real_type x)
  */
 CELER_CONSTEXPR_FUNCTION real_type WentzelDistribution::flat_coeff()
 {
-    using celeritas::units::literals::operator""_fm;
+    using namespace celeritas::units::literals;
     return native_value_to<units::MevMomentum>(2.0_fm / constants::hbar_planck)
         .value();
 }

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -271,7 +271,7 @@ CELER_FUNCTION real_type WentzelDistribution::flat_form_factor(real_type x)
  */
 CELER_CONSTEXPR_FUNCTION real_type WentzelDistribution::flat_coeff()
 {
-    using celeritas::units::literals::operator"" _fm;
+    using celeritas::units::literals::operator""_fm;
     return native_value_to<units::MevMomentum>(2.0_fm / constants::hbar_planck)
         .value();
 }

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -271,8 +271,8 @@ CELER_FUNCTION real_type WentzelDistribution::flat_form_factor(real_type x)
  */
 CELER_CONSTEXPR_FUNCTION real_type WentzelDistribution::flat_coeff()
 {
-    return native_value_to<units::MevMomentum>(2 * units::femtometer
-                                               / constants::hbar_planck)
+    using celeritas::units::literals::operator"" _fm;
+    return native_value_to<units::MevMomentum>(2.0_fm / constants::hbar_planck)
         .value();
 }
 

--- a/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
@@ -81,7 +81,8 @@ class UrbanMscSafetyStepLimit
     //! Minimum range for an empirical step-function approach
     static CELER_CONSTEXPR_FUNCTION real_type min_range()
     {
-        return 1e-3 * units::centimeter;
+        using celeritas::units::literals::operator"" _cm;
+        return 1e-3_cm;
     }
 
     //! Maximum step over the range

--- a/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
@@ -81,7 +81,7 @@ class UrbanMscSafetyStepLimit
     //! Minimum range for an empirical step-function approach
     static CELER_CONSTEXPR_FUNCTION real_type min_range()
     {
-        using celeritas::units::literals::operator""_cm;
+        using namespace celeritas::units::literals;
         return 1e-3_cm;
     }
 

--- a/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
@@ -81,7 +81,7 @@ class UrbanMscSafetyStepLimit
     //! Minimum range for an empirical step-function approach
     static CELER_CONSTEXPR_FUNCTION real_type min_range()
     {
-        using celeritas::units::literals::operator"" _cm;
+        using celeritas::units::literals::operator""_cm;
         return 1e-3_cm;
     }
 

--- a/src/celeritas/em/msc/detail/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscScatter.hh
@@ -105,7 +105,7 @@ class UrbanMscScatter
     //! The minimum step length for geometry 0.05 nm
     static CELER_CONSTEXPR_FUNCTION real_type geom_min()
     {
-        using celeritas::units::literals::operator""_cm;
+        using namespace celeritas::units::literals;
         return 5e-9_cm;
     }
 

--- a/src/celeritas/em/msc/detail/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscScatter.hh
@@ -105,7 +105,7 @@ class UrbanMscScatter
     //! The minimum step length for geometry 0.05 nm
     static CELER_CONSTEXPR_FUNCTION real_type geom_min()
     {
-        using celeritas::units::literals::operator"" _cm;
+        using celeritas::units::literals::operator""_cm;
         return 5e-9_cm;
     }
 

--- a/src/celeritas/em/msc/detail/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscScatter.hh
@@ -105,7 +105,8 @@ class UrbanMscScatter
     //! The minimum step length for geometry 0.05 nm
     static CELER_CONSTEXPR_FUNCTION real_type geom_min()
     {
-        return 5e-9 * units::centimeter;
+        using celeritas::units::literals::operator"" _cm;
+        return 5e-9_cm;
     }
 
     //// HELPER FUNCTIONS ////

--- a/src/celeritas/ext/detail/NaviTouchableUpdater.hh
+++ b/src/celeritas/ext/detail/NaviTouchableUpdater.hh
@@ -39,12 +39,17 @@ class NaviTouchableUpdater final : public TouchableUpdaterInterface
 
   public:
     //! Maximum step to try within the current volume [len]
-    static constexpr double max_step() { return 1.0 * units::millimeter; }
+    static constexpr double max_step()
+    {
+        using celeritas::units::literals::operator"" _mm;
+        return 1.0_mm;
+    }
 
     //! Print diagnostic when the step is greater than this amount [len]
     static constexpr double max_quiet_step()
     {
-        return 1e-3 * units::millimeter;
+        using celeritas::units::literals::operator"" _mm;
+        return 1e-3_mm;
     }
 
     // Construct from detector LVs

--- a/src/celeritas/ext/detail/NaviTouchableUpdater.hh
+++ b/src/celeritas/ext/detail/NaviTouchableUpdater.hh
@@ -41,14 +41,14 @@ class NaviTouchableUpdater final : public TouchableUpdaterInterface
     //! Maximum step to try within the current volume [len]
     static constexpr double max_step()
     {
-        using celeritas::units::literals::operator"" _mm;
+        using celeritas::units::literals::operator""_mm;
         return 1.0_mm;
     }
 
     //! Print diagnostic when the step is greater than this amount [len]
     static constexpr double max_quiet_step()
     {
-        using celeritas::units::literals::operator"" _mm;
+        using celeritas::units::literals::operator""_mm;
         return 1e-3_mm;
     }
 

--- a/src/celeritas/ext/detail/NaviTouchableUpdater.hh
+++ b/src/celeritas/ext/detail/NaviTouchableUpdater.hh
@@ -41,14 +41,14 @@ class NaviTouchableUpdater final : public TouchableUpdaterInterface
     //! Maximum step to try within the current volume [len]
     static constexpr double max_step()
     {
-        using celeritas::units::literals::operator""_mm;
+        using namespace celeritas::units::literals;
         return 1.0_mm;
     }
 
     //! Print diagnostic when the step is greater than this amount [len]
     static constexpr double max_quiet_step()
     {
-        using celeritas::units::literals::operator""_mm;
+        using namespace celeritas::units::literals;
         return 1e-3_mm;
     }
 

--- a/src/celeritas/phys/PhysicsOptions.hh
+++ b/src/celeritas/phys/PhysicsOptions.hh
@@ -64,7 +64,7 @@ struct ParticleOptions
     static ParticleOptions default_light()
     {
         ParticleOptions opts;
-        using celeritas::units::literals::operator""_mm;
+        using namespace celeritas::units::literals;
         opts.min_range = 1.0_mm;
         opts.max_step_over_range = 0.2;
         opts.lowest_energy = ParticleOptions::Energy{0.001};
@@ -78,7 +78,7 @@ struct ParticleOptions
     static ParticleOptions default_heavy()
     {
         ParticleOptions opts;
-        using celeritas::units::literals::operator""_mm;
+        using namespace celeritas::units::literals;
         opts.min_range = 0.1_mm;
         opts.max_step_over_range = 0.2;
         opts.lowest_energy = ParticleOptions::Energy{0.001};

--- a/src/celeritas/phys/PhysicsOptions.hh
+++ b/src/celeritas/phys/PhysicsOptions.hh
@@ -64,7 +64,7 @@ struct ParticleOptions
     static ParticleOptions default_light()
     {
         ParticleOptions opts;
-        using celeritas::units::literals::operator"" _mm;
+        using celeritas::units::literals::operator""_mm;
         opts.min_range = 1.0_mm;
         opts.max_step_over_range = 0.2;
         opts.lowest_energy = ParticleOptions::Energy{0.001};
@@ -78,7 +78,7 @@ struct ParticleOptions
     static ParticleOptions default_heavy()
     {
         ParticleOptions opts;
-        using celeritas::units::literals::operator"" _mm;
+        using celeritas::units::literals::operator""_mm;
         opts.min_range = 0.1_mm;
         opts.max_step_over_range = 0.2;
         opts.lowest_energy = ParticleOptions::Energy{0.001};

--- a/src/celeritas/phys/PhysicsOptions.hh
+++ b/src/celeritas/phys/PhysicsOptions.hh
@@ -64,7 +64,8 @@ struct ParticleOptions
     static ParticleOptions default_light()
     {
         ParticleOptions opts;
-        opts.min_range = real_type{1} * units::millimeter;
+        using celeritas::units::literals::operator"" _mm;
+        opts.min_range = 1.0_mm;
         opts.max_step_over_range = 0.2;
         opts.lowest_energy = ParticleOptions::Energy{0.001};
         opts.displaced = true;
@@ -77,7 +78,8 @@ struct ParticleOptions
     static ParticleOptions default_heavy()
     {
         ParticleOptions opts;
-        opts.min_range = 0.1 * units::millimeter;
+        using celeritas::units::literals::operator"" _mm;
+        opts.min_range = 0.1_mm;
         opts.max_step_over_range = 0.2;
         opts.lowest_energy = ParticleOptions::Energy{0.001};
         opts.displaced = false;

--- a/test/celeritas/Constants.test.cc
+++ b/test/celeritas/Constants.test.cc
@@ -27,6 +27,7 @@ namespace constants
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 // CLHEP units introduce extra error due to repeated operations with
 // non-representable values
@@ -73,7 +74,7 @@ TEST(ConstantsTest, clhep_codata)
     // Values differ from the CLHEP constants (CODATA 2006) by ~1e-7 due to
     // the 2019 change in SI using e- charge as an exact definition
     // rather than a measured constant
-    constexpr Constant old_e_electron{1.602176487e-19 * units::coulomb};
+    constexpr Constant old_e_electron{1.602176487e-19_C};
 
     using MevMass = Quantity<units::MevPerCsq, double>;
 
@@ -123,13 +124,12 @@ TEST(ConstantsTest, clhep)
 TEST(ConstantsTest, derivative)
 {
     // Compared against definition of Dalton, table 8 of SI 2019
-    EXPECT_SOFT_EQ(1.66053906660e-27 * units::kilogram, atomic_mass);
-    EXPECT_SOFT_EQ(1.602176634e-19 * units::joule, e_electron * units::volt);
+    EXPECT_SOFT_EQ(1.66053906660e-27_kg, atomic_mass);
+    EXPECT_SOFT_EQ(1.602176634e-19_J, e_electron * units::volt);
 
     // CODATA 2018 listings
-    EXPECT_SOFT_NEAR(1.49241808560e-10 * units::joule,
-                     atomic_mass * c_light * c_light,
-                     clhep_tol);
+    EXPECT_SOFT_NEAR(
+        1.49241808560e-10_J, atomic_mass * c_light * c_light, clhep_tol);
     EXPECT_SOFT_NEAR(931.49410242e6 * e_electron * units::volt,
                      atomic_mass * c_light * c_light,
                      clhep_tol);

--- a/test/celeritas/Units.test.cc
+++ b/test/celeritas/Units.test.cc
@@ -24,6 +24,7 @@ namespace units
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 // Locally replace the Celeritas "real" expectation for one that forces
 // Constant objects to double-precision
@@ -97,8 +98,6 @@ TEST(UnitsTest, trait_visitor)
 //---------------------------------------------------------------------------//
 TEST(UnitsTest, literals)
 {
-    using namespace celeritas::units::literals;
-
     EXPECT_REAL_EQ(2.5 * units::centimeter, 2.5_centimeter);
     EXPECT_REAL_EQ(2.5 * units::centimeter, 2.5_cm);
     EXPECT_REAL_EQ(3 * units::meter, 3_meter);
@@ -158,20 +157,20 @@ TEST(UnitsTest, clhep)
 
         double g4_native = 2.5 * CLHEP::tesla;
         auto celer_native = convert_from_geant(g4_native, clhep_field);
-        EXPECT_SOFT_EQ(2.5 * units::tesla, celer_native);
+        EXPECT_SOFT_EQ(2.5_T, celer_native);
         EXPECT_SOFT_EQ(2.5, native_value_to<FieldTesla>(celer_native).value());
         EXPECT_SOFT_EQ(g4_native, convert_to_geant(celer_native, clhep_field));
     }
     {
         double g4_native = 1.5 * CLHEP::s;
         auto celer_native = convert_from_geant(g4_native, clhep_time);
-        EXPECT_SOFT_EQ(1.5 * units::second, celer_native);
+        EXPECT_SOFT_EQ(1.5_s, celer_native);
         EXPECT_SOFT_EQ(g4_native, convert_to_geant(celer_native, clhep_time));
     }
     {
         double g4_native = 1.5 * CLHEP::meter;
         auto celer_native = convert_from_geant(g4_native, clhep_length);
-        EXPECT_SOFT_EQ(1.5 * units::meter, celer_native);
+        EXPECT_SOFT_EQ(1.5_m, celer_native);
         EXPECT_SOFT_EQ(g4_native, convert_to_geant(celer_native, clhep_length));
     }
 #else

--- a/test/celeritas/em/distribution/EnergyLossHelper.test.cc
+++ b/test/celeritas/em/distribution/EnergyLossHelper.test.cc
@@ -26,6 +26,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 using units::MevEnergy;
 using EnergySq = RealQuantity<UnitProduct<units::Mev, units::Mev>>;
@@ -156,7 +157,7 @@ TEST_F(EnergyLossDistributionTest, none)
     MevEnergy mean_loss{2e-6};
 
     // Tiny step, little energy loss
-    real_type step = 1e-6 * units::centimeter;
+    real_type step = 1e-6_cm;
     EnergyLossHelper helper(
         fluct->host_ref(), cutoff, material, particle, mean_loss, step);
     EXPECT_EQ(EnergyLossFluctuationModel::none, helper.model());
@@ -180,7 +181,7 @@ TEST_F(EnergyLossDistributionTest, gaussian)
 
     // Larger step samples from gamma distribution, smaller step from Gaussian
     {
-        real_type step = 5e-2 * units::centimeter;
+        real_type step = 5e-2_cm;
         EnergyLossHelper helper(
             fluct->host_ref(), cutoff, material, particle, mean_loss, step);
         EXPECT_EQ(EnergyLossFluctuationModel::gamma, helper.model());
@@ -203,7 +204,7 @@ TEST_F(EnergyLossDistributionTest, gaussian)
         EXPECT_REF_EQ(ref, sampled);
     }
     {
-        real_type step = 5e-4 * units::centimeter;
+        real_type step = 5e-4_cm;
         EnergyLossHelper helper(
             fluct->host_ref(), cutoff, material, particle, mean_loss, step);
         EXPECT_SOFT_EQ(0.00019160444039613,
@@ -251,7 +252,7 @@ TEST_F(EnergyLossDistributionTest, urban)
     material = {PhysMatId{0}};
     CutoffView cutoff(cutoffs->host_ref(), PhysMatId{0});
     MevEnergy mean_loss{0.01};
-    real_type step = 0.01 * units::centimeter;
+    real_type step = 0.01_cm;
 
     EnergyLossHelper helper(
         fluct->host_ref(), cutoff, material, particle, mean_loss, step);

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -40,6 +40,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 constexpr real_type pi{constants::pi};
 constexpr real_type sqrt_three{constants::sqrt_three};
@@ -156,8 +157,7 @@ struct HorribleZField
 
 // Field value (native units) for 10 MeV electron/positron to have a radius of
 // 1 cm
-constexpr real_type unit_radius_field_strength{3.5019461121752274
-                                               * units::tesla};
+constexpr real_type unit_radius_field_strength{3.5019461121752274_T};
 
 //---------------------------------------------------------------------------//
 // TESTS
@@ -171,7 +171,7 @@ TEST_F(TwoBoxesTest, electron_interior)
     auto particle
         = this->make_particle_view(pdg::electron(), MevEnergy{10.9181415106});
     auto geo = this->make_geo_track_view({radius, 0, 0}, {0, 1, 0});
-    UniformZField field(1.0 * units::tesla);
+    UniformZField field(1.0_T);
 
     // Check expected field curvature and geometry cell
     EXPECT_SOFT_EQ(radius, this->calc_field_curvature(particle, geo, field));
@@ -348,7 +348,7 @@ TEST_F(TwoBoxesTest, gamma_pathological)
     auto particle = this->make_particle_view(pdg::gamma(), MevEnergy{1});
 
     // Construct field (shape and magnitude shouldn't matter)
-    HorribleZField field{1.2345 * units::tesla, 5};
+    HorribleZField field{1.2345_T, 5};
     FieldDriverOptions driver_options;
     auto integrate = make_mag_field_integrator<DiagnosticDPIntegrator>(
         field, particle.charge());
@@ -446,7 +446,7 @@ TEST_F(TwoBoxesTest, gamma_exit)
 TEST_F(TwoBoxesTest, electron_super_small_step)
 {
     auto particle = this->make_particle_view(pdg::electron(), MevEnergy{2});
-    UniformZField field(static_cast<real_type>(1 * units::tesla));
+    UniformZField field(static_cast<real_type>(1_T));
     FieldDriverOptions driver_options;
 
     std::vector<real_type> intersect_distance;
@@ -1144,7 +1144,7 @@ TEST_F(LayersTest, revolutions_through_layers)
     auto particle
         = this->make_particle_view(pdg::electron(), MevEnergy{10.9181415106});
     auto geo = this->make_geo_track_view({radius, 0, 0}, {0, 1, 0});
-    UniformZField field(1.0 * units::tesla);
+    UniformZField field(1.0_T);
 
     // Build propagator
     FieldDriverOptions driver_options;
@@ -1231,7 +1231,7 @@ TEST_F(SimpleCmsTest, TEST_IF_CELERITAS_DOUBLE(electron_stuck))
 {
     auto particle = this->make_particle_view(pdg::electron(),
                                              MevEnergy{4.25402379798713e-01});
-    UniformZField field(real_type(1 * units::tesla));
+    UniformZField field(real_type(1_T));
     FieldDriverOptions driver_options;
 
     auto geo = this->make_geo_track_view(
@@ -1329,7 +1329,7 @@ TEST_F(SimpleCmsTest, TEST_IF_CELERITAS_DOUBLE(electron_stuck))
 
 TEST_F(SimpleCmsTest, TEST_IF_CELERITAS_DOUBLE(vecgeom_failure))
 {
-    UniformZField field(real_type(1 * units::tesla));
+    UniformZField field(real_type(1_T));
     FieldDriverOptions driver_options;
     driver_options.max_substeps = 100;
 

--- a/test/celeritas/field/FieldSubstepper.test.cc
+++ b/test/celeritas/field/FieldSubstepper.test.cc
@@ -31,6 +31,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 
 constexpr real_type sqrt_two{constants::sqrt_two};
 using units::ElementaryCharge;
@@ -87,8 +88,8 @@ class RevolutionFieldSubstepperTest : public FieldSubstepperTest
         // Input parameters of an electron in a uniform magnetic field
         test_params.nsteps = 100;
         test_params.revolutions = 10;
-        test_params.radius = 3.8085386036 * units::centimeter;
-        test_params.delta_z = 6.7003310629 * units::centimeter;
+        test_params.radius = 3.8085386036_cm;
+        test_params.delta_z = 6.7003310629_cm;
         test_params.epsilon = 1.0e-5;
     }
 
@@ -117,7 +118,7 @@ make_mag_field_substepper(FieldT&& field,
 //! Z oriented field of 2**(y / scale)
 struct ExpZField
 {
-    real_type strength{1 * units::tesla};
+    real_type strength{1_T};
     real_type scale{1};
 
     Real3 operator()(Real3 const& pos) const
@@ -168,7 +169,7 @@ TEST_F(FieldSubstepperTest, unpleasant_field)
     FieldDriverOptions driver_options;
     driver_options.max_nsteps = 32;
 
-    real_type field_strength = 1.0 * units::tesla;
+    real_type field_strength = 1.0_T;
     MevEnergy e{1.0};
     real_type radius = this->calc_curvature(e, field_strength);
 
@@ -200,7 +201,7 @@ TEST_F(FieldSubstepperTest, horrible_field)
     FieldDriverOptions driver_options;
     driver_options.max_nsteps = 32;
 
-    real_type field_strength = 1.0 * units::tesla;
+    real_type field_strength = 1.0_T;
     MevEnergy e{1.0};
     real_type radius = this->calc_curvature(e, field_strength);
 
@@ -240,7 +241,7 @@ TEST_F(FieldSubstepperTest, pathological_chord)
     FieldDriverOptions driver_options;
     driver_options.max_nsteps = std::numeric_limits<short int>::max();
 
-    real_type field_strength = 1.0 * units::tesla;
+    real_type field_strength = 1.0_T;
     MevEnergy e{1.0};
     real_type radius = this->calc_curvature(e, field_strength);
 
@@ -279,7 +280,7 @@ TEST_F(FieldSubstepperTest, step_counts)
     FieldDriverOptions driver_options;
     driver_options.max_nsteps = std::numeric_limits<short int>::max();
 
-    real_type field_strength = 1.0 * units::tesla;
+    real_type field_strength = 1.0_T;
     auto integrate = make_mag_field_integrator<DiagnosticDPIntegrator>(
         UniformZField{field_strength}, units::ElementaryCharge{-1});
 
@@ -340,7 +341,7 @@ TEST_F(FieldSubstepperTest, step_counts)
 TEST_F(RevolutionFieldSubstepperTest, advance)
 {
     auto advance = make_mag_field_substepper<DormandPrinceIntegrator>(
-        UniformZField{1.0 * units::tesla}, driver_options, electron_charge());
+        UniformZField{1.0_T}, driver_options, electron_charge());
 
     // Test parameters and the sub-step size
     real_type circumference = 2 * constants::pi * test_params.radius;
@@ -382,7 +383,7 @@ TEST_F(RevolutionFieldSubstepperTest, advance)
 TEST_F(RevolutionFieldSubstepperTest, accurate_advance)
 {
     auto advance = make_mag_field_substepper<DormandPrinceIntegrator>(
-        UniformZField{1.0 * units::tesla}, driver_options, electron_charge());
+        UniformZField{1.0_T}, driver_options, electron_charge());
 
     // Test parameters and the sub-step size
     real_type circumference = 2 * constants::pi * test_params.radius;

--- a/test/celeritas/field/Integrators.test.cc
+++ b/test/celeritas/field/Integrators.test.cc
@@ -29,6 +29,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 struct IntegratorTestOutput
 {
     std::vector<real_type> pos_x;
@@ -64,8 +65,7 @@ class IntegratorsTest : public Test
           mom_0 = mass * sqrt(ipow<2>(gamma) - 1) * dir_0
         */
 
-        param.field_value = 1.0 * units::tesla;  //! field value along z
-                                                 //! [tesla]
+        param.field_value = 1.0_T;  //! field value along z [tesla]
         param.radius = 3.8085386036;  //! radius of curvature [cm]
         param.delta_z = 6.7003310629;  //! z-change/revolution [cm]
         param.momentum_y = 10.9610028286;  //! initial momentum_y [MeV/c]

--- a/test/celeritas/io/EventIOTestBase.cc
+++ b/test/celeritas/io/EventIOTestBase.cc
@@ -22,6 +22,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 void EventIOTestBase::ReadAllResult::print_expected() const
 {
@@ -129,14 +130,14 @@ void EventIOTestBase::write_test_event(Writer& write_event) const
                       MevEnergy{1.23},
                       from_cm(Real3{2, 4, 5}),
                       Real3{1, 0, 0},
-                      5.67e-9 * units::second,
+                      5.67e-9_s,
                       EventId{0},
                       PrimaryId{}};
         Primary proton{proton_id,
                        MevEnergy{2.34},
                        from_cm(Real3{3, 5, 8}),
                        Real3{0, 1, 0},
-                       5.78e-9 * units::second,
+                       5.78e-9_s,
                        EventId{0},
                        PrimaryId{}};
         std::vector<Primary> primaries{gamma, proton, gamma, proton};

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -39,6 +39,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 
 struct InvCentimeter
@@ -116,8 +117,8 @@ Span<real_type const> get_water_refractive_index()
 // Convert a wavelength in [micrometer] to a photon energy in [MeV]
 real_type um_to_mev(real_type wavelength_um)
 {
-    return value_as<units::MevEnergy>(optical::detail::wavelength_to_energy(
-        1e-3 * units::millimeter * wavelength_um));
+    return value_as<units::MevEnergy>(
+        optical::detail::wavelength_to_energy(1e-3_mm * wavelength_um));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/WavelengthShift.test.cc
+++ b/test/celeritas/optical/WavelengthShift.test.cc
@@ -26,6 +26,7 @@ namespace optical
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 // TEST HARNESS
 //---------------------------------------------------------------------------//
@@ -72,7 +73,7 @@ TEST_F(WavelengthShiftTest, data)
     // Test the material properties of WLS
     WlsMaterialRecord wls_record = data_.wls_record[material_id_];
     EXPECT_SOFT_EQ(2, wls_record.mean_num_photons);
-    EXPECT_SOFT_EQ(1 * units::nanosecond, wls_record.time_constant);
+    EXPECT_SOFT_EQ(1_ns, wls_record.time_constant);
 
     // Test the vector property (emission spectrum) of WLS
 
@@ -115,7 +116,7 @@ TEST_F(WavelengthShiftTest, time_profile)
     WlsDistributionData dist;
     dist.num_photons = 1000;
     dist.energy = Energy{2e-6};
-    dist.time = 5.0 * units::nanosecond;
+    dist.time = 5.0_ns;
     dist.material = material_id_;
 
     {

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -33,6 +33,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 using MevEnergy = units::MevEnergy;
 
@@ -531,7 +532,7 @@ TEST_F(PhysicsTrackViewHostTest, calc_xs)
 TEST_F(PhysicsTrackViewHostTest, calc_eloss_range)
 {
     // Default range and scaling
-    EXPECT_SOFT_EQ(0.1 * units::centimeter, params_ref.scalars.light.min_range);
+    EXPECT_SOFT_EQ(0.1_cm, params_ref.scalars.light.min_range);
     EXPECT_SOFT_EQ(0.2, params_ref.scalars.light.max_step_over_range);
     std::vector<real_type> eloss;
     std::vector<real_type> range;

--- a/test/celeritas/phys/PhysicsStepUtils.test.cc
+++ b/test/celeritas/phys/PhysicsStepUtils.test.cc
@@ -22,6 +22,7 @@ namespace celeritas
 {
 namespace test
 {
+using namespace celeritas::units::literals;
 //---------------------------------------------------------------------------//
 // TEST HARNESS
 //---------------------------------------------------------------------------//
@@ -399,7 +400,7 @@ class StepLimiterTest : public PhysicsStepUtilsTest
         PhysicsOptions opts;
 
         opts.light.min_range = inf;  // Use analytic range instead of scaled
-        opts.fixed_step_limiter = 1e-3 * units::centimeter;
+        opts.fixed_step_limiter = 1e-3_cm;
         return opts;
     }
 };


### PR DESCRIPTION
Use User-defined literals instead of units multiplication. This update straight-forward cases only.

Credits to Copilot. 