### PR TITLE
Fix conversion of subtractions with no transforms

### DIFF
--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -442,7 +442,7 @@ auto SolidConverter::displaced(arg_type solid_base) -> result_type
     // Note that GetDirectTransform is an affine transform that combines the
     // daughter-to-parent ("object") translation with an inverted
     // [parent-to-daughter, "frame"] rotation
-    return std::make_shared<Transformed>(
+    return Transformed::or_object(
         std::move(daughter), transform_.variant(solid.GetDirectTransform()));
 }
 
@@ -656,8 +656,8 @@ auto SolidConverter::multiunion(arg_type solid_base) -> result_type
     for (auto i : range(n))
     {
         auto vol = (*this)(*(mu.GetSolid(i)));
-        vols[i] = std::make_shared<Transformed>(
-            std::move(vol), transform_(mu.GetTransformation(i)));
+        vols[i] = Transformed::or_object(std::move(vol),
+                                         transform_(mu.GetTransformation(i)));
     }
 
     return std::make_shared<AnyObjects>(std::string{solid_base.GetName()},
@@ -848,8 +848,8 @@ auto SolidConverter::reflectedsolid(arg_type solid_base) -> result_type
     auto converted = (*this)(*underlying);
 
     // Add a reflecting transform
-    return std::make_shared<Transformed>(
-        std::move(converted), transform_(solid.GetDirectTransform3D()));
+    return Transformed::or_object(std::move(converted),
+                                  transform_(solid.GetDirectTransform3D()));
 }
 
 //---------------------------------------------------------------------------//
@@ -864,8 +864,8 @@ auto SolidConverter::scaledsolid(arg_type solid_base) -> result_type
     auto converted = (*this)(*underlying);
 
     // Add a scaling transform
-    return std::make_shared<Transformed>(
-        std::move(converted), transform_(solid.GetScaleTransform()));
+    return Transformed::or_object(std::move(converted),
+                                  transform_(solid.GetScaleTransform()));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -1072,7 +1072,7 @@ TEST_F(SolidConverterTest, subtractionsolid)
         G4Box inner("inner", 50, 50, 50);
         this->build_and_test(
             G4SubtractionSolid("sub", &outer, &inner, G4Transform3D{}),
-            R"json({})json");
+            R"json({"_type":"all","daughters":[{"_type":"shape","interior":{"_type":"box","halfwidths":[10.0,10.0,10.0]},"label":"outer"},{"_type":"negated","daughter":{"_type":"shape","interior":{"_type":"box","halfwidths":[5.0,5.0,5.0]},"label":"inner"},"label":""}],"label":"sub"})json");
     }
 }
 

--- a/test/orange/g4org/SolidConverter.test.cc
+++ b/test/orange/g4org/SolidConverter.test.cc
@@ -1067,6 +1067,13 @@ TEST_F(SolidConverterTest, subtractionsolid)
             G4SubtractionSolid("LAr::DM::SPliceBoxr", &trap, &box, transform),
             R"json({"_type":"all","daughters":[{"_type":"shape","interior":{"_type":"genprism","halfheight":23.75,"lower":[[4.75,-30.700000000000003],[4.75,30.700000000000003],[-4.75,30.700000000000003],[-4.75,-30.700000000000003]],"upper":[[4.75,-25.917],[4.75,25.917],[-4.75,25.917],[-4.75,-25.917]]},"label":"trap"},{"_type":"negated","daughter":{"_type":"transformed","daughter":{"_type":"shape","interior":{"_type":"box","halfwidths":[5.0,24.480000000000004,15.0]},"label":"box"},"transform":{"_type":"transformation","data":[1.0,0.0,0.0,0.0,0.747890784796085,-0.6638217938702345,0.0,0.6638217938702345,0.747890784796085,0.0,-22.349000000000004,19.388]}},"label":""}],"label":"LAr::DM::SPliceBoxr"})json");
     }
+    {
+        G4Box outer("outer", 100, 100, 100);
+        G4Box inner("inner", 50, 50, 50);
+        this->build_and_test(
+            G4SubtractionSolid("sub", &outer, &inner, G4Transform3D{}),
+            R"json({})json");
+    }
 }
 
 TEST_F(SolidConverterTest, reflectedsolid)


### PR DESCRIPTION
This prevents a (superficial) assertion error firing in cases like the ATLAS `LArMgr__LAr__DM__Crate` due to consequences of  #2258.