### PR TITLE
Add make_ref for collections

### DIFF
--- a/src/celeritas/grid/NonuniformGridBuilder.cc
+++ b/src/celeritas/grid/NonuniformGridBuilder.cc
@@ -6,8 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "NonuniformGridBuilder.hh"
 
-#include "corecel/Types.hh"
-#include "corecel/grid/SplineDerivCalculator.hh"
 #include "corecel/io/EnumStringMapper.hh"
 
 #include "detail/GridUtils.hh"

--- a/src/celeritas/grid/NonuniformGridBuilder.hh
+++ b/src/celeritas/grid/NonuniformGridBuilder.hh
@@ -6,15 +6,11 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <utility>
-#include <vector>
-
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
 #include "corecel/data/DedupeCollectionBuilder.hh"
 #include "corecel/grid/NonuniformGridData.hh"
 #include "corecel/inp/Grid.hh"
-#include "celeritas/Types.hh"
 
 namespace celeritas
 {
@@ -23,6 +19,9 @@ namespace celeritas
  * Construct a nonuniform grid.
  *
  * This uses a deduplicating inserter for real values to improve caching.
+ *
+ * \todo Move to corecel/grid
+ * \todo Take grid by capturing and eliminate duplicate points.
  */
 class NonuniformGridBuilder
 {

--- a/src/celeritas/grid/NonuniformGridCalculator.hh
+++ b/src/celeritas/grid/NonuniformGridCalculator.hh
@@ -6,8 +6,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <cmath>
-
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
@@ -29,7 +27,7 @@ class NonuniformGridCalculator
   public:
     //@{
     //! Type aliases
-    using Values
+    using Storage
         = Collection<real_type, Ownership::const_reference, MemSpace::native>;
     using Grid = NonuniformGrid<real_type>;
     //@}
@@ -37,12 +35,12 @@ class NonuniformGridCalculator
   public:
     // Construct by *inverting* a monotonicially increasing nonuniform grid
     static inline CELER_FUNCTION NonuniformGridCalculator
-    from_inverse(NonuniformGridRecord const& grid, Values const& reals);
+    from_inverse(NonuniformGridRecord const& grid, Storage const& reals);
 
     // Construct from grid data and backend storage
     inline CELER_FUNCTION
     NonuniformGridCalculator(NonuniformGridRecord const& grid,
-                             Values const& reals);
+                             Storage const& reals);
 
     // Find and interpolate the y value from the given x value
     inline CELER_FUNCTION real_type operator()(real_type x) const;
@@ -66,7 +64,6 @@ class NonuniformGridCalculator
 
     //// DATA ////
 
-    Values const& reals_;
     Grid x_grid_;
     RealIds y_offset_;
     RealIds deriv_offset_;
@@ -74,10 +71,16 @@ class NonuniformGridCalculator
     //// HELPER FUNCTIONS ////
 
     // Private constructor implementation
-    inline CELER_FUNCTION NonuniformGridCalculator(Values const& reals,
+    inline CELER_FUNCTION NonuniformGridCalculator(Storage const& reals,
                                                    RealIds x_grid,
                                                    RealIds y_grid,
                                                    RealIds deriv);
+
+    //! Low-level access to storage for downstream utilities
+    CELER_FORCEINLINE_FUNCTION Storage const& storage() const
+    {
+        return x_grid_.storage();
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -87,7 +90,7 @@ class NonuniformGridCalculator
  * Construct by \em inverting a monotonicially increasing nonuniform grid.
  */
 CELER_FUNCTION NonuniformGridCalculator NonuniformGridCalculator::from_inverse(
-    NonuniformGridRecord const& grid, Values const& reals)
+    NonuniformGridRecord const& grid, Storage const& reals)
 {
     CELER_EXPECT(grid.derivative.empty());
     return NonuniformGridCalculator{reals, grid.value, grid.grid, {}};
@@ -99,7 +102,7 @@ CELER_FUNCTION NonuniformGridCalculator NonuniformGridCalculator::from_inverse(
  */
 CELER_FUNCTION
 NonuniformGridCalculator::NonuniformGridCalculator(
-    NonuniformGridRecord const& grid, Values const& reals)
+    NonuniformGridRecord const& grid, Storage const& reals)
     : NonuniformGridCalculator{reals, grid.grid, grid.value, grid.derivative}
 {
     CELER_EXPECT(grid);
@@ -137,8 +140,8 @@ CELER_FUNCTION real_type NonuniformGridCalculator::operator()(real_type x) const
     else
     {
         // Use cubic spline interpolation
-        real_type lower_deriv = reals_[deriv_offset_[lower_idx]];
-        real_type upper_deriv = reals_[deriv_offset_[lower_idx + 1]];
+        real_type lower_deriv = this->storage()[deriv_offset_[lower_idx]];
+        real_type upper_deriv = this->storage()[deriv_offset_[lower_idx + 1]];
 
         result = SplineInterpolator<real_type>(
             {x_grid_[lower_idx], (*this)[lower_idx], lower_deriv},
@@ -154,7 +157,7 @@ CELER_FUNCTION real_type NonuniformGridCalculator::operator()(real_type x) const
 CELER_FUNCTION real_type NonuniformGridCalculator::operator[](size_type index) const
 {
     CELER_EXPECT(index < y_offset_.size());
-    return reals_[y_offset_[index]];
+    return this->storage()[y_offset_[index]];
 }
 
 //---------------------------------------------------------------------------//
@@ -179,7 +182,8 @@ CELER_FUNCTION NonuniformGridCalculator
 NonuniformGridCalculator::make_inverse() const
 {
     CELER_EXPECT(!this->use_spline());
-    return NonuniformGridCalculator{reals_, y_offset_, x_grid_.offset(), {}};
+    return NonuniformGridCalculator{
+        this->storage(), y_offset_, x_grid_.offset(), {}};
 }
 
 //---------------------------------------------------------------------------//
@@ -189,18 +193,15 @@ NonuniformGridCalculator::make_inverse() const
  * Construct from grid data and backend storage.
  */
 CELER_FUNCTION
-NonuniformGridCalculator::NonuniformGridCalculator(Values const& reals,
+NonuniformGridCalculator::NonuniformGridCalculator(Storage const& reals,
                                                    RealIds x_grid,
                                                    RealIds y_grid,
                                                    RealIds deriv)
-    : reals_{reals}
-    , x_grid_{x_grid, reals_}
-    , y_offset_{y_grid}
-    , deriv_offset_(deriv)
+    : x_grid_{x_grid, reals}, y_offset_{y_grid}, deriv_offset_(deriv)
 {
     CELER_EXPECT(!x_grid.empty() && x_grid.size() == y_grid.size());
-    CELER_EXPECT(*x_grid.end() <= reals_.size()
-                 && *y_grid.end() <= reals_.size());
+    CELER_EXPECT(*x_grid.end() <= this->storage().size()
+                 && *y_grid.end() <= this->storage().size());
     CELER_EXPECT(deriv.empty() || deriv.size() == x_grid.size());
 }
 

--- a/src/celeritas/grid/detail/GridUtils.hh
+++ b/src/celeritas/grid/detail/GridUtils.hh
@@ -8,9 +8,8 @@
 #pragma once
 
 #include "corecel/Types.hh"
-#include "corecel/grid/NonuniformGridData.hh"
+#include "corecel/data/DedupeCollectionBuilder.hh"
 #include "corecel/grid/SplineDerivCalculator.hh"
-#include "corecel/grid/UniformGridData.hh"
 #include "corecel/inp/Grid.hh"
 #include "corecel/io/EnumStringMapper.hh"
 #include "corecel/io/Logger.hh"

--- a/src/celeritas/grid/detail/GridUtils.hh
+++ b/src/celeritas/grid/detail/GridUtils.hh
@@ -20,15 +20,11 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-template<Ownership W>
-using Values = Collection<real_type, W, MemSpace::host>;
-
-//---------------------------------------------------------------------------//
 /*!
  * Calculate the second derivatives or set the polynomial order.
  */
 template<class GridRecord>
-void set_spline(Values<Ownership::value>* values,
+void set_spline(Collection<real_type, Ownership::value, MemSpace::host>* values,
                 DedupeCollectionBuilder<real_type>& reals,
                 inp::Interpolation const& interpolation,
                 GridRecord& data)
@@ -52,7 +48,7 @@ void set_spline(Values<Ownership::value>* values,
                        << "Boundary condition must be specified for "
                           "calculating cubic spline second derivatives");
 
-        Values<Ownership::const_reference> ref(*values);
+        auto ref = make_ref(*values);
         auto deriv = SplineDerivCalculator(interpolation.bc)(data, ref);
         data.derivative = reals.insert_back(deriv.begin(), deriv.end());
     }

--- a/src/celeritas/mucf/model/detail/InterpolatorHelper.cc
+++ b/src/celeritas/mucf/model/detail/InterpolatorHelper.cc
@@ -31,11 +31,7 @@ InterpolatorHelper::InterpolatorHelper(inp::Grid const& input)
  */
 real_type InterpolatorHelper::operator()(real_type value) const
 {
-    using ItemsCRef
-        = Collection<real_type, Ownership::const_reference, MemSpace::host>;
-
-    ItemsCRef reals_ref_{reals_};
-    NonuniformGridCalculator interpolate{grid_record_, reals_ref_};
+    NonuniformGridCalculator interpolate{grid_record_, make_ref(reals_)};
     return interpolate(value);
 }
 

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -441,9 +441,6 @@ using StateCollection = Collection<T, W, M, TrackSlotId>;
  * space) but can also be used to copy from device to host. The \c
  * detail::CollectionAssigner class statically checks for allowable
  * transformations and memory moves.
- *
- * TODO: add optimization to do an in-place copy (rather than a new allocation)
- * if the host and destination are the same size.
  */
 template<class T, Ownership W, MemSpace M, class I>
 template<Ownership W2, MemSpace M2>
@@ -558,6 +555,30 @@ CELER_FUNCTION auto Collection<T, W, M, I>::operator[](AllItemsT) const
     -> SpanConstT
 {
     return {this->storage().data(), this->storage().size()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a const reference collection.
+ *
+ * This effectively makes a Span for accessing a read-only collection.
+ */
+template<class T, MemSpace M, class I>
+inline auto make_ref(Collection<T, Ownership::value, M, I> const& c)
+{
+    Collection<T, Ownership::const_reference, M, I> result;
+    result = c;
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a const reference collection.
+ */
+template<class T, MemSpace M, class I>
+inline auto make_const_ref(Collection<T, Ownership::value, M, I> const& c)
+{
+    return make_ref(c);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/Ref.hh
+++ b/src/corecel/data/Ref.hh
@@ -7,6 +7,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/Assert.hh"
 #include "corecel/Types.hh"
 
 namespace celeritas

--- a/src/corecel/grid/NonuniformGrid.hh
+++ b/src/corecel/grid/NonuniformGrid.hh
@@ -72,7 +72,7 @@ class NonuniformGrid
     inline CELER_FUNCTION SpanConstT values() const;
 
   private:
-    Storage const& storage_;
+    Storage const storage_;
     ItemRangeT offset_;
 };
 

--- a/src/corecel/grid/NonuniformGrid.hh
+++ b/src/corecel/grid/NonuniformGrid.hh
@@ -65,11 +65,17 @@ class NonuniformGrid
     // Find the index of the given value (*must* be in bounds)
     inline CELER_FUNCTION size_type find(value_type value) const;
 
+    // Construct a span referring to the grid points
+    inline CELER_FUNCTION SpanConstT values() const;
+
     //! Low-level access to offsets for downstream utilities
     CELER_FORCEINLINE_FUNCTION ItemRangeT offset() const { return offset_; }
 
-    // Construct a span referring to the grid points
-    inline CELER_FUNCTION SpanConstT values() const;
+    //! Low-level access to storage for downstream utilities
+    CELER_FORCEINLINE_FUNCTION Storage const& storage() const
+    {
+        return storage_;
+    }
 
   private:
     Storage const storage_;

--- a/src/corecel/io/EnumStringMapper.hh
+++ b/src/corecel/io/EnumStringMapper.hh
@@ -72,8 +72,11 @@ char const* EnumStringMapper<T>::operator()(T value) const
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
-
-// Write an enum to a stream
+/*!
+ * Write an enum to a stream.
+ *
+ * \todo Move to corecel/types.hh
+ */
 template<class T>
 auto operator<<(std::ostream& os, T value) -> std::enable_if_t<
     std::is_enum_v<T> && std::is_same_v<decltype(to_cstring(value)), char const*>,

--- a/src/corecel/io/StreamableContainer.hh
+++ b/src/corecel/io/StreamableContainer.hh
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <iomanip>
 #include <ostream>
 
 namespace celeritas

--- a/test/corecel/data/Collection.test.cc
+++ b/test/corecel/data/Collection.test.cc
@@ -316,6 +316,10 @@ TEST_F(SimpleCollectionTest, accessors)
     EXPECT_EQ(123, host_cref[IntId{0}]);
     EXPECT_EQ(123, host_cref[irange].front());
     EXPECT_EQ(321, host_cref[AllInts<host>{}].back());
+
+    auto host_cref_2 = make_ref(host_val);
+    EXPECT_TRUE((std::is_same_v<decltype(host_cref), decltype(host_cref_2)>));
+    EXPECT_EQ(4, host_cref_2.size());
 }
 
 TEST_F(SimpleCollectionTest, algo_host)

--- a/test/corecel/grid/FindInterp.test.cc
+++ b/test/corecel/grid/FindInterp.test.cc
@@ -53,8 +53,7 @@ TEST(FindInterpTest, nonuniform)
     Collection<double, Ownership::value, MemSpace::host> data;
     auto build = CollectionBuilder{&data};
     auto const irange = build.insert_back({-2.0, -1.5, 1.5, 2.0, 2.0, 8.0});
-    Collection<double, Ownership::const_reference, MemSpace::host> ref{data};
-    NonuniformGrid<double> grid(irange, ref);
+    NonuniformGrid<double> grid(irange, make_ref(data));
 
     {
         auto interp = find_interp(grid, -2);
@@ -86,8 +85,7 @@ TEST(FindInterpTest, nonuniform_int)
     Collection<int, Ownership::value, MemSpace::host> data;
     auto build = CollectionBuilder{&data};
     auto const irange = build.insert_back({0, 2, 6, 6, 8});
-    Collection<int, Ownership::const_reference, MemSpace::host> ref{data};
-    NonuniformGrid<int> grid(irange, ref);
+    NonuniformGrid<int> grid(irange, make_ref(data));
 
     {
         auto interp = find_interp(grid, 0);
@@ -119,8 +117,7 @@ TEST(FindInterpTest, Quantity)
     auto build = CollectionBuilder{&data};
     auto const irange
         = build.insert_back({Turn{0}, Turn{0.5}, Turn{0.75}, Turn{1}});
-    Collection<Turn, Ownership::const_reference, MemSpace::host> ref{data};
-    NonuniformGrid<Turn> grid(irange, ref);
+    NonuniformGrid<Turn> grid(irange, make_ref(data));
 
     {
         auto interp = find_interp(grid, Turn{0});


### PR DESCRIPTION
This simplifies the use pattern @stognini intended for his helper class and, by switching from reference to value, eliminates potential use-after-free errors.