### PR TITLE
Sample scintillation photon emission time from step times when speed is unavailable

### DIFF
--- a/src/celeritas/optical/gen/CherenkovGenerator.hh
+++ b/src/celeritas/optical/gen/CherenkovGenerator.hh
@@ -185,7 +185,7 @@ CELER_FUNCTION TrackInitializer CherenkovGenerator::operator()(Generator& rng)
         = u * dist_.step_length
           / (native_value_from(dist_.points[StepPoint::pre].speed)
              + u * real_type(0.5) * native_value_from(delta_speed_));
-    photon.time = dist_.time + delta_time;
+    photon.time = dist_.points[StepPoint::pre].time + delta_time;
     photon.position = dist_.points[StepPoint::pre].pos;
     axpy(u, delta_pos_, &photon.position);
     photon.primary = dist_.primary;

--- a/src/celeritas/optical/gen/CherenkovOffload.hh
+++ b/src/celeritas/optical/gen/CherenkovOffload.hh
@@ -44,6 +44,7 @@ class CherenkovOffload
                      OffloadPreStepData const& pre_step,
                      optical::MaterialView const& pre_mat,
                      units::LightSpeed post_speed,
+                     real_type post_time,
                      Real3 const& post_pos,
                      NativeCRef<CherenkovData> const& shared);
 
@@ -81,12 +82,13 @@ CherenkovOffload::CherenkovOffload(units::ElementaryCharge charge,
                                    OffloadPreStepData const& pre_step,
                                    optical::MaterialView const& pre_mat,
                                    units::LightSpeed post_speed,
+                                   real_type post_time,
                                    Real3 const& post_pos,
                                    NativeCRef<CherenkovData> const& shared)
     : charge_{charge}
     , step_length_(step_length)
     , pre_step_(pre_step)
-    , post_step_{post_speed, post_pos}
+    , post_step_{post_speed, post_time, post_pos}
 {
     CELER_EXPECT(charge != zero_quantity());
     CELER_EXPECT(step_length_ > 0);
@@ -115,6 +117,7 @@ CherenkovOffload::CherenkovOffload(OffloadPreStepData const& pre_step,
                        pre_step,
                        pre_mat,
                        post_particle.speed(),
+                       post_sim.time(),
                        post_pos,
                        shared}
 {
@@ -141,11 +144,11 @@ CherenkovOffload::operator()(Generator& rng)
     if (data.num_photons > 0)
     {
         data.type = GeneratorType::cherenkov;
-        data.time = pre_step_.time;
         data.step_length = step_length_;
         data.charge = charge_;
         data.material = pre_step_.material;
         data.points[StepPoint::pre].speed = pre_step_.speed;
+        data.points[StepPoint::pre].time = pre_step_.time;
         data.points[StepPoint::pre].pos = pre_step_.pos;
         data.points[StepPoint::post] = post_step_;
     }

--- a/src/celeritas/optical/gen/ScintillationOffload.hh
+++ b/src/celeritas/optical/gen/ScintillationOffload.hh
@@ -89,7 +89,7 @@ CELER_FUNCTION ScintillationOffload::ScintillationOffload(
     : charge_(particle.charge())
     , step_length_(sim.step_length())
     , pre_step_(pre_step)
-    , post_step_({pre_post_step.speed, pos})
+    , post_step_({pre_post_step.speed, sim.time(), pos})
     , shared_(shared)
     , continuous_edep_fraction_(pre_post_step.energy_deposition
                                 / energy_deposition)
@@ -148,12 +148,12 @@ ScintillationOffload::operator()(Generator& rng)
     {
         // Assign remaining data
         result.type = GeneratorType::scintillation;
-        result.time = pre_step_.time;
         result.step_length = step_length_;
         result.charge = charge_;
         result.material = pre_step_.material;
         result.continuous_edep_fraction = continuous_edep_fraction_;
         result.points[StepPoint::pre].speed = pre_step_.speed;
+        result.points[StepPoint::pre].time = pre_step_.time;
         result.points[StepPoint::pre].pos = pre_step_.pos;
         result.points[StepPoint::post] = post_step_;
     }

--- a/test/accel/UserActionIntegration.test.cc
+++ b/test/accel/UserActionIntegration.test.cc
@@ -252,14 +252,14 @@ void LSOOSteppingAction::UserSteppingAction(G4Step const* step)
     data.charge = units::ElementaryCharge{
         static_cast<real_type>(post_step->GetCharge())};
     data.material = OptMatId(0);
-    data.points[StepPoint::pre]
-        = {units::LightSpeed(pre_step->GetBeta()),
-           convert_from_geant(pre_step->GetGlobalTime(), clhep_time),
-           convert_from_geant(pre_step->GetPosition(), clhep_length)};
-    data.points[StepPoint::post]
-        = {units::LightSpeed(post_step->GetBeta()),
-           convert_from_geant(post_step->GetGlobalTime(), clhep_time),
-           convert_from_geant(post_step->GetPosition(), clhep_length)};
+    auto& pre = data.points[StepPoint::pre];
+    pre.speed = units::LightSpeed(pre_step->GetBeta());
+    pre.time = convert_from_geant(pre_step->GetGlobalTime(), clhep_time);
+    pre.pos = convert_from_geant(pre_step->GetPosition(), clhep_length);
+    auto& post = data.points[StepPoint::post];
+    post.speed = units::LightSpeed(post_step->GetBeta());
+    post.time = convert_from_geant(post_step->GetGlobalTime(), clhep_time);
+    post.pos = convert_from_geant(post_step->GetPosition(), clhep_length);
 
     auto& gen_offload = dynamic_cast<LocalOpticalGenOffload&>(local);
     if (num_cherenkov > 0)

--- a/test/accel/UserActionIntegration.test.cc
+++ b/test/accel/UserActionIntegration.test.cc
@@ -247,19 +247,18 @@ void LSOOSteppingAction::UserSteppingAction(G4Step const* step)
 
     // Create distribution and push to Celeritas
     // TODO: Get optical material ID
-    // TODO: Does the post-step speed account for only continuous energy
-    // loss or continuous+discrete?
     optical::GeneratorDistributionData data;
-    data.time = convert_from_geant(post_step->GetGlobalTime(), clhep_time);
     data.step_length = convert_from_geant(step->GetStepLength(), clhep_length);
     data.charge = units::ElementaryCharge{
         static_cast<real_type>(post_step->GetCharge())};
     data.material = OptMatId(0);
     data.points[StepPoint::pre]
         = {units::LightSpeed(pre_step->GetBeta()),
+           convert_from_geant(pre_step->GetGlobalTime(), clhep_time),
            convert_from_geant(pre_step->GetPosition(), clhep_length)};
     data.points[StepPoint::post]
         = {units::LightSpeed(post_step->GetBeta()),
+           convert_from_geant(post_step->GetGlobalTime(), clhep_time),
            convert_from_geant(post_step->GetPosition(), clhep_length)};
 
     auto& gen_offload = dynamic_cast<LocalOpticalGenOffload&>(local);

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -242,15 +242,17 @@ TEST_F(CherenkovWaterTest, pre_generator)
     // 500 keV e-
     {
         // Pre-step values
+        auto pre_particle
+            = this->make_particle_track_view(Energy{0.5}, pdg::electron());
         OffloadPreStepData pre_step;
         pre_step.pos = {0, 0, 0};
-        pre_step.speed = units::LightSpeed{0.63431981443206786};
+        pre_step.speed = pre_particle.speed();
         pre_step.time = 0;
         pre_step.material = material_id;
 
         // Post-step values
         auto particle
-            = this->make_particle_track_view(Energy{0.5}, pdg::electron());
+            = this->make_particle_track_view(Energy{0.15}, pdg::electron());
         auto sim = this->make_sim_track_view(0.15);
         sim.add_time(sim.step_length() / native_value_from(particle.speed()));
         Real3 pos = {sim.step_length(), 0, 0};

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -252,6 +252,7 @@ TEST_F(CherenkovWaterTest, pre_generator)
         auto particle
             = this->make_particle_track_view(Energy{0.5}, pdg::electron());
         auto sim = this->make_sim_track_view(0.15);
+        sim.add_time(sim.step_length() / native_value_from(particle.speed()));
         Real3 pos = {sim.step_length(), 0, 0};
 
         CherenkovOffload pre_generate(
@@ -266,7 +267,6 @@ TEST_F(CherenkovWaterTest, pre_generator)
             sampled_num_photons.push_back(result.num_photons);
 
             // Remaining values are assigned to result from input data
-            EXPECT_EQ(pre_step.time, result.time);
             EXPECT_EQ(particle.charge().value(), result.charge.value());
             EXPECT_EQ(material_id, result.material);
             EXPECT_EQ(sim.step_length(), result.step_length);
@@ -274,6 +274,8 @@ TEST_F(CherenkovWaterTest, pre_generator)
                       result.points[StepPoint::pre].speed.value());
             EXPECT_EQ(particle.speed().value(),
                       result.points[StepPoint::post].speed.value());
+            EXPECT_EQ(pre_step.time, result.points[StepPoint::pre].time);
+            EXPECT_EQ(sim.time(), result.points[StepPoint::post].time);
             EXPECT_VEC_EQ(pre_step.pos, result.points[StepPoint::pre].pos);
             EXPECT_VEC_EQ(pos, result.points[StepPoint::post].pos);
         }

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -449,10 +449,12 @@ TEST_F(CherenkovWaterTest, generator)
                3999, 3924, 3903, 3900, 3959, 3932, 4023, 3873};
         // clang-format on
 
-        sample(pre_step, particle, sim, pos, num_samples);
-
         if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
+            // Only test with double precision: with single precision, pre- and
+            // post-step speed are both equal to 1
+            sample(pre_step, particle, sim, pos, num_samples);
+
             EXPECT_VEC_EQ(expected_costheta_dist, costheta_dist);
             EXPECT_VEC_EQ(expected_energy_dist, energy_dist);
             EXPECT_VEC_EQ(expected_displacement_dist, displacement_dist);

--- a/test/celeritas/optical/Generator.test.cc
+++ b/test/celeritas/optical/Generator.test.cc
@@ -82,9 +82,9 @@ class LArSphereGeneratorTest : public Test
         data.material = OptMatId(0);
         data.continuous_edep_fraction = 1;
         data.points[StepPoint::pre]
-            = {units::LightSpeed(0.7), from_cm(Real3{0, 0, 0})};
+            = {units::LightSpeed(0.7), 0, from_cm(Real3{0, 0, 0})};
         data.points[StepPoint::post]
-            = {units::LightSpeed(0.6), from_cm(Real3{0, 0, 0.2})};
+            = {units::LightSpeed(0.6), 1e-11, from_cm(Real3{0, 0, 0.2})};
 
         VecDistribution result(count, data);
         for (auto i : range(count))

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -341,7 +341,7 @@ TEST_F(MaterialScintillationGaussianTest, basic)
             {
                 // Store individual results
                 energy.push_back(p.energy.value());
-                time.push_back(native_value_to<TimeSecond>(p.time).value());
+                time.push_back(p.time / units::nanosecond);
                 cos_theta.push_back(dot_product(p.direction, inc_dir));
 
                 polarization_x.push_back(p.polarization[0]);
@@ -353,13 +353,13 @@ TEST_F(MaterialScintillationGaussianTest, basic)
     }
 
     avg_lambda = to_cm(avg_lambda / num_photons);
-    avg_time = native_value_to<TimeSecond>(avg_time / num_photons).value();
+    avg_time = avg_time / (units::nanosecond * num_photons);
     avg_cosine /= num_photons;
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         EXPECT_SOFT_EQ(1.8023146707476483e-05, avg_lambda);
-        EXPECT_SOFT_EQ(8.6510374107600554e-07, avg_time);
+        EXPECT_SOFT_EQ(865.10374107600546, avg_time);
         EXPECT_SOFT_EQ(-0.0078894853694884293, avg_cosine);
         EXPECT_EQ(7602, rng.exchange_count());
 
@@ -374,14 +374,14 @@ TEST_F(MaterialScintillationGaussianTest, basic)
             1.2232069181772e-05,
         };
         static double const expected_time[] = {
-            3.3128806993047e-06,
-            1.9448090540859e-07,
-            1.1174848154165e-06,
-            1.2460198181058e-08,
-            3.5306344404732e-08,
-            3.19537294006e-07,
-            7.2757167500751e-09,
-            3.5272895177539e-09,
+            3312.8806993047,
+            194.48090540859,
+            1117.4848154165,
+            12.460198181058,
+            35.306344404732,
+            319.537294006,
+            7.2757167500751,
+            3.5272895177539,
         };
         static double const expected_cos_theta[] = {
             0.99292265109602,
@@ -403,7 +403,6 @@ TEST_F(MaterialScintillationGaussianTest, basic)
             -0.68599121517934,
             -0.35306899564942,
         };
-
         EXPECT_VEC_SOFT_EQ(expected_energy, energy);
         EXPECT_VEC_SOFT_EQ(expected_time, time);
         EXPECT_VEC_SOFT_EQ(expected_cos_theta, cos_theta);

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -413,7 +413,7 @@ TEST_F(MaterialScintillationGaussianTest, time)
     optical::GeneratorDistributionData gdd;
     gdd.type = GeneratorType::scintillation;
     gdd.num_photons = 8;
-    gdd.step_length = step_length_;
+    gdd.step_length = from_cm(step_length_);
     gdd.charge = units::ElementaryCharge{-1};
     gdd.material = opt_mat_;
     gdd.points[StepPoint::pre].pos = {0, 0, 0};
@@ -437,7 +437,7 @@ TEST_F(MaterialScintillationGaussianTest, time)
             = this->make_particle_track_view(post_energy_, pdg::electron());
         gdd.points[StepPoint::pre].time = 0;
         gdd.points[StepPoint::post].time
-            = step_length_ / native_value_from(particle.speed());
+            = from_cm(step_length_) / native_value_from(particle.speed());
 
         auto time = sample_time(gdd);
 

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -59,7 +59,7 @@ class ScintillationTestBase : public ::celeritas::test::OpticalTestBase
     OffloadPreStepData build_pre_step()
     {
         OffloadPreStepData pre_step;
-        pre_step.speed = LightSpeed(0.99862874144970537);  // 10 MeV
+        pre_step.speed = LightSpeed{0.9988175606678128};  // 10 MeV
         pre_step.pos = {0, 0, 0};
         pre_step.time = 0;
         pre_step.material = opt_mat_;
@@ -359,7 +359,7 @@ TEST_F(MaterialScintillationGaussianTest, basic)
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         EXPECT_SOFT_EQ(1.8023146707476483e-05, avg_lambda);
-        EXPECT_SOFT_EQ(865.10374107600546, avg_time);
+        EXPECT_SOFT_EQ(865.10373580428154, avg_time);
         EXPECT_SOFT_EQ(-0.0078894853694884293, avg_cosine);
         EXPECT_EQ(7602, rng.exchange_count());
 
@@ -374,14 +374,14 @@ TEST_F(MaterialScintillationGaussianTest, basic)
             1.2232069181772e-05,
         };
         static double const expected_time[] = {
-            3312.8806993047,
-            194.48090540859,
-            1117.4848154165,
-            12.460198181058,
-            35.306344404732,
-            319.537294006,
-            7.2757167500751,
-            3.5272895177539,
+            3312.8806914137,
+            194.48089853941,
+            1117.4848080538,
+            12.460193974748,
+            35.306336560409,
+            319.53728623218,
+            7.2757102426598,
+            3.5272820100053,
         };
         static double const expected_cos_theta[] = {
             0.99292265109602,

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -251,15 +251,12 @@ TEST_F(MaterialScintillationGaussianTest, pre_generator)
     auto particle
         = this->make_particle_track_view(post_energy_, pdg::electron());
     auto const pre_step = this->build_pre_step();
+    auto sim = this->make_sim_track_view(step_length_);
+    sim.add_time(sim.step_length() / native_value_from(particle.speed()));
     OffloadPrePostStepData pre_post_step{particle.speed(), edep_};
 
-    ScintillationOffload generate(particle,
-                                  this->make_sim_track_view(step_length_),
-                                  post_pos_,
-                                  edep_,
-                                  data,
-                                  pre_step,
-                                  pre_post_step);
+    ScintillationOffload generate(
+        particle, sim, post_pos_, edep_, data, pre_step, pre_post_step);
 
     Rng rng;
     auto const result = generate(rng);
@@ -270,7 +267,6 @@ TEST_F(MaterialScintillationGaussianTest, pre_generator)
     }
 
     EXPECT_EQ(4, result.num_photons);
-    EXPECT_REAL_EQ(0, result.time);
     EXPECT_REAL_EQ(from_cm(step_length_), result.step_length);
     EXPECT_EQ(-1, result.charge.value());
     EXPECT_EQ(0, result.material.get());
@@ -278,6 +274,8 @@ TEST_F(MaterialScintillationGaussianTest, pre_generator)
               result.points[StepPoint::pre].speed.value());
     EXPECT_EQ(particle.speed().value(),
               result.points[StepPoint::post].speed.value());
+    EXPECT_EQ(pre_step.time, result.points[StepPoint::pre].time);
+    EXPECT_EQ(sim.time(), result.points[StepPoint::post].time);
     EXPECT_VEC_EQ(pre_step.pos, result.points[StepPoint::pre].pos);
     EXPECT_VEC_EQ(post_pos_, result.points[StepPoint::post].pos);
 }
@@ -291,17 +289,13 @@ TEST_F(MaterialScintillationGaussianTest, basic)
 
     auto particle
         = this->make_particle_track_view(post_energy_, pdg::electron());
+    auto sim = this->make_sim_track_view(step_length_);
     auto const pre_step = this->build_pre_step();
     OffloadPrePostStepData pre_post_step{particle.speed(), edep_};
 
     // Pre-generate optical distribution data
-    ScintillationOffload generate(particle,
-                                  this->make_sim_track_view(step_length_),
-                                  post_pos_,
-                                  edep_,
-                                  data,
-                                  pre_step,
-                                  pre_post_step);
+    ScintillationOffload generate(
+        particle, sim, post_pos_, edep_, data, pre_step, pre_post_step);
 
     Rng rng;
     auto const generated_dist = generate(rng);
@@ -407,6 +401,85 @@ TEST_F(MaterialScintillationGaussianTest, basic)
         EXPECT_VEC_SOFT_EQ(expected_time, time);
         EXPECT_VEC_SOFT_EQ(expected_cos_theta, cos_theta);
         EXPECT_VEC_SOFT_EQ(expected_polarization_x, polarization_x);
+    }
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(MaterialScintillationGaussianTest, time)
+{
+    auto const params = this->build_scintillation_params();
+    auto const& data = params->host_ref();
+
+    optical::GeneratorDistributionData gdd;
+    gdd.type = GeneratorType::scintillation;
+    gdd.num_photons = 8;
+    gdd.step_length = step_length_;
+    gdd.charge = units::ElementaryCharge{-1};
+    gdd.material = opt_mat_;
+    gdd.points[StepPoint::pre].pos = {0, 0, 0};
+    gdd.points[StepPoint::post].pos = post_pos_;
+
+    auto sample_time = [&](optical::GeneratorDistributionData const& d) {
+        Rng rng;
+        optical::ScintillationGenerator generate(data, d);
+        std::vector<real_type> time;
+        for (size_type i = 0; i < d.num_photons; ++i)
+        {
+            auto p = generate(rng);
+            time.push_back(p.time / units::nanosecond);
+        }
+        return time;
+    };
+
+    // Use pre- and post-step time to sample time
+    {
+        auto particle
+            = this->make_particle_track_view(post_energy_, pdg::electron());
+        gdd.points[StepPoint::pre].time = 0;
+        gdd.points[StepPoint::post].time
+            = step_length_ / native_value_from(particle.speed());
+
+        auto time = sample_time(gdd);
+
+        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+        {
+            static double const expected_time[] = {
+                7.3670494614798,
+                10.58035645366,
+                3117.0542454245,
+                2339.5624814179,
+                2.1742646282647,
+                833.41358173964,
+                2655.4299519772,
+                316.65670948862,
+            };
+            EXPECT_VEC_SOFT_EQ(expected_time, time);
+        }
+    }
+
+    // Use pre- and post-step speed to sample time
+    {
+        auto particle
+            = this->make_particle_track_view(post_energy_, pdg::electron());
+        gdd.points[StepPoint::pre].speed = this->build_pre_step().speed;
+        gdd.points[StepPoint::post].speed = particle.speed();
+
+        auto time = sample_time(gdd);
+
+        if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+        {
+            static double const expected_time[] = {
+                7.367041567676,
+                10.580348559856,
+                3117.0542375307,
+                2339.5624735241,
+                2.1742567344609,
+                833.41357384583,
+                2655.4299440834,
+                316.65670159482,
+            };
+            EXPECT_VEC_SOFT_EQ(expected_time, time);
+        }
     }
 }
 


### PR DESCRIPTION
The `SimEnergyDeposit` in LArSoft doesn't provide the incident particle’s energy or speed. For Cherenkov production this is needed for the dN/dx calculation, but since we aren't currently simulating Cherenkov photons this isn't an immediate issue. For scintillation, the particle speed is used to sample the emitted photon time. In the absence of this, I think we can fall back to using the pre- and post-step times, which are available in `SimEnergyDeposit`, to sample the emission time.