### PR TITLE
Fix back painted surface double interaction

### DIFF
--- a/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
+++ b/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
@@ -73,7 +73,8 @@ SurfaceInteractionApplier<F>::operator()(CoreTrackView const& track) const
             surface_physics.update_traversal_direction(result.direction);
         }
 
-        // Ensure other interactions are taken this step
+        // Ensure no other interactions are taken this step
+        // TODO: switch to more general surface crossing status?
         surface_physics.reflectivity_action(ReflectivityAction::transmit);
 
         if (traverse.is_exiting())

--- a/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
+++ b/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
@@ -73,6 +73,9 @@ SurfaceInteractionApplier<F>::operator()(CoreTrackView const& track) const
             surface_physics.update_traversal_direction(result.direction);
         }
 
+        // Ensure other interactions are taken this step
+        surface_physics.reflectivity_action(ReflectivityAction::transmit);
+
         if (traverse.is_exiting())
         {
             // End boundary crossing if exiting

--- a/test/celeritas/optical/SurfacePhysicsInteractionIntegration.test.cc
+++ b/test/celeritas/optical/SurfacePhysicsInteractionIntegration.test.cc
@@ -263,6 +263,39 @@ class SurfacePhysicsIntegrationOnlyReflectionGroundTest
 };
 
 //---------------------------------------------------------------------------//
+class SurfacePhysicsIntegrationBackPaintedTest
+    : public SurfacePhysicsInteractionIntegrationTest
+{
+  public:
+    void setup_surface_models(inp::OpticalSurfacePhysics& input) const final
+    {
+        PhysSurfaceId phys_surface{0};
+
+        // center-top surface
+
+        input.materials.push_back({OptMatId{1}});
+
+        // Material-Gap surface
+        input.roughness.gaussian.emplace(phys_surface,
+                                         inp::GaussianRoughness{0.3});
+        input.reflectivity.fresnel.emplace(phys_surface,
+                                           inp::FresnelReflection{});
+        input.interaction.dielectric.emplace(
+            phys_surface,
+            inp::DielectricInteraction::from_dielectric(
+                inp::ReflectionForm::from_lobe()));
+
+        // Gap-Painted surface
+        phys_surface++;
+        input.roughness.polished.emplace(phys_surface, inp::NoRoughness{});
+        input.reflectivity.fresnel.emplace(phys_surface,
+                                           inp::FresnelReflection{});
+        input.interaction.only_reflection.emplace(
+            phys_surface, ReflectionMode::specular_spike);
+    }
+};
+
+//---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 // Only back-scattering
@@ -413,6 +446,19 @@ TEST_F(SurfacePhysicsIntegrationOnlyReflectionPolishedTest, polished)
 //---------------------------------------------------------------------------//
 // Only ground reflection
 TEST_F(SurfacePhysicsIntegrationOnlyReflectionGroundTest, ground)
+{
+    std::vector<RealTurn> angles{RealTurn{0}, 30 * degree, 60 * degree};
+
+    SurfaceTestResults expected;
+    expected.num_refracted = {0, 0, 0};
+    expected.num_reflected = {100, 100, 100};
+    expected.num_absorbed = {0, 0, 0};
+
+    this->reference_run(angles, expected);
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(SurfacePhysicsIntegrationBackPaintedTest, backpainted)
 {
     std::vector<RealTurn> angles{RealTurn{0}, 30 * degree, 60 * degree};
 


### PR DESCRIPTION
With back-painted (or more general multi-layer surfaces), there's a sporadic issue where two different interaction models are called twice in the same step.

Example: 
```
A      |        gap       |       B
   dielectric           painted
```
If a track is in the gap and directed towards A, then it'll undergo the dielectric-dielectric surface physics. If it reflects while in the gap, then its state is updated to use the surface physics on the painted surface. If the painted interaction model (`only_reflection`) is _after_ the dielectric interaction model in the step order, then it'll call the painted interaction as well in the same step. However the state (e.g. facet normals) aren't updated for this surface which results in an error.

This PR is a small test + change to stop double sampling of interactions. I've reused the `reflectivity_action` since it already controls overrides on the interaction and doesn't add more variables to the photon state. We could maybe consider changing the optical state status for more general control? I would suggest to wait for adding some more models like dichroic, a simple LUT, and/or coated dielectric-dielectric before refactoring.