### PR TITLE
Remove spurious warning about importing G4OpBoundaryProcess

### DIFF
--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -33,6 +33,7 @@
 #include <G4NuclearFormfactorType.hh>
 #include <G4NucleiProperties.hh>
 #include <G4OpAbsorption.hh>
+#include <G4OpBoundaryProcess.hh>
 #include <G4OpMieHG.hh>
 #include <G4OpRayleigh.hh>
 #include <G4OpWLS.hh>
@@ -1032,6 +1033,13 @@ auto import_processes(GeantImporter::DataSelection selected,
         {
             optical_models.push_back(
                 import_optical_model(optical::ImportModelClass::mie));
+        }
+        else if (import_optical_model
+                 && dynamic_cast<G4OpBoundaryProcess const*>(&process))
+        {
+            // Surface physics importing handled separately from volumetric
+            // discrete importing
+            CELER_DISCARD(process);
         }
 
 #if G4VERSION_NUMBER >= 1070


### PR DESCRIPTION
Because G4OpBoundaryProcess is a discrete process in Geant4, it gets loaded along with the list of optical volumetric processes. Since it's not handled in that section of the GeantImporter, we can just skip over it to remove the warning message.

CELER_DISCARD used to avoid possible warnings of empty if-else statements.