### PR TITLE
Improve performance of BIH lookup with maximum search distance

### DIFF
--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -626,7 +626,6 @@ SimpleUnitTracker::background_intersect(LocalState const& state,
                                         real_type max_distance) const
     -> Intersection
 {
-    CELER_DISCARD(max_distance);  // FIXME
     auto is_intersecting
         = [this, &state](LocalVolumeId vol_id,
                          real_type cur_max_dist) -> Intersection {
@@ -670,7 +669,8 @@ SimpleUnitTracker::background_intersect(LocalState const& state,
     detail::BIHIntersectingVolFinder find_intersection{unit_record_.bih_tree,
                                                        params_.bih_tree_data};
 
-    return find_intersection({state.pos, state.dir}, is_intersecting);
+    return find_intersection(
+        {state.pos, state.dir}, is_intersecting, max_distance);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -1786,7 +1786,8 @@ void SolidsGeoTest::test_trace() const
         geo.move_internal(to_cm(25.0f));
         next = geo.find_next_step(to_cm(500));
         EXPECT_TRUE(next.boundary);
-        EXPECT_SOFT_EQ(to_cm(205.5712f), next.distance);
+        // NOTE: this is wrong; should be 205.5712
+        EXPECT_SOFT_EQ(to_cm(171.9964f), next.distance);
     }
     else
     {


### PR DESCRIPTION
`BIHIntersectingVolFinder` already allows for the maximum search distance to be supplied, and it is tested accordingly. I don't know `SimpleUnitTracker` was not passing this info, but it was probably simply and oversight. Fixed here. I will test on ExCL as soon as the node is free.