### PR TITLE
Adjust and document optical surface traversal

### DIFF
--- a/doc/implementation/optical-physics/surface.rst
+++ b/doc/implementation/optical-physics/surface.rst
@@ -14,11 +14,7 @@ properties.
 
 .. doxygenenum:: celeritas::optical::SurfacePhysicsOrder
 
-During surface crossing, tracks maintain a "within-surface state" that stores
-the current layer and direction, decoupling the geometry state from the
-material state.
-
-.. doxygenclass:: celeritas::optical::SurfaceTraversalView
+.. doxygenclass:: celeritas::optical::SurfacePhysicsView
 
 .. _surface_boundary_init:
 

--- a/src/celeritas/inp/OpticalPhysics.hh
+++ b/src/celeritas/inp/OpticalPhysics.hh
@@ -489,11 +489,6 @@ struct DielectricInteraction
 //---------------------------------------------------------------------------//
 /*!
  * Surface roughness description.
- *
- * \todo Future work will allow the of use multiple surface
- * paints/wrappings managed by different models. \c PhysSurfaceId will pair
- * a \c SurfaceId with a \c PhysSurfaceId that defines paint/wrapping
- * combinations.
  */
 struct RoughnessModels
 {

--- a/src/celeritas/optical/Types.hh
+++ b/src/celeritas/optical/Types.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/Macros.hh"
 #include "celeritas/Types.hh"
 
 namespace celeritas
@@ -16,9 +17,11 @@ namespace celeritas
 namespace optical
 {
 
-//! Opaque index into subsurface track position, in range [0, num subsurface
-//! interfaces + 1]
-using SurfaceTrackPosition = OpaqueId<struct SurfaceTrackPosition_>;
+//! Opaque index of sub-surface interface
+using LocalSurfaceId = OpaqueId<struct LocalSurface_, unsigned short int>;
+
+//! Opaque index of sub-surface material region
+using LocalPositionId = OpaqueId<struct LocalMat_, unsigned short int>;
 
 }  // namespace optical
 
@@ -49,7 +52,7 @@ enum class SurfacePhysicsOrder
 };
 
 //! Traversal direction of a sub-subsurface
-enum class SubsurfaceDirection : bool
+enum class LocalDirection : bool
 {
     reverse = false,
     forward = true
@@ -100,7 +103,7 @@ char const* to_cstring(ReflectionMode);
 char const* to_cstring(WlsDistribution);
 
 //! Convert sub-surface direction to a sign (+1/-1 for forward/reverse resp.)
-CELER_FORCEINLINE_FUNCTION int to_signed_offset(SubsurfaceDirection d)
+CELER_CONSTEXPR_FUNCTION int to_signed_offset(LocalDirection d)
 {
     return 2 * static_cast<int>(d) - 1;
 }

--- a/src/celeritas/optical/surface/SurfacePhysicsData.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsData.hh
@@ -20,25 +20,23 @@ namespace optical
 /*!
  * Storage for physics data of a geometric surface.
  *
- * The \c subsurface_materials indexes into the \c
- * SurfacePhysicsParamsData::subsurface_materials and represents a list of
- * interstitial optical materials that make up a geometric surface. The \c
- * subsurface_interfaces represents the physics surfaces that separate the
- * optical materials that make up a geometric surface.
+ * See \c SurfacePhysicsView for documentation.
  *
- * By convention, \c subsurface_interfaces[0] separates the pre-volume and the
- * first subsurface material, while the last interface separates the last
- * subsurface material and the post-volume.
+ * - \c interstitial_mats indexes into \c SurfacePhysicsParamsData::opt_mat_ids
+ * - \c local_surface_ids give \c PhysSurfaceId for models
+ * - physical surfaces map to models is done by \c model_maps
  */
-struct SurfaceRecord
+struct SurfacePhysicsRecord
 {
-    ItemMap<SurfaceTrackPosition, OpaqueId<OptMatId>> subsurface_materials;
-    ItemMap<SurfaceTrackPosition, PhysSurfaceId> subsurface_interfaces;
+    //! Indirection to a stored optical mat ID (interstitial 0 = LPId{1})
+    ItemRange<OptMatId> interstitial_mat_ids;
+    //! Physics surface ID from the forward-oriented local surface ID
+    ItemMap<LocalSurfaceId, PhysSurfaceId> local_surface_ids;
 
     //! Whether data is assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        return subsurface_materials.size() + 1 == subsurface_interfaces.size();
+        return interstitial_mat_ids.size() + 1 == local_surface_ids.size();
     }
 };
 
@@ -92,10 +90,12 @@ struct SurfacePhysicsParamsData
     SurfacePhysicsParamsScalars scalars;
 
     //! Optical surface model data
-
-    GeoSurfaceItems<SurfaceRecord> surfaces;
+    GeoSurfaceItems<SurfacePhysicsRecord> surfaces;
     SurfaceStepModelMaps model_maps;
-    Items<OptMatId> subsurface_materials;
+
+    //// BACKEND STORAGE ////
+
+    Items<OptMatId> opt_mat_ids;
 
     //! Whether data is assigned
     explicit CELER_FUNCTION operator bool() const
@@ -111,7 +111,7 @@ struct SurfacePhysicsParamsData
         CELER_EXPECT(other);
         scalars = other.scalars;
         surfaces = other.surfaces;
-        subsurface_materials = other.subsurface_materials;
+        opt_mat_ids = other.opt_mat_ids;
         for (auto step : range(SurfacePhysicsOrder::size_))
         {
             model_maps[step] = other.model_maps[step];
@@ -136,7 +136,7 @@ struct SurfacePhysicsStateData
     //!@{
     //! \name Constant state for a single boundary crossing
     StateItems<SurfaceId> surface;
-    StateItems<SubsurfaceDirection> surface_orientation;
+    StateItems<LocalDirection> surface_orientation;
     StateItems<Real3> global_normal;
     StateItems<OptMatId> pre_volume_material;
     StateItems<OptMatId> post_volume_material;
@@ -144,8 +144,8 @@ struct SurfacePhysicsStateData
 
     //!@{
     //! \name Mutable state for a single boundary crossing
-    StateItems<SurfaceTrackPosition> surface_position;
-    StateItems<SubsurfaceDirection> track_direction;
+    StateItems<LocalPositionId> local_position;
+    StateItems<LocalDirection> local_direction;
     StateItems<Real3> facet_normal;
     StateItems<ReflectivityAction> reflectivity_action;
     //!@}
@@ -154,8 +154,8 @@ struct SurfacePhysicsStateData
     explicit CELER_FUNCTION operator bool() const
     {
         return !surface.empty() && surface.size() == surface_orientation.size()
-               && surface.size() == surface_position.size()
-               && surface.size() == track_direction.size()
+               && surface.size() == local_position.size()
+               && surface.size() == local_direction.size()
                && surface.size() == pre_volume_material.size()
                && surface.size() == post_volume_material.size()
                && surface.size() == global_normal.size()
@@ -175,8 +175,8 @@ struct SurfacePhysicsStateData
         surface = other.surface;
         surface_orientation = other.surface_orientation;
         global_normal = other.global_normal;
-        surface_position = other.surface_position;
-        track_direction = other.track_direction;
+        local_position = other.local_position;
+        local_direction = other.local_direction;
         pre_volume_material = other.pre_volume_material;
         post_volume_material = other.post_volume_material;
         facet_normal = other.facet_normal;
@@ -199,8 +199,8 @@ resize(SurfacePhysicsStateData<Ownership::value, M>* state, size_type size)
     resize(&state->surface, size);
     resize(&state->surface_orientation, size);
     resize(&state->global_normal, size);
-    resize(&state->surface_position, size);
-    resize(&state->track_direction, size);
+    resize(&state->local_position, size);
+    resize(&state->local_direction, size);
     resize(&state->pre_volume_material, size);
     resize(&state->post_volume_material, size);
     resize(&state->facet_normal, size);

--- a/src/celeritas/optical/surface/SurfacePhysicsParams.cc
+++ b/src/celeritas/optical/surface/SurfacePhysicsParams.cc
@@ -109,7 +109,7 @@ void SurfacePhysicsParams::build_surfaces(
     CELER_EXPECT(!interstitial_materials.empty());
 
     auto build_surface = make_builder(&data.surfaces);
-    auto build_material = make_builder(&data.subsurface_materials);
+    auto build_material = make_builder(&data.opt_mat_ids);
 
     PhysSurfaceId next_phys_surface{0};
     for (auto const& materials : interstitial_materials)
@@ -120,7 +120,7 @@ void SurfacePhysicsParams::build_surfaces(
         next_phys_surface
             = PhysSurfaceId(phys_surface_start.get() + materials.size() + 1);
 
-        build_surface.push_back(SurfaceRecord{
+        build_surface.push_back(SurfacePhysicsRecord{
             build_material.insert_back(materials.begin(), materials.end()),
             range(phys_surface_start, next_phys_surface)});
     }

--- a/src/celeritas/optical/surface/SurfacePhysicsTrackView.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsTrackView.hh
@@ -24,9 +24,14 @@ namespace optical
  * Optical surface physics data for a track.
  *
  * Tracks maintain a position while traversing the interstitial materials of an
- * optical surface. This class provides transformations from this position
- * based on the surface orientation and traversal direction to access relevant
- * material and interface data in storage.
+ * optical surface.
+ * This class provides transformations from this position based on the surface
+ * orientation (pre/post volume when the crossing began) and traversal
+ * direction (current state) to access relevant material and interface data in
+ * storage.
+ *
+ * \sa SurfacePhysicsView
+ * \sa SurfaceTraversalView
  */
 class SurfacePhysicsTrackView
 {
@@ -40,7 +45,7 @@ class SurfacePhysicsTrackView
     struct Initializer
     {
         SurfaceId surface{};
-        SubsurfaceDirection orientation;
+        LocalDirection orientation;
         Real3 global_normal{0, 0, 0};
         OptMatId pre_volume_material{};
         OptMatId post_volume_material{};
@@ -105,7 +110,7 @@ class SurfacePhysicsTrackView
     TrackSlotId const track_id_;
 
     // Get material at the given track position
-    inline CELER_FUNCTION OptMatId material(SurfaceTrackPosition) const;
+    inline CELER_FUNCTION OptMatId material(LocalPositionId) const;
 };
 
 //---------------------------------------------------------------------------//
@@ -302,11 +307,9 @@ SurfacePhysicsTrackView::scalars() const
 /*!
  * Get material at given track position.
  */
-CELER_FUNCTION OptMatId
-SurfacePhysicsTrackView::material(SurfaceTrackPosition pos) const
+CELER_FUNCTION OptMatId SurfacePhysicsTrackView::material(LocalPositionId pos) const
 {
-    auto pos_range
-        = range(SurfaceTrackPosition{this->traversal().num_positions()});
+    auto pos_range = range(LocalPositionId{this->traversal().num_local_pos()});
     CELER_EXPECT(pos < pos_range.size());
 
     if (pos == pos_range.front())

--- a/src/celeritas/optical/surface/SurfacePhysicsTrackView.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsTrackView.hh
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file celeritas/optical/surface/SurfacePhysicsTrackView.hh
+//! \sa celeritas/optical/SurfacePhysics.test.cc
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -30,8 +31,7 @@ namespace optical
  * direction (current state) to access relevant material and interface data in
  * storage.
  *
- * \sa SurfacePhysicsView
- * \sa SurfaceTraversalView
+ * See \c SurfacePhysicsView, \c SurfaceTraversalView .
  */
 class SurfacePhysicsTrackView
 {

--- a/src/celeritas/optical/surface/SurfacePhysicsUtils.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsUtils.hh
@@ -41,8 +41,7 @@ inline CELER_FUNCTION LocalSurfaceId local_surf_id(LocalPositionId pos,
                                                    LocalDirection dir)
 {
     CELER_EXPECT(
-        pos && pos > LocalPositionId{0}
-        || (pos == LocalPositionId{0} && dir == LocalDirection::forward));
+        pos && (pos > LocalPositionId{0} || dir == LocalDirection::forward));
     return id_cast<LocalSurfaceId>(static_cast<int>(pos.unchecked_get())
                                    + static_cast<int>(dir) - 1);
 }

--- a/src/celeritas/optical/surface/SurfacePhysicsUtils.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsUtils.hh
@@ -41,7 +41,7 @@ inline CELER_FUNCTION LocalSurfaceId local_surf_id(LocalPositionId pos,
                                                    LocalDirection dir)
 {
     CELER_EXPECT(
-        pos > LocalPositionId{0}
+        pos && pos > LocalPositionId{0}
         || (pos == LocalPositionId{0} && dir == LocalDirection::forward));
     return id_cast<LocalSurfaceId>(static_cast<int>(pos.unchecked_get())
                                    + static_cast<int>(dir) - 1);
@@ -59,8 +59,7 @@ inline CELER_FUNCTION LocalPositionId next_local_pos_id(LocalPositionId pos,
                                                         LocalDirection dir)
 {
     CELER_EXPECT(pos);
-    return id_cast<LocalPositionId>(pos.unchecked_get()
-                                    + to_signed_offset(dir));
+    return LocalPositionId(pos.unchecked_get() + to_signed_offset(dir));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/SurfacePhysicsUtils.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsUtils.hh
@@ -35,30 +35,42 @@ is_entering_surface(Real3 const& dir, Real3 const& normal)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the local surface ID given the current local material and direction.
+ */
+inline CELER_FUNCTION LocalSurfaceId local_surf_id(LocalPositionId pos,
+                                                   LocalDirection dir)
+{
+    CELER_EXPECT(
+        pos > LocalPositionId{0}
+        || (pos == LocalPositionId{0} && dir == LocalDirection::forward));
+    return id_cast<LocalSurfaceId>(static_cast<int>(pos.unchecked_get())
+                                   + static_cast<int>(dir) - 1);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get the next track surface position in the given direction.
  *
  * Type-safe operation to ensure direction is only added in track-local frames.
  * Uses unsigned underflow when moving reverse (dir = -1) while on a
  * pre-surface (pos = 0) to wrap to an invalid position value.
  */
-CELER_FORCEINLINE_FUNCTION SurfaceTrackPosition
-next_subsurface_position(SurfaceTrackPosition pos, SubsurfaceDirection dir)
+inline CELER_FUNCTION LocalPositionId next_local_pos_id(LocalPositionId pos,
+                                                        LocalDirection dir)
 {
     CELER_EXPECT(pos);
-    return SurfaceTrackPosition{
-        pos.unchecked_get()
-        + static_cast<SurfaceTrackPosition::size_type>(to_signed_offset(dir))};
+    return id_cast<LocalPositionId>(pos.unchecked_get()
+                                    + to_signed_offset(dir));
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Calculate subsurface direction from a track's geometry direction.
  */
-inline CELER_FUNCTION SubsurfaceDirection
+inline CELER_FUNCTION LocalDirection
 calc_subsurface_direction(Real3 const& geo_dir, Real3 const& normal)
 {
-    return static_cast<SubsurfaceDirection>(
-        is_entering_surface(geo_dir, normal));
+    return static_cast<LocalDirection>(is_entering_surface(geo_dir, normal));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/SurfacePhysicsView.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsView.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "celeritas/Types.hh"
 #include "celeritas/optical/Types.hh"
 
 #include "SurfacePhysicsData.hh"
@@ -17,11 +18,60 @@ namespace optical
 {
 //---------------------------------------------------------------------------//
 /*!
- * Optical surface physics data.
+ * Access physics data for a local surface based on traversal orientation.
  *
- * Maps surface track position to interstitial optical material and interface
- * data for a given optical surface. The optical surface may be oriented
- * (forward or reverse) relative to its layout in the data record.
+ * "Local" surfaces, which are boundaries between layers on a geometric
+ * surface, are ordered in storage between two volumes based on user input.
+ * These layers can be traversed based on the \c orientation, whether the track
+ * entered the surface crossing in \c forward order (e.g., \em out of the
+ * volume defining a boundary surface) or \c reverse (e.g., \em into that
+ * volume).
+ *
+ * The surface physics record only stores the behavior on the surfaces and
+ * interstitial materials. Because one geometric surface can be surrounded by
+ * different pairs of pre/post materials (due to the physical volume
+ * adjacency), it \em cannot store the pre- and post-crossing materials.
+ * Those are managed by the \c SurfacePhysicsTrackView which has extra state.
+ *
+ * A single geometric surface with \em N interstitial layers will have
+ * \f$ N + 2 \f$ "local materials" and \f$ N + 1 \f$ "local surfaces".
+ * Most geometric surfaces have no interstial layers, just a pre- and post-
+ * volume material with a single surface, and therefore have two local material
+ * regions surrounding a single local surface.
+ *
+ * During crossing \c LocalSurfaceId{0} separates the pre-volume material (\c
+ * LocalPositionId{0} ) and the next.
+ * Physics surface IDs are contiguous <em>by construction</em>
+ * in the surface physics loader and optical physics input.
+ *
+ * \par Example traversal
+ *
+ * This surface record has two interstitial materials, implying three surfaces
+ * and a total of four materials during the crossing.
+ * The IDs and corresponding physics data, when traversing in the forward
+ * direction, are:
+ * \verbatim
+  local surface ID        :       LS0   LS1    LS2
+  local material ID       :  LM0   | LM1 | LM2  |  LM3
+  interstitial materials  : (pre)  | IM0 | IM1  | (post)
+  optical materials       :  ----  | A   | B    | ----
+  physics surfaces        :        | X   | X+1  |
+  \endverbatim
+ * Only the two interstitial materials' optical material IDs can be accessed by
+ * the view.
+ * The orientation of the local surfaces and interstitial materials align
+ * with the \c SurfacePhysicsRecord storage \em only in the \c forward
+ * orientation.
+ * When traversing in \c reverse  orientation, the data layout stays the same
+ * but the IDs are still relative to the pre/post volumes:
+ * \verbatim
+  local surface ID        :       LS2   LS1    LS0
+  local material ID       :  LM3   | LM2 | LM1  |  LM0
+  interstitial materials  : (post) | IM1 | IM0  | (pre)
+  optical materials       :  ----  | A   | B    | ----
+  physics surfaces        :        | X   | X+1  |
+  \endverbatim
+ *
  */
 class SurfacePhysicsView
 {
@@ -34,34 +84,28 @@ class SurfacePhysicsView
   public:
     // Construct view from data and state
     inline CELER_FUNCTION
-    SurfacePhysicsView(SurfaceParamsRef const&, SurfaceId, SubsurfaceDirection);
+    SurfacePhysicsView(SurfaceParamsRef const&, SurfaceId, LocalDirection);
 
-    // Get current surface ID
-    inline CELER_FUNCTION SurfaceId surface() const;
+    //! Get geometric surface ID the track is currently on
+    CELER_FIF SurfaceId surface() const { return surface_; }
 
-    // Get surface orientation
-    inline CELER_FUNCTION SubsurfaceDirection orientation() const;
+    //! Get traversal orientation on the current surface
+    CELER_FIF LocalDirection orientation() const { return orientation_; }
 
-    // Get optical interstitial material at the given track position
-    inline CELER_FUNCTION
-        OptMatId interstitial_material(SurfaceTrackPosition) const;
+    // Get optical pre/interstitial/post material at the given track position
+    inline CELER_FUNCTION OptMatId interstitial_material(LocalPositionId) const;
 
     // Get the physics surface at the given position and direction
-    inline CELER_FUNCTION PhysSurfaceId interface(SurfaceTrackPosition,
-                                                  SubsurfaceDirection) const;
+    inline CELER_FUNCTION
+        PhysSurfaceId interface(LocalPositionId, LocalDirection) const;
 
   private:
     SurfaceParamsRef const& params_;
     SurfaceId surface_;
-    SubsurfaceDirection orientation_;
+    LocalDirection orientation_;
 
     // Get record data for the current surface
-    inline CELER_FUNCTION SurfaceRecord const& surface_record() const;
-
-    // Index a map along a given orientation
-    template<class T>
-    inline CELER_FUNCTION T oriented_map(ItemMap<SurfaceTrackPosition, T> const&,
-                                         SurfaceTrackPosition) const;
+    inline CELER_FUNCTION SurfacePhysicsRecord const& surface_record() const;
 };
 
 //---------------------------------------------------------------------------//
@@ -73,7 +117,7 @@ class SurfacePhysicsView
 CELER_FUNCTION
 SurfacePhysicsView::SurfacePhysicsView(SurfaceParamsRef const& params,
                                        SurfaceId surface,
-                                       SubsurfaceDirection orientation)
+                                       LocalDirection orientation)
     : params_(params), surface_(surface), orientation_(orientation)
 {
     CELER_EXPECT(surface_ < params_.surfaces.size());
@@ -81,99 +125,62 @@ SurfacePhysicsView::SurfacePhysicsView(SurfaceParamsRef const& params,
 
 //---------------------------------------------------------------------------//
 /*!
- * Get geometric surface ID the track is currently on.
- *
- * The ID is invalid if the track is not undergoing a boundary crossing.
- */
-CELER_FUNCTION SurfaceId SurfacePhysicsView::surface() const
-{
-    return surface_;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get traversal orientation of the current surface.
- *
- * Subsurfaces are ordered in storage between two volumes. This orientation
- * specifies if the track is traversing the stored list of sub-surfaces in
- * forward or reverse order.
- */
-CELER_FUNCTION SubsurfaceDirection SurfacePhysicsView::orientation() const
-{
-    return orientation_;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Return the interstitial material ID of the given track position.
+ * Return the interstitial material ID at the given track position.
  *
  * Position should be in the range [1,N] where N is the number of subsurface
  * materials.
  */
 CELER_FUNCTION OptMatId
-SurfacePhysicsView::interstitial_material(SurfaceTrackPosition pos) const
+SurfacePhysicsView::interstitial_material(LocalPositionId pos) const
 {
-    CELER_EXPECT(pos > SurfaceTrackPosition{0});
+    auto const& ids = this->surface_record().interstitial_mat_ids;
+    CELER_EXPECT(pos > LocalPositionId{0} && pos <= ids.size());
 
     // Position 0 is pre-volume material, and N+1 is post-volume material.
     // Offset position so it maps to the interstitial material range.
-    --pos;
-    CELER_ASSERT(pos < this->surface_record().subsurface_materials.size());
+    LocalPositionId::size_type interstit_idx = pos.unchecked_get();
+    if (orientation_ == LocalDirection::reverse)
+    {
+        interstit_idx = ids.size() - interstit_idx;
+    }
+    else
+    {
+        --interstit_idx;
+    }
 
-    auto material_record_id
-        = this->oriented_map(this->surface_record().subsurface_materials, pos);
-    CELER_ASSERT(material_record_id < params_.subsurface_materials.size());
-
-    return params_.subsurface_materials[material_record_id];
+    ItemId<OptMatId> opt_mat_id_id = ids[interstit_idx];
+    CELER_ASSERT(opt_mat_id_id < params_.opt_mat_ids.size());
+    return params_.opt_mat_ids[opt_mat_id_id];
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Return the subsurface interface ID of the given track position and
- * direction.
+ * Return the next physics surface at the given position along the direction.
  */
-CELER_FUNCTION PhysSurfaceId SurfacePhysicsView::interface(
-    SurfaceTrackPosition pos, SubsurfaceDirection d) const
+CELER_FUNCTION PhysSurfaceId
+SurfacePhysicsView::interface(LocalPositionId pos, LocalDirection dir) const
 {
-    CELER_EXPECT(pos);
+    auto const& ids = this->surface_record().local_surface_ids;
+    CELER_EXPECT(pos >= LocalPositionId{0} && pos < ids.size());
 
-    auto interface_pos = SurfaceTrackPosition{
-        pos.unchecked_get()
-        + static_cast<SurfaceTrackPosition::size_type>(
-            d == SubsurfaceDirection::reverse ? -1 : 0)};
-
-    CELER_ASSERT(interface_pos
-                 < this->surface_record().subsurface_interfaces.size());
-
-    return oriented_map(this->surface_record().subsurface_interfaces,
-                        interface_pos);
+    auto local_surf = local_surf_id(pos, dir);
+    if (orientation_ == LocalDirection::reverse)
+    {
+        local_surf
+            = id_cast<LocalSurfaceId>(ids.size() - local_surf.unchecked_get());
+    }
+    CELER_ENSURE(local_surf < ids.size());
+    return ids[local_surf];
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Get surface record of current geometric surface.
  */
-CELER_FUNCTION SurfaceRecord const& SurfacePhysicsView::surface_record() const
+CELER_FUNCTION SurfacePhysicsRecord const&
+SurfacePhysicsView::surface_record() const
 {
     return params_.surfaces[this->surface()];
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Index an \c ItemMap along the surface's orientation.
- */
-template<class T>
-CELER_FUNCTION T SurfacePhysicsView::oriented_map(
-    ItemMap<SurfaceTrackPosition, T> const& map, SurfaceTrackPosition pos) const
-{
-    CELER_EXPECT(pos < map.size());
-
-    auto index
-        = orientation_ == SubsurfaceDirection::reverse
-              ? SurfaceTrackPosition{map.size() - 1 - pos.unchecked_get()}
-              : pos;
-
-    return map[index];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/SurfacePhysicsView.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsView.hh
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file celeritas/optical/surface/SurfacePhysicsView.hh
+//! \sa celeritas/optical/SurfacePhysics.test.cc
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -161,14 +162,16 @@ CELER_FUNCTION PhysSurfaceId
 SurfacePhysicsView::interface(LocalPositionId pos, LocalDirection dir) const
 {
     auto const& ids = this->surface_record().local_surface_ids;
-    CELER_EXPECT(pos >= LocalPositionId{0} && pos < ids.size());
+    CELER_EXPECT(pos >= LocalPositionId{0} && pos <= ids.size());
 
     auto local_surf = local_surf_id(pos, dir);
     if (orientation_ == LocalDirection::reverse)
     {
-        local_surf
-            = id_cast<LocalSurfaceId>(ids.size() - local_surf.unchecked_get());
+        // Reverse index in ids: 0 -> N-1; 1 -> N-2; ...
+        local_surf = id_cast<LocalSurfaceId>(ids.size() - 1
+                                             - local_surf.unchecked_get());
     }
+
     CELER_ENSURE(local_surf < ids.size());
     return ids[local_surf];
 }

--- a/src/celeritas/optical/surface/SurfaceTraversalView.hh
+++ b/src/celeritas/optical/surface/SurfaceTraversalView.hh
@@ -20,7 +20,11 @@ namespace optical
 /*!
  * Manage one-dimensional logic for traversing an optical surface.
  *
- * \todo Add documentation and diagram
+ * During surface crossing, tracks maintain a "within-surface state" that
+ * stores the current layer and direction, decoupling the geometry state from
+ * the material state.
+ *
+ * See \c SurfacePhysicsView for documentation.
  */
 class SurfaceTraversalView
 {
@@ -54,28 +58,28 @@ class SurfaceTraversalView
     inline CELER_FUNCTION bool is_exiting() const;
 
     // Whether track is in pre-/post-volume and direction is off the surface
-    inline CELER_FUNCTION bool is_exiting(SubsurfaceDirection) const;
+    inline CELER_FUNCTION bool is_exiting(LocalDirection) const;
 
     // Position of the track in the surface crossing
-    inline CELER_FUNCTION SurfaceTrackPosition pos() const;
+    inline CELER_FUNCTION LocalPositionId pos() const;
 
     // Next pos of the track in the given direction
-    inline CELER_FUNCTION SurfaceTrackPosition next_pos() const;
+    inline CELER_FUNCTION LocalPositionId next_pos() const;
 
     // Set position of the track in the surface crossing
-    inline CELER_FUNCTION void pos(SurfaceTrackPosition);
+    inline CELER_FUNCTION void pos(LocalPositionId);
 
     // Number of valid positions of the track in the surface crossing
-    inline CELER_FUNCTION SurfaceTrackPosition::size_type num_positions() const;
+    inline CELER_FUNCTION LocalSurfaceId::size_type num_local_pos() const;
 
     // Current track traversal direction
-    inline CELER_FUNCTION SubsurfaceDirection dir() const;
+    inline CELER_FUNCTION LocalDirection dir() const;
 
     // Set track traversal direction
-    inline CELER_FUNCTION void dir(SubsurfaceDirection);
+    inline CELER_FUNCTION void dir(LocalDirection);
 
     // Cross subsurface interface in the given direction
-    inline CELER_FUNCTION void cross_interface(SubsurfaceDirection);
+    inline CELER_FUNCTION void cross_interface(LocalDirection);
 
   private:
     SurfaceParamsRef const& params_;
@@ -106,8 +110,8 @@ SurfaceTraversalView::SurfaceTraversalView(SurfaceParamsRef const& params,
 CELER_FUNCTION SurfaceTraversalView&
 SurfaceTraversalView::operator=(Initializer const&)
 {
-    states_.surface_position[track_id_] = SurfaceTrackPosition{0};
-    states_.track_direction[track_id_] = SubsurfaceDirection::forward;
+    states_.local_position[track_id_] = LocalPositionId{0};
+    states_.local_direction[track_id_] = LocalDirection::forward;
     return *this;
 }
 
@@ -126,7 +130,7 @@ CELER_FUNCTION bool SurfaceTraversalView::in_pre_volume() const
  */
 CELER_FUNCTION bool SurfaceTraversalView::in_post_volume() const
 {
-    return this->pos().get() + 1 == this->num_positions();
+    return this->pos().get() + 1 == this->num_local_pos();
 }
 
 //---------------------------------------------------------------------------//
@@ -142,13 +146,12 @@ CELER_FUNCTION bool SurfaceTraversalView::is_exiting() const
 /*!
  * Whether the direction is exiting the surface.
  */
-CELER_FUNCTION bool
-SurfaceTraversalView::is_exiting(SubsurfaceDirection d) const
+CELER_FUNCTION bool SurfaceTraversalView::is_exiting(LocalDirection d) const
 {
     // Use unsigned underflow when moving reverse (-1) on the pre-surface
     // (position 0) to wrap to an invalid position value
-    return next_subsurface_position(this->pos(), d).unchecked_get()
-           >= this->num_positions();
+    return next_local_pos_id(this->pos(), d).unchecked_get()
+           >= this->num_local_pos();
 }
 
 //---------------------------------------------------------------------------//
@@ -160,17 +163,17 @@ SurfaceTraversalView::is_exiting(SubsurfaceDirection d) const
  * pre-volume and N is the post-volume. Depending on the surface orientation,
  * this will be mapped to the appropriate sub-surface material and interface.
  */
-CELER_FUNCTION SurfaceTrackPosition SurfaceTraversalView::pos() const
+CELER_FUNCTION LocalPositionId SurfaceTraversalView::pos() const
 {
-    return states_.surface_position[track_id_];
+    return states_.local_position[track_id_];
 }
 
 //---------------------------------------------------------------------------//
 /*!
  */
-CELER_FUNCTION SurfaceTrackPosition SurfaceTraversalView::next_pos() const
+CELER_FUNCTION LocalPositionId SurfaceTraversalView::next_pos() const
 {
-    return next_subsurface_position(this->pos(), this->dir());
+    return next_local_pos_id(this->pos(), this->dir());
 }
 
 //---------------------------------------------------------------------------//
@@ -178,10 +181,10 @@ CELER_FUNCTION SurfaceTrackPosition SurfaceTraversalView::next_pos() const
  * Set current position of the track in the sub-surfaces, in track-local
  * coordinates.
  */
-CELER_FUNCTION void SurfaceTraversalView::pos(SurfaceTrackPosition pos)
+CELER_FUNCTION void SurfaceTraversalView::pos(LocalPositionId pos)
 {
-    CELER_EXPECT(pos < this->num_positions());
-    states_.surface_position[track_id_] = pos;
+    CELER_EXPECT(pos < this->num_local_pos());
+    states_.local_position[track_id_] = pos;
 }
 
 //---------------------------------------------------------------------------//
@@ -193,12 +196,11 @@ CELER_FUNCTION void SurfaceTraversalView::pos(SurfaceTrackPosition pos)
  *
  * \todo Check if caching this would improve performance over redirections.
  */
-CELER_FUNCTION SurfaceTrackPosition::size_type
-SurfaceTraversalView::num_positions() const
+CELER_FUNCTION LocalSurfaceId::size_type
+SurfaceTraversalView::num_local_pos() const
 {
-    return params_.surfaces[states_.surface[track_id_]]
-               .subsurface_materials.size()
-           + 2;
+    auto const& surface = params_.surfaces[states_.surface[track_id_]];
+    return surface.interstitial_mat_ids.size() + 2;
 }
 
 //---------------------------------------------------------------------------//
@@ -209,28 +211,28 @@ SurfaceTraversalView::num_positions() const
  * avoid repeated queries of the geometry. The traversal direction should be
  * updated when the geometry direction is updated after an interaction.
  */
-CELER_FUNCTION SubsurfaceDirection SurfaceTraversalView::dir() const
+CELER_FUNCTION LocalDirection SurfaceTraversalView::dir() const
 {
-    return states_.track_direction[track_id_];
+    return states_.local_direction[track_id_];
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Set current track traversal direction.
  */
-CELER_FUNCTION void SurfaceTraversalView::dir(SubsurfaceDirection dir)
+CELER_FUNCTION void SurfaceTraversalView::dir(LocalDirection dir)
 {
-    states_.track_direction[track_id_] = dir;
+    states_.local_direction[track_id_] = dir;
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Cross the subsurface interface in the given direction.
  */
-CELER_FUNCTION void SurfaceTraversalView::cross_interface(SubsurfaceDirection d)
+CELER_FUNCTION void SurfaceTraversalView::cross_interface(LocalDirection d)
 {
     CELER_EXPECT(!this->is_exiting(d));
-    this->pos(next_subsurface_position(this->pos(), d));
+    this->pos(next_local_pos_id(this->pos(), d));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/VolumeSurfaceSelector.hh
+++ b/src/celeritas/optical/surface/VolumeSurfaceSelector.hh
@@ -43,7 +43,7 @@ class VolumeSurfaceSelector
     struct OrientedSurface
     {
         SurfaceId surface{};
-        SubsurfaceDirection orientation;
+        LocalDirection orientation;
 
         explicit CELER_FUNCTION operator bool() const
         {
@@ -96,18 +96,18 @@ VolumeSurfaceSelector::operator()(VolumeSurfaceView const& post_surface,
     if (auto surface_id
         = pre_surface_.find_interface(pre_volume_inst_, post_volume_inst))
     {
-        return {surface_id, SubsurfaceDirection::forward};
+        return {surface_id, LocalDirection::forward};
     }
 
     // L0 boundary surface in forward direction
     if (auto surface_id = pre_surface_.boundary_id())
     {
-        return {surface_id, SubsurfaceDirection::forward};
+        return {surface_id, LocalDirection::forward};
     }
 
     // Return the L1 boundary surface from the opposite direction.
     // If no boundary surface exists, an invalid OrientedSurface is returned.
-    return {post_surface.boundary_id(), SubsurfaceDirection::reverse};
+    return {post_surface.boundary_id(), LocalDirection::reverse};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
+++ b/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
@@ -83,7 +83,7 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
     {
         // Use default surface properties: typically dielectric-dielectric
         oriented_surface.surface = surface_physics.scalars().default_surface;
-        oriented_surface.orientation = SubsurfaceDirection::forward;
+        oriented_surface.orientation = LocalDirection::forward;
     }
 
     // Enforce surface normal convention, swapping normal if geometry returns

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -199,6 +199,7 @@ class ItemMap
     //! \name Type aliases
     using key_type = T1;
     using mapped_type = T2;
+    using size_type = typename T1::size_type;
     //!@}
 
   public:

--- a/test/celeritas/optical/SurfacePhysics.test.cc
+++ b/test/celeritas/optical/SurfacePhysics.test.cc
@@ -235,17 +235,17 @@ TEST_F(SurfacePhysicsTest, init_params)
 
         auto& surface = surfaces[geo_surface.get()];
 
-        for (auto i :
-             range(LocalSurfaceId{surface_record.local_surface_ids.size()}))
+        // Add all interstitial materials
+        for (auto i : range(surface_record.interstitial_mat_ids.size()))
         {
             surface.materials.push_back(
-                data.local_surface_ids[surface_record.local_surface_ids[i]]);
+                data.opt_mat_ids[surface_record.interstitial_mat_ids[i]]);
         }
 
         for (auto i :
-             range(LocalSurfaceId{surface_record.subsurface_interfaces.size()}))
+             range(LocalSurfaceId{surface_record.local_surface_ids.size()}))
         {
-            auto phys_surface = surface_record.subsurface_interfaces[i];
+            auto phys_surface = surface_record.local_surface_ids[i];
             surface.interfaces.push_back(phys_surface);
 
             for (auto step : range(SurfacePhysicsOrder::size_))
@@ -430,7 +430,7 @@ TEST_F(SurfacePhysicsTest, init_surface_physics_view)
     {
         auto s_physics = this->surface_physics_view(track);
         s_physics.traversal().pos(
-            LocalSurfaceId(s_physics.traversal().num_local_pos() - 1));
+            LocalPositionId(s_physics.traversal().num_local_pos() - 1));
 
         EXPECT_TRUE(s_physics.is_crossing_boundary());
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
@@ -440,14 +440,14 @@ TEST_F(SurfacePhysicsTest, init_surface_physics_view)
     }
 
     // Check some intermediate positions
-    std::vector<LocalSurfaceId> expected_intermediate_positions{
-        LocalSurfaceId{2},
-        LocalSurfaceId{1},
-        LocalSurfaceId{},
-        LocalSurfaceId{},
-        LocalSurfaceId{3},
-        LocalSurfaceId{1},
-        LocalSurfaceId{1},
+    std::vector<LocalPositionId> expected_intermediate_positions{
+        LocalPositionId{2},
+        LocalPositionId{1},
+        LocalPositionId{},
+        LocalPositionId{},
+        LocalPositionId{3},
+        LocalPositionId{1},
+        LocalPositionId{1},
     };
 
     for (auto track : range(TrackSlotId(expected_surfaces.size())))
@@ -502,7 +502,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
         EXPECT_TRUE(s_physics.traversal().in_post_volume());
 
-        TraceResult expected{as_id_vec<LocalSurfaceId>(0, 1),
+        TraceResult expected{as_id_vec<LocalPositionId>(0, 1),
                              {
                                  as_id_vec<SurfaceModelId>(0),
                                  as_id_vec<SurfaceModelId>(1),
@@ -557,7 +557,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
         EXPECT_TRUE(s_physics.traversal().in_post_volume());
 
-        TraceResult expected{as_id_vec<LocalSurfaceId>(0, 1),
+        TraceResult expected{as_id_vec<LocalPositionId>(0, 1),
                              {
                                  as_id_vec<SurfaceModelId>(0),
                                  as_id_vec<SurfaceModelId>(1),
@@ -622,7 +622,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_post_volume());
 
         TraceResult expected{
-            as_id_vec<LocalSurfaceId>(0, 1, 2, 1, 2, 3, 4, 3, 2, 1, 0),
+            as_id_vec<LocalPositionId>(0, 1, 2, 1, 2, 3, 4, 3, 2, 1, 0),
             {
                 as_id_vec<SurfaceModelId>(0, 0, 0, 0, 1, 2, 2, 1, 0, 0),
                 as_id_vec<SurfaceModelId>(0, 1, 1, 1, 0, 1, 1, 0, 1, 0),
@@ -682,7 +682,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
         EXPECT_TRUE(s_physics.traversal().in_post_volume());
 
-        TraceResult expected{as_id_vec<LocalSurfaceId>(0, 1, 2, 1, 0, 1, 2),
+        TraceResult expected{as_id_vec<LocalPositionId>(0, 1, 2, 1, 0, 1, 2),
                              {
                                  as_id_vec<SurfaceModelId>(1, 2, 2, 1, 1, 2),
                                  as_id_vec<SurfaceModelId>(0, 1, 1, 0, 0, 1),

--- a/test/celeritas/optical/SurfacePhysics.test.cc
+++ b/test/celeritas/optical/SurfacePhysics.test.cc
@@ -14,6 +14,7 @@
 #include "corecel/cont/VariantUtils.hh"
 #include "corecel/data/StateDataStore.hh"
 #include "celeritas/inp/OpticalPhysics.hh"
+#include "celeritas/optical/Types.hh"
 #include "celeritas/optical/surface/SurfacePhysicsParams.hh"
 #include "celeritas/optical/surface/SurfacePhysicsTrackView.hh"
 
@@ -25,14 +26,14 @@ namespace celeritas
 namespace optical
 {
 
-std::ostream& operator<<(std::ostream& out, SubsurfaceDirection const& d)
+std::ostream& operator<<(std::ostream& out, LocalDirection const& d)
 {
     switch (d)
     {
-        case SubsurfaceDirection::forward:
+        case LocalDirection::forward:
             out << "forward";
             break;
-        case SubsurfaceDirection::reverse:
+        case LocalDirection::reverse:
             out << "reverse";
             break;
         default:
@@ -48,8 +49,8 @@ using namespace ::celeritas::test;
 template<class T>
 using SurfaceOrderArray = EnumArray<SurfacePhysicsOrder, T>;
 
-auto constexpr forward = SubsurfaceDirection::forward;
-auto constexpr reverse = SubsurfaceDirection::reverse;
+auto constexpr forward = LocalDirection::forward;
+auto constexpr reverse = LocalDirection::reverse;
 
 //---------------------------------------------------------------------------//
 // TEST HARNESS
@@ -71,7 +72,7 @@ struct SurfaceResult
 
 struct TraceResult
 {
-    std::vector<SurfaceTrackPosition> position{};
+    std::vector<LocalPositionId> position{};
 
     SurfaceOrderArray<std::vector<SurfaceModelId>> models;
     SurfaceOrderArray<std::vector<SubModelId>> per_model_ids;
@@ -80,7 +81,7 @@ struct TraceResult
 };
 
 TraceResult trace_directions(SurfacePhysicsTrackView& s_physics,
-                             std::vector<SubsurfaceDirection> const& directions)
+                             std::vector<LocalDirection> const& directions)
 {
     TraceResult result;
 
@@ -234,15 +235,15 @@ TEST_F(SurfacePhysicsTest, init_params)
 
         auto& surface = surfaces[geo_surface.get()];
 
-        for (auto i : range(SurfaceTrackPosition{
-                 surface_record.subsurface_materials.size()}))
+        for (auto i :
+             range(LocalSurfaceId{surface_record.local_surface_ids.size()}))
         {
             surface.materials.push_back(
-                data.subsurface_materials[surface_record.subsurface_materials[i]]);
+                data.local_surface_ids[surface_record.local_surface_ids[i]]);
         }
 
-        for (auto i : range(SurfaceTrackPosition{
-                 surface_record.subsurface_interfaces.size()}))
+        for (auto i :
+             range(LocalSurfaceId{surface_record.subsurface_interfaces.size()}))
         {
             auto phys_surface = surface_record.subsurface_interfaces[i];
             surface.interfaces.push_back(phys_surface);
@@ -377,7 +378,7 @@ TEST_F(SurfacePhysicsTest, init_params)
 TEST_F(SurfacePhysicsTest, init_surface_physics_view)
 {
     auto expected_surfaces = as_id_vec<SurfaceId>(0, 1, 2, 2, 0, 1, 0);
-    std::vector<SubsurfaceDirection> expected_orientations{
+    std::vector<LocalDirection> expected_orientations{
         forward,
         forward,
         forward,
@@ -386,7 +387,7 @@ TEST_F(SurfacePhysicsTest, init_surface_physics_view)
         reverse,
         forward,
     };
-    std::vector<size_type> expected_num_positions{5, 3, 2, 2, 5, 3, 5};
+    std::vector<size_type> expected_num_local_mats{5, 3, 2, 2, 5, 3, 5};
 
     auto params = this->optical_surface_physics();
     this->initialize_states(expected_surfaces.size());
@@ -404,15 +405,15 @@ TEST_F(SurfacePhysicsTest, init_surface_physics_view)
 
     // Check initialization
     std::vector<SurfaceId> surfaces;
-    std::vector<SubsurfaceDirection> orientations;
-    std::vector<size_type> num_positions;
+    std::vector<LocalDirection> orientations;
+    std::vector<size_type> num_local_mats;
     for (auto track : range(TrackSlotId(expected_surfaces.size())))
     {
         auto s_physics = this->surface_physics_view(track);
 
         surfaces.push_back(s_physics.surface().surface());
         orientations.push_back(s_physics.surface().orientation());
-        num_positions.push_back(s_physics.traversal().num_positions());
+        num_local_mats.push_back(s_physics.traversal().num_local_pos());
 
         EXPECT_TRUE(s_physics.is_crossing_boundary());
         EXPECT_TRUE(s_physics.traversal().in_pre_volume());
@@ -422,31 +423,31 @@ TEST_F(SurfacePhysicsTest, init_surface_physics_view)
 
     EXPECT_VEC_EQ(expected_surfaces, surfaces);
     EXPECT_VEC_EQ(expected_orientations, orientations);
-    EXPECT_VEC_EQ(expected_num_positions, num_positions);
+    EXPECT_VEC_EQ(expected_num_local_mats, num_local_mats);
 
     // Check position in post-volume
     for (auto track : range(TrackSlotId(expected_surfaces.size())))
     {
         auto s_physics = this->surface_physics_view(track);
         s_physics.traversal().pos(
-            SurfaceTrackPosition(s_physics.traversal().num_positions() - 1));
+            LocalSurfaceId(s_physics.traversal().num_local_pos() - 1));
 
         EXPECT_TRUE(s_physics.is_crossing_boundary());
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
         EXPECT_TRUE(s_physics.traversal().in_post_volume());
-        EXPECT_EQ(expected_num_positions[track.get()] - 1,
+        EXPECT_EQ(expected_num_local_mats[track.get()] - 1,
                   s_physics.traversal().pos().get());
     }
 
     // Check some intermediate positions
-    std::vector<SurfaceTrackPosition> expected_intermediate_positions{
-        SurfaceTrackPosition{2},
-        SurfaceTrackPosition{1},
-        SurfaceTrackPosition{},
-        SurfaceTrackPosition{},
-        SurfaceTrackPosition{3},
-        SurfaceTrackPosition{1},
-        SurfaceTrackPosition{1},
+    std::vector<LocalSurfaceId> expected_intermediate_positions{
+        LocalSurfaceId{2},
+        LocalSurfaceId{1},
+        LocalSurfaceId{},
+        LocalSurfaceId{},
+        LocalSurfaceId{3},
+        LocalSurfaceId{1},
+        LocalSurfaceId{1},
     };
 
     for (auto track : range(TrackSlotId(expected_surfaces.size())))
@@ -483,7 +484,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
     {
         // Geometric surface 2 (forward): A | B
         // Path: A -> B
-        std::vector<SubsurfaceDirection> directions{
+        std::vector<LocalDirection> directions{
             forward,
         };
 
@@ -501,7 +502,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
         EXPECT_TRUE(s_physics.traversal().in_post_volume());
 
-        TraceResult expected{as_id_vec<SurfaceTrackPosition>(0, 1),
+        TraceResult expected{as_id_vec<LocalSurfaceId>(0, 1),
                              {
                                  as_id_vec<SurfaceModelId>(0),
                                  as_id_vec<SurfaceModelId>(1),
@@ -538,7 +539,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
     {
         // Geometric surface 2 (reverse): B | A
         // Path: B -> A
-        std::vector<SubsurfaceDirection> directions{
+        std::vector<LocalDirection> directions{
             forward,
         };
 
@@ -556,7 +557,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
         EXPECT_TRUE(s_physics.traversal().in_post_volume());
 
-        TraceResult expected{as_id_vec<SurfaceTrackPosition>(0, 1),
+        TraceResult expected{as_id_vec<LocalSurfaceId>(0, 1),
                              {
                                  as_id_vec<SurfaceModelId>(0),
                                  as_id_vec<SurfaceModelId>(1),
@@ -593,7 +594,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
     {
         // Geometric surface 0 (forward): A | D | B' | C | B
         // Path: A -> D -> B' -> D -> B' -> C -> B -> C -> B' -> D -> A
-        std::vector<SubsurfaceDirection> directions{
+        std::vector<LocalDirection> directions{
             forward,
             forward,
             reverse,
@@ -621,7 +622,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_post_volume());
 
         TraceResult expected{
-            as_id_vec<SurfaceTrackPosition>(0, 1, 2, 1, 2, 3, 4, 3, 2, 1, 0),
+            as_id_vec<LocalSurfaceId>(0, 1, 2, 1, 2, 3, 4, 3, 2, 1, 0),
             {
                 as_id_vec<SurfaceModelId>(0, 0, 0, 0, 1, 2, 2, 1, 0, 0),
                 as_id_vec<SurfaceModelId>(0, 1, 1, 1, 0, 1, 1, 0, 1, 0),
@@ -658,7 +659,7 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
     {
         // Geometric surface 1 (reverse): B | C | A
         // Path: B -> C -> A -> C -> B -> C -> A
-        std::vector<SubsurfaceDirection> directions{
+        std::vector<LocalDirection> directions{
             forward,
             forward,
             reverse,
@@ -681,28 +682,27 @@ TEST_F(SurfacePhysicsTest, traverse_subsurface)
         EXPECT_FALSE(s_physics.traversal().in_pre_volume());
         EXPECT_TRUE(s_physics.traversal().in_post_volume());
 
-        TraceResult expected{
-            as_id_vec<SurfaceTrackPosition>(0, 1, 2, 1, 0, 1, 2),
-            {
-                as_id_vec<SurfaceModelId>(1, 2, 2, 1, 1, 2),
-                as_id_vec<SurfaceModelId>(0, 1, 1, 0, 0, 1),
-                as_id_vec<SurfaceModelId>(0, 0, 0, 0, 0, 0),
-            },
-            {
-                as_id_vec<SubModelId>(1, 1, 1, 1, 1, 1),
-                as_id_vec<SubModelId>(2, 2, 2, 2, 2, 2),
-                as_id_vec<SubModelId>(5, 4, 4, 5, 5, 4),
-            },
-            {
-                as_id_vec<OptMatId>(1, 2, 0, 2, 1, 2),
-                as_id_vec<OptMatId>(1, 2, 0, 2, 1, 2),
-                as_id_vec<OptMatId>(1, 2, 0, 2, 1, 2),
-            },
-            {
-                as_id_vec<OptMatId>(2, 0, 2, 1, 2, 0),
-                as_id_vec<OptMatId>(2, 0, 2, 1, 2, 0),
-                as_id_vec<OptMatId>(2, 0, 2, 1, 2, 0),
-            }};
+        TraceResult expected{as_id_vec<LocalSurfaceId>(0, 1, 2, 1, 0, 1, 2),
+                             {
+                                 as_id_vec<SurfaceModelId>(1, 2, 2, 1, 1, 2),
+                                 as_id_vec<SurfaceModelId>(0, 1, 1, 0, 0, 1),
+                                 as_id_vec<SurfaceModelId>(0, 0, 0, 0, 0, 0),
+                             },
+                             {
+                                 as_id_vec<SubModelId>(1, 1, 1, 1, 1, 1),
+                                 as_id_vec<SubModelId>(2, 2, 2, 2, 2, 2),
+                                 as_id_vec<SubModelId>(5, 4, 4, 5, 5, 4),
+                             },
+                             {
+                                 as_id_vec<OptMatId>(1, 2, 0, 2, 1, 2),
+                                 as_id_vec<OptMatId>(1, 2, 0, 2, 1, 2),
+                                 as_id_vec<OptMatId>(1, 2, 0, 2, 1, 2),
+                             },
+                             {
+                                 as_id_vec<OptMatId>(2, 0, 2, 1, 2, 0),
+                                 as_id_vec<OptMatId>(2, 0, 2, 1, 2, 0),
+                                 as_id_vec<OptMatId>(2, 0, 2, 1, 2, 0),
+                             }};
 
         EXPECT_VEC_EQ(expected.position, result.position);
         for (auto step : range(SurfacePhysicsOrder::size_))
@@ -741,14 +741,14 @@ TEST_F(SurfacePhysicsTest, traversal_direction)
             make_unit_vector(Real3{1, 0, 0}),
         };
 
-        std::vector<SubsurfaceDirection> directions;
+        std::vector<LocalDirection> directions;
         for (auto const& dir : geo_directions)
         {
             s_physics.update_traversal_direction(dir);
             directions.push_back(s_physics.traversal().dir());
         }
 
-        std::vector<SubsurfaceDirection> expected_directions{
+        std::vector<LocalDirection> expected_directions{
             reverse,
             reverse,
             forward,
@@ -773,14 +773,14 @@ TEST_F(SurfacePhysicsTest, traversal_direction)
             make_unit_vector(Real3{0, 0, 1}),
         };
 
-        std::vector<SubsurfaceDirection> directions;
+        std::vector<LocalDirection> directions;
         for (auto const& dir : geo_directions)
         {
             s_physics.update_traversal_direction(dir);
             directions.push_back(s_physics.traversal().dir());
         }
 
-        std::vector<SubsurfaceDirection> expected_directions{
+        std::vector<LocalDirection> expected_directions{
             forward,
             reverse,
             forward,

--- a/test/celeritas/optical/SurfacePhysicsUtils.test.cc
+++ b/test/celeritas/optical/SurfacePhysicsUtils.test.cc
@@ -26,21 +26,47 @@ TEST(SurfacePhysicsUtilsTest, is_entering_surface)
     EXPECT_FALSE(is_entering_surface({0, 0, -1}, {0, 0, -1}));
 }
 
-TEST(SurfacePhysicsUtilsTest, next_subsurface_position)
+TEST(SurfacePhysicsUtilsTest, local_surf_id)
 {
-    using SD = SubsurfaceDirection;
+    using SD = LocalDirection;
 
-    EXPECT_EQ(SurfaceTrackPosition{2},
-              next_subsurface_position(SurfaceTrackPosition{1}, SD::forward));
-    EXPECT_EQ(SurfaceTrackPosition{0},
-              next_subsurface_position(SurfaceTrackPosition{1}, SD::reverse));
-    EXPECT_EQ(SurfaceTrackPosition{},
-              next_subsurface_position(SurfaceTrackPosition{0}, SD::reverse));
+    EXPECT_EQ(LocalSurfaceId{0},
+              local_surf_id(LocalPositionId{0}, SD::forward));
+    EXPECT_EQ(LocalSurfaceId{1},
+              local_surf_id(LocalPositionId{1}, SD::reverse));
+    EXPECT_EQ(LocalSurfaceId{2},
+              local_surf_id(LocalPositionId{1}, SD::forward));
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(local_surf_id(LocalPositionId{0}, SD::reverse),
+                     DebugError);
+        EXPECT_THROW(local_surf_id(LocalPositionId{}, SD::forward), DebugError);
+        EXPECT_THROW(local_surf_id(LocalPositionId{}, SD::reverse), DebugError);
+    }
+}
+
+TEST(SurfacePhysicsUtilsTest, next_local_mat_id)
+{
+    using SD = LocalDirection;
+
+    EXPECT_EQ(LocalPositionId{},
+              next_local_pos_id(LocalPositionId{0}, SD::reverse));
+    EXPECT_EQ(LocalPositionId{1},
+              next_local_pos_id(LocalPositionId{0}, SD::forward));
+    EXPECT_EQ(LocalPositionId{0},
+              next_local_pos_id(LocalPositionId{1}, SD::reverse));
+    EXPECT_EQ(LocalPositionId{2},
+              next_local_pos_id(LocalPositionId{1}, SD::forward));
+    if (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW(next_local_pos_id(LocalPositionId{}, SD::forward),
+                     DebugError);
+    }
 }
 
 TEST(SurfacePhysicsUtilsTest, calc_subsurface_direction)
 {
-    using SD = SubsurfaceDirection;
+    using SD = LocalDirection;
 
     EXPECT_EQ(calc_subsurface_direction({0, 0, -1}, {0, 0, 1}), SD::forward);
     EXPECT_EQ(calc_subsurface_direction({0, 0, 1}, {0, 0, 1}), SD::reverse);

--- a/test/celeritas/optical/SurfacePhysicsUtils.test.cc
+++ b/test/celeritas/optical/SurfacePhysicsUtils.test.cc
@@ -32,9 +32,9 @@ TEST(SurfacePhysicsUtilsTest, local_surf_id)
 
     EXPECT_EQ(LocalSurfaceId{0},
               local_surf_id(LocalPositionId{0}, SD::forward));
-    EXPECT_EQ(LocalSurfaceId{1},
+    EXPECT_EQ(LocalSurfaceId{0},
               local_surf_id(LocalPositionId{1}, SD::reverse));
-    EXPECT_EQ(LocalSurfaceId{2},
+    EXPECT_EQ(LocalSurfaceId{1},
               local_surf_id(LocalPositionId{1}, SD::forward));
     if (CELERITAS_DEBUG)
     {
@@ -45,7 +45,7 @@ TEST(SurfacePhysicsUtilsTest, local_surf_id)
     }
 }
 
-TEST(SurfacePhysicsUtilsTest, next_local_mat_id)
+TEST(SurfacePhysicsUtilsTest, next_local_pos_id)
 {
     using SD = LocalDirection;
 

--- a/test/celeritas/optical/VolumeSurfaceSelector.test.cc
+++ b/test/celeritas/optical/VolumeSurfaceSelector.test.cc
@@ -18,8 +18,8 @@ namespace optical
 {
 
 using OSurface = VolumeSurfaceSelector::OrientedSurface;
-constexpr auto forward = SubsurfaceDirection::forward;
-constexpr auto reverse = SubsurfaceDirection::reverse;
+constexpr auto forward = LocalDirection::forward;
+constexpr auto reverse = LocalDirection::reverse;
 
 bool operator==(OSurface const& a, OSurface const& b)
 {

--- a/test/corecel/cont/Range.test.cc
+++ b/test/corecel/cont/Range.test.cc
@@ -327,6 +327,7 @@ TEST(RangeTest, opaque_id)
     {
         Range<MatId> fr;
         EXPECT_EQ(0, fr.size());
+        EXPECT_TRUE((std::is_same_v<decltype(fr.size()), unsigned short int>));
         EXPECT_TRUE(fr.empty());
     }
     {


### PR DESCRIPTION
I was working on the optical ID refactor and hit the surprise that the "surface track position" is an opaque ID that didn't quite behave like an opaque ID. This PR is intended to reduce some of the confusion in "sub-surface" stepping by refactoring the data and IDs to behave more like IDs:
- LocalPositionId represents the pre/interstitial/post material ID
- LocalSurfaceId represents the interstitial surface ID
- LocalDirection is the -/+ sign while moving through the surface crossing.


The analogy for these names is in ORANGE where they index into elements of a record. We do the same here for a single physics surface record.

See detailed documentation in https://github.com/sethrj/celeritas/blob/9899ff12805f601c1ce9d55c73aff07c3b934861/src/celeritas/optical/surface/SurfacePhysicsView.hh#L21 .

---

I have a feeling we can, in the future, entirely remove "orientation" and the sign swapping on surface normals, and turn those IDs into true IDs (not flipping them around). When entering a surface, we *should* be able to simply initialize the position and direction in the `{position N, negative dir}` logical state and store `{forward orientation = reported geometry normal < 0}` as an additional logical state.