### PR TITLE
Add volume params and view to core data

### DIFF
--- a/scripts/user/volumes-to-dot.py
+++ b/scripts/user/volumes-to-dot.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+Render the Celeritas volume hierarchy JSON as a GraphViz digraph.
+
+The input is the JSON produced by ``VolumeParamsIO.json`` (or the stream
+``operator<<`` of ``VolumeParams``).  Volumes (logical) are rendered as
+rounded-rectangle nodes; volume instances (physical placements / edges) are
+shown as plain box nodes between parent and child volumes.
+
+.. example::
+
+    Generate a PDF of the hierarchy stored in ``volumes.json``::
+
+        ./volumes-to-dot.py volumes.json | dot -Tpdf -o volumes.pdf
+
+    Read from another tool's output via stdin::
+
+        celer-geo --dump-volumes | ./volumes-to-dot.py - | dot -Tsvg -o out.svg
+"""
+
+import argparse
+import json
+import sys
+
+
+def escape(s: str) -> str:
+    """Escape a string for use inside a GraphViz label."""
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def render(data: dict, out, print_ids: bool = False):
+    volumes = data["volumes"]  # list of label strings
+    vis = data["volume_instances"]  # list of label strings (may be empty)
+    world = data["world"]  # int or null
+    children = data["children"]  # children[v] = [vi, ...]
+    i2v = data["instance_to_volume"]  # i2v[vi] = v or null
+
+    w = out.write
+
+    w("digraph volumes {\n")
+    w("  rankdir=TB\n")
+    w(
+        '  node [fontname="Helvetica", shape=box, style="rounded,filled",'
+        " fillcolor=lightblue]\n"
+    )
+    w("\n")
+
+    # Volume nodes (logical)
+    for v_idx, label in enumerate(volumes):
+        lbl = escape(label) if label else ""
+        if print_ids:
+            id_str = f"V{{{v_idx}}}"
+            lbl = f"{lbl}\\n{id_str}" if lbl else id_str
+        elif not lbl:
+            lbl = f"v{v_idx}"
+        w(f'  v{v_idx} [label="{lbl}"]\n')
+
+    w("\n")
+    # Edges: one per volume instance that appears in a children list
+    for v_idx, child_vis in enumerate(children):
+        for vi_idx in child_vis:
+            child_v = i2v[vi_idx]
+            if child_v is None:
+                continue
+            vi_label = vis[vi_idx] if vi_idx < len(vis) else ""
+            if print_ids:
+                id_str = f"VI{{{vi_idx}}}"
+                vi_label = f"{escape(vi_label)}\\n{id_str}" if vi_label else id_str
+            elif vi_label:
+                vi_label = escape(vi_label)
+            edge_lbl = f' [label="{vi_label}"]' if vi_label else ""
+            w(f"  v{v_idx} -> v{child_v}{edge_lbl}\n")
+
+    w("}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("input", help="Input filename (- for stdin)")
+    parser.add_argument(
+        "-o", "--output", default=None, help="Output filename (default: stdout)"
+    )
+    parser.add_argument(
+        "--ids",
+        action="store_true",
+        default=False,
+        help="Append V{NNN}/VI{MMM} IDs to volume/instance labels",
+    )
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        with open(args.input) as f:
+            data = json.load(f)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            render(data, f, print_ids=args.ids)
+    else:
+        render(data, sys.stdout, print_ids=args.ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/celeritas/em/model/RayleighModel.cc
+++ b/src/celeritas/em/model/RayleighModel.cc
@@ -53,9 +53,9 @@ RayleighModel::RayleighModel(ActionId id,
     this->build_data(&host_ref, materials);
 
     // Move to mirrored data, copying to device
-    mirror_ = ParamsDataStore<RayleighData>{std::move(host_ref)};
+    data_ = ParamsDataStore<RayleighData>{std::move(host_ref)};
 
-    CELER_ENSURE(this->mirror_);
+    CELER_ENSURE(this->data_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/model/RayleighModel.hh
+++ b/src/celeritas/em/model/RayleighModel.hh
@@ -54,16 +54,16 @@ class RayleighModel final : public Model, public StaticConcreteAction
     void step(CoreParams const&, CoreStateDevice&) const final;
 
     //! Access Rayleigh data on the host
-    HostRef const& host_ref() const { return mirror_.host_ref(); }
+    HostRef const& host_ref() const { return data_.host_ref(); }
 
     //! Access Rayleigh data on the device
-    DeviceRef const& device_ref() const { return mirror_.device_ref(); }
+    DeviceRef const& device_ref() const { return data_.device_ref(); }
 
   private:
     //// DATA ////
 
     // Host/device storage and reference
-    ParamsDataStore<RayleighData> mirror_;
+    ParamsDataStore<RayleighData> data_;
 
     ImportedModelAdapter imported_;
 

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -84,7 +84,6 @@ build_params_refs(CoreParams::Input const& p, CoreScalars const& scalars)
     ref.physics = get_ref<M>(*p.physics);
     ref.rng = get_ref<M>(*p.rng);
     ref.sim = get_ref<M>(*p.sim);
-    // NOTE: volumes do not yet have device data
     ref.surface = get_ref<M>(*p.surface);
     ref.volumes = get_ref<M>(*p.volume);
     ref.init = get_ref<M>(*p.init);

--- a/src/celeritas/global/CoreParams.cc
+++ b/src/celeritas/global/CoreParams.cc
@@ -86,6 +86,7 @@ build_params_refs(CoreParams::Input const& p, CoreScalars const& scalars)
     ref.sim = get_ref<M>(*p.sim);
     // NOTE: volumes do not yet have device data
     ref.surface = get_ref<M>(*p.surface);
+    ref.volumes = get_ref<M>(*p.volume);
     ref.init = get_ref<M>(*p.init);
     ref.detectors = get_ref<M>(*p.detectors);
     if (p.wentzel)

--- a/src/celeritas/global/CoreParams.hh
+++ b/src/celeritas/global/CoreParams.hh
@@ -108,7 +108,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
         explicit operator bool() const
         {
             return geometry && material && geomaterial && particle && cutoff
-                   && physics && rng && sim && surface && init && volume
+                   && physics && rng && sim && volume && surface && init
                    && action_reg && output_reg && max_streams;
         }
     };

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -12,6 +12,7 @@
 #include "corecel/random/data/RngData.hh"
 #include "geocel/DetectorData.hh"
 #include "geocel/SurfaceData.hh"
+#include "geocel/VolumeData.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/em/data/WentzelOKVIData.hh"
 #include "celeritas/geo/GeoData.hh"
@@ -76,6 +77,7 @@ struct CoreParamsData
     SimParamsData<W, M> sim;
     SurfaceParamsData<W, M> surface;
     DetectorParamsData<W, M> detectors;
+    VolumeParamsData<W, M> volumes;
     TrackInitParamsData<W, M> init;
     WentzelOKVIData<W, M> wentzel;
 
@@ -104,6 +106,7 @@ struct CoreParamsData
         sim = other.sim;
         surface = other.surface;
         detectors = other.detectors;
+        volumes = other.volumes;
         init = other.init;
         wentzel = other.wentzel;
         scalars = other.scalars;

--- a/src/celeritas/global/CoreTrackData.hh
+++ b/src/celeritas/global/CoreTrackData.hh
@@ -86,9 +86,10 @@ struct CoreParamsData
     //! True if all params are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        // OPTIONAL: surface, volumes, detectors
+        // Detectors are optional
         return geometry && materials && geo_mats && particles && cutoffs
-               && physics && rng && sim && init && scalars;
+               && physics && rng && sim && surface && volumes && init
+               && scalars;
     }
 
     //! Assign from another set of data

--- a/src/celeritas/global/CoreTrackView.hh
+++ b/src/celeritas/global/CoreTrackView.hh
@@ -9,6 +9,7 @@
 #include "corecel/math/Atomics.hh"
 #include "corecel/random/engine/RngEngine.hh"
 #include "corecel/sys/ThreadId.hh"
+#include "geocel/AllVolumesView.hh"
 #include "celeritas/geo/CoreGeoTrackView.hh"
 #include "celeritas/geo/GeoMaterialView.hh"
 #include "celeritas/mat/MaterialTrackView.hh"
@@ -102,6 +103,9 @@ class CoreTrackView
 
     // HACK: return scalars (maybe have a struct for all actions?)
     inline CELER_FUNCTION CoreScalars const& core_scalars() const;
+
+    // Return a device-compatible view of all volumes
+    inline CELER_FUNCTION AllVolumesView volumes() const;
 
     //// MUTATORS ////
 
@@ -397,6 +401,15 @@ CELER_FUNCTION ActionId CoreTrackView::tracking_cut_action() const
 CELER_FUNCTION CoreScalars const& CoreTrackView::core_scalars() const
 {
     return params_.scalars;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a device-compatible view of all volumes.
+ */
+CELER_FUNCTION AllVolumesView CoreTrackView::volumes() const
+{
+    return AllVolumesView{params_.volumes};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -63,6 +63,7 @@ build_params_refs(CoreParams::Input const& p, CoreScalars const& scalars)
     ref.surface = get_ref<M>(*p.surface);
     ref.surface_physics = get_ref<M>(*p.surface_physics);
     ref.detectors = get_ref<M>(*p.detectors);
+    ref.volumes = get_ref<M>(*p.volume);
     if (p.cherenkov)
     {
         ref.cherenkov = get_ref<M>(*p.cherenkov);

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -124,11 +124,11 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     CP_VALIDATE_INPUT(geometry);
     CP_VALIDATE_INPUT(material);
     CP_VALIDATE_INPUT(physics);
+    CP_VALIDATE_INPUT(surface_physics);
     CP_VALIDATE_INPUT(rng);
     CP_VALIDATE_INPUT(sim);
     CP_VALIDATE_INPUT(volume);
     CP_VALIDATE_INPUT(surface);
-    CP_VALIDATE_INPUT(surface_physics);
     CP_VALIDATE_INPUT(detectors);
     CP_VALIDATE_INPUT(action_reg);
     CP_VALIDATE_INPUT(gen_reg);

--- a/src/celeritas/optical/CoreParams.hh
+++ b/src/celeritas/optical/CoreParams.hh
@@ -84,7 +84,7 @@ class CoreParams final : public ParamsDataInterface<CoreParamsData>
         SPConstPhysics physics;
         SPConstRng rng;
         SPConstSim sim;
-        SPConstVolume volume;  //!< Currently host-only
+        SPConstVolume volume;
         SPConstSurface surface;
         SPConstSurfacePhysics surface_physics;
         SPConstDetectors detectors;

--- a/src/celeritas/optical/CoreTrackData.cc
+++ b/src/celeritas/optical/CoreTrackData.cc
@@ -36,10 +36,10 @@ void resize(CoreStateData<Ownership::value, M>* state,
 #endif
     resize(&state->particle, size);
     resize(&state->physics, size);
-    resize(&state->rng, params.rng, stream_id, size);
-    resize(&state->detectors, size);
-    resize(&state->sim, size);
     resize(&state->surface_physics, size);
+    resize(&state->rng, params.rng, stream_id, size);
+    resize(&state->sim, size);
+    resize(&state->detectors, size);
     resize(&state->init, stream_id, size);
     state->stream_id = stream_id;
 

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -54,12 +54,12 @@ struct CoreParamsData
     GeoParamsData<W, M> geometry;
     MaterialParamsData<W, M> material;
     PhysicsParamsData<W, M> physics;
+    SurfacePhysicsParamsData<W, M> surface_physics;
     RngParamsData<W, M> rng;
     SimParamsData<W, M> sim;
     SurfaceParamsData<W, M> surface;
-    SurfacePhysicsParamsData<W, M> surface_physics;
-    DetectorParamsData<W, M> detectors;
     VolumeParamsData<W, M> volumes;
+    DetectorParamsData<W, M> detectors;
     CherenkovData<W, M> cherenkov;
     ScintillationData<W, M> scintillation;
 
@@ -68,8 +68,8 @@ struct CoreParamsData
     //! True if all params are assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return geometry && material && physics && surface && surface_physics
-               && rng && sim && scalars;
+        return geometry && material && physics && surface_physics && rng && sim
+               && surface && volumes && scalars;
     }
 
     //! Assign from another set of data
@@ -80,12 +80,12 @@ struct CoreParamsData
         geometry = other.geometry;
         material = other.material;
         physics = other.physics;
+        surface_physics = other.surface_physics;
         rng = other.rng;
         sim = other.sim;
         surface = other.surface;
-        surface_physics = other.surface_physics;
-        detectors = other.detectors;
         volumes = other.volumes;
+        detectors = other.detectors;
         cherenkov = other.cherenkov;
         scintillation = other.scintillation;
         scalars = other.scalars;
@@ -106,10 +106,10 @@ struct CoreStateData
     GeoStateData<W, M> geometry;
     ParticleStateData<W, M> particle;
     PhysicsStateData<W, M> physics;
-    RngStateData<W, M> rng;
-    DetectorStateData<W, M> detectors;
-    SimStateData<W, M> sim;
     SurfacePhysicsStateData<W, M> surface_physics;
+    RngStateData<W, M> rng;
+    SimStateData<W, M> sim;
+    DetectorStateData<W, M> detectors;
     TrackInitStateData<W, M> init;
 
     //! Unique identifier for "thread-local" data.
@@ -133,10 +133,10 @@ struct CoreStateData
         geometry = other.geometry;
         particle = other.particle;
         physics = other.physics;
-        rng = other.rng;
-        detectors = other.detectors;
-        sim = other.sim;
         surface_physics = other.surface_physics;
+        rng = other.rng;
+        sim = other.sim;
+        detectors = other.detectors;
         init = other.init;
         stream_id = other.stream_id;
         return *this;

--- a/src/celeritas/optical/CoreTrackData.hh
+++ b/src/celeritas/optical/CoreTrackData.hh
@@ -11,6 +11,7 @@
 #include "corecel/random/data/RngData.hh"
 #include "geocel/DetectorData.hh"
 #include "geocel/SurfaceData.hh"
+#include "geocel/VolumeData.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/geo/GeoData.hh"
 
@@ -58,6 +59,7 @@ struct CoreParamsData
     SurfaceParamsData<W, M> surface;
     SurfacePhysicsParamsData<W, M> surface_physics;
     DetectorParamsData<W, M> detectors;
+    VolumeParamsData<W, M> volumes;
     CherenkovData<W, M> cherenkov;
     ScintillationData<W, M> scintillation;
 
@@ -83,6 +85,7 @@ struct CoreParamsData
         surface = other.surface;
         surface_physics = other.surface_physics;
         detectors = other.detectors;
+        volumes = other.volumes;
         cherenkov = other.cherenkov;
         scintillation = other.scintillation;
         scalars = other.scalars;

--- a/src/celeritas/optical/CoreTrackView.hh
+++ b/src/celeritas/optical/CoreTrackView.hh
@@ -8,6 +8,7 @@
 
 #include "corecel/math/Atomics.hh"
 #include "corecel/random/engine/RngEngine.hh"
+#include "geocel/AllVolumesView.hh"
 #include "geocel/DetectorView.hh"
 #include "geocel/VolumeSurfaceView.hh"
 #include "celeritas/geo/CoreGeoTrackView.hh"
@@ -82,6 +83,9 @@ class CoreTrackView
 
     // Return a sensitive detector view
     inline CELER_FUNCTION DetectorView detectors() const;
+
+    // Return a device-compatible view of all volumes
+    inline CELER_FUNCTION AllVolumesView volumes() const;
 
     // Return an RNG engine
     inline CELER_FUNCTION RngEngine rng() const;
@@ -268,6 +272,15 @@ CELER_FUNCTION auto CoreTrackView::surface_physics() const
 CELER_FUNCTION auto CoreTrackView::detectors() const -> DetectorView
 {
     return DetectorView{params_.detectors};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return a device-compatible view of all volumes.
+ */
+CELER_FUNCTION AllVolumesView CoreTrackView::volumes() const
+{
+    return AllVolumesView{params_.volumes};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/AllVolumesView.hh
+++ b/src/geocel/AllVolumesView.hh
@@ -22,13 +22,6 @@ namespace celeritas
  * This provides device-accessible accessors over the complete
  * \c VolumeParamsData: scalar graph properties (world ID, depth) and
  * instance-to-volume mapping, as well as per-volume \c VolumeView objects.
- *
- * \code
-   AllVolumesView vols{params.host_ref()};
-   VolumeId world = vols.world();
-   VolumeId vol   = vols.volume_id(vi);
-   GeoMatId mat   = vols.volume(vol).material();
- * \endcode
  */
 class AllVolumesView
 {

--- a/src/geocel/AllVolumesView.hh
+++ b/src/geocel/AllVolumesView.hh
@@ -1,0 +1,109 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/AllVolumesView.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "geocel/Types.hh"
+
+#include "VolumeData.hh"
+#include "VolumeView.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * GPU-compatible view of the full volume hierarchy graph.
+ *
+ * This provides device-accessible accessors over the complete
+ * \c VolumeParamsData: scalar graph properties (world ID, depth) and
+ * instance-to-volume mapping, as well as per-volume \c VolumeView objects.
+ *
+ * \code
+   AllVolumesView vols{params.host_ref()};
+   VolumeId world = vols.world();
+   VolumeId vol   = vols.volume_id(vi);
+   GeoMatId mat   = vols.volume(vol).material();
+ * \endcode
+ */
+class AllVolumesView
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsRef = NativeCRef<VolumeParamsData>;
+    //!@}
+
+  public:
+    // Construct with shared params data
+    explicit inline CELER_FUNCTION AllVolumesView(ParamsRef const& params);
+
+    //! Root volume of the geometry graph
+    inline CELER_FUNCTION VolumeId world() const;
+
+    //! Depth of the volume graph (1 for a world with no children)
+    inline CELER_FUNCTION VolumeLevelId::size_type num_volume_levels() const;
+
+    // Get the logical volume instantiated by a volume instance
+    inline CELER_FUNCTION VolumeId volume_id(VolumeInstanceId vi_id) const;
+
+    // Construct a view for the given volume
+    inline CELER_FUNCTION VolumeView volume(VolumeId vol_id) const;
+
+  private:
+    ParamsRef const& params_;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared params data.
+ */
+CELER_FORCEINLINE_FUNCTION
+AllVolumesView::AllVolumesView(ParamsRef const& params) : params_(params) {}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the root volume of the geometry graph.
+ */
+CELER_FORCEINLINE_FUNCTION VolumeId AllVolumesView::world() const
+{
+    return params_.scalars.world;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the depth of the volume graph.
+ */
+CELER_FORCEINLINE_FUNCTION VolumeLevelId::size_type
+AllVolumesView::num_volume_levels() const
+{
+    return params_.scalars.num_volume_levels;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the logical volume instantiated by a volume instance.
+ */
+CELER_FUNCTION VolumeId AllVolumesView::volume_id(VolumeInstanceId vi_id) const
+{
+    CELER_EXPECT(vi_id < params_.volume_ids.size());
+    return params_.volume_ids[vi_id];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a \c VolumeView for the given volume.
+ */
+CELER_FUNCTION VolumeView AllVolumesView::volume(VolumeId vol_id) const
+{
+    return VolumeView{params_, vol_id};
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/CMakeLists.txt
+++ b/src/geocel/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND SOURCES
   Types.cc
   TypesIO.json.cc
   VolumeParams.cc
+  VolumeParamsIO.json.cc
   VolumeIdBuilder.cc
   VolumeToString.cc
   detail/SurfaceParamsBuilder.cc

--- a/src/geocel/GeoVolumeView.hh
+++ b/src/geocel/GeoVolumeView.hh
@@ -1,0 +1,111 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/GeoVolumeView.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Assert.hh"
+#include "corecel/Macros.hh"
+#include "corecel/cont/Span.hh"
+#include "geocel/Types.hh"
+
+#include "VolumeData.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Access material and connectivity for a single logical volume.
+ *
+ * This GPU-compatible view provides per-volume access to the geometry
+ * material ID and parent/child edges in the volume instance graph.
+ *
+ * \code
+   GeoVolumeView view{params.host_ref(), vol_id};
+   GeoMatId mat = view.material();
+   for (VolumeInstanceId vi : view.children()) { ... }
+ * \endcode
+ */
+class GeoVolumeView
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using ParamsRef = NativeCRef<VolumeParamsData>;
+    using SpanVolInst = Span<VolumeInstanceId const>;
+    //!@}
+
+  public:
+    // Construct with shared data and a volume ID
+    explicit inline CELER_FUNCTION
+    GeoVolumeView(ParamsRef const& params, VolumeId vol_id);
+
+    //! Volume being viewed
+    CELER_FUNCTION VolumeId volume_id() const { return vol_id_; }
+
+    // Get the geometry material ID for this volume
+    inline CELER_FUNCTION GeoMatId material() const;
+
+    // Get the incoming edges (volume instances that place this volume)
+    inline CELER_FUNCTION SpanVolInst parents() const;
+
+    // Get the outgoing edges (child instances placed inside this volume)
+    inline CELER_FUNCTION SpanVolInst children() const;
+
+  private:
+    ParamsRef const& params_;
+    VolumeId vol_id_;
+
+    CELER_FORCEINLINE_FUNCTION VolumeRecord const& record() const;
+};
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with shared data and a volume ID.
+ */
+CELER_FUNCTION
+GeoVolumeView::GeoVolumeView(ParamsRef const& params, VolumeId vol_id)
+    : params_(params), vol_id_(vol_id)
+{
+    CELER_EXPECT(vol_id_ < params_.volumes.size());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the geometry material ID for this volume.
+ */
+CELER_FUNCTION GeoMatId GeoVolumeView::material() const
+{
+    return this->record().material;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the incoming edges (volume instances that place this volume).
+ */
+CELER_FUNCTION auto GeoVolumeView::parents() const -> SpanVolInst
+{
+    return params_.vi_storage[this->record().parents];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the outgoing edges (child instances placed inside this volume).
+ */
+CELER_FUNCTION auto GeoVolumeView::children() const -> SpanVolInst
+{
+    return params_.vi_storage[this->record().children];
+}
+
+//---------------------------------------------------------------------------//
+CELER_FUNCTION VolumeRecord const& GeoVolumeView::record() const
+{
+    return params_.volumes[vol_id_];
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/VolumeData.hh
+++ b/src/geocel/VolumeData.hh
@@ -32,6 +32,24 @@ struct VolumeRecord
 
 //---------------------------------------------------------------------------//
 /*!
+ * Scalar values for the volume hierarchy graph.
+ */
+struct VolumeParamsScalars
+{
+    //! Root volume of the geometry graph
+    VolumeId world;
+    //! Depth of the volume graph (1 for a world with no children)
+    VolumeLevelId::size_type num_volume_levels{0};
+
+    //! True if scalars are in a consistent populated state
+    explicit CELER_FUNCTION operator bool() const
+    {
+        return static_cast<bool>(world) && num_volume_levels > 0;
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Persistent data for the volume hierarchy graph.
  *
  * This stores the volume DAG (directed acyclic graph) in Collection-based
@@ -61,10 +79,7 @@ struct VolumeParamsData
     //! Flat backing storage for per-volume parent and child instance lists
     Items<VolumeInstanceId> vi_storage;
 
-    //! Root volume of the geometry graph
-    VolumeId world;
-    //! Depth of the volume graph (1 for a world with no children)
-    VolumeLevelId::size_type num_volume_levels{0};
+    VolumeParamsScalars scalars;
 
     //// METHODS ////
 
@@ -74,10 +89,9 @@ struct VolumeParamsData
         if (volumes.empty())
         {
             // Valid empty state (e.g., for testing or ORANGE debugging)
-            return volume_ids.empty() && vi_storage.empty() && !world
-                   && num_volume_levels == 0;
+            return volume_ids.empty() && vi_storage.empty() && !scalars;
         }
-        return static_cast<bool>(world);
+        return static_cast<bool>(scalars);
     }
 
     //! Assign from another set of data
@@ -88,8 +102,7 @@ struct VolumeParamsData
         volumes = other.volumes;
         volume_ids = other.volume_ids;
         vi_storage = other.vi_storage;
-        world = other.world;
-        num_volume_levels = other.num_volume_levels;
+        scalars = other.scalars;
         CELER_ENSURE(*this);
         return *this;
     }

--- a/src/geocel/VolumeData.hh
+++ b/src/geocel/VolumeData.hh
@@ -1,0 +1,99 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/VolumeData.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+#include "corecel/Types.hh"
+#include "corecel/data/Collection.hh"
+#include "geocel/Types.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Per-volume data: material assignment and parent/child instance edges.
+ *
+ * Parents and children are stored as ranges into the \c vi_storage backend of
+ * \c VolumeParamsData.
+ */
+struct VolumeRecord
+{
+    //! Material assignment for this volume
+    GeoMatId material;
+    //! Incoming edges: volume instances that instantiate this volume
+    ItemRange<VolumeInstanceId> parents;
+    //! Outgoing edges: child volume instances placed inside this volume
+    ItemRange<VolumeInstanceId> children;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Persistent data for the volume hierarchy graph.
+ *
+ * This stores the volume DAG (directed acyclic graph) in Collection-based
+ * storage for host and device compatibility. Volumes are nodes and volume
+ * instances are edges.
+ *
+ * See \c VolumeParams for construction details and label-based lookup.
+ */
+template<Ownership W, MemSpace M>
+struct VolumeParamsData
+{
+    //// TYPES ////
+
+    template<class T>
+    using VolumeItems = Collection<T, W, M, VolumeId>;
+    template<class T>
+    using VolInstItems = Collection<T, W, M, VolumeInstanceId>;
+    template<class T>
+    using Items = Collection<T, W, M>;
+
+    //// DATA ////
+
+    //! Per-volume records (material, parent/child ranges into vi_storage)
+    VolumeItems<VolumeRecord> volumes;
+    //! Logical volume for each volume instance (vi → v)
+    VolInstItems<VolumeId> volume_ids;
+    //! Flat backing storage for per-volume parent and child instance lists
+    Items<VolumeInstanceId> vi_storage;
+
+    //! Root volume of the geometry graph
+    VolumeId world;
+    //! Depth of the volume graph (1 for a world with no children)
+    VolumeLevelId::size_type num_volume_levels{0};
+
+    //// METHODS ////
+
+    //! True if data is consistent (empty and fully-populated states are valid)
+    explicit CELER_FUNCTION operator bool() const
+    {
+        if (volumes.empty())
+        {
+            // Valid empty state (e.g., for testing or ORANGE debugging)
+            return volume_ids.empty() && vi_storage.empty() && !world
+                   && num_volume_levels == 0;
+        }
+        return static_cast<bool>(world);
+    }
+
+    //! Assign from another set of data
+    template<Ownership W2, MemSpace M2>
+    VolumeParamsData& operator=(VolumeParamsData<W2, M2> const& other)
+    {
+        CELER_EXPECT(other);
+        volumes = other.volumes;
+        volume_ids = other.volume_ids;
+        vi_storage = other.vi_storage;
+        world = other.world;
+        num_volume_levels = other.num_volume_levels;
+        CELER_ENSURE(*this);
+        return *this;
+    }
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/VolumeData.hh
+++ b/src/geocel/VolumeData.hh
@@ -74,7 +74,7 @@ struct VolumeParamsData
 
     //! Per-volume records (material, parent/child ranges into vi_storage)
     VolumeItems<VolumeRecord> volumes;
-    //! Logical volume for each volume instance (vi → v)
+    //! Logical volume for each volume instance (vi -> v)
     VolInstItems<VolumeId> volume_ids;
     //! Flat backing storage for per-volume parent and child instance lists
     Items<VolumeInstanceId> vi_storage;

--- a/src/geocel/VolumeParams.cc
+++ b/src/geocel/VolumeParams.cc
@@ -184,10 +184,10 @@ VolumeParams::VolumeParams(inp::Volumes const& in)
     }
 
     CELER_ENSURE(host_data);
-    mirror_ = ParamsDataStore<VolumeParamsData>{std::move(host_data)};
+    data_ = ParamsDataStore<VolumeParamsData>{std::move(host_data)};
 
-    CELER_ENSURE(mirror_.host_ref().volumes.size() == num_volumes);
-    CELER_ENSURE(mirror_.host_ref().volume_ids.size() == num_volume_instances);
+    CELER_ENSURE(data_.host_ref().volumes.size() == num_volumes);
+    CELER_ENSURE(data_.host_ref().volume_ids.size() == num_volume_instances);
     CELER_ENSURE((this->num_volume_levels() == 0) == this->empty());
 }
 

--- a/src/geocel/VolumeParams.cc
+++ b/src/geocel/VolumeParams.cc
@@ -45,7 +45,7 @@ struct VolumeDataAccessor
 //---------------------------------------------------------------------------//
 int calc_num_volume_levels(HostVal<VolumeParamsData> const& params)
 {
-    CELER_EXPECT(params.world);
+    CELER_EXPECT(params.scalars.world);
     int max_level{0};
 
     VolumeVisitor visit_vol{VolumeDataAccessor<Ownership::value>{params}};
@@ -55,7 +55,7 @@ int calc_num_volume_levels(HostVal<VolumeParamsData> const& params)
             max_level = std::max(max_level, level);
             return true;
         },
-        params.world);
+        params.scalars.world);
     return max_level + 1;
 }
 
@@ -175,12 +175,12 @@ VolumeParams::VolumeParams(inp::Volumes const& in)
 
     // Set scalars
     CELER_EXPECT(!in.world || in.world < in.volumes.size());
-    host_data.world = in.world;
+    host_data.scalars.world = in.world;
 
     // Calculate depth via VolumeVisitor
     if (in.world)
     {
-        host_data.num_volume_levels = calc_num_volume_levels(host_data);
+        host_data.scalars.num_volume_levels = calc_num_volume_levels(host_data);
     }
 
     CELER_ENSURE(host_data);

--- a/src/geocel/VolumeParams.cc
+++ b/src/geocel/VolumeParams.cc
@@ -6,6 +6,9 @@
 //---------------------------------------------------------------------------//
 #include "VolumeParams.hh"
 
+#include "corecel/cont/Range.hh"
+#include "corecel/data/CollectionBuilder.hh"
+#include "corecel/data/ParamsDataStore.hh"
 #include "corecel/io/Logger.hh"
 
 #include "VolumeVisitor.hh"
@@ -16,19 +19,41 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-int calc_num_volume_levels(VolumeParams const& params)
+/*!
+ * Accessor wrapping a HostCRef for use with VolumeVisitor.
+ */
+struct HostDataAccessor
 {
-    CELER_EXPECT(params.world());
+    using VolumeRef = VolumeId;
+    using VolumeInstanceRef = VolumeInstanceId;
+
+    HostCRef<VolumeParamsData> const& params;
+
+    VolumeId volume(VolumeInstanceId vi) const
+    {
+        return params.volume_ids[vi];
+    }
+
+    Span<VolumeInstanceId const> children(VolumeId v) const
+    {
+        return params.vi_storage[params.volumes[v].children];
+    }
+};
+
+//---------------------------------------------------------------------------//
+int calc_num_volume_levels(HostCRef<VolumeParamsData> const& params)
+{
+    CELER_EXPECT(params.world);
     int max_level{0};
 
-    VolumeVisitor visit_vol{params};
+    VolumeVisitor visit_vol{HostDataAccessor{params}};
     visit_vol(
         [&max_level](VolumeId, int level) {
             CELER_ASSERT(level >= 0);
             max_level = std::max(max_level, level);
             return true;
         },
-        params.world());
+        params.world);
     return max_level + 1;
 }
 
@@ -96,67 +121,86 @@ VolumeParams::VolumeParams(inp::Volumes const& in)
 
     // TODO: warn about duplicate labels (see LabelIdMultiMap::duplicates)
 
-    // Unzip volume properties
-    materials_.resize(this->num_volumes());
-    children_.resize(this->num_volumes());
-    for (auto vol_idx : range(this->num_volumes()))
-    {
-        materials_[vol_idx] = in.volumes[vol_idx].material;
+    auto const num_volumes = this->num_volumes();
+    auto const num_volume_instances = this->num_volume_instances();
 
-        // Set children instances
-        auto const& vol_children = in.volumes[vol_idx].children;
-        CELER_EXPECT(std::all_of(
-            vol_children.begin(), vol_children.end(), [this](auto const& id) {
-                return id < this->num_volume_instances();
-            }));
-        children_[vol_idx].assign(vol_children.begin(), vol_children.end());
-    }
-
-    // Unzip volume instances and add parent relationships
-    volumes_.resize(this->num_volume_instances());
-    parents_.resize(this->num_volumes());
-    for (auto vi_idx : range(this->num_volume_instances()))
+    // Aggregate parents: scan all volume instances and record which volumes
+    // each instance belongs to
+    std::vector<std::vector<VolumeInstanceId>> parent_lists(num_volumes);
+    for (auto vi_idx : range(num_volume_instances))
     {
         auto const& vol_inst = in.volume_instances[vi_idx];
         if (!vol_inst)
         {
-            // Skip null volume instance
             continue;
         }
-
-        // Store the logical volume that this physical volume instantiates
-        volumes_[vi_idx] = vol_inst.volume;
-
-        // Add this instance as a parent of its referenced volume
-        CELER_EXPECT(vol_inst.volume < this->num_volumes());
-        parents_[vol_inst.volume.unchecked_get()].push_back(
+        CELER_EXPECT(vol_inst.volume < num_volumes);
+        parent_lists[vol_inst.volume.unchecked_get()].push_back(
             VolumeInstanceId{vi_idx});
     }
 
-    // Save world
-    CELER_EXPECT(!in.world || in.world < in.volumes.size());
-    world_ = in.world;
+    // Build host data
+    HostVal<VolumeParamsData> host_data;
+    CollectionBuilder vol_builder{&host_data.volumes};
+    CollectionBuilder vi_ids_builder{&host_data.volume_ids};
+    CollectionBuilder vi_storage_builder{&host_data.vi_storage};
 
-    // Calculate additional properties
-    if (world_)
+    // Build per-volume records
+    for (auto vol_idx : range(num_volumes))
     {
-        num_volume_levels_ = calc_num_volume_levels(*this);
+        auto const& vol_children = in.volumes[vol_idx].children;
+        CELER_EXPECT(std::all_of(
+            vol_children.begin(), vol_children.end(), [&](auto const& id) {
+                return id < num_volume_instances;
+            }));
+
+        VolumeRecord rec;
+        rec.material = in.volumes[vol_idx].material;
+        rec.children = vi_storage_builder.insert_back(vol_children.begin(),
+                                                      vol_children.end());
+        auto const& parents = parent_lists[vol_idx];
+        rec.parents
+            = vi_storage_builder.insert_back(parents.begin(), parents.end());
+        vol_builder.push_back(rec);
     }
 
-    CELER_ENSURE(this->num_volumes() == in.volumes.size());
-    CELER_ENSURE(this->num_volume_instances() == in.volume_instances.size());
-    CELER_ENSURE(v_labels_.size() == this->num_volumes());
-    CELER_ENSURE(vi_labels_.size() == this->num_volume_instances());
-    CELER_ENSURE(materials_.size() == this->num_volumes());
-    CELER_ENSURE(parents_.size() == this->num_volumes());
-    CELER_ENSURE(children_.size() == this->num_volumes());
-    CELER_ENSURE(volumes_.size() == this->num_volume_instances());
+    // Build volume_ids: map VolumeInstanceId -> VolumeId
+    for (auto vi_idx : range(num_volume_instances))
+    {
+        auto const& vol_inst = in.volume_instances[vi_idx];
+        vi_ids_builder.push_back(vol_inst ? vol_inst.volume : VolumeId{});
+    }
+
+    // Set scalars
+    CELER_EXPECT(!in.world || in.world < in.volumes.size());
+    host_data.world = in.world;
+
+    // Calculate depth via VolumeVisitor
+    if (in.world)
+    {
+        HostCRef<VolumeParamsData> tmp_ref;
+        tmp_ref = host_data;
+        host_data.num_volume_levels = calc_num_volume_levels(tmp_ref);
+    }
+
+    CELER_ENSURE(host_data);
+    mirror_ = ParamsDataStore<VolumeParamsData>{std::move(host_data)};
+
+    CELER_ENSURE(mirror_.host_ref().volumes.size() == num_volumes);
+    CELER_ENSURE(mirror_.host_ref().volume_ids.size() == num_volume_instances);
     CELER_ENSURE((this->num_volume_levels() == 0) == this->empty());
 }
 
 //---------------------------------------------------------------------------//
 //! Construct with no volumes, often for unit testing
 VolumeParams::VolumeParams() : VolumeParams{inp::Volumes{}} {}
+
+//---------------------------------------------------------------------------//
+// EXPLICIT INSTANTIATION
+//---------------------------------------------------------------------------//
+
+template class ParamsDataStore<VolumeParamsData>;
+template class ParamsDataInterface<VolumeParamsData>;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/VolumeParams.cc
+++ b/src/geocel/VolumeParams.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "VolumeParams.hh"
 
+#include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/ParamsDataStore.hh"
@@ -20,14 +21,15 @@ namespace
 {
 //---------------------------------------------------------------------------//
 /*!
- * Accessor wrapping a HostCRef for use with VolumeVisitor.
+ * Accessor wrapping a host VolumeParamsData for use with VolumeVisitor.
  */
-struct HostDataAccessor
+template<Ownership W>
+struct VolumeDataAccessor
 {
     using VolumeRef = VolumeId;
     using VolumeInstanceRef = VolumeInstanceId;
 
-    HostCRef<VolumeParamsData> const& params;
+    VolumeParamsData<W, MemSpace::host> const& params;
 
     VolumeId volume(VolumeInstanceId vi) const
     {
@@ -41,12 +43,12 @@ struct HostDataAccessor
 };
 
 //---------------------------------------------------------------------------//
-int calc_num_volume_levels(HostCRef<VolumeParamsData> const& params)
+int calc_num_volume_levels(HostVal<VolumeParamsData> const& params)
 {
     CELER_EXPECT(params.world);
     int max_level{0};
 
-    VolumeVisitor visit_vol{HostDataAccessor{params}};
+    VolumeVisitor visit_vol{VolumeDataAccessor<Ownership::value>{params}};
     visit_vol(
         [&max_level](VolumeId, int level) {
             CELER_ASSERT(level >= 0);
@@ -178,9 +180,7 @@ VolumeParams::VolumeParams(inp::Volumes const& in)
     // Calculate depth via VolumeVisitor
     if (in.world)
     {
-        HostCRef<VolumeParamsData> tmp_ref;
-        tmp_ref = host_data;
-        host_data.num_volume_levels = calc_num_volume_levels(tmp_ref);
+        host_data.num_volume_levels = calc_num_volume_levels(host_data);
     }
 
     CELER_ENSURE(host_data);

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -87,24 +87,18 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     VolumeId world() const { return data_.host_ref().world; }
 
     //! Depth of the volume DAG (a world without children is 1)
-    vol_level_uint num_volume_levels() const
-    {
-        return data_.host_ref().num_volume_levels;
-    }
+    inline vol_level_uint num_volume_levels() const;
 
     //! Number of volumes
     VolumeId::size_type num_volumes() const { return v_labels_.size(); }
 
-    //! Number of volume instances
-    VolumeInstanceId::size_type num_volume_instances() const
-    {
-        return vi_labels_.size();
-    }
+    // Number of volume instances
+    inline VolumeInstanceId::size_type num_volume_instances() const;
 
     //! Get volume metadata
     VolumeMap const& volume_labels() const { return v_labels_; }
 
-    //! Get volume instance metadata
+    // Get volume instance metadata
     VolInstMap const& volume_instance_labels() const { return vi_labels_; }
 
     // Construct a view for accessing volume properties
@@ -151,6 +145,24 @@ std::weak_ptr<VolumeParams const> const& global_volumes();
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
+ * Depth of the volume DAG.
+ */
+auto VolumeParams::num_volume_levels() const -> vol_level_uint
+{
+    return data_.host_ref().num_volume_levels;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Number of volume instances.
+ */
+auto VolumeParams::num_volume_instances() const -> VolumeInstanceId::size_type
+{
+    return vi_labels_.size();
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct a lightweight view for accessing volume properties.
  */
 VolumeView VolumeParams::get(VolumeId v_id) const
@@ -177,6 +189,8 @@ VolumeId VolumeParams::volume(VolumeInstanceId vi_id) const
     return this->host_ref().volume_ids[vi_id];
 }
 
+//---------------------------------------------------------------------------//
+// DEPRECATED
 //---------------------------------------------------------------------------//
 auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
 {

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -14,6 +14,7 @@
 #include "corecel/data/ParamsDataInterface.hh"
 #include "corecel/data/ParamsDataStore.hh"
 
+#include "AllVolumesView.hh"
 #include "Types.hh"
 #include "VolumeData.hh"
 #include "VolumeView.hh"
@@ -84,7 +85,7 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     bool empty() const { return v_labels_.empty(); }
 
     //! World volume
-    VolumeId world() const { return data_.host_ref().scalars.world; }
+    VolumeId world() const { return this->view().world(); }
 
     //! Depth of the volume DAG (a world without children is 1)
     inline vol_level_uint num_volume_levels() const;
@@ -100,6 +101,9 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
 
     // Get volume instance metadata
     VolInstMap const& volume_instance_labels() const { return vi_labels_; }
+
+    // Construct view of device-compatible volume data
+    inline AllVolumesView view() const;
 
     // Construct a view for accessing volume properties
     inline VolumeView get(VolumeId v_id) const;
@@ -147,9 +151,9 @@ std::weak_ptr<VolumeParams const> const& global_volumes();
 /*!
  * Depth of the volume DAG.
  */
-auto VolumeParams::num_volume_levels() const -> vol_level_uint
+CELER_FORCEINLINE auto VolumeParams::num_volume_levels() const -> vol_level_uint
 {
-    return data_.host_ref().scalars.num_volume_levels;
+    return this->view().num_volume_levels();
 }
 
 //---------------------------------------------------------------------------//
@@ -163,9 +167,18 @@ auto VolumeParams::num_volume_instances() const -> VolumeInstanceId::size_type
 
 //---------------------------------------------------------------------------//
 /*!
+ * Construct a device-compatible view of all volume data.
+ */
+CELER_FORCEINLINE AllVolumesView VolumeParams::view() const
+{
+    return AllVolumesView{this->host_ref()};
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct a lightweight view for accessing volume properties.
  */
-VolumeView VolumeParams::get(VolumeId v_id) const
+CELER_FORCEINLINE VolumeView VolumeParams::get(VolumeId v_id) const
 {
     return VolumeView{this->host_ref(), v_id};
 }

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -7,12 +7,15 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 
 #include "corecel/cont/LabelIdMultiMap.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/data/ParamsDataInterface.hh"
+#include "corecel/data/ParamsDataStore.hh"
 
+#include "GeoVolumeView.hh"
 #include "Types.hh"
+#include "VolumeData.hh"
 
 namespace celeritas
 {
@@ -40,15 +43,16 @@ struct Volumes;
  * In conjunction with \c GeantGeoParams, this class allows conversion between
  * the Celeritas geometry implementation and the Geant4 geometry navigation.
  *
+ * Label-based lookup (volume and volume instance names) is provided through
+ * the \c volume_labels and \c volume_instance_labels accessors. Graph
+ * properties (material, connectivity, world) are stored in the underlying
+ * \c VolumeParamsData and accessed efficiently via \c GeoVolumeView.
+ *
  * \internal Construction requirements:
  * - At least one volume must be defined.
  * - Material IDs are allowed to be null for testing purposes.
- *
- * \todo We should be able to easily move the ID-related methods to a
- * GPU-friendly view rather than just this metadata class. It's not needed at
- * the moment though.
  */
-class VolumeParams
+class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
 {
   public:
     //!@{
@@ -77,10 +81,13 @@ class VolumeParams
     bool empty() const { return v_labels_.empty(); }
 
     //! World volume
-    VolumeId world() const { return world_; }
+    VolumeId world() const { return mirror_.host_ref().world; }
 
     //! Depth of the volume DAG (a world without children is 1)
-    vol_level_uint num_volume_levels() const { return num_volume_levels_; }
+    vol_level_uint num_volume_levels() const
+    {
+        return mirror_.host_ref().num_volume_levels;
+    }
 
     //! Number of volumes
     VolumeId::size_type num_volumes() const { return v_labels_.size(); }
@@ -109,17 +116,19 @@ class VolumeParams
     // Get the volume being instantiated (outgoing node)
     inline VolumeId volume(VolumeInstanceId vi_id) const;
 
+    //!@{
+    //! \name Data interface
+
+    //! Access volume graph data on the host
+    HostRef const& host_ref() const final { return mirror_.host_ref(); }
+    //! Access volume graph data on the device
+    DeviceRef const& device_ref() const final { return mirror_.device_ref(); }
+    //!@}
+
   private:
     VolumeMap v_labels_;
     VolInstMap vi_labels_;
-
-    VolumeId world_;
-    vol_level_uint num_volume_levels_{0};
-
-    std::vector<std::vector<VolumeInstanceId>> parents_;
-    std::vector<std::vector<VolumeInstanceId>> children_;
-    std::vector<GeoMatId> materials_;
-    std::vector<VolumeId> volumes_;
+    ParamsDataStore<VolumeParamsData> mirror_;
 };
 
 //---------------------------------------------------------------------------//
@@ -139,8 +148,7 @@ std::weak_ptr<VolumeParams const> const& global_volumes();
  */
 auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
 {
-    CELER_EXPECT(v_id < parents_.size());
-    return make_span(parents_[v_id.unchecked_get()]);
+    return GeoVolumeView{this->host_ref(), v_id}.parents();
 }
 
 //---------------------------------------------------------------------------//
@@ -149,8 +157,7 @@ auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
  */
 auto VolumeParams::children(VolumeId v_id) const -> SpanVolInst
 {
-    CELER_EXPECT(v_id < children_.size());
-    return make_span(children_[v_id.unchecked_get()]);
+    return GeoVolumeView{this->host_ref(), v_id}.children();
 }
 
 //---------------------------------------------------------------------------//
@@ -159,8 +166,7 @@ auto VolumeParams::children(VolumeId v_id) const -> SpanVolInst
  */
 GeoMatId VolumeParams::material(VolumeId v_id) const
 {
-    CELER_EXPECT(v_id < materials_.size());
-    return materials_[v_id.unchecked_get()];
+    return GeoVolumeView{this->host_ref(), v_id}.material();
 }
 
 //---------------------------------------------------------------------------//
@@ -169,8 +175,8 @@ GeoMatId VolumeParams::material(VolumeId v_id) const
  */
 VolumeId VolumeParams::volume(VolumeInstanceId vi_id) const
 {
-    CELER_EXPECT(vi_id < volumes_.size());
-    return volumes_[vi_id.unchecked_get()];
+    CELER_EXPECT(vi_id < this->host_ref().volume_ids.size());
+    return this->host_ref().volume_ids[vi_id];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -107,17 +107,22 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     //! Get volume instance metadata
     VolInstMap const& volume_instance_labels() const { return vi_labels_; }
 
-    // Find all instances of a volume (incoming edges)
-    inline SpanVolInst parents(VolumeId v_id) const;
+    // Construct a view for accessing volume properties
+    inline VolumeView get(VolumeId v_id) const;
 
-    // Get the list of daughter volumes (outgoing edges)
+    // Get the child instance edges from a volume (VolumeAccessor interface)
     inline SpanVolInst children(VolumeId v_id) const;
 
-    // Get the geometry material of a volume
-    inline GeoMatId material(VolumeId v_id) const;
-
-    // Get the volume being instantiated (outgoing node)
+    // Get the volume being instantiated by an instance (VolumeAccessor
+    // interface)
     inline VolumeId volume(VolumeInstanceId vi_id) const;
+
+    //!@{
+    //! \deprecated Use \c get(v_id).parents() / \c get(v_id).material()
+    //! instead
+    [[deprecated]] inline SpanVolInst parents(VolumeId v_id) const;
+    [[deprecated]] inline GeoMatId material(VolumeId v_id) const;
+    //!@}
 
     //!@{
     //! \name Data interface
@@ -147,29 +152,20 @@ std::weak_ptr<VolumeParams const> const& global_volumes();
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Find all instances of a volume (incoming edges).
+ * Construct a lightweight view for accessing volume properties.
  */
-auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
+VolumeView VolumeParams::get(VolumeId v_id) const
 {
-    return VolumeView{this->host_ref(), v_id}.parents();
+    return VolumeView{this->host_ref(), v_id};
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Get the list of daughter volumes (outgoing edges).
+ * Get the child instance edges from a volume.
  */
 auto VolumeParams::children(VolumeId v_id) const -> SpanVolInst
 {
-    return VolumeView{this->host_ref(), v_id}.children();
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the geometry material of a volume.
- */
-GeoMatId VolumeParams::material(VolumeId v_id) const
-{
-    return VolumeView{this->host_ref(), v_id}.material();
+    return this->get(v_id).children();
 }
 
 //---------------------------------------------------------------------------//
@@ -181,6 +177,18 @@ VolumeId VolumeParams::volume(VolumeInstanceId vi_id) const
     CELER_EXPECT(vi_id < this->host_ref().volume_ids.size());
     return this->host_ref().volume_ids[vi_id];
 }
+
+//---------------------------------------------------------------------------//
+//!@{ \deprecated
+auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
+{
+    return this->get(v_id).parents();
+}
+GeoMatId VolumeParams::material(VolumeId v_id) const
+{
+    return this->get(v_id).material();
+}
+//!@}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -14,9 +14,9 @@
 #include "corecel/data/ParamsDataInterface.hh"
 #include "corecel/data/ParamsDataStore.hh"
 
-#include "GeoVolumeView.hh"
 #include "Types.hh"
 #include "VolumeData.hh"
+#include "VolumeView.hh"
 
 namespace celeritas
 {
@@ -47,7 +47,7 @@ struct Volumes;
  * Label-based lookup (volume and volume instance names) is provided through
  * the \c volume_labels and \c volume_instance_labels accessors. Graph
  * properties (material, connectivity, world) are stored in the underlying
- * \c VolumeParamsData and accessed efficiently via \c GeoVolumeView.
+ * \c VolumeParamsData and accessed efficiently via \c VolumeView.
  *
  * \internal Construction requirements:
  * - At least one volume must be defined.
@@ -151,7 +151,7 @@ std::weak_ptr<VolumeParams const> const& global_volumes();
  */
 auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
 {
-    return GeoVolumeView{this->host_ref(), v_id}.parents();
+    return VolumeView{this->host_ref(), v_id}.parents();
 }
 
 //---------------------------------------------------------------------------//
@@ -160,7 +160,7 @@ auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
  */
 auto VolumeParams::children(VolumeId v_id) const -> SpanVolInst
 {
-    return GeoVolumeView{this->host_ref(), v_id}.children();
+    return VolumeView{this->host_ref(), v_id}.children();
 }
 
 //---------------------------------------------------------------------------//
@@ -169,7 +169,7 @@ auto VolumeParams::children(VolumeId v_id) const -> SpanVolInst
  */
 GeoMatId VolumeParams::material(VolumeId v_id) const
 {
-    return GeoVolumeView{this->host_ref(), v_id}.material();
+    return VolumeView{this->host_ref(), v_id}.material();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "corecel/Macros.hh"
 #include "corecel/cont/LabelIdMultiMap.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/data/ParamsDataInterface.hh"
@@ -76,6 +77,8 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
 
     // Construct empty volume params for unit testing: no volumes
     VolumeParams();
+
+    CELER_DEFAULT_MOVE_DELETE_COPY(VolumeParams);
 
     //! Empty if no volumes are present (e.g., ORANGE debugging)
     bool empty() const { return v_labels_.empty(); }

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -84,7 +84,7 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     bool empty() const { return v_labels_.empty(); }
 
     //! World volume
-    VolumeId world() const { return data_.host_ref().world; }
+    VolumeId world() const { return data_.host_ref().scalars.world; }
 
     //! Depth of the volume DAG (a world without children is 1)
     inline vol_level_uint num_volume_levels() const;
@@ -149,7 +149,7 @@ std::weak_ptr<VolumeParams const> const& global_volumes();
  */
 auto VolumeParams::num_volume_levels() const -> vol_level_uint
 {
-    return data_.host_ref().num_volume_levels;
+    return data_.host_ref().scalars.num_volume_levels;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -84,12 +84,12 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     bool empty() const { return v_labels_.empty(); }
 
     //! World volume
-    VolumeId world() const { return mirror_.host_ref().world; }
+    VolumeId world() const { return data_.host_ref().world; }
 
     //! Depth of the volume DAG (a world without children is 1)
     vol_level_uint num_volume_levels() const
     {
-        return mirror_.host_ref().num_volume_levels;
+        return data_.host_ref().num_volume_levels;
     }
 
     //! Number of volumes
@@ -128,15 +128,15 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     //! \name Data interface
 
     //! Access volume graph data on the host
-    HostRef const& host_ref() const final { return mirror_.host_ref(); }
+    HostRef const& host_ref() const final { return data_.host_ref(); }
     //! Access volume graph data on the device
-    DeviceRef const& device_ref() const final { return mirror_.device_ref(); }
+    DeviceRef const& device_ref() const final { return data_.device_ref(); }
     //!@}
 
   private:
     VolumeMap v_labels_;
     VolInstMap vi_labels_;
-    ParamsDataStore<VolumeParamsData> mirror_;
+    ParamsDataStore<VolumeParamsData> data_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -118,8 +118,7 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     inline VolumeId volume(VolumeInstanceId vi_id) const;
 
     //!@{
-    //! \deprecated Use \c get(v_id).parents() / \c get(v_id).material()
-    //! instead
+    //! \deprecated Use \c get instead
     [[deprecated]] inline SpanVolInst parents(VolumeId v_id) const;
     [[deprecated]] inline GeoMatId material(VolumeId v_id) const;
     //!@}
@@ -179,7 +178,6 @@ VolumeId VolumeParams::volume(VolumeInstanceId vi_id) const
 }
 
 //---------------------------------------------------------------------------//
-//!@{ \deprecated
 auto VolumeParams::parents(VolumeId v_id) const -> SpanVolInst
 {
     return this->get(v_id).parents();
@@ -188,7 +186,6 @@ GeoMatId VolumeParams::material(VolumeId v_id) const
 {
     return this->get(v_id).material();
 }
-//!@}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -146,6 +146,13 @@ void global_volumes(std::shared_ptr<VolumeParams const> const&);
 std::weak_ptr<VolumeParams const> const& global_volumes();
 
 //---------------------------------------------------------------------------//
+// FREE FUNCTIONS
+//---------------------------------------------------------------------------//
+// Write volume hierarchy to a stream (defined in IO.json.cc)
+// see scripts/user/volumes-to-dot.py
+std::ostream& operator<<(std::ostream& os, VolumeParams const& vp);
+
+//---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!

--- a/src/geocel/VolumeParamsIO.json.cc
+++ b/src/geocel/VolumeParamsIO.json.cc
@@ -1,0 +1,91 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/VolumeParamsIO.json.cc
+//---------------------------------------------------------------------------//
+#include "VolumeParamsIO.json.hh"
+
+#include <istream>
+#include <ostream>
+
+#include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
+#include "corecel/io/JsonUtils.json.hh"
+#include "corecel/io/LabelIO.json.hh"
+
+#include "inp/Model.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Write volume hierarchy data to JSON.
+ *
+ * The output object has:
+ * - \c volumes : array of volume labels (indexed by VolumeId)
+ * - \c volume_instances : array of volume instance labels (indexed by
+ *   VolumeInstanceId)
+ * - \c world : integer VolumeId of the root, or null if empty
+ * - \c children : array of arrays; \c children[v] lists the VolumeInstanceId
+ *   integers of the direct children placed inside volume \c v
+ * - \c instance_to_volume : array; \c instance_to_volume[vi] is the integer
+ *   VolumeId that instance \c vi instantiates, or null if \c vi is a null
+ *   instance
+ */
+void to_json(nlohmann::json& j, VolumeParams const& vp)
+{
+    using json = nlohmann::json;
+
+    // Volume labels
+    auto j_vols = json::array();
+    for (auto v : range(VolumeId{vp.num_volumes()}))
+    {
+        j_vols.push_back(vp.volume_labels().at(v));
+    }
+
+    // Volume instance labels
+    auto j_vis = json::array();
+    for (auto vi : range(VolumeInstanceId{vp.num_volume_instances()}))
+    {
+        j_vis.push_back(vp.volume_instance_labels().at(vi));
+    }
+
+    // Children: children[v] = [vi, ...]
+    auto j_children = json::array();
+    for (auto v : range(VolumeId{vp.num_volumes()}))
+    {
+        auto ch = json::array();
+        for (VolumeInstanceId vi : vp.children(v))
+        {
+            ch.push_back(vi);
+        }
+        j_children.push_back(std::move(ch));
+    }
+
+    // volume_ids: volume_ids[vi] = v (null for a null instance)
+    auto j_vids = json::array();
+    for (auto vi : range(VolumeInstanceId{vp.num_volume_instances()}))
+    {
+        j_vids.push_back(vp.volume(vi));
+    }
+
+    j = {
+        {"volumes", std::move(j_vols)},
+        {"volume_instances", std::move(j_vis)},
+        {"world", vp.world()},
+        {"children", std::move(j_children)},
+        {"instance_to_volume", std::move(j_vids)},
+    };
+}
+
+//---------------------------------------------------------------------------//
+// Helper to write the volume hierarchy to a stream.
+std::ostream& operator<<(std::ostream& os, VolumeParams const& vp)
+{
+    nlohmann::json j = vp;
+    os << j.dump(0);
+    return os;
+}
+
+}  // namespace celeritas

--- a/src/geocel/VolumeParamsIO.json.hh
+++ b/src/geocel/VolumeParamsIO.json.hh
@@ -1,0 +1,25 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file geocel/VolumeParamsIO.json.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <iosfwd>
+#include <nlohmann/json.hpp>
+
+#include "geocel/inp/Model.hh"
+
+#include "VolumeParams.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+// Write volume hierarchy to JSON
+void to_json(nlohmann::json& j, VolumeParams const& vp);
+
+// Write volume hierarchy to a stream
+std::ostream& operator<<(std::ostream& os, VolumeParams const& vp);
+
+}  // namespace celeritas

--- a/src/geocel/VolumeView.hh
+++ b/src/geocel/VolumeView.hh
@@ -22,6 +22,7 @@ namespace celeritas
  * This GPU-compatible view provides per-volume access to the geometry
  * material ID and parent/child edges in the volume instance graph.
  *
+ * \par Example:
  * \code
    VolumeView view{params.host_ref(), vol_id};
    GeoMatId mat = view.material();

--- a/src/geocel/VolumeView.hh
+++ b/src/geocel/VolumeView.hh
@@ -8,7 +8,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
-#include "corecel/cont/Span.hh"
+#include "corecel/data/LdgIterator.hh"
 #include "geocel/Types.hh"
 
 #include "VolumeData.hh"
@@ -34,7 +34,7 @@ class VolumeView
     //!@{
     //! \name Type aliases
     using ParamsRef = NativeCRef<VolumeParamsData>;
-    using SpanVolInst = Span<VolumeInstanceId const>;
+    using SpanVolInst = LdgSpan<VolumeInstanceId const>;
     //!@}
 
   public:
@@ -58,7 +58,7 @@ class VolumeView
     ParamsRef const& params_;
     VolumeId vol_id_;
 
-    CELER_FORCEINLINE_FUNCTION VolumeRecord const& record() const;
+    inline CELER_FUNCTION VolumeRecord const& record() const;
 };
 
 //---------------------------------------------------------------------------//
@@ -102,7 +102,7 @@ CELER_FUNCTION auto VolumeView::children() const -> SpanVolInst
 }
 
 //---------------------------------------------------------------------------//
-CELER_FUNCTION VolumeRecord const& VolumeView::record() const
+CELER_FORCEINLINE_FUNCTION VolumeRecord const& VolumeView::record() const
 {
     return params_.volumes[vol_id_];
 }

--- a/src/geocel/VolumeView.hh
+++ b/src/geocel/VolumeView.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file geocel/GeoVolumeView.hh
+//! \file geocel/VolumeView.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -23,12 +23,12 @@ namespace celeritas
  * material ID and parent/child edges in the volume instance graph.
  *
  * \code
-   GeoVolumeView view{params.host_ref(), vol_id};
+   VolumeView view{params.host_ref(), vol_id};
    GeoMatId mat = view.material();
    for (VolumeInstanceId vi : view.children()) { ... }
  * \endcode
  */
-class GeoVolumeView
+class VolumeView
 {
   public:
     //!@{
@@ -40,7 +40,7 @@ class GeoVolumeView
   public:
     // Construct with shared data and a volume ID
     explicit inline CELER_FUNCTION
-    GeoVolumeView(ParamsRef const& params, VolumeId vol_id);
+    VolumeView(ParamsRef const& params, VolumeId vol_id);
 
     //! Volume being viewed
     CELER_FUNCTION VolumeId volume_id() const { return vol_id_; }
@@ -68,7 +68,7 @@ class GeoVolumeView
  * Construct with shared data and a volume ID.
  */
 CELER_FUNCTION
-GeoVolumeView::GeoVolumeView(ParamsRef const& params, VolumeId vol_id)
+VolumeView::VolumeView(ParamsRef const& params, VolumeId vol_id)
     : params_(params), vol_id_(vol_id)
 {
     CELER_EXPECT(vol_id_ < params_.volumes.size());
@@ -78,7 +78,7 @@ GeoVolumeView::GeoVolumeView(ParamsRef const& params, VolumeId vol_id)
 /*!
  * Get the geometry material ID for this volume.
  */
-CELER_FUNCTION GeoMatId GeoVolumeView::material() const
+CELER_FUNCTION GeoMatId VolumeView::material() const
 {
     return this->record().material;
 }
@@ -87,7 +87,7 @@ CELER_FUNCTION GeoMatId GeoVolumeView::material() const
 /*!
  * Get the incoming edges (volume instances that place this volume).
  */
-CELER_FUNCTION auto GeoVolumeView::parents() const -> SpanVolInst
+CELER_FUNCTION auto VolumeView::parents() const -> SpanVolInst
 {
     return params_.vi_storage[this->record().parents];
 }
@@ -96,13 +96,13 @@ CELER_FUNCTION auto GeoVolumeView::parents() const -> SpanVolInst
 /*!
  * Get the outgoing edges (child instances placed inside this volume).
  */
-CELER_FUNCTION auto GeoVolumeView::children() const -> SpanVolInst
+CELER_FUNCTION auto VolumeView::children() const -> SpanVolInst
 {
     return params_.vi_storage[this->record().children];
 }
 
 //---------------------------------------------------------------------------//
-CELER_FUNCTION VolumeRecord const& GeoVolumeView::record() const
+CELER_FUNCTION VolumeRecord const& VolumeView::record() const
 {
     return params_.volumes[vol_id_];
 }

--- a/src/geocel/VolumeVisitor.hh
+++ b/src/geocel/VolumeVisitor.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <iterator>
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
 
@@ -72,8 +73,9 @@ template<class VA>
 class VolumeVisitor
 {
   public:
-    using VolumeRef = typename VA::VolumeRef;
-    using VolumeInstanceRef = typename VA::VolumeInstanceRef;
+    using VolAccessT = std::remove_reference_t<VA>;
+    using VolumeRef = typename VolAccessT::VolumeRef;
+    using VolumeInstanceRef = typename VolAccessT::VolumeInstanceRef;
 
     //! Construct from accessor for obtaining volumes
     explicit VolumeVisitor(VA va) : accessor_(std::forward<VA>(va)) {}
@@ -143,6 +145,15 @@ auto make_visit_volume_once(F&& visit)
 {
     return VisitVolumeOnce<T, F>{std::forward<F>(visit)};
 }
+
+//---------------------------------------------------------------------------//
+// DEDUCTION GUIDES
+//---------------------------------------------------------------------------//
+
+template<class VA>
+VolumeVisitor(VA&&) -> VolumeVisitor<VA>;
+template<class VA>
+VolumeVisitor(VA const&) -> VolumeVisitor<VA const&>;
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS

--- a/src/orange/univ/detail/LocalVolumeView.hh
+++ b/src/orange/univ/detail/LocalVolumeView.hh
@@ -31,6 +31,8 @@ namespace detail
  * Polish Notation-type operations (push, negate, and, or) that is evaluated at
  * tracking time to determine whether a particle is inside the volume. The
  * encoded set of operations is the \c logic accessor.
+ *
+ * \todo Rename or put in detail namespace!
  */
 class LocalVolumeView
 {

--- a/test/corecel/OpaqueIdUtils.hh
+++ b/test/corecel/OpaqueIdUtils.hh
@@ -11,6 +11,7 @@
 
 #include "corecel/OpaqueId.hh"
 #include "corecel/cont/Span.hh"
+#include "corecel/data/LdgIterator.hh"
 
 namespace celeritas
 {
@@ -44,6 +45,16 @@ inline auto id_to_int(Span<OpaqueId<I, T> const> vals)
         result.push_back(id_to_int(val));
     }
     return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a vector of opaque IDs for easier testing.
+ */
+template<class I, class T>
+inline auto id_to_int(LdgSpan<OpaqueId<I, T> const> vals)
+{
+    return id_to_int(Span<OpaqueId<I, T> const>(vals));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -143,17 +143,17 @@ TEST_F(SingleVolumeTest, params)
     EXPECT_TRUE(params.volume_labels().find_unique("A") == vol_id);
 
     // Verify material assignment
-    EXPECT_EQ(GeoMatId{0}, params.material(vol_id));
+    EXPECT_EQ(GeoMatId{0}, params.get(vol_id).material());
 
     // A single volume should have no parents or children
-    EXPECT_TRUE(params.parents(vol_id).empty());
+    EXPECT_TRUE(params.get(vol_id).parents().empty());
     EXPECT_TRUE(params.children(vol_id).empty());
 
     // Test out-of-bounds access should assert
     if (CELERITAS_DEBUG)
     {
-        EXPECT_THROW(params.material(VolumeId{1}), DebugError);
-        EXPECT_THROW(params.parents(VolumeId{1}), DebugError);
+        EXPECT_THROW(params.get(VolumeId{1}).material(), DebugError);
+        EXPECT_THROW(params.get(VolumeId{1}).parents(), DebugError);
         EXPECT_THROW(params.children(VolumeId{1}), DebugError);
         EXPECT_THROW(params.volume(VolumeInstanceId{0}), DebugError);
     }
@@ -210,9 +210,10 @@ TEST_F(ComplexVolumeTest, params)
     // Loop over all volumes to collect children and parents
     for (auto vol_id : range(VolumeId(params.num_volumes())))
     {
+        auto v = params.get(vol_id);
         children.push_back(id_to_int(params.children(vol_id)));
-        parents.push_back(id_to_int(params.parents(vol_id)));
-        geo_mat.push_back(id_to_int(params.material(vol_id)));
+        parents.push_back(id_to_int(v.parents()));
+        geo_mat.push_back(id_to_int(v.material()));
     }
 
     static std::vector<int> const expected_children[]

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -9,6 +9,7 @@
 
 #include "corecel/OpaqueIdUtils.hh"
 #include "corecel/cont/LabelIdMultiMapUtils.hh"
+#include "geocel/AllVolumesView.hh"
 #include "geocel/Types.hh"
 #include "geocel/VolumeParams.hh"
 #include "geocel/VolumeToString.hh"
@@ -234,6 +235,34 @@ TEST_F(ComplexVolumeTest, params)
 
     static int const expected_volume_mapping[] = {1, 2, 2, 2, 3, -1, 4};
     EXPECT_VEC_EQ(expected_volume_mapping, volume_mapping);
+}
+
+TEST_F(ComplexVolumeTest, view)
+{
+    VolumeParams const& params = this->volumes();
+    AllVolumesView vv = params.view();
+
+    // Scalar accessors match params
+    EXPECT_EQ(params.world(), vv.world());
+    EXPECT_EQ(params.num_volume_levels(), vv.num_volume_levels());
+
+    // volume_id maps instance -> logical volume
+    std::vector<int> vol_ids;
+    for (auto vi : range(VolumeInstanceId{params.num_volume_instances()}))
+    {
+        vol_ids.push_back(id_to_int(vv.volume_id(vi)));
+    }
+    static int const expected_vol_ids[] = {1, 2, 2, 2, 3, -1, 4};
+    EXPECT_VEC_EQ(expected_vol_ids, vol_ids);
+
+    // volume() constructs a VolumeView with correct material
+    static int const expected_geo_mat[] = {0, 1, 2, 3, 4};
+    std::vector<int> geo_mat;
+    for (auto v : range(VolumeId{params.num_volumes()}))
+    {
+        geo_mat.push_back(id_to_int(vv.volume(v).material()));
+    }
+    EXPECT_VEC_EQ(expected_geo_mat, geo_mat);
 }
 
 TEST_F(ComplexVolumeTest, volume_to_string)

--- a/test/geocel/Volume.test.cc
+++ b/test/geocel/Volume.test.cc
@@ -5,10 +5,16 @@
 //! \file geocel/Volume.test.cc
 //! Test VolumeParams and related utilities
 //---------------------------------------------------------------------------//
+#include <fstream>
 #include <unordered_map>
+
+#include "celeritas_test_config.h"
 
 #include "corecel/OpaqueIdUtils.hh"
 #include "corecel/cont/LabelIdMultiMapUtils.hh"
+#include "corecel/io/Join.hh"
+#include "corecel/io/Label.hh"
+#include "corecel/io/StreamUtils.hh"
 #include "geocel/AllVolumesView.hh"
 #include "geocel/Types.hh"
 #include "geocel/VolumeParams.hh"
@@ -401,6 +407,28 @@ TEST_F(MultiLevelTest, visit)
         };
         EXPECT_VEC_EQ(expected_names, mpv.get_names());
     }
+}
+
+TEST_F(MultiLevelTest, io)
+{
+    auto const& vols = this->volumes();
+    auto vols_json_str = stream_to_string(vols);
+    EXPECT_JSON_EQ(R"json({
+"children": [
+[],
+[],
+[0, 1, 2 ],
+[3, 4, 5, 6, 10 ],
+[7, 8, 9 ],
+[],
+[]
+],
+"instance_to_volume": [ 0, 0, 1, 2, 0, 2, 2, 5, 5, 6, 4, 3 ],
+"volume_instances": [ "boxsph1@0", "boxsph2@0", "boxtri@0", "topbox1", "topsph1", "topbox2", "topbox3", "boxsph1@1", "boxsph2@1", "boxtri@1", "topbox4", "world_PV" ],
+"volumes": [ "sph", "tri", "box", "world", "box_refl", "sph_refl", "tri_refl" ],
+"world": 3
+})json",
+                   vols_json_str);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This next step to #1748 is an AI-assisted refactor of the volume params into a `VolumeView` (with device-compatible data) and add to the core params. Device-compatible data is necessary to reconstruct the touchable history.

This also includes a utility for rendering volume graphs using GraphViz:

![multilevel](https://github.com/user-attachments/assets/10212272-8b14-4830-8b12-af69221e5ecb)