### PR TITLE
Store geometry to optical material ID mapping in `GeantGeoParams`

### DIFF
--- a/src/accel/LocalOpticalGenOffload.cc
+++ b/src/accel/LocalOpticalGenOffload.cc
@@ -126,6 +126,7 @@ void LocalOpticalGenOffload::InitializeEvent(int id)
 void LocalOpticalGenOffload::Push(optical::GeneratorDistributionData const& data)
 {
     CELER_EXPECT(*this);
+    CELER_EXPECT(data);
 
     ScopedProfiling profile_this{"push"};
 

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -242,7 +242,6 @@ if(CELERITAS_USE_Geant4)
     ext/detail/GeantProcessImporter.cc
     ext/detail/GeantSurfacePhysicsHelper.cc
     ext/detail/GeantSurfacePhysicsLoader.cc
-    ext/detail/GeoOpticalIdMap.cc
     ext/detail/HitProcessor.cc
     ext/detail/LevelTouchableUpdater.cc
     ext/detail/NaviTouchableUpdater.cc

--- a/src/celeritas/ext/detail/GeantOpticalModelImporter.hh
+++ b/src/celeritas/ext/detail/GeantOpticalModelImporter.hh
@@ -11,10 +11,9 @@
 #include <vector>
 
 #include "corecel/OpaqueId.hh"
+#include "geocel/GeoOpticalIdMap.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/io/ImportOpticalModel.hh"
-
-#include "GeoOpticalIdMap.hh"
 
 class G4VProcess;
 class G4MaterialPropertiesTable;

--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -51,6 +51,7 @@ if(CELERITAS_USE_Geant4)
     GeantUtils.cc
     GeantGeoUtils.cc
     GeantGdmlLoader.cc
+    GeoOpticalIdMap.cc
     ScopedGeantExceptionHandler.cc
     ScopedGeantLogger.cc
     GeantGeoParams.cc

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -7,6 +7,7 @@
 #include "GeantGeoParams.hh"
 
 #include <map>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -38,6 +39,7 @@
 
 #include "GeantGdmlLoader.hh"
 #include "GeantGeoUtils.hh"
+#include "GeoOpticalIdMap.hh"
 #include "ScopedGeantExceptionHandler.hh"
 #include "ScopedGeantLogger.hh"
 #include "g4/Convert.hh"  // IWYU pragma: associated
@@ -718,6 +720,8 @@ GeantGeoParams::from_gdml(std::string const& filename)
  */
 GeantGeoParams::GeantGeoParams(G4VPhysicalVolume const* world, Ownership owns)
     : ownership_{owns}
+    , geo_to_opt_(
+          std::make_shared<GeoOpticalIdMap>(*G4Material::GetMaterialTable()))
 {
     CELER_EXPECT(world);
     data_.world = const_cast<G4VPhysicalVolume*>(world);

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -31,6 +31,8 @@ class G4VSensitiveDetector;
 
 namespace celeritas
 {
+class GeoOpticalIdMap;
+
 //---------------------------------------------------------------------------//
 /*!
  * Manage and provide access to a Geant4 geometry model.
@@ -154,6 +156,9 @@ class GeantGeoParams final : public GeoParamsInterface,
     // Get the volume instance ID corresponding to a Geant4 physical volume
     inline VolumeInstanceId geant_to_id(G4VPhysicalVolume const& volume) const;
 
+    // Get the mapping from geometry material ID to optical material ID
+    inline std::shared_ptr<GeoOpticalIdMap> const& geo_optical_id_map() const;
+
     //!@{
     //! Access the world volume
     G4VPhysicalVolume const* world() const { return data_.world; }
@@ -187,6 +192,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     // Host metadata/access
     ImplVolumeMap impl_volumes_;
     detail::GeantVolumeInstanceMapper vi_mapper_;
+    std::shared_ptr<GeoOpticalIdMap> geo_to_opt_;
     std::vector<G4LogicalSurface const*> surfaces_;
     BBox bbox_;
 
@@ -283,6 +289,16 @@ VolumeId GeantGeoParams::volume_id(ImplVolumeId iv_id) const
     }
 
     return id_cast<VolumeId>(iv_id.get());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the mapping from geometry material ID to optical material ID.
+ */
+CELER_FORCEINLINE std::shared_ptr<GeoOpticalIdMap> const&
+GeantGeoParams::geo_optical_id_map() const
+{
+    return geo_to_opt_;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/GeoOpticalIdMap.cc
+++ b/src/geocel/GeoOpticalIdMap.cc
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/GeoOpticalIdMap.cc
+//! \file geocel/GeoOpticalIdMap.cc
 //---------------------------------------------------------------------------//
 #include "GeoOpticalIdMap.hh"
 
@@ -10,11 +10,7 @@
 
 #include "corecel/cont/Range.hh"
 
-#include "GeantMaterialPropertyGetter.hh"
-
 namespace celeritas
-{
-namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -50,5 +46,4 @@ GeoOpticalIdMap::GeoOpticalIdMap(G4MaterialTable const& mt)
 }
 
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas

--- a/src/geocel/GeoOpticalIdMap.hh
+++ b/src/geocel/GeoOpticalIdMap.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file celeritas/ext/detail/GeoOpticalIdMap.hh
+//! \file geocel/GeoOpticalIdMap.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -13,8 +13,6 @@
 #include "celeritas/Types.hh"
 
 namespace celeritas
-{
-namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
@@ -73,5 +71,4 @@ OptMatId GeoOpticalIdMap::operator[](GeoMatId m) const
 }
 
 //---------------------------------------------------------------------------//
-}  // namespace detail
 }  // namespace celeritas


### PR DESCRIPTION
This lets us look up the optical material ID from the `G4Material` when offloading optical distributions from Geant4, which is cheaper than initializing the geometry state from the pre-step point.