### PR TITLE
Add Rivanna cmake presets and environment script

### DIFF
--- a/scripts/cmake-presets/rivanna.json
+++ b/scripts/cmake-presets/rivanna.json
@@ -38,14 +38,6 @@
       "cacheVariables": {
           "CMAKE_CXX_FLAGS": "-march=x86-64-v3"
       }
-    },
-    {
-      "name": "rivanna-gpu",
-      "description": "Build on UVA's Rivanna HPC, optimized for A100 nodes",
-      "inherits": [".base", ".ndebug"],
-      "cacheVariables": {
-          "CMAKE_CXX_FLAGS": "-march=znver2 -mtune=znver2"
-      }
     }
   ],
   "buildPresets": [
@@ -56,8 +48,7 @@
       "nativeToolOptions": ["-k0"]
     },
     {"name": "rivanna", "configurePreset": "rivanna", "inherits": "base"},
-    {"name": "rivanna-debug", "configurePreset": "rivanna-debug", "inherits": "base"},
-    {"name": "rivanna-gpu", "configurePreset": "rivanna-gpu", "inherits": "base"}
+    {"name": "rivanna-debug", "configurePreset": "rivanna-debug", "inherits": "base"}
   ],
   "testPresets": [
     {
@@ -68,7 +59,6 @@
       "environment": {"CELER_DISABLE_DEVICE": "1"}
     },
     {"name": "rivanna", "configurePreset": "rivanna", "inherits": "base"},
-    {"name": "rivanna-debug", "configurePreset": "rivanna-debug", "inherits": "base"},
-    {"name": "rivanna-gpu", "configurePreset": "rivanna-gpu", "inherits": "base"}
+    {"name": "rivanna-debug", "configurePreset": "rivanna-debug", "inherits": "base"}
   ]
 }

--- a/scripts/cmake-presets/rivanna.json
+++ b/scripts/cmake-presets/rivanna.json
@@ -1,0 +1,63 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {"major": 3, "minor": 23, "patch": 0},
+  "configurePresets": [
+    {
+      "name": ".base",
+      "hidden": true,
+      "inherits": ["default", ".cuda", ".spack-env"],
+      "cacheVariables": {
+        "CMAKE_CUDA_ARCHITECTURES":         {"type": "STRING", "value": "80"},
+        "CELERITAS_CORE_GEO":               {"type": "STRING", "value": "ORANGE"},
+        "CELERITAS_BUILD_DOCS":             {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_Geant4":             {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_HepMC3":             {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_PNG":                {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":               {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_VecGeom":            {"type": "BOOL", "value": "ON"},
+        "CELERITAS_USE_DD4hep":             {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_covfie":             {"type": "BOOL", "value": "ON"},
+        "CMAKE_CXX_EXTENSIONS":             {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP":             {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_MPI":                {"type": "BOOL", "value": "OFF"},
+        "CMAKE_INSTALL_PREFIX":             "${sourceDir}/install-${presetName}"
+      }
+    },
+    {
+      "name": "rivanna",
+      "description": "Build on UVA's Rivanna HPC",
+      "inherits": [".base", ".ndebug"],
+      "cacheVariables": {
+          "CMAKE_CXX_FLAGS": "-march=x86-64-v3"
+      }
+    },
+    {
+      "name": "rivanna-gpu",
+      "description": "Build on UVA's Rivanna HPC, optimized for A100 nodes",
+      "inherits": [".base", ".ndebug"],
+      "cacheVariables": {
+          "CMAKE_CXX_FLAGS": "-march=znver2 -mtune=znver2"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base",
+      "configurePreset": ".base",
+      "jobs": 8,
+      "nativeToolOptions": ["-k0"]
+    },
+    {"name": "rivanna", "configurePreset": "rivanna", "inherits": "base"},
+    {"name": "rivanna-gpu", "configurePreset": "rivanna-gpu", "inherits": "base"}
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "configurePreset": ".base",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8}
+    },
+    {"name": "rivanna", "configurePreset": "rivanna", "inherits": "base"},
+    {"name": "rivanna-gpu", "configurePreset": "rivanna-gpu", "inherits": "base"}
+  ]
+}

--- a/scripts/cmake-presets/rivanna.json
+++ b/scripts/cmake-presets/rivanna.json
@@ -28,7 +28,7 @@
       "description": "Build on UVA's Rivanna HPC",
       "inherits": [".base", ".ndebug"],
       "cacheVariables": {
-          "CMAKE_CXX_FLAGS": "-march=x86-64-v3"
+        "CMAKE_CXX_FLAGS": "-march=x86-64-v3"
       }
     },
     {
@@ -36,7 +36,8 @@
       "description": "Build on UVA's Rivanna HPC (debug)",
       "inherits": [".base", ".debug"],
       "cacheVariables": {
-          "CMAKE_CXX_FLAGS": "-march=x86-64-v3"
+        "CMAKE_CXX_FLAGS": "-march=x86-64-v3",
+        "CMAKE_CUDA_FLAGS": "-lineinfo -Xptxas=-v -Xcompiler -Wno-psabi"
       }
     }
   ],

--- a/scripts/cmake-presets/rivanna.json
+++ b/scripts/cmake-presets/rivanna.json
@@ -32,6 +32,14 @@
       }
     },
     {
+      "name": "rivanna-debug",
+      "description": "Build on UVA's Rivanna HPC (debug)",
+      "inherits": [".base", ".debug"],
+      "cacheVariables": {
+          "CMAKE_CXX_FLAGS": "-march=x86-64-v3"
+      }
+    },
+    {
       "name": "rivanna-gpu",
       "description": "Build on UVA's Rivanna HPC, optimized for A100 nodes",
       "inherits": [".base", ".ndebug"],
@@ -48,6 +56,7 @@
       "nativeToolOptions": ["-k0"]
     },
     {"name": "rivanna", "configurePreset": "rivanna", "inherits": "base"},
+    {"name": "rivanna-debug", "configurePreset": "rivanna-debug", "inherits": "base"},
     {"name": "rivanna-gpu", "configurePreset": "rivanna-gpu", "inherits": "base"}
   ],
   "testPresets": [
@@ -55,9 +64,11 @@
       "name": "base",
       "configurePreset": ".base",
       "output": {"outputOnFailure": true},
-      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8}
+      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8},
+      "environment": {"CELER_DISABLE_DEVICE": "1"}
     },
     {"name": "rivanna", "configurePreset": "rivanna", "inherits": "base"},
+    {"name": "rivanna-debug", "configurePreset": "rivanna-debug", "inherits": "base"},
     {"name": "rivanna-gpu", "configurePreset": "rivanna-gpu", "inherits": "base"}
   ]
 }

--- a/scripts/env/rivanna.sh
+++ b/scripts/env/rivanna.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -e
+
+# The A100 GPU nodes in Rivanna/Afton have a different architecture from the rest of the nodes on the cluster.
+# Ensure the spack environment is built with the target x86_64_v3 for cross-platform support.
+
+# Similar with Perlmutter, do not use NVHPC but instead GCC and CUDA modules directly
+# Miniforge is load for python support on different nodes
+module load miniforge/24.11.3-py3.12 gcc/14.2.0 cuda/13.0.2
+
+# Expects the spack git repo to have been cloned at _SPACK_INSTALL (default to $SPACK_ROOT)
+# The environment named celeritas must exists
+_SPACK_INSTALL=${SPACK_ROOT:-$SCRATCH/spack}
+_SPACK_SOURCE_FILE=${_SPACK_INSTALL}/share/spack/setup-env.sh
+if [ ! -f "${_SPACK_SOURCE_FILE}" ]; then
+    echo "Expected to find a spack install at ${_SPACK_INSTALL}" >&2
+    exit 2
+fi
+
+. ${_SPACK_SOURCE_FILE}
+spack env activate celeritas


### PR DESCRIPTION
Adds the appropriate configurations for using `scripts/build.sh` with UVA's Rivanna/Afton HPC clusters. Includes some reminders for building with spack to be able to run on the different queues (specifically using `x86-64-v3` for both crystal-lake and zen-2 processors). The `rivanna-gpu` specifically targets the architecture for the A100 nodes. 