### PR TITLE
Implement check on Celeritas-Geant4 fast simulation particle consistency

### DIFF
--- a/src/accel/FastSimulationIntegration.cc
+++ b/src/accel/FastSimulationIntegration.cc
@@ -6,16 +6,159 @@
 //---------------------------------------------------------------------------//
 #include "FastSimulationIntegration.hh"
 
+#include <set>
+#include <G4FastSimulationManagerProcess.hh>
+#include <G4ParticleDefinition.hh>
+#include <G4ProcessManager.hh>
+#include <G4ProcessVector.hh>
 #include <G4Threading.hh>
 #include <G4Version.hh>
 
 #include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
+#include "corecel/cont/Span.hh"
+#include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
+#include "geocel/GeantUtils.hh"
 
 #include "ExceptionConverter.hh"
 
+#include "detail/IntegrationSingleton.hh"
+
+using G4PD = G4ParticleDefinition;
+
 namespace celeritas
 {
+namespace
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Check actual versus expected offloading for particles/processes.
+ *
+ * - All particles used by Celeritas should probably be offloaded
+ * - All particles used by the FSM constructor should be in Celeritas
+ * - All particles in the TM constructor should use the Celeritas TM and have
+ *   the correct local transporter/shared
+ */
+
+void verify_fast_processes(Span<G4PD const* const> expected,
+                           Span<G4PD const* const> actual)
+{
+    std::set<G4PD const*> not_offloaded{actual.begin(), actual.end()};
+    std::vector<G4PD const*> missing;
+
+    bool all_attached_correctly{true};
+    auto log_fs_failure = [&all_attached_correctly](G4PD const* p) {
+        all_attached_correctly = false;
+        auto msg = CELER_LOG(error);
+        msg << "Particle " << StreamablePD{p} << ": ";
+        return msg;
+    };
+
+    auto contains_fs_process = [](G4ProcessManager const* pm) {
+        G4ProcessVector* pv = pm->GetProcessList();
+        CELER_ASSERT(pv);
+        for (auto j : range(pv->size()))
+        {
+            if (dynamic_cast<G4FastSimulationManagerProcess*>((*pv)[j]))
+            {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    for (auto* p : expected)
+    {
+        CELER_ASSERT(p);
+
+        auto iter = not_offloaded.find(p);
+        if (iter == not_offloaded.end())
+        {
+            missing.push_back(p);
+        }
+        else
+        {
+            not_offloaded.erase(iter);
+        }
+
+#if G4VERSION_NUMBER >= 1110
+        // Step 1. Check that particle has G4FastSimulationManagerProcess
+        // attached at all
+        if (auto* pm = p->GetProcessManager())
+        {
+            if (!contains_fs_process(pm))
+            {
+                log_fs_failure(p)
+                    << R"(does not have G4FastSimulationManagerProcess attached)";
+            }
+        }
+        else
+        {
+            log_fs_failure(p) << "does not have G4ProcessManager attached";
+        }
+#else
+        CELER_DISCARD(expected_shared);
+        CELER_DISCARD(expected_local);
+        CELER_DISCARD(log_fs_failure);
+        CELER_DISCARD(contains_fs_process);
+        CELER_ASSERT_UNREACHABLE();
+#endif
+    }
+
+    auto printable_pd = [](G4PD const* p) { return StreamablePD{p}; };
+
+    if (!not_offloaded.empty())
+    {
+        CELER_LOG(warning) << "Some particles known to Celeritas are not "
+                              "offloaded by FastSimulationModel: "
+                           << join(not_offloaded.begin(),
+                                   not_offloaded.end(),
+                                   ", ",
+                                   printable_pd)
+                           << " (perhaps SetupOptions::offload_particles has "
+                              "not been updated?)";
+    }
+    CELER_VALIDATE(missing.empty(),
+                   << "not all particles from FastSimulationModel are "
+                      "active in Celeritas: missing "
+                   << join(missing.begin(), missing.end(), ", ", printable_pd));
+
+    CELER_VALIDATE(all_attached_correctly,
+                   << "fast simulation process(es) are not attached correctly "
+                      "(maybe add G4FastSimulationPhysics to your physics "
+                      "list?)");
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Check actual versus expected offloading for regions.
+ *
+ * - All regions handled by Celeritas should exist
+ * - All of these regions should have a G4FastSimulationManagerProcess attached
+ * - All of these managers should hold a FastSimulationModel instance
+ * - All of these FastSimulationModels should have the correct local
+ *   transporter/shared params
+ *
+ * - Setup is a bit different to tracking manager
+ *   - Models are added to regions as part of ConstructSDandField (nominal
+ *     location, but guarantees geometry/physics state at this point).
+ *   - Means we have to check two separate things:
+ *     1. G4ProcessManager for offload particle p must have
+ *        G4FastSimulationManagerProcess attached.
+ *     2. Each offload region r must have:
+ *        a. A non-null G4FastSimulationManager instance:
+ *             auto* fsm = region->GetFastSimulationManager();
+ *        b. That G4FastSimulationManager must contain an instance of the
+ *           Celeritas FastSimulationModel:
+ *             auto fsm_list = fsm->GetFastSimulationModelList();
+ *             ... iterate/dynamic_cast ...
+ *        c. Probably... check the model has the correct shared_params and
+ *           local transport as we do in TrackingManager offload.
+ */
+
+//---------------------------------------------------------------------------//
+}  // namespace
 
 //---------------------------------------------------------------------------//
 /*!
@@ -38,7 +181,18 @@ void FastSimulationIntegration::verify_local_setup()
                    << ") is too old to support the fast simulation offload "
                       "interface (11.1 or higher is required)");
 
-    // TODO: Check requested offload particles have G4 fast sim process/manager
+    auto& singleton = detail::IntegrationSingleton::instance();
+
+    // Check particle/processes are consistent
+    auto const& user_offload = singleton.setup_options().offload_particles;
+    auto const& offload_particles
+        = user_offload ? *user_offload
+                       : SharedParams::default_offload_particles();
+
+    CELER_LOG(debug) << "Verifying fast simulation particles and processes";
+    verify_fast_processes(
+        make_span(singleton.shared_params().OffloadParticles()),
+        make_span(offload_particles));
 
     // TODO: Check requested regions have our FastSimulationModel attached
 }

--- a/test/accel/CMakeLists.txt
+++ b/test/accel/CMakeLists.txt
@@ -159,4 +159,11 @@ celeritas_add_integration_tests(
   RMTYPE ${_optical_rm_type}
 )
 
+# Test that Fast Simulation setup fails if particles/regions are not correct
+celeritas_add_integration_tests(
+  FastSimulationIntegration LarSphereSetupFailure run
+  OFFLOAD cpu
+  RMTYPE serial
+)
+
 #-----------------------------------------------------------------------------#

--- a/test/accel/FastSimulationIntegration.test.cc
+++ b/test/accel/FastSimulationIntegration.test.cc
@@ -196,6 +196,36 @@ class LarSphere : public LarSphereIntegrationMixin, public FSITestBase
 };
 
 /*!
+ * Test the FastSimulationIntegration (FSI) failure cases.
+ *
+ * An exception should be raised when:
+ *
+ * - A particle that Celeritas has been asked to handle does not have a
+ *   G4FastSimulationManagerProcess attached.
+ *
+ * TODO: add check (or separate test) that the offload regions have
+ * the Celeritas model attached.
+ */
+class LarSphereSetupFailure : public LarSphere
+{
+    using Base = IntegrationTestBase;
+
+  protected:
+    // Physics
+    UPPhysicsList make_physics_list() const override
+    {
+        auto physics = Base::make_physics_list();
+        CELER_ASSERT(physics);
+        // Leave out positrons
+        auto fast_physics = new G4FastSimulationPhysics();
+        fast_physics->ActivateFastSimulation("e-");
+        fast_physics->ActivateFastSimulation("gamma");
+        physics->RegisterPhysics(fast_physics);
+        return physics;
+    }
+};
+
+/*!
  * Check that multiple sequential runs complete successfully.
  */
 TEST_F(LarSphere, run)
@@ -269,6 +299,32 @@ TEST_F(LarSphere, run_ui)
     ui.ApplyCommand("/run/beamOn 2");
 
     EXPECT_EQ(get_geant_num_threads(rm), check_count.load());
+}
+
+/*!
+ * Check that mismatch between offload/G4FastSimulationProcess fails.
+ */
+TEST_F(LarSphereSetupFailure, run)
+{
+    check_runtime_errors_ = true;
+
+    CELER_LOG(status) << "LarSphereSetupFailure SETUP";
+
+    auto& rm = this->run_manager();
+    FSI::Instance().SetOptions(this->make_setup_options());
+
+    CELER_LOG(status) << "Run initialization";
+    rm.Initialize();
+
+    CELER_LOG(status) << "Beam on (first run)";
+    rm.BeamOn(2);
+
+    std::vector<std::string> expected_exceptions = {
+        "fast simulation process(es) are not attached correctly (maybe add "
+        "G4FastSimulationPhysics to your physics list?)",
+    };
+    EXPECT_VEC_EQ(expected_exceptions, exceptions_);
+    exceptions_.clear();
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Offload of particles from Geant4 to Celeritas via`FastSimulationIntegration` relies on:

1. Particles requested for offload via `SetupOptions.offload_particles` having `G4FastSimulationManagerProcess` attached.
2. Regions in which these particles should be offloaded have `celeritas::FastSimulationModel` attached.

The changes here implements a _basic_ check and test on the first item, with placeholder documentation for the second (this requires addition of regions to `SetupOptions`, which is a larger task). The implementation of `FastSimulationIntegration::verify_local_setup` is extended to check the offload particles in general as is done in `TrackingManagerIntegration` (so is largely copy-paste), adding the needed loop over particles to check the presence of the needed process and `CELER_VALIDATE` on the result.

I wasn't sure about policy on testing expected failure cases, but implemented an additional fixture/test to check that the expected exception is thrown when a known offload particle does not have `G4FastSimulationManagerProcess` attached.

