### PR TITLE
Support covfie fieldmap in ddceler

### DIFF
--- a/example/ddceler/input/steeringFile.py
+++ b/example/ddceler/input/steeringFile.py
@@ -54,8 +54,11 @@ def setup_physics(kernel):
     # Optional: load a covfie binary field map instead of using the DD4hep
     # ConstantField.  Requires CELERITAS_USE_covfie=ON at build time.
     # Coordinates must be in centimetres and field values in tesla.
-    # Example (commented out):
+    # FieldMapCoordType selects the coordinate system:
+    #   "BrBz"   - 2D cylindrical (r,z) with Br,Bz components
+    #   "BxByBz" - 3D Cartesian (x,y,z) with Bx,By,Bz components (default)
     # celer_phys.FieldMapFile = "/path/to/field.covfie"
+    # celer_phys.FieldMapCoordType = "BrBz"
     phys.adopt(celer_phys)
     phys.dump()
     return None

--- a/example/ddceler/input/steeringFile.py
+++ b/example/ddceler/input/steeringFile.py
@@ -51,6 +51,11 @@ def setup_physics(kernel):
     celer_phys.InitCapacity = 245760
     # Celeritas does not support single scattering
     celer_phys.IgnoreProcesses = ["CoulombScat"]
+    # Optional: load a covfie binary field map instead of using the DD4hep
+    # ConstantField.  Requires CELERITAS_USE_covfie=ON at build time.
+    # Coordinates must be in centimetres and field values in tesla.
+    # Example (commented out):
+    # celer_phys.FieldMapFile = "/path/to/field.covfie"
     phys.adopt(celer_phys)
     phys.dump()
     return None

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -195,6 +195,8 @@ if(CELERITAS_USE_covfie)
   )
   celeritas_polysource_append(_celer_covfie_src
     alongstep/AlongStepCartMapFieldMscAction)
+  celeritas_polysource_append(_celer_covfie_src
+    alongstep/AlongStepRZMapFieldMscAction)
   if(CELERITAS_USE_CUDA OR CELERITAS_USE_HIP)
     # NOTE: object libraries do not work properly with RDC builds or HIP
     list(APPEND SOURCES ${_celer_covfie_src})
@@ -219,6 +221,8 @@ if(CELERITAS_USE_covfie)
 else()
   celeritas_polysource_append(SOURCES
     alongstep/AlongStepCartMapFieldMscAction)
+  celeritas_polysource_append(SOURCES
+    alongstep/AlongStepRZMapFieldMscAction)
 endif()
 
 if(CELERITAS_USE_Geant4)
@@ -364,7 +368,6 @@ endmacro()
 celeritas_polysource(alongstep/AlongStepGeneralLinearAction)
 celeritas_polysource(alongstep/AlongStepNeutralAction)
 celeritas_polysource(alongstep/AlongStepUniformMscAction)
-celeritas_polysource(alongstep/AlongStepRZMapFieldMscAction)
 celeritas_polysource(alongstep/AlongStepCylMapFieldMscAction)
 celeritas_polysource(em/model/BetheHeitlerModel)
 celeritas_polysource(em/model/BetheBlochModel)

--- a/src/celeritas/CMakeLists.txt
+++ b/src/celeritas/CMakeLists.txt
@@ -191,6 +191,7 @@ endif()
 if(CELERITAS_USE_covfie)
   set(_celer_covfie_src
     field/CartMapFieldParams.covfie.cc
+    field/RZMapFieldParams.covfie.cc
   )
   celeritas_polysource_append(_celer_covfie_src
     alongstep/AlongStepCartMapFieldMscAction)

--- a/src/celeritas/field/RZMapField.covfie.hh
+++ b/src/celeritas/field/RZMapField.covfie.hh
@@ -1,0 +1,105 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/field/RZMapField.covfie.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <cmath>
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/cont/Array.hh"
+#include "corecel/math/Algorithms.hh"
+#include "celeritas/Types.hh"
+
+#include "RZMapFieldData.hh"  // IWYU pragma: keep
+
+#include "detail/CovfieRZFieldTraits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Evaluate the value of magnetic field based on a volume-based RZ field map.
+ *
+ * Uses covfie for 2D bilinear interpolation on the R-Z grid and reconstructs
+ * the 3D field vector by projecting the radial component onto Cartesian axes.
+ */
+class RZMapField
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using real_type = float;
+    using Real3 = Array<celeritas::real_type, 3>;
+    using ParamsRef = NativeCRef<RZMapFieldParamsData>;
+    //!@}
+
+  public:
+    // Construct with the shared map data
+    inline CELER_FUNCTION explicit RZMapField(ParamsRef const& shared);
+
+    // Evaluate the magnetic field value for the given position
+    CELER_FUNCTION
+    inline Real3 operator()(Real3 const& pos) const;
+
+  private:
+    using field_view_t = ParamsRef::view_t;
+    field_view_t const& field_;
+    celeritas::real_type min_r_;
+    celeritas::real_type max_r_;
+    celeritas::real_type min_z_;
+    celeritas::real_type max_z_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with the shared magnetic field map data.
+ */
+CELER_FUNCTION
+RZMapField::RZMapField(ParamsRef const& shared)
+    : field_{shared.get_view()}
+    , min_r_{shared.min_r}
+    , max_r_{shared.max_r}
+    , min_z_{shared.min_z}
+    , max_z_{shared.max_z}
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Calculate the magnetic field vector for the given position.
+ *
+ * This uses covfie for 2-D bilinear interpolation on the input R-Z grid
+ * and reconstructs the magnetic field vector from the stored R and Z
+ * components of the field. Values outside the grid return zero, matching
+ * the non-covfie implementation. The result is in the native Celeritas unit
+ * system.
+ */
+CELER_FUNCTION auto RZMapField::operator()(Real3 const& pos) const -> Real3
+{
+    celeritas::real_type r = hypot(pos[0], pos[1]);
+
+    // Return zero outside grid (matching non-covfie behavior)
+    if (r < min_r_ || r > max_r_ || pos[2] < min_z_ || pos[2] > max_z_)
+        return {0, 0, 0};
+
+    // Covfie does 2D bilinear interpolation
+    auto bfield = detail::CovfieRZFieldTraits<MemSpace::native>::to_real2(
+        field_.at(static_cast<real_type>(r), static_cast<real_type>(pos[2])));
+    celeritas::real_type br = bfield[0];
+    celeritas::real_type bz = bfield[1];
+
+    // Project Br onto Cartesian x/y components
+    celeritas::real_type bx = (r != 0) ? br * pos[0] / r : 0;
+    celeritas::real_type by = (r != 0) ? br * pos[1] / r : 0;
+
+    return {bx, by, bz};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/field/RZMapField.hh
+++ b/src/celeritas/field/RZMapField.hh
@@ -6,17 +6,22 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <cmath>
+#include "corecel/Config.hh"
 
-#include "corecel/Macros.hh"
-#include "corecel/Types.hh"
-#include "corecel/grid/FindInterp.hh"
-#include "corecel/grid/UniformGrid.hh"
-#include "corecel/math/Algorithms.hh"
-#include "celeritas/Types.hh"
-#include "celeritas/Units.hh"
+#if CELERITAS_USE_COVFIE || __DOXYGEN__
+#    include "RZMapField.covfie.hh"
+#else
+#    include <cmath>
 
-#include "RZMapFieldData.hh"
+#    include "corecel/Macros.hh"
+#    include "corecel/Types.hh"
+#    include "corecel/grid/FindInterp.hh"
+#    include "corecel/grid/UniformGrid.hh"
+#    include "corecel/math/Algorithms.hh"
+#    include "celeritas/Types.hh"
+#    include "celeritas/Units.hh"
+
+#    include "RZMapFieldData.hh"
 
 namespace celeritas
 {
@@ -107,3 +112,5 @@ CELER_FUNCTION auto RZMapField::operator()(Real3 const& pos) const -> Real3
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas
+
+#endif  // CELERITAS_USE_COVFIE

--- a/src/celeritas/field/RZMapFieldData.covfie.hh
+++ b/src/celeritas/field/RZMapFieldData.covfie.hh
@@ -1,0 +1,142 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/field/RZMapFieldData.covfie.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "corecel/Config.hh"
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/data/DeviceVector.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/field/FieldDriverOptions.hh"
+
+#include "detail/CovfieRZFieldTraits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+template<MemSpace M>
+struct RZMapFieldParamsDataBase
+{
+    using field_t = typename detail::CovfieRZFieldTraits<M>::field_t;
+    using view_t = typename field_t::view_t;
+
+    FieldDriverOptions options;
+
+    //! Grid bounds for validity check
+    real_type min_r{};
+    real_type max_r{};
+    real_type min_z{};
+    real_type max_z{};
+};
+
+// We need to specialize this for every combination of ownership and memory
+// space to handle covfie move, ownership semantics.
+template<Ownership W, MemSpace M>
+struct RZMapFieldParamsData;
+
+template<>
+struct RZMapFieldParamsData<Ownership::value, MemSpace::host>
+    : RZMapFieldParamsDataBase<MemSpace::host>
+{
+    CELER_FUNCTION view_t get_view() const { return view_t(*field); }
+
+    CELER_FUNCTION explicit operator bool() const { return field.get(); }
+
+    std::unique_ptr<field_t> field;
+};
+template<>
+struct RZMapFieldParamsData<Ownership::const_reference, MemSpace::host>
+    : RZMapFieldParamsDataBase<MemSpace::host>
+{
+    CELER_FUNCTION view_t const& get_view() const { return field_view; }
+
+    CELER_FUNCTION explicit operator bool() const { return true; }
+
+    view_t field_view;
+};
+
+template<>
+struct RZMapFieldParamsData<Ownership::value, MemSpace::device>
+    : RZMapFieldParamsDataBase<MemSpace::device>
+{
+    CELER_FUNCTION view_t const& get_view() const
+    {
+        return field_view.device_ref()[0];
+    }
+
+    CELER_FUNCTION explicit operator bool() const
+    {
+        return field.get() && field_view.size() == 1;
+    }
+
+    RZMapFieldParamsData& operator=(
+        RZMapFieldParamsData<Ownership::value, MemSpace::host> const& other)
+    {
+        if constexpr (!std::is_same_v<
+                          field_t,
+                          detail::CovfieRZFieldTraits<MemSpace::host>::field_t>)
+        {
+            if constexpr (CELERITAS_USE_HIP)
+            {
+                // No texture memory support: simply copy from the host field
+                field = std::make_unique<field_t>(*other.field);
+            }
+            else
+            {
+                auto const& host_backend = other.field->backend();
+                auto const& strided_backend
+                    = host_backend.get_backend().get_backend().get_backend();
+                field = std::make_unique<field_t>(covfie::make_parameter_pack(
+                    host_backend.get_configuration(), strided_backend));
+            }
+            field_view = DeviceVector<view_t>{1};
+            field_view.copy_to_device(make_span<view_t const>({{*field}}));
+        }
+        else
+        {
+            field = std::make_unique<field_t>(*other.field);
+        }
+        options = other.options;
+        min_r = other.min_r;
+        max_r = other.max_r;
+        min_z = other.min_z;
+        max_z = other.max_z;
+        return *this;
+    }
+
+    std::unique_ptr<field_t> field;
+    DeviceVector<view_t> field_view;
+};
+template<>
+struct RZMapFieldParamsData<Ownership::const_reference, MemSpace::device>
+    : RZMapFieldParamsDataBase<MemSpace::device>
+{
+    CELER_FUNCTION view_t const& get_view() const { return *field_view; }
+
+    CELER_FUNCTION explicit operator bool() const { return field_view; }
+
+    RZMapFieldParamsData& operator=(
+        RZMapFieldParamsData<Ownership::value, MemSpace::device> const& other)
+    {
+        field_view = &other.field_view.device_ref()[0];
+        options = other.options;
+        min_r = other.min_r;
+        max_r = other.max_r;
+        min_z = other.min_z;
+        max_z = other.max_z;
+        return *this;
+    }
+
+    view_t const* field_view;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/field/RZMapFieldData.hh
+++ b/src/celeritas/field/RZMapFieldData.hh
@@ -6,12 +6,17 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Macros.hh"
-#include "corecel/Types.hh"
-#include "corecel/data/Collection.hh"
-#include "corecel/grid/UniformGridData.hh"
+#include "corecel/Config.hh"
 
-#include "FieldDriverOptions.hh"
+#if CELERITAS_USE_COVFIE || __DOXYGEN__
+#    include "RZMapFieldData.covfie.hh"  // IWYU pragma: export
+#else
+#    include "corecel/Macros.hh"
+#    include "corecel/Types.hh"
+#    include "corecel/data/Collection.hh"
+#    include "corecel/grid/UniformGridData.hh"
+
+#    include "FieldDriverOptions.hh"
 
 namespace celeritas
 {
@@ -89,3 +94,5 @@ struct RZMapFieldParamsData
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas
+
+#endif  // CELERITAS_USE_COVFIE

--- a/src/celeritas/field/RZMapFieldParams.cc
+++ b/src/celeritas/field/RZMapFieldParams.cc
@@ -6,18 +6,20 @@
 //---------------------------------------------------------------------------//
 #include "RZMapFieldParams.hh"
 
-#include <utility>
-#include <vector>
+#if !CELERITAS_USE_COVFIE
 
-#include "corecel/Assert.hh"
-#include "corecel/Types.hh"
-#include "corecel/cont/Range.hh"
-#include "corecel/data/CollectionBuilder.hh"
-#include "corecel/grid/UniformGridData.hh"
-#include "celeritas/Units.hh"
+#    include <utility>
+#    include <vector>
 
-#include "RZMapFieldData.hh"
-#include "RZMapFieldInput.hh"
+#    include "corecel/Assert.hh"
+#    include "corecel/Types.hh"
+#    include "corecel/cont/Range.hh"
+#    include "corecel/data/CollectionBuilder.hh"
+#    include "corecel/grid/UniformGridData.hh"
+#    include "celeritas/Units.hh"
+
+#    include "RZMapFieldData.hh"
+#    include "RZMapFieldInput.hh"
 
 namespace celeritas
 {
@@ -84,3 +86,5 @@ RZMapFieldParams::RZMapFieldParams(RZMapFieldInput const& inp)
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas
+
+#endif  // !CELERITAS_USE_COVFIE

--- a/src/celeritas/field/RZMapFieldParams.covfie.cc
+++ b/src/celeritas/field/RZMapFieldParams.covfie.cc
@@ -1,0 +1,193 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/field/RZMapFieldParams.covfie.cc
+//---------------------------------------------------------------------------//
+#include "RZMapFieldParams.hh"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "corecel/Assert.hh"
+#include "corecel/Types.hh"
+#include "corecel/cont/Range.hh"
+#include "corecel/data/ParamsDataInterface.hh"
+#include "corecel/io/Logger.hh"
+#include "corecel/sys/Device.hh"
+#include "geocel/Types.hh"
+#include "celeritas/Types.hh"
+#include "celeritas/field/RZMapFieldData.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
+
+#include "RZMapField.covfie.hh"
+
+#include "detail/CovfieRZFieldTraits.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+struct RZMapFieldParams::Impl
+{
+    explicit Impl(Input const& inp)
+        : host_{[&inp] {
+            CELER_VALIDATE(inp.num_grid_z >= 2,
+                           << "invalid field parameter (num_grid_z="
+                           << inp.num_grid_z << ")");
+            CELER_VALIDATE(inp.num_grid_r >= 2,
+                           << "invalid field parameter (num_grid_r="
+                           << inp.num_grid_r << ")");
+            CELER_VALIDATE(inp.min_r >= 0,
+                           << "invalid field parameter (min_r=" << inp.min_r
+                           << ")");
+            CELER_VALIDATE(inp.max_r > inp.min_r,
+                           << "invalid field parameter (max_r=" << inp.max_r
+                           << " <= min_r= " << inp.min_r << ")");
+            CELER_VALIDATE(inp.max_z > inp.min_z,
+                           << "invalid field parameter (max_z=" << inp.max_z
+                           << " <= min_z= " << inp.min_z << ")");
+            CELER_VALIDATE(
+                inp.field_z.size() == inp.num_grid_z * inp.num_grid_r,
+                << "invalid field length (field_z size=" << inp.field_z.size()
+                << "): should be " << inp.num_grid_z * inp.num_grid_r);
+            CELER_VALIDATE(
+                inp.field_r.size() == inp.field_z.size(),
+                << "invalid field length (field_r size=" << inp.field_r.size()
+                << "): should be " << inp.field_z.size());
+            validate_input(inp.driver_options);
+
+            HostVal<RZMapFieldParamsData> host;
+
+            using builder_t
+                = detail::CovfieRZFieldTraits<MemSpace::host>::builder_t;
+
+            builder_t builder{covfie::make_parameter_pack(
+                builder_t::backend_t::configuration_t{inp.num_grid_r,
+                                                      inp.num_grid_z})};
+            builder_t::view_t builder_view{builder};
+
+            // Fill the covfie field data
+            // Input layout is [Z][R]: index = iz * num_grid_r + ir
+            for (auto iz : range(inp.num_grid_z))
+            {
+                for (auto ir : range(inp.num_grid_r))
+                {
+                    auto idx = iz * inp.num_grid_r + ir;
+                    builder_view.at(ir, iz)
+                        = {static_cast<float>(inp.field_r[idx]),
+                           static_cast<float>(inp.field_z[idx])};
+                }
+            }
+
+            using field_real_type = RZMapField::real_type;
+            // Shift world coordinates so the grid minimum maps to zero.
+            auto affine_translate = covfie::algebra::affine<2>::translation(
+                static_cast<field_real_type>(-inp.min_r),
+                static_cast<field_real_type>(-inp.min_z));
+
+            // Scale world units to index units so max maps to (num - 1).
+            auto affine_scale = covfie::algebra::affine<2>::scaling(
+                static_cast<field_real_type>((inp.num_grid_r - 1)
+                                             / (inp.max_r - inp.min_r)),
+                static_cast<field_real_type>((inp.num_grid_z - 1)
+                                             / (inp.max_z - inp.min_z)));
+
+            using traits_t = detail::CovfieRZFieldTraits<MemSpace::host>;
+            using field_t = typename traits_t::field_t;
+            using clamp_config_t =
+                typename traits_t::clamped_t::configuration_t;
+            using clamp_vec_t = decltype(clamp_config_t{}.min);
+            using clamp_scalar_t = typename clamp_vec_t::value_type;
+
+            auto clamp_max = [](size_type n) {
+                auto const max = static_cast<clamp_scalar_t>(n - 1);
+                return std::nextafter(
+                    max, -std::numeric_limits<clamp_scalar_t>::infinity());
+            };
+
+            // Clamp in index space before interpolation: keep coords in-bounds
+            // and avoid the (n-1) corner that would request n in linear.
+            clamp_config_t clamp_config{
+                clamp_vec_t{static_cast<clamp_scalar_t>(0),
+                            static_cast<clamp_scalar_t>(0)},
+                clamp_vec_t{clamp_max(inp.num_grid_r),
+                            clamp_max(inp.num_grid_z)}};
+
+            host.field = std::make_unique<field_t>(covfie::make_parameter_pack(
+                field_t::backend_t::configuration_t(affine_scale
+                                                    * affine_translate),
+                std::move(clamp_config),
+                typename traits_t::interp_t::configuration_t{},
+                builder.backend()));
+            host.options = inp.driver_options;
+            host.min_r = inp.min_r;
+            host.max_r = inp.max_r;
+            host.min_z = inp.min_z;
+            host.max_z = inp.max_z;
+            return host;
+        }()}
+        , host_ref_{
+              {host_.options, host_.min_r, host_.max_r, host_.min_z, host_.max_z},
+              *host_.field}
+    {
+        if (celeritas::device())
+        {
+            device_ = host_;
+            device_ref_ = device_;
+            CELER_ENSURE(static_cast<bool>(device_)
+                         && static_cast<bool>(device_ref_));
+        }
+        CELER_LOG(debug) << "Constructed RZMapField with covfie 2D "
+                            "interpolation ("
+                         << inp.num_grid_r << "x" << inp.num_grid_z
+                         << " grid)";
+        if (celeritas::device())
+        {
+            CELER_LOG(debug) << "Copied RZMapField covfie data to device";
+        }
+        CELER_ENSURE(static_cast<bool>(host_) && static_cast<bool>(host_ref_));
+    }
+
+    HostVal<RZMapFieldParamsData> host_;
+    HostCRef<RZMapFieldParamsData> host_ref_;
+    RZMapFieldParamsData<Ownership::value, MemSpace::device> device_;
+    DeviceRef device_ref_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Custom deleter for the implementation.
+ */
+void RZMapFieldParams::ImplDeleter::operator()(Impl* impl) const noexcept
+{
+    delete impl;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from a user-defined field map.
+ */
+RZMapFieldParams::RZMapFieldParams(Input const& inp)
+    : impl_{std::unique_ptr<Impl, ImplDeleter>(new Impl{inp})}
+{
+}
+
+//---------------------------------------------------------------------------//
+//! Access field map data on the host
+auto RZMapFieldParams::host_ref() const -> HostRef const&
+{
+    return impl_->host_ref_;
+}
+
+//---------------------------------------------------------------------------//
+//! Access field map data on the device
+auto RZMapFieldParams::device_ref() const -> DeviceRef const&
+{
+    return impl_->device_ref_;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/celeritas/field/RZMapFieldParams.hh
+++ b/src/celeritas/field/RZMapFieldParams.hh
@@ -6,8 +6,16 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <memory>
+
+#include "corecel/Config.hh"
+
+#include "corecel/Assert.hh"
 #include "corecel/data/ParamsDataInterface.hh"
-#include "corecel/data/ParamsDataStore.hh"
+
+#if !CELERITAS_USE_COVFIE
+#    include "corecel/data/ParamsDataStore.hh"
+#endif
 
 #include "RZMapFieldData.hh"
 
@@ -35,15 +43,38 @@ class RZMapFieldParams final : public ParamsDataInterface<RZMapFieldParamsData>
     explicit RZMapFieldParams(Input const& inp);
 
     //! Access field map data on the host
-    HostRef const& host_ref() const final { return mirror_.host_ref(); }
+    HostRef const& host_ref() const final;
 
     //! Access field map data on the device
-    DeviceRef const& device_ref() const final { return mirror_.device_ref(); }
+    DeviceRef const& device_ref() const final;
 
   private:
+#if CELERITAS_USE_COVFIE
+    struct Impl;
+    struct ImplDeleter
+    {
+        void operator()(Impl*) const noexcept;
+    };
+    std::unique_ptr<Impl, ImplDeleter> impl_;
+#else
     // Host/device storage and reference
     ParamsDataStore<RZMapFieldParamsData> mirror_;
+#endif
 };
+
+#if !CELERITAS_USE_COVFIE
+//! Access field map data on the host
+inline auto RZMapFieldParams::host_ref() const -> HostRef const&
+{
+    return mirror_.host_ref();
+}
+
+//! Access field map data on the device
+inline auto RZMapFieldParams::device_ref() const -> DeviceRef const&
+{
+    return mirror_.device_ref();
+}
+#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/field/detail/CovfieRZFieldTraits.hh
+++ b/src/celeritas/field/detail/CovfieRZFieldTraits.hh
@@ -1,0 +1,90 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/field/detail/CovfieRZFieldTraits.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/clamp.hpp>
+#include <covfie/core/backend/transformer/linear.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
+
+#include "corecel/Config.hh"
+#include "corecel/DeviceRuntimeApi.hh"  // IWYU pragma: keep
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "geocel/Types.hh"
+
+#if CELERITAS_USE_CUDA
+#    include <covfie/cuda/backend/primitive/cuda_texture.hpp>
+#elif CELERITAS_USE_HIP
+#    include <covfie/hip/backend/primitive/hip_device_array.hpp>
+#endif
+
+namespace celeritas
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+//! Covfie 2D RZ field type
+template<MemSpace M>
+struct CovfieRZFieldTraits;
+
+template<>
+struct CovfieRZFieldTraits<MemSpace::host>
+{
+    using storage_t = covfie::backend::array<covfie::vector::float2>;
+    using dimensioned_t
+        = covfie::backend::strided<covfie::vector::size2, storage_t>;
+    using interp_t = covfie::backend::linear<dimensioned_t>;
+    using clamped_t = covfie::backend::clamp<interp_t>;
+    using transformed_t = covfie::backend::affine<clamped_t>;
+    using field_t = covfie::field<transformed_t>;
+    using builder_t = covfie::field<dimensioned_t>;
+
+    static Array<real_type, 2> to_real2(field_t::output_t const& vec)
+    {
+        return {vec[0], vec[1]};
+    }
+};
+
+template<>
+struct CovfieRZFieldTraits<MemSpace::device>
+{
+    using float2 = covfie::vector::float2;
+#if CELERITAS_USE_CUDA
+    using storage_t = covfie::backend::cuda_texture<float2, float2>;
+    using transformed_t = covfie::backend::affine<storage_t>;
+#else
+// Manually interpolate rather than relying on texture memory
+#    if CELERITAS_USE_HIP
+    using storage_t = covfie::backend::hip_device_array<float2>;
+#    else
+    using storage_t = covfie::backend::array<float2>;
+#    endif
+
+    using dimensioned_t
+        = covfie::backend::strided<covfie::vector::size2, storage_t>;
+    using interp_t = covfie::backend::linear<dimensioned_t>;
+    using clamped_t = covfie::backend::clamp<interp_t>;
+    using transformed_t = covfie::backend::affine<clamped_t>;
+#endif
+
+    using field_t = covfie::field<transformed_t>;
+
+    CELER_FUNCTION static Array<real_type, 2>
+    to_real2(field_t::output_t const& vec)
+    {
+        return {vec[0], vec[1]};
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace celeritas

--- a/src/ddceler/CMakeLists.txt
+++ b/src/ddceler/CMakeLists.txt
@@ -114,9 +114,19 @@ endfunction()
 #----------------------------------------------------------------------------#
 # Add plugins
 
+set(_celerphysics_sources CelerPhysics.cc)
+set(_celerphysics_uses
+  DD4hep::DDG4 Celeritas::accel Celeritas::celeritas Celeritas::corecel
+)
+
+if(CELERITAS_USE_covfie)
+  list(APPEND _celerphysics_sources LoadCovfieField.covfie.cc)
+  list(APPEND _celerphysics_uses Celeritas::Extcovfie)
+endif()
+
 celer_dd4hep_plugin(CelerPhysics
-  SOURCES CelerPhysics.cc
-  USES DD4hep::DDG4 Celeritas::accel Celeritas::celeritas Celeritas::corecel
+  SOURCES ${_celerphysics_sources}
+  USES ${_celerphysics_uses}
 )
 
 celer_dd4hep_plugin(CelerRun

--- a/src/ddceler/CelerPhysics.cc
+++ b/src/ddceler/CelerPhysics.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "CelerPhysics.hh"
 
+#include <fstream>
 #include <DD4hep/Detector.h>
 #include <DD4hep/FieldTypes.h>
 #include <DDG4/Factories.h>
@@ -21,6 +22,8 @@
 
 #if CELERITAS_USE_COVFIE
 #    include "celeritas/field/CartMapFieldInput.hh"
+#    include "celeritas/field/RZMapFieldInput.hh"
+
 #    include "LoadCovfieField.hh"
 #endif
 
@@ -71,6 +74,7 @@ CelerPhysics::CelerPhysics(Geant4Context* ctxt, std::string const& name)
     declareProperty("InitCapacity", init_capacity_);
     declareProperty("IgnoreProcesses", ignore_processes_);
     declareProperty("FieldMapFile", field_map_file_);
+    declareProperty("FieldMapCoordType", field_map_coord_type_);
 }
 
 //---------------------------------------------------------------------------//
@@ -141,16 +145,36 @@ SetupOptions CelerPhysics::make_options()
     {
         // Covfie field map mode: load binary field file
         CELER_LOG(info) << "Loading covfie field map from '" << field_map_file_
-                        << "'";
+                        << "' (coord_type=" << field_map_coord_type_ << ")";
 
-        auto load_field = [filename = field_map_file_, driver_options] {
-            CartMapFieldInput inp = LoadCovfieField(filename);
-            inp.driver_options = driver_options;
-            return inp;
-        };
-        opts.make_along_step = CartMapFieldAlongStepFactory(load_field);
+        CELER_VALIDATE(field_map_coord_type_ == "BrBz"
+                           || field_map_coord_type_ == "BxByBz",
+                       << "invalid FieldMapCoordType='" << field_map_coord_type_
+                       << "': must be \"BrBz\" or \"BxByBz\"");
 
-        CELER_LOG(info) << "Using covfie CartMapField for along-step";
+        if (field_map_coord_type_ == "BrBz")
+        {
+            auto load_field = [filename = field_map_file_, driver_options] {
+                RZMapFieldInput inp = LoadCovfieFieldBrBz(filename);
+                inp.driver_options = driver_options;
+                std::ofstream("rzmap-field-dump.json") << inp;
+                CELER_LOG(debug) << "Dumped RZMapFieldInput to "
+                                    "rzmap-field-dump.json";
+                return inp;
+            };
+            opts.make_along_step = RZMapFieldAlongStepFactory(load_field);
+            CELER_LOG(info) << "Using covfie RZMapField for along-step";
+        }
+        else
+        {
+            auto load_field = [filename = field_map_file_, driver_options] {
+                CartMapFieldInput inp = LoadCovfieField(filename);
+                inp.driver_options = driver_options;
+                return inp;
+            };
+            opts.make_along_step = CartMapFieldAlongStepFactory(load_field);
+            CELER_LOG(info) << "Using covfie CartMapField for along-step";
+        }
     }
     else
 #endif
@@ -175,16 +199,17 @@ SetupOptions CelerPhysics::make_options()
         Direction field_direction(0, 0, 0);
         for (auto const& mag_component : overlaid_obj->magnetic_components)
         {
-            auto* cartesian_obj
-                = mag_component.data<CartesianField::Object>();
+            auto* cartesian_obj = mag_component.data<CartesianField::Object>();
             auto* const_field
                 = dynamic_cast<ConstantField const*>(cartesian_obj);
 
-            CELER_VALIDATE(
-                const_field,
-                << "Celeritas uniform field mode only supports ConstantField "
-                   "components. Found non-constant field in DD4hep description."
-                   " Set FieldMapFile to use a covfie field map instead.");
+            CELER_VALIDATE(const_field,
+                           << "Celeritas uniform field mode only supports "
+                              "ConstantField "
+                              "components. Found non-constant field in DD4hep "
+                              "description."
+                              " Set FieldMapFile to use a covfie field map "
+                              "instead.");
             field_direction += const_field->direction;
         }
 

--- a/src/ddceler/CelerPhysics.cc
+++ b/src/ddceler/CelerPhysics.cc
@@ -12,10 +12,17 @@
 #include <DDG4/Geant4ActionPhase.h>
 #include <DDG4/Geant4Kernel.h>
 
+#include "corecel/Config.hh"
+
 #include "corecel/io/Logger.hh"
 #include "celeritas/field/FieldDriverOptions.hh"
 #include "celeritas/inp/Field.hh"
 #include "accel/TrackingManagerIntegration.hh"
+
+#if CELERITAS_USE_COVFIE
+#    include "celeritas/field/CartMapFieldInput.hh"
+#    include "LoadCovfieField.hh"
+#endif
 
 using TMI = celeritas::TrackingManagerIntegration;
 using Geant4Context = dd4hep::sim::Geant4Context;
@@ -63,6 +70,7 @@ CelerPhysics::CelerPhysics(Geant4Context* ctxt, std::string const& name)
     declareProperty("MaxNumTracks", max_num_tracks_);
     declareProperty("InitCapacity", init_capacity_);
     declareProperty("IgnoreProcesses", ignore_processes_);
+    declareProperty("FieldMapFile", field_map_file_);
 }
 
 //---------------------------------------------------------------------------//
@@ -87,54 +95,10 @@ SetupOptions CelerPhysics::make_options()
         opts.ignore_processes.push_back(proc);
     }
 
-    // Get the field from DD4hep detector description and validate its type
-    auto& detector = context()->detectorDescription();
-    auto&& field = detector.field();
-    auto* overlaid_obj = field.data<OverlayedField::Object>();
-
-    // Validate field configuration: no electric components
-    CELER_VALIDATE(overlaid_obj->electric_components.empty(),
-                   << "Celeritas does not support electric field components. "
-                      "Found "
-                   << overlaid_obj->electric_components.size()
-                   << " electric component(s).");
-
-    CELER_VALIDATE(!overlaid_obj->magnetic_components.empty(),
-                   << "No magnetic field components found in DD4hep field "
-                      "description.");
-
-    // Check that all magnetic components are ConstantField and sum them
-    Direction field_direction(0, 0, 0);
-    for (auto const& mag_component : overlaid_obj->magnetic_components)
-    {
-        auto* cartesian_obj = mag_component.data<CartesianField::Object>();
-        auto* const_field = dynamic_cast<ConstantField const*>(cartesian_obj);
-
-        CELER_VALIDATE(const_field,
-                       << "Celeritas currently only supports ConstantField "
-                          "magnetic "
-                       << "fields. Found non-constant field component in "
-                          "DD4hep "
-                       << "description.");
-        field_direction += const_field->direction;
-    }
-
-    // Print field strength
-    // Note: field_direction is already in DD4hep internal units (parsed from
-    // XML) DD4hep supports tesla, gauss, kilogauss, etc. in XML and converts
-    // to internal units
-    constexpr double dd4hep_tesla = dd4hep::tesla;
-    CELER_LOG(debug) << "Field strength: ("
-                     << field_direction.X() / dd4hep_tesla << ", "
-                     << field_direction.Y() / dd4hep_tesla << ", "
-                     << field_direction.Z() / dd4hep_tesla << ") T";
-
-    // Get field tracking parameters from DD4hep FieldSetup action
-    // These parameters are set in the steering file (runner.field.*)
+    // Load field driver options from the DD4hep MagFieldTrackingSetup action
     dd4hep::sim::Geant4Action* field_action = nullptr;
     if (auto* config_phase = context()->kernel().getPhase("configure"))
     {
-        // Find the MagFieldTrackingSetup action in the configure phase
         for (auto const& [action, callback] : config_phase->members())
         {
             if (action->name() == "MagFieldTrackingSetup")
@@ -167,18 +131,80 @@ SetupOptions CelerPhysics::make_options()
         << " mm, delta_intersection="
         << driver_options.delta_intersection / celer_mm << " mm";
 
-    // Use a uniform magnetic field based on DD4hep ConstantField
-    auto make_field_input = [field_direction, driver_options] {
-        inp::UniformField input;
+    CELER_VALIDATE(field_map_file_.empty() || CELERITAS_USE_COVFIE,
+                   << "FieldMapFile='" << field_map_file_
+                   << "' was set but Celeritas was built without covfie "
+                      "support (CELERITAS_USE_covfie=OFF)");
 
-        // Convert from DD4hep (tesla) to Celeritas field units
-        input.strength = {field_direction.X() / dd4hep_tesla,
-                          field_direction.Y() / dd4hep_tesla,
-                          field_direction.Z() / dd4hep_tesla};
-        input.driver_options = driver_options;
-        return input;
-    };
-    opts.make_along_step = UniformAlongStepFactory(make_field_input);
+#if CELERITAS_USE_COVFIE
+    if (!field_map_file_.empty())
+    {
+        // Covfie field map mode: load binary field file
+        CELER_LOG(info) << "Loading covfie field map from '" << field_map_file_
+                        << "'";
+
+        auto load_field = [filename = field_map_file_, driver_options] {
+            CartMapFieldInput inp = LoadCovfieField(filename);
+            inp.driver_options = driver_options;
+            return inp;
+        };
+        opts.make_along_step = CartMapFieldAlongStepFactory(load_field);
+
+        CELER_LOG(info) << "Using covfie CartMapField for along-step";
+    }
+    else
+#endif
+    {
+        // Uniform field mode: read ConstantField from DD4hep detector
+        // description
+        auto& detector = context()->detectorDescription();
+        auto&& field = detector.field();
+        auto* overlaid_obj = field.data<OverlayedField::Object>();
+
+        CELER_VALIDATE(overlaid_obj->electric_components.empty(),
+                       << "Celeritas does not support electric field "
+                          "components. Found "
+                       << overlaid_obj->electric_components.size()
+                       << " electric component(s).");
+
+        CELER_VALIDATE(!overlaid_obj->magnetic_components.empty(),
+                       << "No magnetic field components found in DD4hep field "
+                          "description.");
+
+        // Sum all ConstantField components
+        Direction field_direction(0, 0, 0);
+        for (auto const& mag_component : overlaid_obj->magnetic_components)
+        {
+            auto* cartesian_obj
+                = mag_component.data<CartesianField::Object>();
+            auto* const_field
+                = dynamic_cast<ConstantField const*>(cartesian_obj);
+
+            CELER_VALIDATE(
+                const_field,
+                << "Celeritas uniform field mode only supports ConstantField "
+                   "components. Found non-constant field in DD4hep description."
+                   " Set FieldMapFile to use a covfie field map instead.");
+            field_direction += const_field->direction;
+        }
+
+        constexpr double dd4hep_tesla = dd4hep::tesla;
+        CELER_LOG(debug) << "Field strength: ("
+                         << field_direction.X() / dd4hep_tesla << ", "
+                         << field_direction.Y() / dd4hep_tesla << ", "
+                         << field_direction.Z() / dd4hep_tesla << ") T";
+
+        auto make_field_input = [field_direction, driver_options] {
+            inp::UniformField input;
+            constexpr double dd4hep_t = dd4hep::tesla;
+            input.strength = {field_direction.X() / dd4hep_t,
+                              field_direction.Y() / dd4hep_t,
+                              field_direction.Z() / dd4hep_t};
+            input.driver_options = driver_options;
+            return input;
+        };
+        opts.make_along_step = UniformAlongStepFactory(make_field_input);
+    }
     opts.sd.ignore_zero_deposition = false;
 
     // Save diagnostic file to a unique name

--- a/src/ddceler/CelerPhysics.hh
+++ b/src/ddceler/CelerPhysics.hh
@@ -25,8 +25,9 @@ namespace dd
  *  - Uniform field (default): reads a \c ConstantField from the DD4hep
  *    detector description and creates a \c UniformAlongStepFactory.
  *  - Covfie field map: when \c FieldMapFile is set to a non-empty path, loads
- *    a binary covfie file (affine → nearest_neighbour → strided → array
- *    pipeline, coordinates in cm, field in T) and creates a
+ *    a binary covfie file (coordinates in cm, field in T).  The
+ *    \c FieldMapCoordType property selects the pipeline and factory:
+ *    "BrBz" uses \c RZMapFieldAlongStepFactory, "BxByBz" (default) uses
  *    \c CartMapFieldAlongStepFactory.  Requires \c CELERITAS_USE_covfie.
  *
  * Steering-file properties:
@@ -34,6 +35,7 @@ namespace dd
  *  - \c InitCapacity  (int)         : initial state-vector capacity
  *  - \c IgnoreProcesses (string[])  : physics processes to bypass
  *  - \c FieldMapFile  (string)      : path to a covfie field-map binary
+ *  - \c FieldMapCoordType (string)  : "BrBz" or "BxByBz" (default)
  */
 class CelerPhysics final : public dd4hep::sim::Geant4PhysicsList
 {
@@ -51,7 +53,9 @@ class CelerPhysics final : public dd4hep::sim::Geant4PhysicsList
     int max_num_tracks_{0};
     int init_capacity_{0};
     std::vector<std::string> ignore_processes_;
-    std::string field_map_file_;  //!< Path to covfie binary field map (optional)
+    std::string field_map_file_;  //!< Path to covfie binary field map
+                                  //!< (optional)
+    std::string field_map_coord_type_{"BxByBz"};  //!< "BrBz" or "BxByBz"
 
     // Make options for Celeritas tracking manager
     SetupOptions make_options();

--- a/src/ddceler/CelerPhysics.hh
+++ b/src/ddceler/CelerPhysics.hh
@@ -20,6 +20,20 @@ namespace dd
 //---------------------------------------------------------------------------//
 /*!
  * DDG4 action plugin for Celeritas tracking manager integration (TMI).
+ *
+ * Two field modes are supported:
+ *  - Uniform field (default): reads a \c ConstantField from the DD4hep
+ *    detector description and creates a \c UniformAlongStepFactory.
+ *  - Covfie field map: when \c FieldMapFile is set to a non-empty path, loads
+ *    a binary covfie file (affine → nearest_neighbour → strided → array
+ *    pipeline, coordinates in cm, field in T) and creates a
+ *    \c CartMapFieldAlongStepFactory.  Requires \c CELERITAS_USE_covfie.
+ *
+ * Steering-file properties:
+ *  - \c MaxNumTracks  (int)         : maximum tracks in flight
+ *  - \c InitCapacity  (int)         : initial state-vector capacity
+ *  - \c IgnoreProcesses (string[])  : physics processes to bypass
+ *  - \c FieldMapFile  (string)      : path to a covfie field-map binary
  */
 class CelerPhysics final : public dd4hep::sim::Geant4PhysicsList
 {
@@ -37,6 +51,7 @@ class CelerPhysics final : public dd4hep::sim::Geant4PhysicsList
     int max_num_tracks_{0};
     int init_capacity_{0};
     std::vector<std::string> ignore_processes_;
+    std::string field_map_file_;  //!< Path to covfie binary field map (optional)
 
     // Make options for Celeritas tracking manager
     SetupOptions make_options();

--- a/src/ddceler/LoadCovfieField.covfie.cc
+++ b/src/ddceler/LoadCovfieField.covfie.cc
@@ -9,10 +9,9 @@
 #include <cstddef>
 #include <fstream>
 #include <string>
-
 #include <covfie/core/backend/primitive/array.hpp>
 #include <covfie/core/backend/transformer/affine.hpp>
-#include <covfie/core/backend/transformer/nearest_neighbour.hpp>
+#include <covfie/core/backend/transformer/linear.hpp>
 #include <covfie/core/backend/transformer/strided.hpp>
 #include <covfie/core/field.hpp>
 #include <covfie/core/vector.hpp>
@@ -32,7 +31,7 @@ namespace
 /*!
  * Covfie field type as written by the covfie \c convert_bfield tool.
  *
- * Pipeline: affine → nearest_neighbour → strided → array(float3)
+ * Pipeline: affine → linear → strided → array(float3)
  *
  * The affine transform matrix has shape [3 × 4]:
  * \verbatim
@@ -45,7 +44,7 @@ namespace
  */
 using storage_t = covfie::backend::array<covfie::vector::float3>;
 using strided_t = covfie::backend::strided<covfie::vector::size3, storage_t>;
-using interp_t = covfie::backend::nearest_neighbour<strided_t>;
+using interp_t = covfie::backend::linear<strided_t>;
 using file_field_t = covfie::field<covfie::backend::affine<interp_t>>;
 
 //---------------------------------------------------------------------------//
@@ -56,7 +55,7 @@ using file_field_t = covfie::field<covfie::backend::affine<interp_t>>;
  * Load a Cartesian magnetic field map from a binary covfie file.
  *
  * The file must have been written with the standard covfie \c convert_bfield
- * pipeline: affine → nearest_neighbour → strided → array(float3).
+ * pipeline: affine → linear → strided → array(float3).
  *
  * Coordinates in the file are in centimetres and field values in tesla.
  * Both are converted to Celeritas native units on load.
@@ -77,8 +76,7 @@ CartMapFieldInput LoadCovfieField(std::string const& filename)
     auto const& mat = affine_data.get_configuration();
 
     // Access the strided backend to read the grid dimensions [nx, ny, nz]
-    auto const& strided_data
-        = affine_data.get_backend().get_backend();
+    auto const& strided_data = affine_data.get_backend().get_backend();
     auto const sizes = strided_data.get_configuration();
 
     std::size_t const nx = sizes[0];
@@ -110,49 +108,51 @@ CartMapFieldInput LoadCovfieField(std::string const& filename)
     CartMapFieldInput inp;
 
     inp.x.min = static_cast<real_type>((-tx / sx) * cm);
-    inp.x.max = static_cast<real_type>(((static_cast<float>(nx) - 1.f - tx) / sx) * cm);
+    inp.x.max = static_cast<real_type>(
+        ((static_cast<float>(nx) - 1.f - tx) / sx) * cm);
     inp.x.num = static_cast<size_type>(nx);
 
     inp.y.min = static_cast<real_type>((-ty / sy) * cm);
-    inp.y.max = static_cast<real_type>(((static_cast<float>(ny) - 1.f - ty) / sy) * cm);
+    inp.y.max = static_cast<real_type>(
+        ((static_cast<float>(ny) - 1.f - ty) / sy) * cm);
     inp.y.num = static_cast<size_type>(ny);
 
     inp.z.min = static_cast<real_type>((-tz / sz) * cm);
-    inp.z.max = static_cast<real_type>(((static_cast<float>(nz) - 1.f - tz) / sz) * cm);
+    inp.z.max = static_cast<real_type>(
+        ((static_cast<float>(nz) - 1.f - tz) / sz) * cm);
     inp.z.num = static_cast<size_type>(nz);
 
     // Allocate field data: layout is [X][Y][Z][3]
     inp.field.resize(static_cast<size_type>(Axis::size_) * nx * ny * nz);
 
-    // Build a view to query the loaded field
+    // Access the strided backend directly to read grid node values without
+    // going through the linear interpolator (which would try to access
+    // out-of-bounds neighbors at the grid boundary)
     file_field_t::view_t field_view{file_field};
+    // Chain: affine → linear → strided
+    auto const& strided_view = field_view.backend().get_backend().get_backend();
 
-    // Iterate over the grid and recover world positions by inverting the
-    // affine transform: pos_i = (idx_i - t_i) / s_i
     for (auto ix : range(nx))
     {
-        float const wx = (static_cast<float>(ix) - tx) / sx;
         for (auto iy : range(ny))
         {
-            float const wy = (static_cast<float>(iy) - ty) / sy;
             for (auto iz : range(nz))
             {
-                float const wz = (static_cast<float>(iz) - tz) / sz;
+                auto const bvec
+                    = strided_view.at({static_cast<std::size_t>(ix),
+                                       static_cast<std::size_t>(iy),
+                                       static_cast<std::size_t>(iz)});
 
-                // Query field at this world position (nearest-neighbour lookup
-                // maps back to the correct grid node)
-                auto const bvec = field_view.at(wx, wy, wz);
+                size_type const base
+                    = static_cast<size_type>((ix * ny + iy) * nz + iz)
+                      * static_cast<size_type>(Axis::size_);
 
-                size_type const base = static_cast<size_type>(
-                    (ix * ny + iy) * nz + iz)
-                    * static_cast<size_type>(Axis::size_);
-
-                inp.field[base + 0]
-                    = static_cast<real_type>(bvec[0]) * to_native_field;
-                inp.field[base + 1]
-                    = static_cast<real_type>(bvec[1]) * to_native_field;
-                inp.field[base + 2]
-                    = static_cast<real_type>(bvec[2]) * to_native_field;
+                inp.field[base + 0] = static_cast<real_type>(bvec[0])
+                                      * to_native_field;
+                inp.field[base + 1] = static_cast<real_type>(bvec[1])
+                                      * to_native_field;
+                inp.field[base + 2] = static_cast<real_type>(bvec[2])
+                                      * to_native_field;
             }
         }
     }

--- a/src/ddceler/LoadCovfieField.covfie.cc
+++ b/src/ddceler/LoadCovfieField.covfie.cc
@@ -18,8 +18,10 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/io/Logger.hh"
 #include "celeritas/Units.hh"
 #include "celeritas/field/CartMapFieldInput.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
 
 namespace celeritas
 {
@@ -46,6 +48,23 @@ using storage_t = covfie::backend::array<covfie::vector::float3>;
 using strided_t = covfie::backend::strided<covfie::vector::size3, storage_t>;
 using interp_t = covfie::backend::linear<strided_t>;
 using file_field_t = covfie::field<covfie::backend::affine<interp_t>>;
+
+/*!
+ * Covfie field type for 2D BrBz cylindrical field maps.
+ *
+ * Pipeline: affine → linear → strided(size2) → array(float2)
+ *
+ * The affine transform matrix has shape [2 × 3]:
+ * \verbatim
+ *   [sr   0  tr]
+ *   [ 0  sz  tz]
+ * \endverbatim
+ * where r is the first axis and z is the second.
+ */
+using storage2_t = covfie::backend::array<covfie::vector::float2>;
+using strided2_t = covfie::backend::strided<covfie::vector::size2, storage2_t>;
+using interp2_t = covfie::backend::linear<strided2_t>;
+using file_field_brbz_t = covfie::field<covfie::backend::affine<interp2_t>>;
 
 //---------------------------------------------------------------------------//
 }  // namespace
@@ -155,6 +174,120 @@ CartMapFieldInput LoadCovfieField(std::string const& filename)
                                       * to_native_field;
             }
         }
+    }
+
+    CELER_ENSURE(inp);
+    return inp;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Load a 2D BrBz cylindrical magnetic field map from a binary covfie file.
+ *
+ * The file must have been written with the pipeline:
+ *   affine → linear → strided(size2) → array(float2)
+ * where the two axes are (r, z) and the two field components are (Br, Bz).
+ *
+ * Coordinates in the file are in centimetres and field values in tesla.
+ * Both are converted to Celeritas native units on load.
+ *
+ * The returned \c RZMapFieldInput uses [Z][R] indexing (R stride 1).
+ */
+RZMapFieldInput LoadCovfieFieldBrBz(std::string const& filename)
+{
+    // Open the binary covfie file
+    std::ifstream ifs(filename, std::ifstream::binary);
+    CELER_VALIDATE(ifs.good(),
+                   << "failed to open covfie field file '" << filename << "'");
+
+    // Deserialise the field (must match the 2D BrBz pipeline)
+    file_field_brbz_t file_field(ifs);
+    ifs.close();
+
+    // Access the affine backend to read the [2x3] transform matrix
+    auto const& affine_data = file_field.backend();
+    auto const& mat = affine_data.get_configuration();
+
+    // Access the strided backend to read grid dimensions [nr, nz]
+    auto const& strided_data = affine_data.get_backend().get_backend();
+    auto const sizes = strided_data.get_configuration();
+
+    std::size_t const nr = sizes[0];
+    std::size_t const nz = sizes[1];
+
+    CELER_VALIDATE(nr > 1 && nz > 1,
+                   << "covfie BrBz field grid is degenerate: nr=" << nr
+                   << " nz=" << nz);
+
+    // Extract scale and translation from the affine matrix
+    // Matrix layout: [sr 0 tr; 0 sz tz]
+    float const sr = mat(0, 0);
+    float const sz = mat(1, 1);
+    float const tr = mat(0, 2);
+    float const tz = mat(1, 2);
+
+    CELER_VALIDATE(sr > 0 && sz > 0,
+                   << "covfie BrBz affine transform has non-positive scale "
+                   << "factors sr=" << sr << " sz=" << sz);
+
+    // Recover world-coordinate bounds (file units: centimetres)
+    float const r_min = -tr / sr;
+    float const r_max = (static_cast<float>(nr) - 1.f - tr) / sr;
+    float const z_min = -tz / sz;
+    float const z_max = (static_cast<float>(nz) - 1.f - tz) / sz;
+
+    // Convert to Celeritas native units
+    using namespace celeritas::units;
+    auto const cm = static_cast<double>(centimeter);
+    auto const to_native_field = static_cast<double>(tesla);
+
+    RZMapFieldInput inp;
+    inp.num_grid_r = static_cast<unsigned int>(nr);
+    inp.num_grid_z = static_cast<unsigned int>(nz);
+    inp.min_r = static_cast<double>(r_min) * cm;
+    inp.max_r = static_cast<double>(r_max) * cm;
+    inp.min_z = static_cast<double>(z_min) * cm;
+    inp.max_z = static_cast<double>(z_max) * cm;
+
+    // Allocate field data: layout is [Z][R] (R has stride 1)
+    std::size_t const grid_size = nr * nz;
+    inp.field_r.resize(grid_size);
+    inp.field_z.resize(grid_size);
+
+    // Access the strided backend directly to read grid node values without
+    // going through the linear interpolator (which would try to access
+    // out-of-bounds neighbors at the grid boundary)
+    file_field_brbz_t::view_t field_view{file_field};
+    // Chain: affine → linear → strided
+    auto const& strided_view = field_view.backend().get_backend().get_backend();
+
+    for (auto iz : range(nz))
+    {
+        for (auto ir : range(nr))
+        {
+            // Query the strided storage directly at integer grid indices
+            auto const bvec = strided_view.at(
+                {static_cast<std::size_t>(ir), static_cast<std::size_t>(iz)});
+
+            // Index: [Z][R] with R stride 1
+            std::size_t const idx = iz * nr + ir;
+
+            inp.field_r[idx] = static_cast<double>(bvec[0]) * to_native_field;
+            inp.field_z[idx] = static_cast<double>(bvec[1]) * to_native_field;
+        }
+    }
+
+    // Report on-axis Bz at mid-z for a quick sanity check
+    {
+        std::size_t iz_mid = nz / 2;
+        double bz_on_axis = inp.field_z[iz_mid * nr] / to_native_field;
+        double br_on_axis = inp.field_r[iz_mid * nr] / to_native_field;
+        CELER_LOG(debug) << "BrBz covfie field: " << nr << "x" << nz
+                         << " grid, r=[" << r_min << ", " << r_max
+                         << "] cm, z=[" << z_min << ", " << z_max << "] cm";
+        CELER_LOG(debug) << "On-axis field at z_mid=" << 0.5f * (z_min + z_max)
+                         << " cm: Br=" << br_on_axis << " T, Bz=" << bz_on_axis
+                         << " T";
     }
 
     CELER_ENSURE(inp);

--- a/src/ddceler/LoadCovfieField.covfie.cc
+++ b/src/ddceler/LoadCovfieField.covfie.cc
@@ -1,0 +1,166 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ddceler/LoadCovfieField.covfie.cc
+//---------------------------------------------------------------------------//
+#include "LoadCovfieField.hh"
+
+#include <cstddef>
+#include <fstream>
+#include <string>
+
+#include <covfie/core/backend/primitive/array.hpp>
+#include <covfie/core/backend/transformer/affine.hpp>
+#include <covfie/core/backend/transformer/nearest_neighbour.hpp>
+#include <covfie/core/backend/transformer/strided.hpp>
+#include <covfie/core/field.hpp>
+#include <covfie/core/vector.hpp>
+
+#include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
+#include "celeritas/Units.hh"
+#include "celeritas/field/CartMapFieldInput.hh"
+
+namespace celeritas
+{
+namespace dd
+{
+namespace
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Covfie field type as written by the covfie \c convert_bfield tool.
+ *
+ * Pipeline: affine → nearest_neighbour → strided → array(float3)
+ *
+ * The affine transform matrix has shape [3 × 4]:
+ * \verbatim
+ *   [sx   0   0  tx]
+ *   [ 0  sy   0  ty]
+ *   [ 0   0  sz  tz]
+ * \endverbatim
+ * mapping world coordinates to index space: idx_i = s_i * pos_i + t_i.
+ * Inverting: pos_min_i = -t_i / s_i, pos_max_i = (n_i - 1 - t_i) / s_i.
+ */
+using storage_t = covfie::backend::array<covfie::vector::float3>;
+using strided_t = covfie::backend::strided<covfie::vector::size3, storage_t>;
+using interp_t = covfie::backend::nearest_neighbour<strided_t>;
+using file_field_t = covfie::field<covfie::backend::affine<interp_t>>;
+
+//---------------------------------------------------------------------------//
+}  // namespace
+
+//---------------------------------------------------------------------------//
+/*!
+ * Load a Cartesian magnetic field map from a binary covfie file.
+ *
+ * The file must have been written with the standard covfie \c convert_bfield
+ * pipeline: affine → nearest_neighbour → strided → array(float3).
+ *
+ * Coordinates in the file are in centimetres and field values in tesla.
+ * Both are converted to Celeritas native units on load.
+ */
+CartMapFieldInput LoadCovfieField(std::string const& filename)
+{
+    // Open the binary covfie file
+    std::ifstream ifs(filename, std::ifstream::binary);
+    CELER_VALIDATE(ifs.good(),
+                   << "failed to open covfie field file '" << filename << "'");
+
+    // Deserialise the field (must match the pipeline used when writing)
+    file_field_t file_field(ifs);
+    ifs.close();
+
+    // Access the affine backend's owning data to read the transform
+    auto const& affine_data = file_field.backend();
+    auto const& mat = affine_data.get_configuration();
+
+    // Access the strided backend to read the grid dimensions [nx, ny, nz]
+    auto const& strided_data
+        = affine_data.get_backend().get_backend();
+    auto const sizes = strided_data.get_configuration();
+
+    std::size_t const nx = sizes[0];
+    std::size_t const ny = sizes[1];
+    std::size_t const nz = sizes[2];
+
+    CELER_VALIDATE(nx > 1 && ny > 1 && nz > 1,
+                   << "covfie field grid is degenerate: nx=" << nx
+                   << " ny=" << ny << " nz=" << nz);
+
+    // Extract scale (diagonal) and translation (last column) from the affine
+    float const sx = mat(0, 0);
+    float const sy = mat(1, 1);
+    float const sz = mat(2, 2);
+    float const tx = mat(0, 3);
+    float const ty = mat(1, 3);
+    float const tz = mat(2, 3);
+
+    CELER_VALIDATE(sx > 0 && sy > 0 && sz > 0,
+                   << "covfie affine transform has non-positive scale factors "
+                   << "sx=" << sx << " sy=" << sy << " sz=" << sz);
+
+    // Recover world-coordinate bounds (file units: centimetres)
+    // and convert to Celeritas native units
+    using namespace celeritas::units;
+    auto const cm = static_cast<float>(centimeter);
+    auto const to_native_field = static_cast<float>(tesla);
+
+    CartMapFieldInput inp;
+
+    inp.x.min = static_cast<real_type>((-tx / sx) * cm);
+    inp.x.max = static_cast<real_type>(((static_cast<float>(nx) - 1.f - tx) / sx) * cm);
+    inp.x.num = static_cast<size_type>(nx);
+
+    inp.y.min = static_cast<real_type>((-ty / sy) * cm);
+    inp.y.max = static_cast<real_type>(((static_cast<float>(ny) - 1.f - ty) / sy) * cm);
+    inp.y.num = static_cast<size_type>(ny);
+
+    inp.z.min = static_cast<real_type>((-tz / sz) * cm);
+    inp.z.max = static_cast<real_type>(((static_cast<float>(nz) - 1.f - tz) / sz) * cm);
+    inp.z.num = static_cast<size_type>(nz);
+
+    // Allocate field data: layout is [X][Y][Z][3]
+    inp.field.resize(static_cast<size_type>(Axis::size_) * nx * ny * nz);
+
+    // Build a view to query the loaded field
+    file_field_t::view_t field_view{file_field};
+
+    // Iterate over the grid and recover world positions by inverting the
+    // affine transform: pos_i = (idx_i - t_i) / s_i
+    for (auto ix : range(nx))
+    {
+        float const wx = (static_cast<float>(ix) - tx) / sx;
+        for (auto iy : range(ny))
+        {
+            float const wy = (static_cast<float>(iy) - ty) / sy;
+            for (auto iz : range(nz))
+            {
+                float const wz = (static_cast<float>(iz) - tz) / sz;
+
+                // Query field at this world position (nearest-neighbour lookup
+                // maps back to the correct grid node)
+                auto const bvec = field_view.at(wx, wy, wz);
+
+                size_type const base = static_cast<size_type>(
+                    (ix * ny + iy) * nz + iz)
+                    * static_cast<size_type>(Axis::size_);
+
+                inp.field[base + 0]
+                    = static_cast<real_type>(bvec[0]) * to_native_field;
+                inp.field[base + 1]
+                    = static_cast<real_type>(bvec[1]) * to_native_field;
+                inp.field[base + 2]
+                    = static_cast<real_type>(bvec[2]) * to_native_field;
+            }
+        }
+    }
+
+    CELER_ENSURE(inp);
+    return inp;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace dd
+}  // namespace celeritas

--- a/src/ddceler/LoadCovfieField.hh
+++ b/src/ddceler/LoadCovfieField.hh
@@ -19,7 +19,7 @@ namespace dd
  * Load a Cartesian magnetic field map from a binary covfie file.
  *
  * The covfie file must have been written with the format:
- *   affine -> nearest_neighbour -> strided -> array (float3)
+ *   affine -> linear -> strided -> array (float3)
  *
  * Coordinates in the file are assumed to be in centimetres and field values
  * in tesla; both are converted to Celeritas native units on load.

--- a/src/ddceler/LoadCovfieField.hh
+++ b/src/ddceler/LoadCovfieField.hh
@@ -1,0 +1,35 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file ddceler/LoadCovfieField.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+
+#include "celeritas/field/CartMapFieldInput.hh"
+
+namespace celeritas
+{
+namespace dd
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Load a Cartesian magnetic field map from a binary covfie file.
+ *
+ * The covfie file must have been written with the format:
+ *   affine -> nearest_neighbour -> strided -> array (float3)
+ *
+ * Coordinates in the file are assumed to be in centimetres and field values
+ * in tesla; both are converted to Celeritas native units on load.
+ *
+ * The returned \c CartMapFieldInput has the field driver options left at their
+ * defaults (zero). The caller is responsible for setting them from the DD4hep
+ * steering-file parameters before passing the input to a factory.
+ */
+CartMapFieldInput LoadCovfieField(std::string const& filename);
+
+//---------------------------------------------------------------------------//
+}  // namespace dd
+}  // namespace celeritas

--- a/src/ddceler/LoadCovfieField.hh
+++ b/src/ddceler/LoadCovfieField.hh
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "celeritas/field/CartMapFieldInput.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
 
 namespace celeritas
 {
@@ -29,6 +30,23 @@ namespace dd
  * steering-file parameters before passing the input to a factory.
  */
 CartMapFieldInput LoadCovfieField(std::string const& filename);
+
+//---------------------------------------------------------------------------//
+/*!
+ * Load a 2D BrBz cylindrical magnetic field map from a binary covfie file.
+ *
+ * The covfie file must have been written with the format:
+ *   affine -> linear -> strided(size2) -> array (float2)
+ *
+ * The two axes are (r, z) and the two field components are (Br, Bz).
+ * Coordinates in the file are assumed to be in centimetres and field values
+ * in tesla; both are converted to Celeritas native units on load.
+ *
+ * The returned \c RZMapFieldInput has the field driver options left at their
+ * defaults (zero). The caller is responsible for setting them from the DD4hep
+ * steering-file parameters before passing the input to a factory.
+ */
+RZMapFieldInput LoadCovfieFieldBrBz(std::string const& filename);
 
 //---------------------------------------------------------------------------//
 }  // namespace dd

--- a/test/celeritas/field/Fields.test.cc
+++ b/test/celeritas/field/Fields.test.cc
@@ -285,6 +285,49 @@ TEST_F(CylMapFieldTest, all)
     EXPECT_VEC_NEAR(expected_field, actual, real_type{1e-7});
 }
 
+TEST_F(RZMapFieldTest, TEST_IF_CELER_DEVICE(device))
+{
+    RZMapFieldInput inp;
+    auto filename = this->test_data_path("celeritas", "cms-tiny.field.json");
+    std::ifstream(filename) >> inp;
+
+    int const nsamples = 8;
+
+    // Compute host reference values
+    RZMapFieldParams field_map{inp};
+    RZMapField calc_field(field_map.host_ref());
+
+    real_type delta_z = from_cm(25.0);
+    real_type delta_r = from_cm(12.0);
+
+    std::vector<real_type> host_values;
+    for (int i : range(nsamples))
+    {
+        Real3 field = calc_field(Real3{i * delta_r, i * delta_r, i * delta_z});
+        for (real_type f : field)
+        {
+            host_values.push_back(
+                native_value_to<units::FieldTesla>(f).value());
+        }
+    }
+
+    // Compute device values
+    std::vector<real_type> device_field_values(nsamples * 3);
+    auto span = make_span(device_field_values);
+    rzfield_test(inp, span, nsamples);
+
+    std::vector<real_type> device_values;
+    for (real_type f : device_field_values)
+    {
+        device_values.push_back(native_value_to<units::FieldTesla>(f).value());
+    }
+
+    // Compare device against host (both use covfie when covfie is enabled);
+    // CUDA texture interpolation differs from host covfie linear interpolation
+    constexpr real_type tol = CELERITAS_USE_HIP ? 5e-2 : 2e-2;
+    EXPECT_VEC_NEAR(host_values, device_values, tol);
+}
+
 #if !CELERITAS_USE_COVFIE
 #    define CartMapFieldTest DISABLED_CartMapFieldTest
 #endif

--- a/test/celeritas/field/Fields.test.cu
+++ b/test/celeritas/field/Fields.test.cu
@@ -16,9 +16,13 @@
 #include "corecel/grid/Interpolator.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/sys/KernelParamCalculator.device.hh"
+#include "geocel/UnitUtils.hh"
 #include "celeritas/field/CartMapField.hh"
 #include "celeritas/field/CartMapFieldInput.hh"
 #include "celeritas/field/CartMapFieldParams.hh"
+#include "celeritas/field/RZMapField.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
+#include "celeritas/field/RZMapFieldParams.hh"
 
 #include "TestMacros.hh"
 
@@ -107,6 +111,69 @@ void field_test(CartMapFieldInput& inp,
                         inp.y,
                         inp.z,
                         n_samples,
+                        field_values_d.data());
+    CELER_DEVICE_API_CALL(DeviceSynchronize());
+
+    field_values_d.copy_to_host(field_values);
+}
+
+//---------------------------------------------------------------------------//
+// RZ FIELD TESTING
+//---------------------------------------------------------------------------//
+
+namespace
+{
+using RZDeviceCRef = RZMapFieldParams::DeviceRef;
+
+__global__ void rzfield_test_kernel(unsigned int const size,
+                                    RZDeviceCRef field_map_data,
+                                    real_type delta_r,
+                                    real_type delta_z,
+                                    unsigned int num_samples,
+                                    real_type* field_values)
+{
+    auto tid = TrackSlotId{KernelParamCalculator::thread_id().unchecked_get()};
+    if (tid.get() >= size)
+        return;
+
+    RZMapField calc_field(field_map_data);
+
+    size_type index = 0;
+    for (unsigned int i = 0; i < num_samples; ++i)
+    {
+        Real3 field = calc_field({i * delta_r, i * delta_r, i * delta_z});
+        field_values[index++] = field[0];
+        field_values[index++] = field[1];
+        field_values[index++] = field[2];
+    }
+}
+
+}  // namespace
+
+//---------------------------------------------------------------------------//
+//! Run RZ field on device and return results
+void rzfield_test(RZMapFieldInput& inp,
+                  Span<real_type>& field_values,
+                  unsigned int num_samples)
+{
+    RZMapFieldParams field_map{inp};
+
+    DeviceVector<real_type> field_values_d(field_values.size());
+
+    RZDeviceCRef device_cref = field_map.device_ref();
+
+    // Use the same sampling deltas as the host test
+    real_type delta_r = from_cm(12.0);
+    real_type delta_z = from_cm(25.0);
+
+    CELER_LAUNCH_KERNEL(rzfield_test,
+                        1,
+                        0,
+                        1,
+                        device_cref,
+                        delta_r,
+                        delta_z,
+                        num_samples,
                         field_values_d.data());
     CELER_DEVICE_API_CALL(DeviceSynchronize());
 

--- a/test/celeritas/field/Fields.test.hh
+++ b/test/celeritas/field/Fields.test.hh
@@ -10,6 +10,7 @@
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Span.hh"
 #include "celeritas/field/CartMapFieldInput.hh"
+#include "celeritas/field/RZMapFieldInput.hh"
 
 namespace celeritas
 {
@@ -23,9 +24,17 @@ namespace test
 //! Run on device and return results
 void field_test(CartMapFieldInput&, Span<real_type>&, Array<size_type, 3>&);
 
+//! Run RZ field on device and return results
+void rzfield_test(RZMapFieldInput&, Span<real_type>&, unsigned int num_samples);
+
 #if !CELER_USE_DEVICE
 inline void
 field_test(CartMapFieldInput&, Span<real_type>&, Array<size_type, 3>&)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+
+inline void rzfield_test(RZMapFieldInput&, Span<real_type>&, unsigned int)
 {
     CELER_NOT_CONFIGURED("CUDA or HIP");
 }


### PR DESCRIPTION
Parts were moved to:
- https://github.com/celeritas-project/celeritas/pull/2335
- https://github.com/celeritas-project/celeritas/pull/2344


Summary
  - Add helper classes for loading covfie field maps with ddceler (f8689c0)
  - Add covfie field map support to ddceler CelerPhysics plugin (d5cb97c)
  - Fix 3D Cartesian covfie loader to match converter output format (aafeada)
  - Add LoadCovfieFieldBrBz for 2D cylindrical covfie field maps (0692491)
  - Add FieldMapCoordType property to select BrBz or BxByBz field loader (35eea59)
  - Include placeholder values for field map parameters in steering file (ec9f96b)
