### PR TITLE
Consolidate stream operators into the classes that need them

### DIFF
--- a/app/celer-g4/DetectorConstruction.cc
+++ b/app/celer-g4/DetectorConstruction.cc
@@ -17,7 +17,6 @@
 #include <G4UniformMagField.hh>
 #include <G4VPhysicalVolume.hh>
 
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputRegistry.hh"
 #include "corecel/math/ArrayUtils.hh"

--- a/src/accel/AlongStepFactory.cc
+++ b/src/accel/AlongStepFactory.cc
@@ -11,7 +11,6 @@
 
 #include "corecel/io/Logger.hh"
 #include "corecel/math/ArrayUtils.hh"
-#include "corecel/math/QuantityIO.hh"
 #include "geocel/g4/Convert.hh"
 #include "celeritas/alongstep/AlongStepCartMapFieldMscAction.hh"
 #include "celeritas/alongstep/AlongStepCylMapFieldMscAction.hh"

--- a/src/accel/ExceptionConverter.cc
+++ b/src/accel/ExceptionConverter.cc
@@ -12,11 +12,8 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "corecel/OpaqueIdIO.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
-#include "corecel/math/QuantityIO.hh"
 #include "celeritas/geo/CoreGeoParams.hh"
 #include "celeritas/geo/GeoMaterialParams.hh"
 #include "celeritas/global/CoreParams.hh"

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -21,7 +21,6 @@
 #include "corecel/Config.hh"
 
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/io/BuildOutput.hh"
 #include "corecel/io/Logger.hh"

--- a/src/accel/SharedParams.cc
+++ b/src/accel/SharedParams.cc
@@ -28,7 +28,6 @@
 #include "corecel/Version.hh"
 
 #include "corecel/Assert.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/BuildOutput.hh"
 #include "corecel/io/Join.hh"

--- a/src/celeritas/global/DebugIO.json.cc
+++ b/src/celeritas/global/DebugIO.json.cc
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "DebugIO.json.hh"
 
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/JsonUtils.json.hh"
 #include "corecel/io/LabelIO.json.hh"
 #include "corecel/math/QuantityIO.json.hh"

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -6,8 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "KernelContextException.hh"
 
-#include "corecel/OpaqueIdIO.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/ArrayIO.json.hh"
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/math/QuantityIO.json.hh"

--- a/src/celeritas/mucf/model/DTMixMucfModel.cc
+++ b/src/celeritas/mucf/model/DTMixMucfModel.cc
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 
-#include "corecel/OpaqueIdIO.hh"
 #include "corecel/inp/Grid.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/TrackExecutor.hh"

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -14,6 +14,10 @@
 #include "Macros.hh"
 #include "Types.hh"
 
+#if !CELER_DEVICE_COMPILE
+#    include <ostream>
+#endif
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -296,6 +300,26 @@ inline CELER_FUNCTION IdT id_cast(U value) noexcept(!CELERITAS_DEBUG)
 
     return IdT{detail::id_cast_impl<typename IdT::size_type, U>(value)};
 }
+
+#if !CELER_DEVICE_COMPILE
+//---------------------------------------------------------------------------//
+/*!
+ * Output an opaque ID's value or a placeholder if unavailable.
+ */
+template<class V, class S>
+std::ostream& operator<<(std::ostream& os, OpaqueId<V, S> const& v)
+{
+    if (v)
+    {
+        os << v.unchecked_get();
+    }
+    else
+    {
+        os << "<null>";
+    }
+    return os;
+}
+#endif
 
 //---------------------------------------------------------------------------//
 // TRAITS

--- a/src/corecel/OpaqueIdIO.hh
+++ b/src/corecel/OpaqueIdIO.hh
@@ -2,34 +2,6 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/OpaqueIdIO.hh
-//! \todo guard for GPU and move into OpaqueId.hh
-//---------------------------------------------------------------------------//
 #pragma once
 
-#include <ostream>
-
-#include "OpaqueId.hh"
-
-namespace celeritas
-{
-//---------------------------------------------------------------------------//
-/*!
- * Output an opaque ID's value or a placeholder if unavailable.
- */
-template<class V, class S>
-std::ostream& operator<<(std::ostream& os, OpaqueId<V, S> const& v)
-{
-    if (v)
-    {
-        os << v.unchecked_get();
-    }
-    else
-    {
-        os << "<null>";
-    }
-    return os;
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace celeritas
+#warning "Deprecated: this file is no longer necessary to include"

--- a/src/corecel/OpaqueIdIO.hh
+++ b/src/corecel/OpaqueIdIO.hh
@@ -5,3 +5,5 @@
 #pragma once
 
 #warning "Deprecated: this file is no longer necessary to include"
+
+#include "OpaqueId.hh"

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -13,6 +13,10 @@
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 
+#if !CELER_DEVICE_COMPILE
+#    include "corecel/io/StreamableContainer.hh"
+#endif
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -178,6 +182,20 @@ CELER_CEF bool operator!=(Array<T, N> const& lhs, Array<T, N> const& rhs)
 {
     return !(lhs == rhs);
 }
+
+#if !CELER_DEVICE_COMPILE
+//---------------------------------------------------------------------------//
+/*!
+ * Write the elements of array \a a to stream \a os.
+ */
+template<class T, size_type N>
+CELER_FORCEINLINE std::ostream&
+operator<<(std::ostream& os, Array<T, N> const& a)
+{
+    os << StreamableContainer{a.data(), a.size()};
+    return os;
+}
+#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -35,7 +35,6 @@ namespace celeritas
  * \note For supplementary functionality, include:
  * - \c corecel/math/ArrayUtils.hh for real-number vector/matrix applications
  * - \c corecel/math/ArrayOperators.hh for mathematical operators
- * - \c ArrayIO.hh for streaming and string conversion
  * - \c ArrayIO.json.hh for JSON input and output
  */
 template<class T, ::celeritas::size_type N>

--- a/src/corecel/cont/ArrayIO.hh
+++ b/src/corecel/cont/ArrayIO.hh
@@ -2,41 +2,6 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/cont/ArrayIO.hh
-//---------------------------------------------------------------------------//
-#pragma once
 
-#include <ostream>
-#include <sstream>
-#include <string>
-
-#include "Array.hh"
-#include "SpanIO.hh"
-
-namespace celeritas
-{
-//---------------------------------------------------------------------------//
-/*!
- * Write the elements of array \a a to stream \a os.
- */
-template<class T, size_type N>
-std::ostream& operator<<(std::ostream& os, Array<T, N> const& a)
-{
-    os << make_span(a);
-    return os;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Convert an array to a string representation for debugging.
- */
-template<class T, size_type N>
-std::string to_string(Array<T, N> const& a)
-{
-    std::ostringstream os;
-    os << a;
-    return os.str();
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace celeritas
+// DEPRECATED: remove in 1.0
+#warning "Deprecated:his file is no longer necessary to include"

--- a/src/corecel/cont/ArrayIO.hh
+++ b/src/corecel/cont/ArrayIO.hh
@@ -4,4 +4,6 @@
 //---------------------------------------------------------------------------//
 
 // DEPRECATED: remove in 1.0
-#warning "Deprecated:his file is no longer necessary to include"
+#warning "Deprecated: this file is no longer necessary to include"
+
+#include "Array.hh"

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -15,6 +15,10 @@
 
 #include "detail/SpanImpl.hh"
 
+#if !CELER_DEVICE_COMPILE
+#    include "corecel/io/StreamableContainer.hh"
+#endif
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -256,6 +260,20 @@ CELER_CONSTEXPR_FUNCTION auto make_array(Span<T, N> const& s)
     }
     return result;
 }
+
+#if !CELER_DEVICE_COMPILE
+//---------------------------------------------------------------------------//
+/*!
+ * Write the elements of array \a a to stream \a os.
+ */
+template<class T, std::size_t N>
+CELER_FORCEINLINE std::ostream&
+operator<<(std::ostream& os, Span<T, N> const& s)
+{
+    os << StreamableContainer{s.data(), s.size()};
+    return os;
+}
+#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/cont/SpanIO.hh
+++ b/src/corecel/cont/SpanIO.hh
@@ -4,24 +4,5 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/io/StreamableContainer.hh"
-
-#include "Span.hh"
-
-namespace celeritas
-{
-//---------------------------------------------------------------------------//
-/*!
- * Write the elements of array \a a to stream \a os.
- */
-template<class T, std::size_t N>
-CELER_FORCEINLINE std::ostream&
-operator<<(std::ostream& os, Span<T, N> const& s)
-{
-    os << StreamableContainer{s.data(), s.size()};
-    return os;
-}
-#endif
-
-//---------------------------------------------------------------------------//
-}  // namespace celeritas
+// DEPRECATED: remove in 1.0
+#warning "Deprecated: this file is no longer necessary to include"

--- a/src/corecel/cont/SpanIO.hh
+++ b/src/corecel/cont/SpanIO.hh
@@ -2,12 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/cont/SpanIO.hh
-//---------------------------------------------------------------------------//
 #pragma once
 
-#include <iomanip>
-#include <ostream>
+#include "corecel/io/StreamableContainer.hh"
 
 #include "Span.hh"
 
@@ -15,48 +12,16 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Write the elements of span \a s to stream \a os.
+ * Write the elements of array \a a to stream \a os.
  */
-template<class T, std::size_t E>
-std::ostream& operator<<(std::ostream& os, Span<T, E> const& s)
+template<class T, std::size_t N>
+CELER_FORCEINLINE std::ostream&
+operator<<(std::ostream& os, Span<T, N> const& s)
 {
-    std::streamsize size = s.size();
-    std::streamsize width = os.width();
-    std::streamsize remainder = 0;
-
-    os.width(0);
-    os << '{';
-    if (width > 2 + (size - 1))
-    {
-        // Subtract width for spaces and braces
-        width -= 2 + (size - 1);
-        // Individual width is 1/N of that, rounded down, keep remainder
-        // separate
-        remainder = width % size;
-        width = width / size;
-    }
-    else
-    {
-        width = 0;
-    }
-
-    // First element gets the remainder
-    os.width(width + remainder);
-    if (!s.empty())
-    {
-        os << s[0];
-    }
-
-    for (std::streamsize i = 1; i < size; ++i)
-    {
-        os << ',';
-        os.width(width);
-        os << s[i];
-    }
-    os << '}';
-
+    os << StreamableContainer{s.data(), s.size()};
     return os;
 }
+#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/cont/SpanIO.hh
+++ b/src/corecel/cont/SpanIO.hh
@@ -6,3 +6,5 @@
 
 // DEPRECATED: remove in 1.0
 #warning "Deprecated: this file is no longer necessary to include"
+
+#include "Span.hh"

--- a/src/corecel/io/JsonUtils.json.cc
+++ b/src/corecel/io/JsonUtils.json.cc
@@ -13,6 +13,7 @@
 #include "corecel/sys/Version.hh"
 
 #include "Logger.hh"
+#include "StreamToString.hh"
 
 namespace celeritas
 {
@@ -38,7 +39,7 @@ void save_format(nlohmann::json& j, std::string const& format)
 {
     CELER_EXPECT(j.is_object());
     j["_format"] = format;
-    j["_version"] = to_string(celer_version());
+    j["_version"] = stream_to_string(celer_version());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/Label.cc
+++ b/src/corecel/io/Label.cc
@@ -8,6 +8,8 @@
 
 #include <ostream>
 
+#include "StreamToString.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -59,9 +61,7 @@ std::ostream& operator<<(std::ostream& os, Label const& lab)
  */
 std::string to_string(Label const& lab)
 {
-    std::ostringstream os;
-    os << lab;
-    return os.str();
+    return stream_to_string(lab);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/OutputInterface.cc
+++ b/src/corecel/io/OutputInterface.cc
@@ -11,6 +11,7 @@
 
 #include "EnumStringMapper.hh"
 #include "JsonPimpl.hh"
+#include "StreamToString.hh"
 
 using Category = celeritas::OutputInterface::Category;
 
@@ -40,9 +41,7 @@ char const* to_cstring(Category value)
  */
 std::string to_string(OutputInterface const& output)
 {
-    std::ostringstream os;
-    os << output;
-    return std::move(os).str();
+    return stream_to_string(output);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/StreamToString.hh
+++ b/src/corecel/io/StreamToString.hh
@@ -2,25 +2,25 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/phys/InteractionIO.hh
+//! \file corecel/io/StreamToString.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iosfwd>
-
-#include "corecel/io/StreamToString.hh"  // IWYU pragma: export
-#include "celeritas/phys/Interaction.hh"
+#include <sstream>
+#include <string>
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
-// Write a host-side Interaction to a stream for debugging.
-std::ostream& operator<<(std::ostream& os, Interaction const& i);
-
-//! Allow printing of pos/dir for convenience
-inline std::string to_string(Real3 const& r)
+/*!
+ * Return as a string any object that has an ostream operator.
+ */
+template<class T>
+inline std::string stream_to_string(T const& item)
 {
-    return stream_to_string(r);
+    std::ostringstream os;
+    os << item;
+    return std::move(os).str();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/StreamableContainer.hh
+++ b/src/corecel/io/StreamableContainer.hh
@@ -1,0 +1,88 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/StreamableContainer.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <iomanip>
+#include <ostream>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Helper class to print a contiguous range of data.
+ *
+ * Since this is reused for Array, we provide
+ *
+ * \code
+   std::cout << StreamableSpan{s.data(), s.size()} << std::endl;
+   \endcode
+ */
+template<class T>
+struct StreamableContainer
+{
+    T const* data{};
+    size_type size{};
+};
+
+//---------------------------------------------------------------------------//
+// Template deduction guides
+//---------------------------------------------------------------------------//
+
+template<class T>
+StreamableContainer(T const*, size_type) -> StreamableContainer<T>;
+template<class T>
+StreamableContainer(T*, size_type) -> StreamableContainer<T>;
+
+//---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Write a container to a stream.
+ */
+template<class T>
+inline std::ostream& operator<<(std::ostream& os, StreamableContainer<T> sc)
+{
+    std::streamsize size = static_cast<std::streamsize>(sc.size);
+    std::streamsize width = os.width();
+    std::streamsize remainder = 0;
+
+    os.width(0);
+    os << '{';
+    if (width > 2 + (size - 1))
+    {
+        // Subtract width for spaces and braces
+        width -= 2 + (size - 1);
+        // Individual width is 1/N of that, rounded down, keep remainder
+        // separate
+        remainder = width % size;
+        width = width / size;
+    }
+    else
+    {
+        width = 0;
+    }
+
+    // First element gets the remainder
+    os.width(width + remainder);
+    if (size > 0)
+    {
+        os << sc.data[0];
+    }
+
+    for (std::streamsize i = 1; i < size; ++i)
+    {
+        os << ',';
+        os.width(width);
+        os << sc.data[i];
+    }
+    os << '}';
+
+    return os;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/StreamableContainer.hh
+++ b/src/corecel/io/StreamableContainer.hh
@@ -33,7 +33,7 @@ struct StreamableContainer
 //---------------------------------------------------------------------------//
 
 template<class T>
-StreamableContainer(T const*, size_type) -> StreamableContainer<T>;
+StreamableContainer(T const*, std::size_t) -> StreamableContainer<T>;
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS

--- a/src/corecel/io/StreamableContainer.hh
+++ b/src/corecel/io/StreamableContainer.hh
@@ -25,7 +25,7 @@ template<class T>
 struct StreamableContainer
 {
     T const* data{};
-    size_type size{};
+    std::size_t size{};
 };
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/StreamableContainer.hh
+++ b/src/corecel/io/StreamableContainer.hh
@@ -15,10 +15,10 @@ namespace celeritas
 /*!
  * Helper class to print a contiguous range of data.
  *
- * Since this is reused for Array, we provide
- *
+ * Since this class is used by both \c Array and \c Span, it is templated
+ * solely on the item type, and directly uses a non-owning pointer with a size.
  * \code
-   std::cout << StreamableSpan{s.data(), s.size()} << std::endl;
+   std::cout << StreamableContainer{s.data(), s.size()} << std::endl;
    \endcode
  */
 template<class T>
@@ -34,8 +34,6 @@ struct StreamableContainer
 
 template<class T>
 StreamableContainer(T const*, size_type) -> StreamableContainer<T>;
-template<class T>
-StreamableContainer(T*, size_type) -> StreamableContainer<T>;
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS

--- a/src/corecel/io/StreamableVariant.hh
+++ b/src/corecel/io/StreamableVariant.hh
@@ -59,7 +59,8 @@ struct GenericToStream
  * Write a variant object's value to a stream.
  */
 template<class T>
-std::ostream& operator<<(std::ostream& os, StreamableVariant<T> const& svar)
+inline std::ostream&
+operator<<(std::ostream& os, StreamableVariant<T> const& svar)
 {
     CELER_ASSUME(!svar.value.valueless_by_exception());
     std::visit(detail::GenericToStream{os}, svar.value);
@@ -69,9 +70,11 @@ std::ostream& operator<<(std::ostream& os, StreamableVariant<T> const& svar)
 //---------------------------------------------------------------------------//
 /*!
  * Save a variant object's value to a string.
+ *
+ * \todo Separate generic to-string.
  */
 template<class T>
-std::string to_string(StreamableVariant<T> const& svar)
+inline std::string to_string(StreamableVariant<T> const& svar)
 {
     std::ostringstream os;
     os << svar;

--- a/src/corecel/io/StreamableVariant.hh
+++ b/src/corecel/io/StreamableVariant.hh
@@ -13,6 +13,8 @@
 
 #include "corecel/Assert.hh"
 
+#include "StreamToString.hh"
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -70,15 +72,11 @@ operator<<(std::ostream& os, StreamableVariant<T> const& svar)
 //---------------------------------------------------------------------------//
 /*!
  * Save a variant object's value to a string.
- *
- * \todo Separate generic to-string.
  */
 template<class T>
 inline std::string to_string(StreamableVariant<T> const& svar)
 {
-    std::ostringstream os;
-    os << svar;
-    return os.str();
+    return stream_to_string(svar);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/detail/Joined.hh
+++ b/src/corecel/io/detail/Joined.hh
@@ -8,8 +8,9 @@
 
 #include <iosfwd>
 #include <iterator>
-#include <sstream>
 #include <string>
+
+#include "corecel/io/StreamToString.hh"
 
 namespace celeritas
 {
@@ -62,7 +63,7 @@ struct Joined
 
 //---------------------------------------------------------------------------//
 template<class I, class C, class S>
-std::ostream& operator<<(std::ostream& os, Joined<I, C, S> const& j)
+inline std::ostream& operator<<(std::ostream& os, Joined<I, C, S> const& j)
 {
     auto iter = j.first;
     auto op = j.op;
@@ -85,11 +86,9 @@ std::ostream& operator<<(std::ostream& os, Joined<I, C, S> const& j)
 
 //---------------------------------------------------------------------------//
 template<class I, class C, class S>
-std::string to_string(Joined<I, C, S> const& j)
+inline std::string to_string(Joined<I, C, S> const& j)
 {
-    std::ostringstream os;
-    os << j;
-    return std::move(os).str();
+    return stream_to_string(j);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/io/detail/ReprImpl.hh
+++ b/src/corecel/io/detail/ReprImpl.hh
@@ -8,11 +8,11 @@
 
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <type_traits>
 
 #include "corecel/Assert.hh"
+#include "corecel/io/StreamToString.hh"
 
 #include "../ScopedStreamFormat.hh"
 
@@ -41,7 +41,7 @@ struct Repr
  * Write a streamable object to a stream.
  */
 template<class T>
-std::ostream& operator<<(std::ostream& os, Repr<T> const& s)
+inline std::ostream& operator<<(std::ostream& os, Repr<T> const& s)
 {
     ScopedStreamFormat save_fmt(&os);
     ReprTraits<T>::init(os);
@@ -63,11 +63,9 @@ std::ostream& operator<<(std::ostream& os, Repr<T> const& s)
  * Convert a streamable object to a string.
  */
 template<class T>
-std::string to_string(Repr<T> const& s)
+inline std::string to_string(Repr<T> const& s)
 {
-    std::ostringstream os;
-    os << s;
-    return os.str();
+    return stream_to_string(s);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -13,6 +13,10 @@
 
 #include "detail/QuantityImpl.hh"
 
+#if !CELER_DEVICE_COMPILE
+#    include <ostream>
+#endif
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -347,6 +351,21 @@ inline char const* accessor_unit_label()
 {
     return detail::AccessorResultType<T>::unit_type::label();
 }
+
+#if !CELER_DEVICE_COMPILE
+//---------------------------------------------------------------------------//
+/*!
+ * Output an quantity with its label.
+ */
+template<class UnitT, class ValueT>
+std::ostream& operator<<(std::ostream& os, Quantity<UnitT, ValueT> const& q)
+{
+    static_assert(sizeof(UnitT::label()) > 0,
+                  "Unit does not have a 'label' definition");
+    os << q.value() << " [" << UnitT::label() << ']';
+    return os;
+}
+#endif
 
 //---------------------------------------------------------------------------//
 //! True if T is a Quantity

--- a/src/corecel/math/QuantityIO.hh
+++ b/src/corecel/math/QuantityIO.hh
@@ -5,3 +5,5 @@
 #pragma once
 
 #warning "Deprecated: this file is no longer necessary to include"
+
+#include "Quantity.hh"

--- a/src/corecel/math/QuantityIO.hh
+++ b/src/corecel/math/QuantityIO.hh
@@ -2,28 +2,6 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/math/QuantityIO.hh
-//---------------------------------------------------------------------------//
 #pragma once
 
-#include <ostream>
-
-#include "Quantity.hh"
-
-namespace celeritas
-{
-//---------------------------------------------------------------------------//
-/*!
- * Output an quantity with its label.
- */
-template<class UnitT, class ValueT>
-std::ostream& operator<<(std::ostream& os, Quantity<UnitT, ValueT> const& q)
-{
-    static_assert(sizeof(UnitT::label()) > 0,
-                  "Unit does not have a 'label' definition");
-    os << q.value() << " [" << UnitT::label() << ']';
-    return os;
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace celeritas
+#warning "Deprecated: this file is no longer necessary to include"

--- a/src/corecel/sys/Version.cc
+++ b/src/corecel/sys/Version.cc
@@ -56,15 +56,6 @@ std::ostream& operator<<(std::ostream& os, Version const& v)
 }
 
 //---------------------------------------------------------------------------//
-//! Save as a string
-std::string to_string(Version const& v)
-{
-    std::ostringstream os;
-    os << v;
-    return os.str();
-}
-
-//---------------------------------------------------------------------------//
 /*!
  * Get the Celeritas version.
  */

--- a/src/corecel/sys/Version.hh
+++ b/src/corecel/sys/Version.hh
@@ -137,9 +137,6 @@ CELER_DEFINE_VERSION_CMP(>=)
 // Write to stream
 std::ostream& operator<<(std::ostream&, Version const&);
 
-// Save as string
-std::string to_string(Version const&);
-
 // Get the Celeritas version as an object
 Version celer_version();
 

--- a/src/geocel/rasterize/Image.cc
+++ b/src/geocel/rasterize/Image.cc
@@ -8,7 +8,6 @@
 
 #include <cmath>
 
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/io/Repr.hh"

--- a/src/orange/BoundingBoxUtils.cc
+++ b/src/orange/BoundingBoxUtils.cc
@@ -9,7 +9,6 @@
 #include <iostream>
 
 #include "corecel/Assert.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/NumericLimits.hh"
 

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "corecel/Assert.hh"
-#include "corecel/OpaqueIdIO.hh"  // IWYU pragma: keep
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/ArrayIO.json.hh"  // IWYU pragma: keep

--- a/src/orange/g4org/ProtoConstructor.cc
+++ b/src/orange/g4org/ProtoConstructor.cc
@@ -8,7 +8,6 @@
 
 #include <iostream>
 
-#include "corecel/OpaqueIdIO.hh"
 #include "corecel/io/StreamableVariant.hh"
 #include "geocel/VolumeParams.hh"
 #include "orange/inp/Import.hh"

--- a/src/orange/orangeinp/CsgTreeUtils.cc
+++ b/src/orange/orangeinp/CsgTreeUtils.cc
@@ -187,7 +187,7 @@ TransformedTree transform_negated_joins(CsgTree const& tree)
     detail::InfixStringBuilder build_impl{tree, &os};
 
     build_impl(n);
-    return os.str();
+    return std::move(os).str();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/CsgTypes.cc
+++ b/src/orange/orangeinp/CsgTypes.cc
@@ -6,8 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "CsgTypes.hh"
 
-#include <iostream>
-#include <sstream>
+#include <ostream>
 
 #include "corecel/io/Join.hh"
 #include "corecel/io/StreamableVariant.hh"
@@ -69,15 +68,6 @@ std::ostream& operator<<(std::ostream& os, Node const& node)
 }
 
 //!@}
-//---------------------------------------------------------------------------//
-//! Convert a node variant to a string
-std::string to_string(Node const& n)
-{
-    std::ostringstream os;
-    os << n;
-    return os.str();
-}
-
 //---------------------------------------------------------------------------//
 }  // namespace orangeinp
 }  // namespace celeritas

--- a/src/orange/orangeinp/CsgTypes.hh
+++ b/src/orange/orangeinp/CsgTypes.hh
@@ -126,9 +126,6 @@ std::ostream& operator<<(std::ostream& os, Joined const&);
 // Write a variant node to a stream
 std::ostream& operator<<(std::ostream& os, Node const&);
 
-// Get a string representation of a variant node
-std::string to_string(Node const&);
-
 //---------------------------------------------------------------------------//
 // Helper functions
 //---------------------------------------------------------------------------//

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -11,7 +11,6 @@
 #include "corecel/Assert.hh"
 #include "corecel/Constants.hh"
 #include "corecel/Macros.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/Join.hh"

--- a/src/orange/orangeinp/UnitProto.cc
+++ b/src/orange/orangeinp/UnitProto.cc
@@ -13,7 +13,6 @@
 #include <nlohmann/json.hpp>
 
 #include "corecel/Assert.hh"
-#include "corecel/OpaqueIdIO.hh"  // IWYU pragma: keep
 #include "corecel/io/Join.hh"
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/io/JsonUtils.json.hh"  // IWYU pragma: keep

--- a/src/orange/surf/SurfaceIO.cc
+++ b/src/orange/surf/SurfaceIO.cc
@@ -9,7 +9,7 @@
 #include <cmath>
 #include <ostream>
 
-#include "corecel/cont/ArrayIO.hh"
+#include "corecel/cont/Array.hh"
 #include "orange/OrangeTypes.hh"
 
 #include "ConeAligned.hh"  // IWYU pragma: associated

--- a/src/orange/transform/TransformIO.cc
+++ b/src/orange/transform/TransformIO.cc
@@ -6,7 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "TransformIO.hh"
 
-#include "corecel/cont/ArrayIO.hh"
+#include "corecel/cont/Array.hh"
 
 #include "Transformation.hh"
 #include "Translation.hh"

--- a/test/accel/LinearMagFieldTestBase.hh
+++ b/test/accel/LinearMagFieldTestBase.hh
@@ -10,7 +10,6 @@
 #include <G4MagneticField.hh>
 
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"  // IWYU pragma: keep
 #include "corecel/math/ArrayOperators.hh"
 #include "geocel/UnitUtils.hh"
 #include "celeritas/Quantities.hh"

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -12,7 +12,6 @@
 #include "corecel/Config.hh"
 
 #include "corecel/ScopedLogStorer.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/ColorUtils.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"

--- a/test/celeritas/field/FieldSubstepper.test.cc
+++ b/test/celeritas/field/FieldSubstepper.test.cc
@@ -7,7 +7,6 @@
 #include "celeritas/field/FieldSubstepper.hh"
 
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayOperators.hh"

--- a/test/celeritas/field/LinearPropagator.test.cc
+++ b/test/celeritas/field/LinearPropagator.test.cc
@@ -8,7 +8,6 @@
 
 #include <string_view>
 
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/data/StateDataStore.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"

--- a/test/celeritas/geo/HeuristicGeoExecutor.hh
+++ b/test/celeritas/geo/HeuristicGeoExecutor.hh
@@ -23,10 +23,6 @@
 #include "geocel/UnitUtils.hh"
 #include "celeritas/geo/CoreGeoTrackView.hh"
 
-#if !CELER_DEVICE_SOURCE
-#    include "corecel/cont/ArrayIO.hh"
-#endif
-
 #include "HeuristicGeoData.hh"
 
 namespace celeritas

--- a/test/celeritas/phys/InteractionIO.cc
+++ b/test/celeritas/phys/InteractionIO.cc
@@ -6,8 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "InteractionIO.hh"
 
-#include "corecel/cont/ArrayIO.hh"
-#include "corecel/cont/SpanIO.hh"
 #include "celeritas/Quantities.hh"
 
 #include "SecondaryIO.hh"

--- a/test/celeritas/phys/InteractorHostTestBase.hh
+++ b/test/celeritas/phys/InteractorHostTestBase.hh
@@ -12,7 +12,6 @@
 
 #include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/data/StackAllocator.hh"
 #include "corecel/data/StateDataStore.hh"

--- a/test/celeritas/phys/SecondaryIO.cc
+++ b/test/celeritas/phys/SecondaryIO.cc
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "SecondaryIO.hh"
 
-#include "corecel/cont/ArrayIO.hh"
 #include "celeritas/Quantities.hh"
 
 namespace celeritas

--- a/test/corecel/cont/Span.test.cc
+++ b/test/corecel/cont/Span.test.cc
@@ -11,7 +11,6 @@
 #include <type_traits>
 
 #include "corecel/OpaqueId.hh"
-#include "corecel/cont/SpanIO.hh"
 #include "corecel/data/LdgIterator.hh"
 #include "corecel/sys/TypeDemangler.hh"
 

--- a/test/corecel/math/ArrayUtils.test.cc
+++ b/test/corecel/math/ArrayUtils.test.cc
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "corecel/math/ArrayUtils.hh"
 
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/Constants.hh"
 
@@ -37,7 +36,7 @@ enum
 TEST(ArrayUtilsTest, io)
 {
     Array<int, 3> x{1, 3, 2};
-    EXPECT_EQ("{1,3,2}", to_string(x));
+    EXPECT_EQ("{1,3,2}", stream_to_string(x));
 }
 
 TEST(ArrayUtilsTest, axpy)

--- a/test/corecel/math/ArrayUtils.test.cc
+++ b/test/corecel/math/ArrayUtils.test.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "corecel/math/ArrayUtils.hh"
 
+#include "corecel/io/StreamToString.hh"
 #include "corecel/math/Algorithms.hh"
 #include "celeritas/Constants.hh"
 

--- a/test/corecel/random/RanluxppRngEngine.test.cc
+++ b/test/corecel/random/RanluxppRngEngine.test.cc
@@ -8,7 +8,6 @@
 
 #include <memory>
 
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/data/StateDataStore.hh"
 #include "corecel/io/HexRepr.hh"
 #include "corecel/random/data/RanluxppRngData.hh"

--- a/test/geocel/BoundingBox.test.cc
+++ b/test/geocel/BoundingBox.test.cc
@@ -10,7 +10,6 @@
 
 #include "corecel/Config.hh"
 
-#include "corecel/cont/ArrayIO.hh"
 #include "geocel/BoundingBoxIO.json.hh"
 
 #include "celeritas_test.hh"

--- a/test/geocel/CheckedGeoTrackView.cc
+++ b/test/geocel/CheckedGeoTrackView.cc
@@ -10,7 +10,6 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Types.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/Repr.hh"
 #include "corecel/math/ArrayOperators.hh"

--- a/test/geocel/Detector.test.cc
+++ b/test/geocel/Detector.test.cc
@@ -4,8 +4,6 @@
 //---------------------------------------------------------------------------//
 //! \file geocel/Detector.test.cc
 //---------------------------------------------------------------------------//
-
-#include "corecel/OpaqueIdIO.hh"  // IWYU pragma: keep
 #include "geocel/DetectorParams.hh"
 #include "geocel/DetectorView.hh"
 #include "geocel/VolumeParams.hh"

--- a/test/orange/g4org/Converter.test.cc
+++ b/test/orange/g4org/Converter.test.cc
@@ -9,7 +9,6 @@
 #include <fstream>
 #include <variant>
 
-#include "corecel/OpaqueIdIO.hh"
 #include "corecel/ScopedLogStorer.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Environment.hh"

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -45,7 +45,6 @@
 
 #include "corecel/Constants.hh"
 #include "corecel/ScopedLogStorer.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/Turn.hh"

--- a/test/orange/orangeinp/CsgTree.test.cc
+++ b/test/orange/orangeinp/CsgTree.test.cc
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #include "orange/orangeinp/CsgTree.hh"
 
+#include "corecel/io/StreamToString.hh"
+
 #include "CsgTestUtils.hh"
 #include "celeritas_test.hh"
 
@@ -242,7 +244,7 @@ TEST_F(CsgTreeTest, manual_simplify)
     {
         // Shell combines join
         tree_.exchange(shell, Joined{op_and, {not_inner, inside_outer}});
-        EXPECT_EQ("all{5,9}", to_string(tree_[shell]));
+        EXPECT_EQ("all{5,9}", stream_to_string(tree_[shell]));
     }
     {
         // below mz is false

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -11,7 +11,6 @@
 #include <sstream>
 
 #include "corecel/ScopedLogStorer.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/LoggerTypes.hh"

--- a/test/orange/orangeinp/detail/PolygonUtils.test.cc
+++ b/test/orange/orangeinp/detail/PolygonUtils.test.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "corecel/Constants.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "corecel/math/SoftEqual.hh"
 

--- a/test/orange/surf/CylCentered.test.cc
+++ b/test/orange/surf/CylCentered.test.cc
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <vector>
 
-#include "corecel/cont/ArrayIO.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayUtils.hh"
 

--- a/test/orange/surf/SurfaceSimplifier.test.cc
+++ b/test/orange/surf/SurfaceSimplifier.test.cc
@@ -9,7 +9,6 @@
 #include <iomanip>
 
 #include "corecel/Constants.hh"
-#include "corecel/cont/ArrayIO.hh"
 #include "orange/surf/SurfaceIO.hh"
 #include "orange/surf/detail/AllSurfaces.hh"
 


### PR DESCRIPTION
This reverses a nonintuitive paradigm meant to reduce CUDA compile times/compiler errors by shielding .cu files from standard library IO headers. The change should help poor @Rashika-Gupta and @davidsgr debug more easily: you can now just directly stream arrays, quantities, etc.

A new helper `stream_to_string` allows streamable classes to be converted to strings without overloading `to_string`.