### PR TITLE
Fix infinite safety distance edge case

### DIFF
--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -662,7 +662,15 @@ CELER_FUNCTION real_type OrangeTrackView::find_safety()
 
     TrackerVisitor visit_tracker{params_};
 
-    real_type min_safety_dist = NumericLimits<real_type>::infinity();
+    // If we're intersecting a surface, the safety cannot be more than that.
+    // Use that as a bound for degenerate cases such as starting in the exact
+    // center of a sphere (where the safety can't correctly be calculated).
+    // This fixes incorrectly large safety when a next step has been found,
+    // necessary for CheckedGeoTrackView::find_next_step and more consistent in
+    // general .
+    real_type min_safety_dist = this->has_next_surface()
+                                    ? this->next_step()
+                                    : NumericLimits<real_type>::infinity();
 
     for (auto ulev_id : range(this->univ_level() + 1))
     {

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -662,15 +662,15 @@ CELER_FUNCTION real_type OrangeTrackView::find_safety()
 
     TrackerVisitor visit_tracker{params_};
 
-    real_type min_safety_dist = numeric_limits<real_type>::infinity();
+    real_type min_safety_dist = NumericLimits<real_type>::infinity();
 
     for (auto ulev_id : range(this->univ_level() + 1))
     {
         auto lsa = this->make_lsa(ulev_id);
-        auto sd = visit_tracker(
+        auto local_safety = visit_tracker(
             [&lsa](auto&& t) { return t.safety(lsa.pos(), lsa.vol()); },
             lsa.univ());
-        min_safety_dist = celeritas::min(min_safety_dist, sd);
+        min_safety_dist = celeritas::min(min_safety_dist, local_safety);
     }
     return min_safety_dist;
 }

--- a/src/orange/OrangeTrackView.hh
+++ b/src/orange/OrangeTrackView.hh
@@ -650,6 +650,45 @@ CELER_FUNCTION Propagation OrangeTrackView::find_next_step(real_type max_step)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Find the distance to the nearest boundary in any direction.
+ *
+ * The safety distance at a given point is the minimum safety distance over all
+ * universe levels, since surface deduplication can potentionally elide
+ * bounding surfaces at more deeply embedded universe levels.
+ */
+CELER_FUNCTION real_type OrangeTrackView::find_safety()
+{
+    CELER_EXPECT(!this->is_on_boundary());
+
+    TrackerVisitor visit_tracker{params_};
+
+    real_type min_safety_dist = numeric_limits<real_type>::infinity();
+
+    for (auto ulev_id : range(this->univ_level() + 1))
+    {
+        auto lsa = this->make_lsa(ulev_id);
+        auto sd = visit_tracker(
+            [&lsa](auto&& t) { return t.safety(lsa.pos(), lsa.vol()); },
+            lsa.univ());
+        min_safety_dist = celeritas::min(min_safety_dist, sd);
+    }
+    return min_safety_dist;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Find the distance to the nearest nearby boundary.
+ *
+ * Since we currently support only "simple" safety distances, we can't
+ * eliminate anything by checking only nearby surfaces.
+ */
+CELER_FUNCTION real_type OrangeTrackView::find_safety(real_type)
+{
+    return this->find_safety();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Move to the next straight-line boundary but do not change volume.
  */
 CELER_FUNCTION void OrangeTrackView::move_to_boundary()
@@ -1130,45 +1169,6 @@ OrangeTrackView::find_next_step_impl(detail::Intersection isect)
     result.distance = isect.distance;
     result.boundary = static_cast<bool>(isect);
     return result;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Find the distance to the nearest boundary in any direction.
- *
- * The safety distance at a given point is the minimum safety distance over all
- * universe levels, since surface deduplication can potentionally elide
- * bounding surfaces at more deeply embedded universe levels.
- */
-CELER_FUNCTION real_type OrangeTrackView::find_safety()
-{
-    CELER_EXPECT(!this->is_on_boundary());
-
-    TrackerVisitor visit_tracker{params_};
-
-    real_type min_safety_dist = numeric_limits<real_type>::infinity();
-
-    for (auto ulev_id : range(this->univ_level() + 1))
-    {
-        auto lsa = this->make_lsa(ulev_id);
-        auto sd = visit_tracker(
-            [&lsa](auto&& t) { return t.safety(lsa.pos(), lsa.vol()); },
-            lsa.univ());
-        min_safety_dist = celeritas::min(min_safety_dist, sd);
-    }
-    return min_safety_dist;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Find the distance to the nearest nearby boundary.
- *
- * Since we currently support only "simple" safety distances, we can't
- * eliminate anything by checking only nearby surfaces.
- */
-CELER_FUNCTION real_type OrangeTrackView::find_safety(real_type)
-{
-    return this->find_safety();
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -893,7 +893,6 @@ void FourLevelsGeoTest::test_trace() const
         };
 
         auto tol = test_->tracking_tol();
-        delete_orange_safety(*test_, ref, result);
         EXPECT_REF_NEAR(ref, result, tol);
     }
     {
@@ -915,7 +914,6 @@ void FourLevelsGeoTest::test_trace() const
         // clang-format on
 
         auto tol = test_->tracking_tol();
-        delete_orange_safety(*test_, ref, result);
         EXPECT_REF_NEAR(ref, result, tol);
     }
     {
@@ -958,7 +956,6 @@ void LarSphereGeoTest::test_trace() const
         GTEST_SKIP() << "Fails to cross +y";
     }
 
-    bool const is_orange = test_->geometry_type() == "ORANGE";
     {
         SCOPED_TRACE("+y");
         auto result = test_->track({0, -120, 0}, {0, 1, 0});
@@ -981,11 +978,6 @@ void LarSphereGeoTest::test_trace() const
         ref.distances = {10, 10, 200, 10, 890};
         ref.halfway_safeties = {5, 5, 100, 5, 445};
         ref.bumps = {};
-        if (is_orange)
-        {
-            // TODO: at this exact point it ignores the spherical distance
-            ref.halfway_safeties[2] = result.halfway_safeties[2];
-        }
 
         auto tol = test_->tracking_tol();
         EXPECT_REF_NEAR(ref, result, tol);
@@ -2193,7 +2185,6 @@ void SimpleCmsGeoTest::test_detailed_tracking() const
 //---------------------------------------------------------------------------//
 void SimpleCmsGeoTest::test_trace() const
 {
-    bool const is_orange = test_->geometry_type() == "ORANGE";
     {
         SCOPED_TRACE("outward radially");
         auto result = test_->track({-75, 0, 0}, {1, 0, 0});
@@ -2223,11 +2214,6 @@ void SimpleCmsGeoTest::test_trace() const
         // All surface normals are along track dir: ref.dot_normal = {}
         ref.halfway_safeties = {22.5, 30, 47.5, 25, 50, 50, 162.5, 150};
 
-        if (is_orange)
-        {
-            // TODO: at this exact point it ignores the cylindrical distance
-            ref.halfway_safeties[1] = result.halfway_safeties[1];
-        }
         auto tol = test_->tracking_tol();
         EXPECT_REF_NEAR(ref, result, tol);
     }
@@ -2242,11 +2228,8 @@ void SimpleCmsGeoTest::test_trace() const
         // All surface normals are along track dir: ref.dot_normal = {}
         ref.halfway_safeties = {0.5, 5, 650};
 
-        if (is_orange)
-        {
-            ref.halfway_safeties[2] = result.halfway_safeties[2];
-        }
         auto tol = test_->tracking_tol();
+        fixup_orange(*test_, ref, result, "world");
         EXPECT_REF_NEAR(ref, result, tol);
     }
 }

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -77,9 +77,6 @@ class InputBuilderTest : public JsonOrangeTest
         return geometry_basename();
     }
 
-  protected:
-    bool supports_surface_normal_{true};
-
   private:
     std::string basename_;
 };
@@ -779,7 +776,6 @@ TEST_F(InputBuilderTest, globalspheres)
 
 TEST_F(InputBuilderTest, lar_split_detector)
 {
-    auto inf = std::numeric_limits<real_type>::infinity();
     {
         auto result = this->track({0, 0, -14}, {0, 0, 1});
 

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -799,7 +799,7 @@ TEST_F(InputBuilderTest, lar_split_detector)
             "outer_region@global",
         };
         ref.distances = {4, 5, 10, 5, 5};
-        ref.halfway_safeties = {2, 2.5, inf, 2.5, 2.5};
+        ref.halfway_safeties = {2, 2.5, 5, 2.5, 2.5};
         ref.bumps = {};
         auto tol = this->tracking_tol();
         EXPECT_REF_NEAR(ref, result, tol);
@@ -934,7 +934,7 @@ TEST_F(InputBuilderTest, hierarchy)
         static real_type const expected_distances[]
             = {3, 2, 8, 2, 4, 87.979589711327};
         EXPECT_VEC_SOFT_EQ(expected_distances, result.distances);
-        static real_type const expected_hw_safety[] = {1.5, 5, 4, 5, 2, 39};
+        static real_type const expected_hw_safety[] = {1.5, 1, 4, 1, 2, 39};
         EXPECT_VEC_SOFT_EQ(expected_hw_safety, result.halfway_safeties);
     }
     {


### PR DESCRIPTION
ORANGE currently approximates the safety distance by finding the local gradient of the quadric/planar equation for certain special surfaces, calculating the distance along that direction, and taking the minimum of all distances (even to internal surfaces). This approach returns infinities when the gradient is zero, e.g. along the axis of a cylinder.

When we have recently found the distance to the next boundary, we can bound the safety distance to that value, rather than infinity. Without this fix, `CheckedGeoTrackView::find_next_step(real_type)` (which checks the safety distance) can fail for ORANGE.