### PR TITLE
Correctly set optical options in celer-sim

### DIFF
--- a/app/celer-sim/RunnerInput.cc
+++ b/app/celer-sim/RunnerInput.cc
@@ -195,14 +195,8 @@ inp::Problem load_problem(RunnerInput const& ri)
     // Optical options
     if (ri.optical)
     {
-        p.control.optical_capacity = [&ri] {
-            inp::OpticalStateCapacity sc;
-            sc.primaries = ri.optical->auto_flush;
-            sc.tracks = ri.optical->num_track_slots;
-            sc.generators = ri.optical->buffer_capacity;
-            return sc;
-        }();
-        p.tracking.optical_limits.step_iters = ri.optical->max_steps;
+        p.control.optical_capacity = ri.optical->capacity;
+        p.tracking.optical_limits = ri.optical->limits;
 
         // NOTE: optical physics setup is applied to g4 physics list and
         // then copied from import data (i.e., you can't currently disable it
@@ -271,19 +265,10 @@ inp::StandaloneInput to_input(RunnerInput const& ri)
     {
         // Set up Geant4
         si.geant_setup = ri.physics_options;
-        // Set up processes to spawn optical photons
-        if (ri.optical)
-        {
-            if (!si.geant_setup->optical)
-                si.geant_setup->optical.emplace();
-        }
-        if (si.geant_setup->optical)
-        {
-            if (!ri.optical->cherenkov)
-                si.geant_setup->optical->cherenkov = std::nullopt;
-            if (!ri.optical->scintillation)
-                si.geant_setup->optical->scintillation = std::nullopt;
-        }
+
+        CELER_VALIDATE(
+            !si.geant_setup->optical == !ri.optical,
+            << R"(optical setup options require optical physics to be enabled and vice versa)");
 
         inp::PhysicsFromGeant geant_import;
         GeantImportDataSelection::Flags selection

--- a/app/celer-sim/RunnerInput.cc
+++ b/app/celer-sim/RunnerInput.cc
@@ -286,6 +286,18 @@ inp::StandaloneInput to_input(RunnerInput const& ri)
         }
 
         inp::PhysicsFromGeant geant_import;
+        GeantImportDataSelection::Flags selection
+            = GeantImportDataSelection::em_basic;
+        if (si.geant_setup->muon || si.geant_setup->mucf_physics)
+        {
+            selection |= GeantImportDataSelection::em_ex;
+        }
+        if (si.geant_setup->optical)
+        {
+            selection |= GeantImportDataSelection::optical;
+        }
+        geant_import.data_selection.particles = selection;
+        geant_import.data_selection.processes = selection;
         CELER_VALIDATE(
             ri.poly_spline_order == 1
                 || ri.interpolation == InterpolationType::poly_spline,

--- a/app/celer-sim/RunnerInput.cc
+++ b/app/celer-sim/RunnerInput.cc
@@ -197,12 +197,12 @@ inp::Problem load_problem(RunnerInput const& ri)
     {
         p.control.optical_capacity = [&ri] {
             inp::OpticalStateCapacity sc;
-            sc.primaries = ri.optical.auto_flush;
-            sc.tracks = ri.optical.num_track_slots;
-            sc.generators = ri.optical.buffer_capacity;
+            sc.primaries = ri.optical->auto_flush;
+            sc.tracks = ri.optical->num_track_slots;
+            sc.generators = ri.optical->buffer_capacity;
             return sc;
         }();
-        p.tracking.optical_limits.step_iters = ri.optical.max_steps;
+        p.tracking.optical_limits.step_iters = ri.optical->max_steps;
 
         // NOTE: optical physics setup is applied to g4 physics list and
         // then copied from import data (i.e., you can't currently disable it
@@ -272,16 +272,16 @@ inp::StandaloneInput to_input(RunnerInput const& ri)
         // Set up Geant4
         si.geant_setup = ri.physics_options;
         // Set up processes to spawn optical photons
-        if (ri.optical.cherenkov || ri.optical.scintillation)
+        if (ri.optical)
         {
             if (!si.geant_setup->optical)
                 si.geant_setup->optical.emplace();
         }
         if (si.geant_setup->optical)
         {
-            if (!ri.optical.cherenkov)
+            if (!ri.optical->cherenkov)
                 si.geant_setup->optical->cherenkov = std::nullopt;
-            if (!ri.optical.scintillation)
+            if (!ri.optical->scintillation)
                 si.geant_setup->optical->scintillation = std::nullopt;
         }
 

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -74,7 +74,7 @@ struct RunnerInput
         explicit operator bool() const
         {
             return num_track_slots > 0 && buffer_capacity > 0 && auto_flush > 0
-                   && max_steps > 0;
+                   && max_steps > 0 && (cherenkov || scintillation);
         }
     };
     static constexpr Real3 no_field() { return Real3{0, 0, 0}; }
@@ -141,7 +141,7 @@ struct RunnerInput
     GeantPhysicsOptions physics_options;
 
     // Options when optical physics is enabled
-    OpticalOptions optical;
+    std::optional<OpticalOptions> optical;
 
     //! Whether the run arguments are valid
     explicit operator bool() const

--- a/app/celer-sim/RunnerInput.hh
+++ b/app/celer-sim/RunnerInput.hh
@@ -21,6 +21,8 @@
 #include "celeritas/ext/GeantPhysicsOptions.hh"
 #include "celeritas/ext/RootFileManager.hh"
 #include "celeritas/field/FieldDriverOptions.hh"
+#include "celeritas/inp/Control.hh"
+#include "celeritas/inp/Tracking.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 #include "celeritas/user/RootStepWriter.hh"
 #include "celeritas/user/RootStepWriterInput.hh"
@@ -60,23 +62,12 @@ struct RunnerInput
 
     struct OpticalOptions
     {
-        // *Per-process* capacities
-        size_type num_track_slots{};  //!< Number of optical loop tracks slots
-        size_type buffer_capacity{};  //!< Number of steps that created photons
-        size_type auto_flush{};  //!< Threshold number of primaries for
-                                 //!< launching optical tracking loop
-        size_type max_steps = static_cast<size_type>(-1);  //!< Step iterations
-
-        // Optical photon generation
-        bool cherenkov{true};
-        bool scintillation{true};
-
-        explicit operator bool() const
-        {
-            return num_track_slots > 0 && buffer_capacity > 0 && auto_flush > 0
-                   && max_steps > 0 && (cherenkov || scintillation);
-        }
+        //! Hard cutoffs for counters
+        inp::OpticalTrackingLimits limits;
+        //! Per-process state sizes for optical tracking loop
+        inp::OpticalStateCapacity capacity;
     };
+
     static constexpr Real3 no_field() { return Real3{0, 0, 0}; }
     static constexpr size_type unspecified{0};
 

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -124,7 +124,7 @@ void from_json(nlohmann::json const& j, RunnerInput& v)
         track_order, v.use_device ? TrackOrder::init_charge : TrackOrder::none);
     LDIO_LOAD_OPTION(physics_options);
 
-    LDIO_LOAD_OPTION(optical);
+    CELER_JSON_LOAD_OPTIONAL(j, v, optical)
 
 #undef LDIO_LOAD_DEPRECATED
 #undef LDIO_LOAD_OPTION
@@ -146,6 +146,18 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
 #define LDIO_SAVE_WHEN(NAME, COND) CELER_JSON_SAVE_WHEN(j, v, NAME, COND)
 #define LDIO_SAVE_OPTION(NAME) \
     LDIO_SAVE_WHEN(NAME, v.NAME != default_args.NAME)
+#define LDIO_SAVE_OPTIONAL(NAME)  \
+    do                            \
+    {                             \
+        if (v.NAME)               \
+        {                         \
+            j[#NAME] = *(v.NAME); \
+        }                         \
+        else                      \
+        {                         \
+            j[#NAME] = nullptr;   \
+        }                         \
+    } while (0)
 
     j = nlohmann::json::object();
     RunnerInput const default_args;
@@ -201,8 +213,9 @@ void to_json(nlohmann::json& j, RunnerInput const& v)
                    v.physics_file.empty()
                        || !ends_with(v.physics_file, ".root"));
 
-    LDIO_SAVE_WHEN(optical, v.optical);
+    LDIO_SAVE_OPTIONAL(optical);
 
+#undef LDIO_SAVE_OPTIONAL
 #undef LDIO_SAVE_OPTION
 #undef LDIO_SAVE_WHEN
 #undef LDIO_SAVE

--- a/app/celer-sim/RunnerInputIO.json.cc
+++ b/app/celer-sim/RunnerInputIO.json.cc
@@ -22,6 +22,8 @@
 #include "celeritas/ext/GeantPhysicsOptionsIO.json.hh"
 #include "celeritas/field/FieldDriverOptionsIO.json.hh"
 #include "celeritas/inp/Control.hh"
+#include "celeritas/inp/ControlIO.json.hh"
+#include "celeritas/inp/TrackingIO.json.hh"
 #include "celeritas/phys/PrimaryGeneratorOptionsIO.json.hh"
 #include "celeritas/user/RootStepWriterIO.json.hh"
 
@@ -239,23 +241,15 @@ void to_json(nlohmann::json& j, app::RunnerInput::EventFileSampling const& efs)
 
 void from_json(nlohmann::json const& j, app::RunnerInput::OpticalOptions& oo)
 {
-    CELER_JSON_LOAD_REQUIRED(j, oo, num_track_slots);
-    CELER_JSON_LOAD_REQUIRED(j, oo, buffer_capacity);
-    CELER_JSON_LOAD_REQUIRED(j, oo, auto_flush);
-    CELER_JSON_LOAD_OPTION(j, oo, max_steps);
-    CELER_JSON_LOAD_OPTION(j, oo, cherenkov);
-    CELER_JSON_LOAD_OPTION(j, oo, scintillation);
+    CELER_JSON_LOAD_REQUIRED(j, oo, capacity);
+    CELER_JSON_LOAD_OPTION(j, oo, limits);
 }
 
 void to_json(nlohmann::json& j, app::RunnerInput::OpticalOptions const& oo)
 {
     j = nlohmann::json{
-        CELER_JSON_PAIR(oo, num_track_slots),
-        CELER_JSON_PAIR(oo, buffer_capacity),
-        CELER_JSON_PAIR(oo, auto_flush),
-        CELER_JSON_PAIR(oo, max_steps),
-        CELER_JSON_PAIR(oo, cherenkov),
-        CELER_JSON_PAIR(oo, scintillation),
+        CELER_JSON_PAIR(oo, capacity),
+        CELER_JSON_PAIR(oo, limits),
     };
 }
 

--- a/app/celer-sim/simple-driver.py
+++ b/app/celer-sim/simple-driver.py
@@ -42,12 +42,6 @@ physics_options = {
     "msc": "urban" if core_geo == "vecgeom" else "none",
     "eloss_fluctuation": True,
     "lpm": True,
-    "optical": {
-        "absorption": True,
-        "rayleigh_scattering": True,
-        "wavelength_shifting": {"enable": True, "time_profile": "exponential"},
-        "wavelength_shifting2": {"enable": True, "time_profile": "exponential"},
-    },
 }
 
 physics_filename = None
@@ -111,14 +105,22 @@ if "lar" in geometry_filename:
     # Volume and surface properties are currently only loaded if Geant4 import
     # is enabled
     physics_filename = None
-    num_optical_tracks = 4096
-    inp["max_steps"] = 2
-    inp["optical"] = {
-        "num_track_slots": num_optical_tracks,
-        "buffer_capacity": 3 * max_steps * num_optical_tracks,
-        "max_steps": 4,
-        "auto_flush": num_optical_tracks,
+    optical_physics = {
+        "absorption": True,
+        "rayleigh_scattering": True,
+        "wavelength_shifting": {"time_profile": "exponential"},
+        "wavelength_shifting2": {"time_profile": "exponential"},
     }
+    physics_options["optical"] = optical_physics
+
+    num_optical_tracks = 4096
+    optical_capacity = {
+        "tracks": num_optical_tracks,
+        "generators": 3 * max_steps * num_optical_tracks,
+        "primaries": num_optical_tracks,
+    }
+    inp["optical"] = {"capacity": optical_capacity, "limits": {"steps": 4}}
+    inp["max_steps"] = 2
 
 if "simple-cms" in geometry_filename:
     inp["merge_events"] = True


### PR DESCRIPTION
Following #2291, optical physics was _always_ enabled in celer-sim because we'd check if Cherenkov or scintillation were on  in `RunnerInput::OpticalOptions` (true by default) and enable optical if so. This change prevents this by removing Cherenkov and scintillation from those options (I don't think they're needed here anymore) and making the options `optional`.

This also prevents the geant importer from attempting to load optical materials for an EM-only problem by updating the `GeantImportDataSelection` according to the physics options.