### PR TITLE
Accelerate ORANGE construction by two orders of magnitude

### DIFF
--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -476,14 +476,6 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
     // 1. It has a Join ancestor that is not negated
     // 2. It has a negated parent, and that negated node has a negated join
     // parent (double negation of that join)
-    auto has_negated_join_parent = [&](NodeId n) {
-        for (auto p : range(first_node_id_, NodeId{tree_.size()}))
-        {
-            if (this->is_parent_of(p, n) && negated_join_nodes_.count(p))
-                return true;
-        }
-        return false;
-    };
 
     for (auto p : range(first_node_id_, NodeId{tree_.size()}))
     {
@@ -493,13 +485,23 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
 
         // Check if a parent requires that node to be inserted
         // TODO: Is it really correct in all cases...
-        if (Node const& dealiased{this->get_node(p)};
-            (std::holds_alternative<Joined>(dealiased)
-             && this->should_insert_join(p))
-            || (std::holds_alternative<Negated>(dealiased)
-                && has_negated_join_parent(p)))
+        Node const& dealiased = {this->get_node(p)};
+        if (std::holds_alternative<Joined>(dealiased)
+            && this->should_insert_join(p))
         {
             return true;
+        }
+        if (std::holds_alternative<Negated>(dealiased))
+        {
+            // Loop over grandparents
+            for (auto gp : range(first_node_id_, NodeId{tree_.size()}))
+            {
+                if (this->is_parent_of(gp, p) && negated_join_nodes_.count(gp))
+                {
+                    // has negated join
+                    return true;
+                }
+            }
         }
     }
 

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -47,10 +47,7 @@ NodeId DeMorganSimplifier::MatchingNodes::equivalent_node() const
 /*!
  * Construct and fix bitsets size.
  */
-DeMorganSimplifier::DeMorganSimplifier(CsgTree const& tree)
-    : tree_(tree), parents_(tree_.size())
-{
-}
+DeMorganSimplifier::DeMorganSimplifier(CsgTree const& tree) : tree_(tree) {}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -163,11 +160,12 @@ bool DeMorganSimplifier::insert_parent(NodeId parent, NodeId child)
     CELER_EXPECT(child);
     CELER_EXPECT(parent >= child);
 
-    auto&& [iter, inserted] = parents_.insert({child, parent});
-    if (inserted)
-    {
-        parents_.insert({child, has_parents_index_});
-    }
+    // Insert child row
+    auto&& [iter, inserted] = parents_.try_emplace(child);
+    CELER_ASSERT(iter != parents_.end());
+    // Insert parent entry
+    inserted = iter->second.insert(parent).second;
+
     return inserted;
 }
 
@@ -213,16 +211,27 @@ bool DeMorganSimplifier::insert_negated_children(NodeId node_id)
  */
 bool DeMorganSimplifier::is_parent_of(NodeId parent, NodeId child) const
 {
-    return parents_.count({child, parent});
+    auto iter = parents_.find(child);
+    if (iter == parents_.end())
+    {
+        return false;
+    }
+    return iter->second.count(parent);
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Whether a child has any parent.
  */
-bool DeMorganSimplifier::has_parent(NodeId child_id) const
+bool DeMorganSimplifier::has_parent(NodeId child) const
 {
-    return parents_.count({child_id, has_parents_index_});
+    auto iter = parents_.find(child);
+    if (iter == parents_.end())
+    {
+        return false;
+    }
+    CELER_ENSURE(!iter->second.empty());
+    return true;
 }
 
 //---------------------------------------------------------------------------//
@@ -352,17 +361,19 @@ bool DeMorganSimplifier::process_negated_joined_nodes(NodeId node_id,
 
         // Check if the negation is a root or a volume. If so, we must
         // insert it in the simplified tree
-        if (is_volume_node_[node_id.get()] || !this->has_parent(node_id))
+        if (is_volume_node_[node_id.get()])
+        {
+            return true;
+        }
+        auto parents_iter = parents_.find(node_id);
+        if (parents_iter == parents_.end())
         {
             return true;
         }
 
-        for (auto p : range(first_node_id_, NodeId{tree_.size()}))
+        // Loop over all parents of node_id
+        for (NodeId p : parents_iter->second)
         {
-            // Not a parent
-            if (!parents_.count({node_id, p}))
-                continue;
-
             // A negated node should never have a negated parent
             CELER_ASSERT(!std::holds_alternative<Negated>(this->get_node(p)));
 

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -53,22 +53,10 @@ DeMorganSimplifier::DeMorganSimplifier(CsgTree const& tree) : tree_(tree) {}
 /*!
  * Access or create a translation entry.
  */
-DeMorganSimplifier::MatchingNodes& DeMorganSimplifier::translation(NodeId id)
+auto DeMorganSimplifier::translation(NodeId id) -> MatchingNodes&
 {
-    return node_ids_translation_.try_emplace(id).first->second;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Find a translation entry.
- */
-DeMorganSimplifier::MatchingNodes const*
-DeMorganSimplifier::find_translation(NodeId id) const
-{
-    auto iter = node_ids_translation_.find(id);
-    if (iter == node_ids_translation_.end())
-        return nullptr;
-    return &iter->second;
+    CELER_EXPECT(id < matching_nodes_.size());
+    return matching_nodes_[id.get()];
 }
 
 //---------------------------------------------------------------------------//
@@ -79,6 +67,7 @@ DeMorganSimplifier::find_translation(NodeId id) const
 TransformedTree DeMorganSimplifier::operator()()
 {
     // Mark nodes related to negated joins
+    matching_nodes_.assign(tree_.size(), {});
     this->find_join_negations();
 
     // Save volume nodes
@@ -96,10 +85,8 @@ TransformedTree DeMorganSimplifier::operator()()
     std::vector<NodeId> equivalent_nodes(tree_.size());
     for (auto node_id : range(NodeId{tree_.size()}))
     {
-        if (auto const* trans = this->find_translation(node_id))
-        {
-            equivalent_nodes[node_id.get()] = trans->equivalent_node();
-        }
+        equivalent_nodes[node_id.get()]
+            = this->translation(node_id).equivalent_node();
     }
 
     return {simplified_tree, equivalent_nodes};
@@ -264,14 +251,14 @@ CsgTree DeMorganSimplifier::build_simplified_tree()
         {
             // This is not a negated join, they are inserted in
             // process_negated_joined_nodes
-            for (auto& op : joined->nodes)
+            for (auto& child : joined->nodes)
             {
                 // That means we should find an equivalent node for
                 // each operand, either a simplified negated join or an
                 // unmodified node
-                auto& trans = this->translation(op);
+                auto& trans = this->translation(child);
                 CELER_ASSERT(trans.equivalent_node());
-                op = trans.equivalent_node();
+                child = trans.equivalent_node();
             }
         }
 
@@ -498,7 +485,7 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
                     if (this->is_parent_of(gp, p)
                         && negated_join_nodes_.count(gp))
                     {
-                        // has negated join
+                        // Has negated join
                         return true;
                     }
                 }

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -221,21 +221,6 @@ bool DeMorganSimplifier::is_parent_of(NodeId parent, NodeId child) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Whether a child has any parent.
- */
-bool DeMorganSimplifier::has_parent(NodeId child) const
-{
-    auto iter = parents_.find(child);
-    if (iter == parents_.end())
-    {
-        return false;
-    }
-    CELER_ENSURE(!iter->second.empty());
-    return true;
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Second pass through the tree to build the simplified tree.
  *
  * \return the simplified tree.

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -78,6 +78,7 @@ DeMorganSimplifier::find_translation(NodeId id) const
  */
 TransformedTree DeMorganSimplifier::operator()()
 {
+    // Mark nodes related to negated joins
     this->find_join_negations();
 
     // Save volume nodes
@@ -88,8 +89,10 @@ TransformedTree DeMorganSimplifier::operator()()
         is_volume_node_[node_id.unchecked_get()] = true;
     }
 
-    auto simplified_tree{this->build_simplified_tree()};
+    // Perform simplification
+    CsgTree simplified_tree = this->build_simplified_tree();
 
+    // Find equivalent nodes
     std::vector<NodeId> equivalent_nodes(tree_.size());
     for (auto node_id : range(NodeId{tree_.size()}))
     {
@@ -98,6 +101,7 @@ TransformedTree DeMorganSimplifier::operator()()
             equivalent_nodes[node_id.get()] = trans->equivalent_node();
         }
     }
+
     return {simplified_tree, equivalent_nodes};
 }
 

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -13,6 +13,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "orange/OrangeTypes.hh"
 
 #include "../CsgTree.hh"
@@ -81,18 +82,15 @@ DeMorganSimplifier::find_translation(NodeId id) const
 TransformedTree DeMorganSimplifier::operator()()
 {
     this->find_join_negations();
+
     auto simplified_tree{this->build_simplified_tree()};
-    std::vector<NodeId> equivalent_nodes;
-    equivalent_nodes.reserve(tree_.size());
+
+    std::vector<NodeId> equivalent_nodes(tree_.size());
     for (auto node_id : range(NodeId{tree_.size()}))
     {
         if (auto const* trans = this->find_translation(node_id))
         {
-            equivalent_nodes.push_back(trans->equivalent_node());
-        }
-        else
-        {
-            equivalent_nodes.push_back(NodeId{});
+            equivalent_nodes[node_id.get()] = trans->equivalent_node();
         }
     }
     return {simplified_tree, equivalent_nodes};
@@ -100,9 +98,9 @@ TransformedTree DeMorganSimplifier::operator()()
 
 //---------------------------------------------------------------------------//
 /*!
- * Find the real node id to access by dereferencing Aliased nodes.
+ * Get a non-aliased Node variant
  */
-NodeId DeMorganSimplifier::dealias(NodeId node_id) const
+Node const& DeMorganSimplifier::get_node(NodeId node_id) const
 {
     CELER_EXPECT(node_id < tree_.size());
     NodeId dealiased{node_id};
@@ -111,7 +109,7 @@ NodeId DeMorganSimplifier::dealias(NodeId node_id) const
         dealiased = aliased->node;
         CELER_ASSERT(dealiased < tree_.size());
     }
-    return dealiased;
+    return tree_[dealiased];
 }
 
 //---------------------------------------------------------------------------//
@@ -121,22 +119,22 @@ NodeId DeMorganSimplifier::dealias(NodeId node_id) const
  */
 void DeMorganSimplifier::find_join_negations()
 {
+    ScopedProfiling profile_this{"orange-demorgan-find"};
     for (auto node_id : range(NodeId{tree_.size()}))
     {
-        auto const* node = &tree_[this->dealias(node_id)];
-        if (auto* negated = std::get_if<Negated>(node))
+        auto const& node = this->get_node(node_id);
+        if (auto* negated = std::get_if<Negated>(&node))
         {
             parents_.insert({negated->node, node_id});
             parents_.insert({negated->node, has_parents_index_});
-            if (std::holds_alternative<Joined>(
-                    tree_[this->dealias(negated->node)]))
+            if (std::holds_alternative<Joined>(this->get_node(negated->node)))
             {
                 // This is a negated join node
                 negated_join_nodes_.insert(negated->node);
                 this->add_negation_for_operands(negated->node);
             }
         }
-        else if (auto* joined = std::get_if<Joined>(node))
+        else if (auto* joined = std::get_if<Joined>(&node))
         {
             for (auto const& join_operand : joined->nodes)
             {
@@ -163,12 +161,12 @@ void DeMorganSimplifier::find_join_negations()
  */
 void DeMorganSimplifier::add_negation_for_operands(NodeId node_id)
 {
-    CELER_ASSUME(std::holds_alternative<Joined>(tree_[this->dealias(node_id)]));
+    CELER_ASSUME(std::holds_alternative<Joined>(this->get_node(node_id)));
     auto& [op, operands] = std::get<Joined>(tree_[node_id]);
 
     for (auto const& join_operand : operands)
     {
-        Node const& target_node = tree_[this->dealias(join_operand)];
+        Node const& target_node = this->get_node(join_operand);
         if (std::holds_alternative<Joined>(target_node))
         {
             // This negated join node has a join operand, so we'll have to
@@ -193,6 +191,7 @@ void DeMorganSimplifier::add_negation_for_operands(NodeId node_id)
  */
 CsgTree DeMorganSimplifier::build_simplified_tree()
 {
+    ScopedProfiling profile_this{"orange-demorgan-simplify"};
     CsgTree result{};
 
     // We can now build the new tree
@@ -208,7 +207,7 @@ CsgTree DeMorganSimplifier::build_simplified_tree()
         // to update the node ids of its children
 
         // deref aliased nodes, we don't want to insert them in the new tree
-        Node new_node = tree_[this->dealias(node_id)];
+        Node new_node = this->get_node(node_id);
 
         CELER_ASSERT(!std::holds_alternative<Aliased>(new_node));
 
@@ -246,7 +245,7 @@ CsgTree DeMorganSimplifier::build_simplified_tree()
         // We might have to insert a negated version of that node
         if (new_negated_nodes_.count(node_id))
         {
-            Node const& target_node{tree_[this->dealias(node_id)]};
+            Node const& target_node{this->get_node(node_id)};
             CELER_ASSERT(!std::holds_alternative<Negated>(target_node)
                          && !std::holds_alternative<Joined>(target_node)
                          && !trans.new_negation);
@@ -291,12 +290,12 @@ CsgTree DeMorganSimplifier::build_simplified_tree()
 bool DeMorganSimplifier::process_negated_joined_nodes(NodeId node_id,
                                                       CsgTree& result)
 {
-    Node const* target_node = &tree_[this->dealias(node_id)];
-    if (auto const* negated = std::get_if<Negated>(target_node))
+    Node const& target_node = this->get_node(node_id);
+    if (auto const* negated = std::get_if<Negated>(&target_node))
     {
         // This node has a joined child, we must never insert it in the
         // simplified tree
-        if (std::holds_alternative<Joined>(tree_[this->dealias(negated->node)]))
+        if (std::holds_alternative<Joined>(this->get_node(negated->node)))
         {
             // Redirect parents looking for this node to the new Joined
             // node which is logically equivalent
@@ -324,12 +323,11 @@ bool DeMorganSimplifier::process_negated_joined_nodes(NodeId node_id,
                 continue;
 
             // A negated node should never have a negated parent
-            CELER_ASSERT(
-                !std::holds_alternative<Negated>(tree_[this->dealias(p)]));
+            CELER_ASSERT(!std::holds_alternative<Negated>(this->get_node(p)));
 
             // If an ancestor is a join node that should be inserted
             // unmodified, this negated node is still necessary
-            if (std::holds_alternative<Joined>(tree_[this->dealias(p)])
+            if (std::holds_alternative<Joined>(this->get_node(p))
                 && this->should_insert_join(p))
             {
                 return true;
@@ -340,7 +338,7 @@ bool DeMorganSimplifier::process_negated_joined_nodes(NodeId node_id,
         // is no longer necessary in the simplified tree
         return false;
     }
-    else if (auto const* joined = std::get_if<Joined>(target_node))
+    else if (auto const* joined = std::get_if<Joined>(&target_node))
     {
         // Check if this node needs a simplification
         if (negated_join_nodes_.count(node_id))
@@ -377,7 +375,7 @@ Joined DeMorganSimplifier::build_negated_node(Joined const& joined)
     {
         // Negation of a negated operand cancel each other, we can
         // just use the child of that negated operand
-        if (auto const* neg = std::get_if<Negated>(&tree_[this->dealias(n)]))
+        if (auto const* neg = std::get_if<Negated>(&this->get_node(n)))
         {
             // We should have recorded that this node was necessary
             // for a join
@@ -414,7 +412,7 @@ Joined DeMorganSimplifier::build_negated_node(Joined const& joined)
  */
 bool DeMorganSimplifier::should_insert_join(NodeId node_id)
 {
-    CELER_EXPECT(std::holds_alternative<Joined>(tree_[this->dealias(node_id)]));
+    CELER_EXPECT(std::holds_alternative<Joined>(this->get_node(node_id)));
 
     // This join node is referred by a volume or a root node, we must insert it
     if (parents_.count({node_id, is_volume_index_})
@@ -444,7 +442,7 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
 
         // Check if a parent requires that node to be inserted
         // TODO: Is it really correct in all cases...
-        if (Node const& dealiased{tree_[this->dealias(p)]};
+        if (Node const& dealiased{this->get_node(p)};
             (std::holds_alternative<Joined>(dealiased)
              && this->should_insert_join(p))
             || (std::holds_alternative<Negated>(dealiased)

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -368,6 +368,7 @@ bool DeMorganSimplifier::process_negated_joined_nodes(NodeId node_id,
         auto parents_iter = parents_.find(node_id);
         if (parents_iter == parents_.end())
         {
+            // No parents: root node
             return true;
         }
 
@@ -466,9 +467,18 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
 {
     CELER_EXPECT(std::holds_alternative<Joined>(this->get_node(node_id)));
 
+    // TODO: logic is very similar to process_negated_joined_nodes
+
     // This join node is referred by a volume or a root node, we must insert it
-    if (is_volume_node_[node_id.get()] || !this->has_parent(node_id))
+    if (is_volume_node_[node_id.get()])
     {
+        return true;
+    }
+
+    auto parents_iter = parents_.find(node_id);
+    if (parents_iter == parents_.end())
+    {
+        // No parents: root node
         return true;
     }
 
@@ -476,16 +486,13 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
     // 1. It has a Join ancestor that is not negated
     // 2. It has a negated parent, and that negated node has a negated join
     // parent (double negation of that join)
-
-    for (auto p : range(first_node_id_, NodeId{tree_.size()}))
+    // Loop over all parents of node_id
+    for (NodeId p : parents_iter->second)
     {
-        // Not a parent
-        if (!this->is_parent_of(p, node_id))
-            continue;
-
         // Check if a parent requires that node to be inserted
         // TODO: Is it really correct in all cases...
-        Node const& dealiased = {this->get_node(p)};
+        Node const& dealiased = this->get_node(p);
+
         if (std::holds_alternative<Joined>(dealiased)
             && this->should_insert_join(p))
         {
@@ -494,12 +501,17 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
         if (std::holds_alternative<Negated>(dealiased))
         {
             // Loop over grandparents
-            for (auto gp : range(first_node_id_, NodeId{tree_.size()}))
+            auto gp_iter = parents_.find(p);
+            if (gp_iter != parents_.end())
             {
-                if (this->is_parent_of(gp, p) && negated_join_nodes_.count(gp))
+                for (NodeId gp : gp_iter->second)
                 {
-                    // has negated join
-                    return true;
+                    if (this->is_parent_of(gp, p)
+                        && negated_join_nodes_.count(gp))
+                    {
+                        // has negated join
+                        return true;
+                    }
                 }
             }
         }

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -209,6 +209,24 @@ bool DeMorganSimplifier::insert_negated_children(NodeId node_id)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Whether the second node is a child of the first.
+ */
+bool DeMorganSimplifier::is_parent_of(NodeId parent, NodeId child) const
+{
+    return parents_.count({child, parent});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Whether a child has any parent.
+ */
+bool DeMorganSimplifier::has_parent(NodeId child_id) const
+{
+    return parents_.count({child_id, has_parents_index_});
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Second pass through the tree to build the simplified tree.
  *
  * \return the simplified tree.
@@ -334,8 +352,7 @@ bool DeMorganSimplifier::process_negated_joined_nodes(NodeId node_id,
 
         // Check if the negation is a root or a volume. If so, we must
         // insert it in the simplified tree
-        if (is_volume_node_[node_id.get()]
-            || !parents_.count({node_id, has_parents_index_}))
+        if (is_volume_node_[node_id.get()] || !this->has_parent(node_id))
         {
             return true;
         }
@@ -439,8 +456,7 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
     CELER_EXPECT(std::holds_alternative<Joined>(this->get_node(node_id)));
 
     // This join node is referred by a volume or a root node, we must insert it
-    if (is_volume_node_[node_id.get()]
-        || !parents_.count({node_id, has_parents_index_}))
+    if (is_volume_node_[node_id.get()] || !this->has_parent(node_id))
     {
         return true;
     }
@@ -452,7 +468,7 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
     auto has_negated_join_parent = [&](NodeId n) {
         for (auto p : range(first_node_id_, NodeId{tree_.size()}))
         {
-            if (parents_.count({n, p}) && negated_join_nodes_.count(p))
+            if (this->is_parent_of(p, n) && negated_join_nodes_.count(p))
                 return true;
         }
         return false;
@@ -461,7 +477,7 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
     for (auto p : range(first_node_id_, NodeId{tree_.size()}))
     {
         // Not a parent
-        if (!parents_.count({node_id, p}))
+        if (!this->is_parent_of(p, node_id))
             continue;
 
         // Check if a parent requires that node to be inserted

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -83,6 +83,14 @@ TransformedTree DeMorganSimplifier::operator()()
 {
     this->find_join_negations();
 
+    // Save volume nodes
+    is_volume_node_.assign(tree_.size(), false);
+    for (auto node_id : tree_.volumes())
+    {
+        CELER_ASSERT(node_id < is_volume_node_.size());
+        is_volume_node_[node_id.unchecked_get()] = true;
+    }
+
     auto simplified_tree{this->build_simplified_tree()};
 
     std::vector<NodeId> equivalent_nodes(tree_.size());
@@ -142,13 +150,6 @@ void DeMorganSimplifier::find_join_negations()
                 parents_.insert({join_operand, has_parents_index_});
             }
         }
-    }
-
-    // Volumes act as parents of nodes.
-    // We can reuse node id 0 to set that a node has a parent volume
-    for (auto node_id : tree_.volumes())
-    {
-        parents_.insert({node_id, is_volume_index_});
     }
 }
 
@@ -310,7 +311,7 @@ bool DeMorganSimplifier::process_negated_joined_nodes(NodeId node_id,
 
         // Check if the negation is a root or a volume. If so, we must
         // insert it in the simplified tree
-        if (parents_.count({node_id, is_volume_index_})
+        if (is_volume_node_[node_id.get()]
             || !parents_.count({node_id, has_parents_index_}))
         {
             return true;
@@ -415,7 +416,7 @@ bool DeMorganSimplifier::should_insert_join(NodeId node_id)
     CELER_EXPECT(std::holds_alternative<Joined>(this->get_node(node_id)));
 
     // This join node is referred by a volume or a root node, we must insert it
-    if (parents_.count({node_id, is_volume_index_})
+    if (is_volume_node_[node_id.get()]
         || !parents_.count({node_id, has_parents_index_}))
     {
         return true;

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -137,9 +137,7 @@ void DeMorganSimplifier::find_join_negations()
             parents_.insert({negated->node, has_parents_index_});
             if (std::holds_alternative<Joined>(this->get_node(negated->node)))
             {
-                // This is a negated join node
-                negated_join_nodes_.insert(negated->node);
-                this->add_negation_for_operands(negated->node);
+                this->insert_negated_children(negated->node);
             }
         }
         else if (auto* joined = std::get_if<Joined>(&node))
@@ -160,28 +158,33 @@ void DeMorganSimplifier::find_join_negations()
  *
  * \param node_id a \c Joined node_id with a \c Negated parent.
  */
-void DeMorganSimplifier::add_negation_for_operands(NodeId node_id)
+bool DeMorganSimplifier::insert_negated_children(NodeId node_id)
 {
     CELER_ASSUME(std::holds_alternative<Joined>(this->get_node(node_id)));
+    auto&& [iter, inserted] = negated_join_nodes_.insert(node_id);
+    if (!inserted)
+    {
+        return inserted;
+    }
     auto& [op, operands] = std::get<Joined>(tree_[node_id]);
 
-    for (auto const& join_operand : operands)
+    for (auto const& child_node : operands)
     {
-        Node const& target_node = this->get_node(join_operand);
+        Node const& target_node = this->get_node(child_node);
         if (std::holds_alternative<Joined>(target_node))
         {
             // This negated join node has a join operand, so we'll have to
             // insert a negated join of that join operand and its operands
-            negated_join_nodes_.insert(join_operand);
-            this->add_negation_for_operands(join_operand);
+            this->insert_negated_children(child_node);
         }
         else if (!std::holds_alternative<Negated>(target_node))
         {
             // Negate each operand unless it's a negated node, in which
             // case double negation will cancel to the child of that operand
-            new_negated_nodes_.insert(join_operand);
+            new_negated_nodes_.insert(child_node);
         }
     }
+    return inserted;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.cc
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.cc
@@ -133,8 +133,9 @@ void DeMorganSimplifier::find_join_negations()
         auto const& node = this->get_node(node_id);
         if (auto* negated = std::get_if<Negated>(&node))
         {
-            parents_.insert({negated->node, node_id});
-            parents_.insert({negated->node, has_parents_index_});
+            // Mark the parent relationship
+            this->insert_parent(node_id, negated->node);
+
             if (std::holds_alternative<Joined>(this->get_node(negated->node)))
             {
                 this->insert_negated_children(negated->node);
@@ -142,13 +143,32 @@ void DeMorganSimplifier::find_join_negations()
         }
         else if (auto* joined = std::get_if<Joined>(&node))
         {
-            for (auto const& join_operand : joined->nodes)
+            for (auto const& child_node_id : joined->nodes)
             {
-                parents_.insert({join_operand, node_id});
-                parents_.insert({join_operand, has_parents_index_});
+                this->insert_parent(node_id, child_node_id);
             }
         }
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Mark that the first node is a parent of the second.
+ *
+ * \param node_id a \c Joined node_id with a \c Negated parent.
+ */
+bool DeMorganSimplifier::insert_parent(NodeId parent, NodeId child)
+{
+    CELER_EXPECT(parent);
+    CELER_EXPECT(child);
+    CELER_EXPECT(parent >= child);
+
+    auto&& [iter, inserted] = parents_.insert({child, parent});
+    if (inserted)
+    {
+        parents_.insert({child, has_parents_index_});
+    }
+    return inserted;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -63,6 +63,7 @@ class DeMorganSimplifier
 
     //! Helper struct to translate ids from the original tree to ids in the
     //! simplified tree
+    // TODO: are more than one of these ever set simultaneously?
     struct MatchingNodes
     {
         //! Set if a node has the exact same node in the simplified tree
@@ -88,8 +89,6 @@ class DeMorganSimplifier
         // Lookup a node an equal node in the simplified tree
         NodeId equivalent_node() const;
     };
-
-    using MapNodeMatching = std::unordered_map<NodeId, MatchingNodes>;
 
     //// HELPER FUNCTIONS ////
 
@@ -144,9 +143,10 @@ class DeMorganSimplifier
     //! Whether the index is a volume in the original tree
     std::vector<bool> is_volume_node_;
 
+    //! Map old node ID -> new node IDs:
     //! Used during construction of the simplified tree to map replaced nodes
     //! in the original tree to their new id in the simplified tree
-    MapNodeMatching node_ids_translation_;
+    std::vector<MatchingNodes> matching_nodes_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -108,8 +108,8 @@ class DeMorganSimplifier
 
     using NodeMap = std::unordered_map<NodeId, MatchingNodes>;
 
-    // Dereference Aliased nodes
-    NodeId dealias(NodeId) const;
+    // Get a non-aliased Node variant from the original tree
+    Node const& get_node(NodeId) const;
 
     // First pass to find negated set operations
     void find_join_negations();

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -11,8 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include "corecel/math/HashUtils.hh"
-
 #include "../CsgTree.hh"
 #include "../CsgTypes.hh"
 
@@ -54,24 +52,11 @@ class DeMorganSimplifier
     TransformedTree operator()();
 
   private:
-    using NodePair = std::pair<NodeId, NodeId>;
+    //// TYPES ////
 
-    struct NodePairHash
-    {
-        std::size_t operator()(NodePair const& p) const noexcept
-        {
-            return hash_combine(p.first, p.second);
-        }
-    };
-
-    using SetNodeNode = std::unordered_set<NodePair, NodePairHash>;
     using MapNodeVecNode = std::unordered_map<NodeId, std::vector<NodeId>>;
     using SetNode = std::unordered_set<NodeId>;
-
-    //! CsgTree node 1 is always a Negated node parent of node 0, so we can
-    //! reuse that bit to tell if a node has a parent as it's never set for
-    //! node id >= 2
-    static constexpr auto has_parents_index_{NodeId{1}};
+    using MapNodeSetNode = std::unordered_map<NodeId, SetNode>;
 
     //! First meaningful node id in a CsgTree
     static constexpr auto first_node_id_{NodeId{2}};
@@ -105,6 +90,8 @@ class DeMorganSimplifier
     };
 
     using MapNodeMatching = std::unordered_map<NodeId, MatchingNodes>;
+
+    //// HELPER FUNCTIONS ////
 
     // Get a non-aliased Node variant from the original tree
     Node const& get_node(NodeId) const;
@@ -141,6 +128,8 @@ class DeMorganSimplifier
     // Find a translation entry, or nullptr if none exist
     MatchingNodes const* find_translation(NodeId) const;
 
+    //// DATA ////
+
     //! the tree to simplify
     CsgTree const& tree_;
 
@@ -152,8 +141,8 @@ class DeMorganSimplifier
     SetNode negated_join_nodes_;
 
     //! Parents matrix (original tree)
-    // If the pair {e1, e2} exists, e2 is parent of e1
-    SetNodeNode parents_;
+    // If parents_[c].count(p), p is parent of c
+    MapNodeSetNode parents_;
 
     //! Whether the index is a volume in the original tree
     std::vector<bool> is_volume_node_;

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -67,9 +67,6 @@ class DeMorganSimplifier
     using SparseMatrix2D = std::unordered_set<NodePair, NodePairHash>;
     using NodeSet = std::unordered_set<NodeId>;
 
-    //! CsgTree node 0 is always True{} and can't be the parent of any node
-    //! so reuse that bit to tell that a given node is a volume
-    static constexpr auto is_volume_index_{NodeId{0}};
     //! CsgTree node 1 is always a Negated node parent of node 0, so we can
     //! reuse that bit to tell if a node has a parent as it's never set for
     //! node id >= 2
@@ -144,8 +141,12 @@ class DeMorganSimplifier
     //! an opposite join node with negated operands
     NodeSet negated_join_nodes_;
 
-    //! Parents matrix. If the pair {e1, e2} exists, e2 is parent of e1
+    //! Parents matrix (original tree)
+    // If the pair {e1, e2} exists, e2 is parent of e1
     SparseMatrix2D parents_;
+
+    //! Whether the index is a volume in the original tree
+    std::vector<bool> is_volume_node_;
 
     //! Used during construction of the simplified tree to map replaced nodes
     //! in the original tree to their new id in the simplified tree

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -113,7 +113,7 @@ class DeMorganSimplifier
     void find_join_negations();
 
     // Declare negated nodes to add in the simplified tree
-    void add_negation_for_operands(NodeId);
+    bool insert_negated_children(NodeId);
 
     // Second pass to build the simplified tree
     CsgTree build_simplified_tree();

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -106,9 +106,6 @@ class DeMorganSimplifier
     bool insert_negated_children(NodeId);
 
     // Whether a child has any parent
-    bool has_parent(NodeId) const;
-
-    // Whether a child has any parent
     bool is_parent_of(NodeId parent, NodeId child) const;
 
     // Second pass to build the simplified tree

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -118,6 +118,12 @@ class DeMorganSimplifier
     // Declare negated nodes to add in the simplified tree
     bool insert_negated_children(NodeId);
 
+    // Whether a child has any parent
+    bool has_parent(NodeId) const;
+
+    // Whether a child has any parent
+    bool is_parent_of(NodeId parent, NodeId child) const;
+
     // Second pass to build the simplified tree
     CsgTree build_simplified_tree();
 

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -64,8 +64,9 @@ class DeMorganSimplifier
         }
     };
 
-    using SparseMatrix2D = std::unordered_set<NodePair, NodePairHash>;
-    using NodeSet = std::unordered_set<NodeId>;
+    using SetNodeNode = std::unordered_set<NodePair, NodePairHash>;
+    using MapNodeVecNode = std::unordered_map<NodeId, std::vector<NodeId>>;
+    using SetNode = std::unordered_set<NodeId>;
 
     //! CsgTree node 1 is always a Negated node parent of node 0, so we can
     //! reuse that bit to tell if a node has a parent as it's never set for
@@ -103,7 +104,7 @@ class DeMorganSimplifier
         NodeId equivalent_node() const;
     };
 
-    using NodeMap = std::unordered_map<NodeId, MatchingNodes>;
+    using MapNodeMatching = std::unordered_map<NodeId, MatchingNodes>;
 
     // Get a non-aliased Node variant from the original tree
     Node const& get_node(NodeId) const;
@@ -135,22 +136,22 @@ class DeMorganSimplifier
     CsgTree const& tree_;
 
     //! Set when we must insert a \c Negated parent for the given index
-    NodeSet new_negated_nodes_;
+    SetNode new_negated_nodes_;
 
     //! Set when \c Joined nodes have a \c Negated parent, so we need to insert
     //! an opposite join node with negated operands
-    NodeSet negated_join_nodes_;
+    SetNode negated_join_nodes_;
 
     //! Parents matrix (original tree)
     // If the pair {e1, e2} exists, e2 is parent of e1
-    SparseMatrix2D parents_;
+    SetNodeNode parents_;
 
     //! Whether the index is a volume in the original tree
     std::vector<bool> is_volume_node_;
 
     //! Used during construction of the simplified tree to map replaced nodes
     //! in the original tree to their new id in the simplified tree
-    NodeMap node_ids_translation_;
+    MapNodeMatching node_ids_translation_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -29,7 +29,7 @@ namespace detail
  * DeMorgan's law on a \c CsgTree so that all negations of a set operator are
  * removed and transformed into their equivalent operation.
  *
- * The simplification preserves subtrees referred to by \c CsgTree::volumes
+ * The simplification preserves subtrees referred to by \c CsgTree::volumes .
  *
  * Instances of this class shouldn't outlive the \c CsgTree used to construct
  * it as we keep a reference to it.
@@ -37,8 +37,8 @@ namespace detail
  * It is currently single-use: calling operator() twice on the same instance
  * isn't supported.
  *
- * The \c CsgTree being simplified shouldn't contain alias nodes or double
- * negations.
+ * The \c CsgTree being transformed should \em not have double negations
+ * (the tree's insertion method will have simplified those).
  */
 class DeMorganSimplifier
 {

--- a/src/orange/orangeinp/detail/DeMorganSimplifier.hh
+++ b/src/orange/orangeinp/detail/DeMorganSimplifier.hh
@@ -112,6 +112,9 @@ class DeMorganSimplifier
     // First pass to find negated set operations
     void find_join_negations();
 
+    // Record a parent-child relationship
+    bool insert_parent(NodeId parent, NodeId child);
+
     // Declare negated nodes to add in the simplified tree
     bool insert_negated_children(NodeId);
 


### PR DESCRIPTION
Following on to #2231 and #2232, looking at performance and setup time with #2247 and #2246, I saw that the DUNE construction time was taking ~30s with a release build, most of it coming from the cryostat with 30k CSG nodes inside the demorgan simplifier. I took at close look for nested loops and behold I found the simplification was O(N^3) due to a double nested search over parents inside the outer tree loop.

This replaces the matrix representation with a {child -> {parents}} map of sets, allowing constant time lookup (assuming a sparse matrix). The build time for DUNE is now 0.3 seconds.

Before:
<img width="1001" height="150" alt="before" src="https://github.com/user-attachments/assets/5c69419e-7c3a-4ac4-8648-8e99fc0c37ea" />


After:
<img width="1003" height="175" alt="after" src="https://github.com/user-attachments/assets/6e12dfc2-b850-43ad-bce0-61e19fd049cc" />
