### PR TITLE
Avoid `id_cast` when null ID is allowed

### DIFF
--- a/src/celeritas/geo/GeoMaterialParams.cc
+++ b/src/celeritas/geo/GeoMaterialParams.cc
@@ -323,7 +323,8 @@ GeoMaterialParams::from_import(ImportData const& data,
             if (!inp_vol)
                 continue;
 
-            vol_to_mat[vol_idx] = id_cast<PhysMatId>(inp_vol.phys_material_id);
+            // Note that that volume might not have an associated material
+            vol_to_mat[vol_idx] = PhysMatId(inp_vol.phys_material_id);
         }
         input.volume_to_mat = std::move(vol_to_mat);
     }
@@ -343,10 +344,10 @@ GeoMaterialParams::from_import(ImportData const& data,
             if (!inp_vol)
                 continue;
 
-            CELER_EXPECT(!inp_vol.name.empty());
-            auto&& [iter, inserted] = label_to_mat.emplace(
-                Label::from_separator(inp_vol.name),
-                id_cast<PhysMatId>(inp_vol.phys_material_id));
+            CELER_ASSERT(!inp_vol.name.empty());
+            auto&& [iter, inserted]
+                = label_to_mat.emplace(Label::from_separator(inp_vol.name),
+                                       PhysMatId(inp_vol.phys_material_id));
             if (!inserted)
             {
                 CELER_LOG(error)

--- a/src/celeritas/geo/GeoMaterialParams.cc
+++ b/src/celeritas/geo/GeoMaterialParams.cc
@@ -324,7 +324,10 @@ GeoMaterialParams::from_import(ImportData const& data,
                 continue;
 
             // Note that that volume might not have an associated material
-            vol_to_mat[vol_idx] = PhysMatId(inp_vol.phys_material_id);
+            vol_to_mat[vol_idx]
+                = inp_vol.phys_material_id == ImportVolume::unspecified
+                      ? PhysMatId{}
+                      : id_cast<PhysMatId>(inp_vol.phys_material_id);
         }
         input.volume_to_mat = std::move(vol_to_mat);
     }
@@ -345,9 +348,11 @@ GeoMaterialParams::from_import(ImportData const& data,
                 continue;
 
             CELER_ASSERT(!inp_vol.name.empty());
-            auto&& [iter, inserted]
-                = label_to_mat.emplace(Label::from_separator(inp_vol.name),
-                                       PhysMatId(inp_vol.phys_material_id));
+            auto&& [iter, inserted] = label_to_mat.emplace(
+                Label::from_separator(inp_vol.name),
+                inp_vol.phys_material_id == ImportVolume::unspecified
+                    ? PhysMatId{}
+                    : id_cast<PhysMatId>(inp_vol.phys_material_id));
             if (!inserted)
             {
                 CELER_LOG(error)


### PR DESCRIPTION
With the dune-full GDML I hit the failure:
```console
./bin/celer-sim: critical: assertion failure: /home/alund/celeritas_project/celeritas/src/corecel/OpaqueId.hh:251:
celeritas: precondition failed: static_cast<T>(value) != nullid_value<T>
```
I traced it back to the `GeoMaterialParams` construction, where we were using `id_cast` (which prohibits the "null" value) for the `PhysMatId`, which we allow to be null.