### PR TITLE
Make operators inline friends to improve template matching

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -249,7 +249,8 @@ set(DOXYGEN_ALIASES
 # Annotations break breathe parsing
 foreach(_var
   CELER_FUNCTION CELER_FORCEINLINE CELER_FORCEINLINE_FUNCTION CELER_CONSTEXPR_FUNCTION
-  [[maybe_unused]] CFIF_)
+  CELER_FIF CELER_CEF
+  [[maybe_unused]])
   list(APPEND DOXYGEN_PREDEFINED "${_var}=")
 endforeach()
 

--- a/src/celeritas/phys/AtomicNumber.hh
+++ b/src/celeritas/phys/AtomicNumber.hh
@@ -53,6 +53,23 @@ class AtomicNumber
     // Get the Z or A value
     inline CELER_FUNCTION int get() const;
 
+    //// FRIENDLY OPERATORS ////
+
+#define CELER_DEFINE_ATOMICNUMBER_CMP(TOKEN)                                 \
+    CELER_CEF friend bool operator TOKEN(AtomicNumber lhs, AtomicNumber rhs) \
+    {                                                                        \
+        return lhs.unchecked_get() TOKEN rhs.unchecked_get();                \
+    }
+
+    CELER_DEFINE_ATOMICNUMBER_CMP(==)
+    CELER_DEFINE_ATOMICNUMBER_CMP(!=)
+    CELER_DEFINE_ATOMICNUMBER_CMP(<)
+    CELER_DEFINE_ATOMICNUMBER_CMP(>)
+    CELER_DEFINE_ATOMICNUMBER_CMP(<=)
+    CELER_DEFINE_ATOMICNUMBER_CMP(>=)
+
+#undef CELER_DEFINE_ATOMICNUMBER_CMP
+
   private:
     int value_{0};
 };
@@ -68,25 +85,6 @@ inline CELER_FUNCTION int AtomicNumber::get() const
     CELER_ENSURE(*this);
     return value_;
 }
-
-//---------------------------------------------------------------------------//
-// COMPARATORS
-//---------------------------------------------------------------------------//
-#define CELER_DEFINE_ATOMICNUMBER_CMP(TOKEN)                       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(AtomicNumber lhs, \
-                                                 AtomicNumber rhs) \
-    {                                                              \
-        return lhs.unchecked_get() TOKEN rhs.unchecked_get();      \
-    }
-
-CELER_DEFINE_ATOMICNUMBER_CMP(==)
-CELER_DEFINE_ATOMICNUMBER_CMP(!=)
-CELER_DEFINE_ATOMICNUMBER_CMP(<)
-CELER_DEFINE_ATOMICNUMBER_CMP(>)
-CELER_DEFINE_ATOMICNUMBER_CMP(<=)
-CELER_DEFINE_ATOMICNUMBER_CMP(>=)
-
-#undef CELER_DEFINE_ATOMICNUMBER_CMP
 
 #if !CELER_DEVICE_COMPILE
 //---------------------------------------------------------------------------//

--- a/src/celeritas/phys/PDGNumber.hh
+++ b/src/celeritas/phys/PDGNumber.hh
@@ -45,6 +45,26 @@ class PDGNumber
     // Get the PDG value
     inline int get() const;
 
+    //// FRIENDLY OPERATORS ////
+
+    //! Test equality
+    constexpr friend bool operator==(PDGNumber lhs, PDGNumber rhs)
+    {
+        return lhs.unchecked_get() == rhs.unchecked_get();
+    }
+
+    //! Test inequality
+    constexpr friend bool operator!=(PDGNumber lhs, PDGNumber rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    //! Allow less-than comparison for sorting
+    constexpr friend bool operator<(PDGNumber lhs, PDGNumber rhs)
+    {
+        return lhs.unchecked_get() < rhs.unchecked_get();
+    }
+
   private:
     int value_{0};
 };
@@ -59,27 +79,6 @@ inline int PDGNumber::get() const
 {
     CELER_ENSURE(*this);
     return value_;
-}
-
-//---------------------------------------------------------------------------//
-// COMPARATORS
-//---------------------------------------------------------------------------//
-//! Test equality
-inline constexpr bool operator==(PDGNumber lhs, PDGNumber rhs)
-{
-    return lhs.unchecked_get() == rhs.unchecked_get();
-}
-
-//! Test inequality
-inline constexpr bool operator!=(PDGNumber lhs, PDGNumber rhs)
-{
-    return !(lhs == rhs);
-}
-
-//! Allow less-than comparison for sorting
-inline constexpr bool operator<(PDGNumber lhs, PDGNumber rhs)
-{
-    return lhs.unchecked_get() < rhs.unchecked_get();
 }
 
 /*!

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -222,8 +222,6 @@ class OpaqueId
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
-template<class IdT, class U>
-inline CELER_FUNCTION IdT id_cast(U value) noexcept(!CELERITAS_DEBUG);
 
 namespace detail
 {
@@ -295,11 +293,9 @@ inline constexpr bool is_opaque_id_v = detail::IsOpaqueId<T>::value;
  * <code> static_cast<FooId>(FooId{}.unchecked_get()) </code> will not work.
  */
 template<class IdT, class U>
-inline CELER_FUNCTION IdT id_cast(U value) noexcept(!CELERITAS_DEBUG)
+inline CELER_FUNCTION auto id_cast(U value) noexcept(!CELERITAS_DEBUG)
+    -> std::enable_if_t<is_opaque_id_v<IdT> && std::is_integral_v<U>, IdT>
 {
-    static_assert(is_opaque_id_v<IdT>, "target type must be an opaque ID");
-    static_assert(std::is_integral_v<U>, "source type must be an integer");
-
     return IdT{detail::id_cast_impl<typename IdT::size_type, U>(value)};
 }
 

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -220,7 +220,8 @@ class OpaqueId
 };
 
 //---------------------------------------------------------------------------//
-// FREE FUNCTIONS
+// DETAIL IMPLEMENTATION
+// (not a separate file due to living in the top level)
 //---------------------------------------------------------------------------//
 
 namespace detail
@@ -271,6 +272,29 @@ struct IsOpaqueId<OpaqueId<V, S> const> : std::true_type
 {
 };
 
+#if !CELER_DEVICE_COMPILE
+// Print an opaque ID: ignore instantiator to reduce duplicate symbols
+template<class S>
+inline void stream_opaqueid_impl(std::ostream& os, S v, S nullid)
+{
+    os << '{';
+    if (v != nullid)
+    {
+        os << v;
+    }
+    os << '}';
+}
+
+// Specialization avoids printing integers as '\x1'
+template<>
+CELER_FORCEINLINE void
+stream_opaqueid_impl(std::ostream& os, unsigned char v, unsigned char nullid)
+{
+    return stream_opaqueid_impl(
+        os, static_cast<unsigned int>(v), static_cast<unsigned int>(nullid));
+}
+#endif
+
 //---------------------------------------------------------------------------//
 }  // namespace detail
 
@@ -305,16 +329,10 @@ inline CELER_FUNCTION auto id_cast(U value) noexcept(!CELERITAS_DEBUG)
  * Output an opaque ID's value or a placeholder if unavailable.
  */
 template<class V, class S>
-std::ostream& operator<<(std::ostream& os, OpaqueId<V, S> const& v)
+CELER_FORCEINLINE std::ostream&
+operator<<(std::ostream& os, OpaqueId<V, S> const& v)
 {
-    if (v)
-    {
-        os << v.unchecked_get();
-    }
-    else
-    {
-        os << "<null>";
-    }
+    detail::stream_opaqueid_impl(os, v.unchecked_get(), nullid_value<S>);
     return os;
 }
 #endif

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -72,21 +72,16 @@ class OpaqueId
 
   public:
     //! Default to null state
-    CELER_CONSTEXPR_FUNCTION OpaqueId() : value_(null_) {}
+    CELER_CEF OpaqueId() : value_(null_) {}
 
     //! Construct explicitly with stored value
-    explicit CELER_CONSTEXPR_FUNCTION OpaqueId(size_type index) : value_(index)
-    {
-    }
+    explicit CELER_CEF OpaqueId(size_type index) : value_(index) {}
 
     //! Whether this ID is in a valid (assigned) state
-    explicit CELER_CONSTEXPR_FUNCTION operator bool() const
-    {
-        return value_ != null_;
-    }
+    explicit CELER_CEF operator bool() const { return value_ != null_; }
 
     //! Pre-increment of the ID
-    CELER_FUNCTION OpaqueId& operator++()
+    CELER_CEF OpaqueId& operator++()
     {
         CELER_EXPECT(*this);
         value_ += 1;
@@ -94,7 +89,7 @@ class OpaqueId
     }
 
     //! Post-increment of the ID
-    CELER_FUNCTION OpaqueId operator++(int)
+    CELER_CEF OpaqueId operator++(int)
     {
         OpaqueId old{*this};
         ++*this;
@@ -102,7 +97,7 @@ class OpaqueId
     }
 
     //! Pre-decrement of the ID
-    CELER_FUNCTION OpaqueId& operator--()
+    CELER_CEF OpaqueId& operator--()
     {
         CELER_EXPECT(*this && value_ > 0);
         value_ -= 1;
@@ -110,7 +105,7 @@ class OpaqueId
     }
 
     //! Post-decrement of the ID
-    CELER_FUNCTION OpaqueId operator--(int)
+    CELER_CEF OpaqueId operator--(int)
     {
         OpaqueId old{*this};
         --*this;
@@ -118,7 +113,7 @@ class OpaqueId
     }
 
     //! Get the ID's value
-    CELER_FORCEINLINE_FUNCTION size_type get() const
+    CELER_CEF size_type get() const
     {
         CELER_EXPECT(*this);
         return value_;

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -152,7 +152,7 @@ class OpaqueId
 #define CELER_DEFINE_OPAQUEID_CMP(TOKEN)                               \
     template<class U>                                                  \
     CELER_CEF friend auto operator TOKEN(OpaqueId lhs, U rhs) noexcept \
-        -> bool                                                        \
+        -> std::enable_if_t<std::is_unsigned_v<U>, bool>               \
     {                                                                  \
         return lhs && (static_cast<U>(lhs.unchecked_get()) TOKEN rhs); \
     }
@@ -177,7 +177,8 @@ class OpaqueId
 
     //! Increment an opaque ID by an offset
     template<class U>
-    CELER_FUNCTION friend auto operator+(OpaqueId id, U offset) -> OpaqueId
+    CELER_FUNCTION friend auto operator+(OpaqueId id, U offset)
+        -> std::enable_if_t<std::is_integral_v<U>, OpaqueId>
     {
         CELER_EXPECT(id);
         CELER_EXPECT(
@@ -193,14 +194,16 @@ class OpaqueId
 
     //! Increment an opaque ID by an offset (symmetric)
     template<class U>
-    CELER_FUNCTION friend auto operator+(U offset, OpaqueId id) -> OpaqueId
+    CELER_FUNCTION friend auto operator+(U offset, OpaqueId id)
+        -> std::enable_if_t<std::is_integral_v<U>, OpaqueId>
     {
         return id + offset;
     }
 
     //! Decrement an opaque ID by an offset
     template<class U>
-    CELER_FUNCTION friend auto operator-(OpaqueId id, U offset) -> OpaqueId
+    CELER_FUNCTION friend auto operator-(OpaqueId id, U offset)
+        -> std::enable_if_t<std::is_integral_v<U>, OpaqueId>
     {
         CELER_EXPECT(id);
         CELER_EXPECT(offset <= 0

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -50,6 +50,9 @@ inline constexpr T nullid_value{static_cast<T>(-1)};
  * integer values (avoid compile-time warnings or errors from signed/truncated
  * integers).
  *
+ * \note Comparators are defined as inline friend functions to allow
+ * ADL-assisted conversion, including from \c LdgRefWrapper.
+ *
  * \todo This interface will be changed to be more like \c std::optional : \c
  * size_type will become \c value_type (the value of a 'dereferenced' ID) and
  * \c operator* or \c value will be used to access the integer.
@@ -127,6 +130,87 @@ class OpaqueId
     //! Access the underlying data for more efficient loading from memory
     CELER_CONSTEXPR_FUNCTION size_type const* data() const { return &value_; }
 
+    //// INLINE COMPARATOR FRIENDS ////
+
+#define CELER_DEFINE_OPAQUEID_CMP(TOKEN)                                      \
+    CELER_CEF friend bool operator TOKEN(OpaqueId lhs, OpaqueId rhs) noexcept \
+    {                                                                         \
+        return lhs.unchecked_get() TOKEN rhs.unchecked_get();                 \
+    }
+
+    //!@{
+    //! Compare two OpaqueId of the same type
+    CELER_DEFINE_OPAQUEID_CMP(==)
+    CELER_DEFINE_OPAQUEID_CMP(!=)
+    CELER_DEFINE_OPAQUEID_CMP(<)
+    CELER_DEFINE_OPAQUEID_CMP(>)
+    CELER_DEFINE_OPAQUEID_CMP(<=)
+    CELER_DEFINE_OPAQUEID_CMP(>=)
+    //!@}
+
+#undef CELER_DEFINE_OPAQUEID_CMP
+#define CELER_DEFINE_OPAQUEID_CMP(TOKEN)                               \
+    template<class U>                                                  \
+    CELER_CEF friend auto operator TOKEN(OpaqueId lhs, U rhs) noexcept \
+        -> bool                                                        \
+    {                                                                  \
+        return lhs && (static_cast<U>(lhs.unchecked_get()) TOKEN rhs); \
+    }
+
+    //!@{
+    //! Allow less-than comparison with unsigned int for containers
+    CELER_DEFINE_OPAQUEID_CMP(<)
+    CELER_DEFINE_OPAQUEID_CMP(<=)
+    //!@}
+
+#undef CELER_DEFINE_OPAQUEID_CMP
+
+    //// INLINE OPERATOR FRIENDS ////
+
+    //! Get the distance between two opaque IDs
+    CELER_FUNCTION friend SizeT operator-(OpaqueId self, OpaqueId other)
+    {
+        CELER_EXPECT(self);
+        CELER_EXPECT(other);
+        return self.unchecked_get() - other.unchecked_get();
+    }
+
+    //! Increment an opaque ID by an offset
+    template<class U>
+    CELER_FUNCTION friend auto operator+(OpaqueId id, U offset) -> OpaqueId
+    {
+        CELER_EXPECT(id);
+        CELER_EXPECT(
+            offset >= 0
+            || static_cast<SizeT>(-static_cast<std::make_signed_t<U>>(offset))
+                   <= id.unchecked_get());
+
+        // Note: an extra cast is needed for short SizeT due to integer
+        // promotion
+        return OpaqueId{static_cast<SizeT>(id.unchecked_get()
+                                           + static_cast<SizeT>(offset))};
+    }
+
+    //! Increment an opaque ID by an offset (symmetric)
+    template<class U>
+    CELER_FUNCTION friend auto operator+(U offset, OpaqueId id) -> OpaqueId
+    {
+        return id + offset;
+    }
+
+    //! Decrement an opaque ID by an offset
+    template<class U>
+    CELER_FUNCTION friend auto operator-(OpaqueId id, U offset) -> OpaqueId
+    {
+        CELER_EXPECT(id);
+        CELER_EXPECT(offset <= 0
+                     || static_cast<SizeT>(offset) <= id.unchecked_get());
+        // Note: an extra cast is needed for short SizeT due to integer
+        // promotion
+        return OpaqueId{static_cast<SizeT>(id.unchecked_get()
+                                           - static_cast<SizeT>(offset))};
+    }
+
   private:
     size_type value_;
 
@@ -139,89 +223,6 @@ class OpaqueId
 //---------------------------------------------------------------------------//
 template<class IdT, class U>
 inline CELER_FUNCTION IdT id_cast(U value) noexcept(!CELERITAS_DEBUG);
-
-//---------------------------------------------------------------------------//
-#define CELER_DEFINE_OPAQUEID_CMP(TOKEN)                             \
-    template<class I, class T>                                       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(OpaqueId<I, T> lhs, \
-                                                 OpaqueId<I, T> rhs) \
-    {                                                                \
-        return lhs.unchecked_get() TOKEN rhs.unchecked_get();        \
-    }
-
-//!@{
-//! Comparison for OpaqueId
-CELER_DEFINE_OPAQUEID_CMP(==)
-CELER_DEFINE_OPAQUEID_CMP(!=)
-CELER_DEFINE_OPAQUEID_CMP(<)
-CELER_DEFINE_OPAQUEID_CMP(>)
-CELER_DEFINE_OPAQUEID_CMP(<=)
-CELER_DEFINE_OPAQUEID_CMP(>=)
-//!@}
-
-#undef CELER_DEFINE_OPAQUEID_CMP
-
-//---------------------------------------------------------------------------//
-//! Allow less-than comparison with *integer* for container comparison
-template<class I, class T, class U>
-CELER_CONSTEXPR_FUNCTION bool operator<(OpaqueId<I, T> lhs, U rhs)
-{
-    // Cast to RHS
-    return lhs && (U(lhs.unchecked_get()) < rhs);
-}
-
-//---------------------------------------------------------------------------//
-//! Allow less-than-equal comparison with *integer* for container comparison
-template<class I, class T, class U>
-CELER_CONSTEXPR_FUNCTION bool operator<=(OpaqueId<I, T> lhs, U rhs)
-{
-    // Cast to RHS
-    return lhs && (U(lhs.unchecked_get()) <= rhs);
-}
-
-//---------------------------------------------------------------------------//
-//! Get the distance between two opaque IDs
-template<class I, class T>
-inline CELER_FUNCTION T operator-(OpaqueId<I, T> self, OpaqueId<I, T> other)
-{
-    CELER_EXPECT(self);
-    CELER_EXPECT(other);
-    return self.unchecked_get() - other.unchecked_get();
-}
-
-//---------------------------------------------------------------------------//
-//! Increment an opaque ID by an offset
-template<class I, class T>
-inline CELER_FUNCTION OpaqueId<I, T>
-operator+(OpaqueId<I, T> id, std::make_signed_t<T> offset)
-{
-    CELER_EXPECT(id);
-    CELER_EXPECT(offset >= 0 || static_cast<T>(-offset) <= id.unchecked_get());
-    // Note: an extra cast is needed for short T due to integer promotion
-    return OpaqueId<I, T>{
-        static_cast<T>(id.unchecked_get() + static_cast<T>(offset))};
-}
-
-//! Increment an opaque ID by an offset
-template<class I, class T>
-CELER_FORCEINLINE_FUNCTION auto
-operator+(std::make_signed_t<T> offset, OpaqueId<I, T> id)
-{
-    return id + offset;
-}
-
-//---------------------------------------------------------------------------//
-//! Decrement an opaque ID by an offset
-template<class I, class T>
-inline CELER_FUNCTION OpaqueId<I, T>
-operator-(OpaqueId<I, T> id, std::make_signed_t<T> offset)
-{
-    CELER_EXPECT(id);
-    CELER_EXPECT(offset <= 0 || static_cast<T>(offset) <= id.unchecked_get());
-    // Note: an extra cast is needed for short T due to integer promotion
-    return OpaqueId<I, T>{
-        static_cast<T>(id.unchecked_get() - static_cast<T>(offset))};
-}
 
 namespace detail
 {

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -175,21 +175,19 @@ class OpaqueId
         return self.unchecked_get() - other.unchecked_get();
     }
 
-    //! Increment an opaque ID by an offset
+    //! Increment an opaque ID by an offset, checking against underflow
     template<class U>
     CELER_FUNCTION friend auto operator+(OpaqueId id, U offset)
         -> std::enable_if_t<std::is_integral_v<U>, OpaqueId>
     {
         CELER_EXPECT(id);
-        CELER_EXPECT(
-            offset >= 0
-            || static_cast<SizeT>(-static_cast<std::make_signed_t<U>>(offset))
-                   <= id.unchecked_get());
+        CELER_EXPECT(offset >= 0
+                     || static_cast<SizeT>(U{0} - offset)
+                            <= id.unchecked_get());
 
         // Note: an extra cast is needed for short SizeT due to integer
         // promotion
-        return OpaqueId{static_cast<SizeT>(id.unchecked_get()
-                                           + static_cast<SizeT>(offset))};
+        return OpaqueId{static_cast<SizeT>(id.unchecked_get() + offset)};
     }
 
     //! Increment an opaque ID by an offset (symmetric)

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -139,6 +139,29 @@ class Array
     }
     //!@}
 
+    //// FRIENDLY OPERATORS ////
+
+    //! Test equality of two arrays
+    template<class U>
+    CELER_CEF friend auto operator==(Array const& lhs, Array<U, N> const& rhs)
+        -> std::enable_if_t<std::is_convertible_v<U, T>, bool>
+    {
+        for (size_type i = 0; i != N; ++i)
+        {
+            if (lhs[i] != rhs[i])
+                return false;
+        }
+        return true;
+    }
+
+    //! Test inequality of two arrays
+    template<class U>
+    CELER_CEF friend auto operator!=(Array const& lhs, Array<U, N> const& rhs)
+        -> std::enable_if_t<std::is_convertible_v<U, T>, bool>
+    {
+        return !(lhs == rhs);
+    }
+
   private:
     T d_[N];  //!< Storage
 };
@@ -155,30 +178,6 @@ CELER_FUNCTION Array(T, Us...)
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
-//---------------------------------------------------------------------------//
-/*!
- * Test equality of two arrays.
- */
-template<class T, std::size_t N>
-CELER_CEF bool operator==(Array<T, N> const& lhs, Array<T, N> const& rhs)
-{
-    for (size_type i = 0; i != N; ++i)
-    {
-        if (lhs[i] != rhs[i])
-            return false;
-    }
-    return true;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Test inequality of two arrays.
- */
-template<class T, std::size_t N>
-CELER_CEF bool operator!=(Array<T, N> const& lhs, Array<T, N> const& rhs)
-{
-    return !(lhs == rhs);
-}
 
 #if !CELER_DEVICE_COMPILE
 //---------------------------------------------------------------------------//

--- a/src/corecel/data/ObserverPtr.hh
+++ b/src/corecel/data/ObserverPtr.hh
@@ -8,6 +8,7 @@
 
 #include <type_traits>
 
+#include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
 
@@ -48,7 +49,7 @@ class ObserverPtr
     {
     }
 
-    template<class T2>
+    template<class T2, std::enable_if_t<std::is_convertible_v<T2*, T*>, bool> = true>
     CELER_CONSTEXPR_FUNCTION ObserverPtr(ObserverPtr<T2, M> other) noexcept
         : ptr_{other.ptr_}
     {
@@ -107,6 +108,45 @@ class ObserverPtr
 
     template<class, MemSpace>
     friend class ObserverPtr;
+
+//!@{
+//! Comparators
+#define CELER_DEFINE_OBSPTR_CMP(TOKEN)                    \
+    template<class T2>                                    \
+    CELER_CONSTEXPR_FUNCTION friend bool operator TOKEN(  \
+        ObserverPtr lhs, ObserverPtr<T2, M> rhs) noexcept \
+    {                                                     \
+        return lhs.get() TOKEN rhs.get();                 \
+    }
+    CELER_DEFINE_OBSPTR_CMP(==)
+    CELER_DEFINE_OBSPTR_CMP(!=)
+    CELER_DEFINE_OBSPTR_CMP(<)
+    CELER_DEFINE_OBSPTR_CMP(>)
+    CELER_DEFINE_OBSPTR_CMP(<=)
+    CELER_DEFINE_OBSPTR_CMP(>=)
+#undef CELER_DEFINE_OBSPTR_CMP
+
+    CELER_CONSTEXPR_FUNCTION friend bool
+    operator==(ObserverPtr const& lhs, std::nullptr_t) noexcept
+    {
+        return !static_cast<bool>(lhs);
+    }
+    CELER_CONSTEXPR_FUNCTION friend bool
+    operator!=(ObserverPtr const& lhs, std::nullptr_t) noexcept
+    {
+        return static_cast<bool>(lhs);
+    }
+    CELER_CONSTEXPR_FUNCTION friend bool
+    operator==(std::nullptr_t, ObserverPtr const& rhs) noexcept
+    {
+        return !static_cast<bool>(rhs);
+    }
+    CELER_CONSTEXPR_FUNCTION friend bool
+    operator!=(std::nullptr_t, ObserverPtr const& rhs) noexcept
+    {
+        return static_cast<bool>(rhs);
+    }
+    //!@}
 };
 
 //---------------------------------------------------------------------------//
@@ -125,50 +165,6 @@ swap(ObserverPtr<T, M>& lhs, ObserverPtr<T, M>& rhs) noexcept
 {
     return lhs.swap(rhs);
 }
-
-//---------------------------------------------------------------------------//
-//!@{
-//! Comparators
-#define CELER_DEFINE_OBSPTR_CMP(TOKEN)                                         \
-    template<class T1, class T2, MemSpace M>                                   \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                              \
-        ObserverPtr<T1, M> const& lhs, ObserverPtr<T2, M> const& rhs) noexcept \
-    {                                                                          \
-        return lhs.get() TOKEN rhs.get();                                      \
-    }
-CELER_DEFINE_OBSPTR_CMP(==)
-CELER_DEFINE_OBSPTR_CMP(!=)
-CELER_DEFINE_OBSPTR_CMP(<)
-CELER_DEFINE_OBSPTR_CMP(>)
-CELER_DEFINE_OBSPTR_CMP(<=)
-CELER_DEFINE_OBSPTR_CMP(>=)
-#undef CELER_DEFINE_OBSPTR_CMP
-
-template<class T, MemSpace M>
-CELER_CONSTEXPR_FUNCTION bool
-operator==(ObserverPtr<T, M> const& lhs, std::nullptr_t) noexcept
-{
-    return !static_cast<bool>(lhs);
-}
-template<class T, MemSpace M>
-CELER_CONSTEXPR_FUNCTION bool
-operator!=(ObserverPtr<T, M> const& lhs, std::nullptr_t) noexcept
-{
-    return static_cast<bool>(lhs);
-}
-template<class T, MemSpace M>
-CELER_CONSTEXPR_FUNCTION bool
-operator==(std::nullptr_t, ObserverPtr<T, M> const& rhs) noexcept
-{
-    return !static_cast<bool>(rhs);
-}
-template<class T, MemSpace M>
-CELER_CONSTEXPR_FUNCTION bool
-operator!=(std::nullptr_t, ObserverPtr<T, M> const& rhs) noexcept
-{
-    return static_cast<bool>(rhs);
-}
-//!@}
 
 //---------------------------------------------------------------------------//
 //! Create an observer pointer from a pointer in the native memspace.

--- a/src/corecel/data/PinnedAllocator.hh
+++ b/src/corecel/data/PinnedAllocator.hh
@@ -8,6 +8,8 @@
 
 #include <cstdlib>
 
+#include "corecel/Macros.hh"
+
 #include "detail/PinnedAllocatorImpl.hh"
 
 namespace celeritas
@@ -39,19 +41,18 @@ struct PinnedAllocator
     {
         return detail::free_pinned(ptr);
     }
+
+    template<class U>
+    friend bool operator==(PinnedAllocator const&, PinnedAllocator<U> const&)
+    {
+        return true;
+    }
+    template<class U>
+    friend bool operator!=(PinnedAllocator const&, PinnedAllocator<U> const&)
+    {
+        return false;
+    }
 };
-
-template<class T, class U>
-bool operator==(PinnedAllocator<T> const&, PinnedAllocator<U> const&)
-{
-    return true;
-}
-
-template<class T, class U>
-bool operator!=(PinnedAllocator<T> const&, PinnedAllocator<U> const&)
-{
-    return false;
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/data/detail/PinnedAllocatorImpl.cc
+++ b/src/corecel/data/detail/PinnedAllocatorImpl.cc
@@ -12,7 +12,6 @@
 #include "corecel/DeviceRuntimeApi.hh"
 
 #include "corecel/Assert.hh"
-#include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/Device.hh"
 

--- a/src/corecel/io/Label.hh
+++ b/src/corecel/io/Label.hh
@@ -71,26 +71,27 @@ struct Label
 
     // Construct a label from by splitting on a separator
     static Label from_separator(std::string_view name, char sep = default_sep);
+
+    //// FRIENDLY COMPARATORS ////
+
+    //! Test equality
+    friend bool operator==(Label const& lhs, Label const& rhs)
+    {
+        return lhs.name == rhs.name && lhs.ext == rhs.ext;
+    }
+
+    //! Test inequality
+    friend bool operator!=(Label const& lhs, Label const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    //! Less-than comparison for sorting
+    friend bool operator<(Label const& lhs, Label const& rhs)
+    {
+        return std::tie(lhs.name, lhs.ext) < std::tie(rhs.name, rhs.ext);
+    }
 };
-
-//---------------------------------------------------------------------------//
-//! Test equality
-inline bool operator==(Label const& lhs, Label const& rhs)
-{
-    return lhs.name == rhs.name && lhs.ext == rhs.ext;
-}
-
-//! Test inequality
-inline bool operator!=(Label const& lhs, Label const& rhs)
-{
-    return !(lhs == rhs);
-}
-
-//! Less-than comparison for sorting
-inline bool operator<(Label const& lhs, Label const& rhs)
-{
-    return std::tie(lhs.name, lhs.ext) < std::tie(rhs.name, rhs.ext);
-}
 
 //---------------------------------------------------------------------------//
 // Write a label to a stream

--- a/src/corecel/math/Constant.hh
+++ b/src/corecel/math/Constant.hh
@@ -42,126 +42,133 @@ class Constant
 
   public:
     //! Explicitly construct from a full-precision value
-    explicit CELER_CONSTEXPR_FUNCTION Constant(real_type v) : value_{v} {}
+    explicit CELER_CEF Constant(real_type v) : value_{v} {}
 
     //! Access the value explicitly
-    CELER_CONSTEXPR_FUNCTION real_type value() const { return value_; }
+    CELER_CEF real_type value() const { return value_; }
 
     //! Explicit conversion of stored value
-    explicit CELER_CONSTEXPR_FUNCTION operator float() const { return value_; }
+    explicit CELER_CEF operator float() const { return value_; }
     //! Explicit access to stored value
-    explicit CELER_CONSTEXPR_FUNCTION operator double() const
+    explicit CELER_CEF operator double() const { return value_; }
+
+    //// FRIENDLY OPERATORS ////
+
+    //! Unary negation
+    CELER_CEF friend Constant operator-(Constant lhs) noexcept
     {
-        return value_;
+        return Constant{-lhs.value()};
     }
+
+  private:
+    template<class T>
+    using EnableIfFloating
+        = std::enable_if_t<std::is_floating_point_v<T>, bool>;
+    template<class T>
+    using EnableIfIntegral = std::enable_if_t<std::is_integral_v<T>, bool>;
+
+  public:
+//! \cond (CELERITAS_DOC_DEV)
+//!@{
+//! Comparison
+#define CELER_DEFINE_CONSTANT_CMP(TOKEN)                                      \
+    template<class T, EnableIfFloating<T> = true>                             \
+    CELER_CEF friend bool operator TOKEN(Constant lhs, T rhs) noexcept        \
+    {                                                                         \
+        return static_cast<T>(lhs.value()) TOKEN rhs;                         \
+    }                                                                         \
+    template<class T, EnableIfFloating<T> = true>                             \
+    CELER_CEF friend bool operator TOKEN(T lhs, Constant rhs) noexcept        \
+    {                                                                         \
+        return lhs TOKEN static_cast<T>(rhs.value());                         \
+    }                                                                         \
+                                                                              \
+    template<class T, EnableIfIntegral<T> = true>                             \
+    CELER_CEF friend bool operator TOKEN(Constant lhs, T rhs) noexcept        \
+    {                                                                         \
+        return lhs.value() TOKEN static_cast<Constant::real_type>(rhs);       \
+    }                                                                         \
+    template<class T, EnableIfIntegral<T> = true>                             \
+    CELER_CEF friend bool operator TOKEN(T lhs, Constant rhs) noexcept        \
+    {                                                                         \
+        return static_cast<Constant::real_type>(lhs) TOKEN rhs.value();       \
+    }                                                                         \
+                                                                              \
+    CELER_CEF friend bool operator TOKEN(Constant lhs, Constant rhs) noexcept \
+    {                                                                         \
+        return lhs.value() TOKEN rhs.value();                                 \
+    }
+
+    CELER_DEFINE_CONSTANT_CMP(==)
+    CELER_DEFINE_CONSTANT_CMP(!=)
+    CELER_DEFINE_CONSTANT_CMP(<)
+    CELER_DEFINE_CONSTANT_CMP(>)
+    CELER_DEFINE_CONSTANT_CMP(<=)
+    CELER_DEFINE_CONSTANT_CMP(>=)
+    //!@}
+
+#undef CELER_DEFINE_CONSTANT_CMP
+
+//!@{
+//! Arithmetic
+#define CELER_DEFINE_CONSTANT_OP(TOKEN)                                    \
+    template<class T, EnableIfFloating<T> = true>                          \
+    CELER_CEF friend T operator TOKEN(Constant lhs, T rhs) noexcept        \
+    {                                                                      \
+        return static_cast<T>(lhs.value()) TOKEN rhs;                      \
+    }                                                                      \
+    template<class T, EnableIfFloating<T> = true>                          \
+    CELER_CEF friend T operator TOKEN(T lhs, Constant rhs) noexcept        \
+    {                                                                      \
+        return lhs TOKEN static_cast<T>(rhs.value());                      \
+    }                                                                      \
+                                                                           \
+    template<class T, EnableIfIntegral<T> = true>                          \
+    CELER_CEF friend Constant operator TOKEN(Constant lhs, T rhs) noexcept \
+    {                                                                      \
+        return Constant{lhs.value() TOKEN rhs};                            \
+    }                                                                      \
+    template<class T, EnableIfIntegral<T> = true>                          \
+    CELER_CEF friend Constant operator TOKEN(T lhs, Constant rhs) noexcept \
+    {                                                                      \
+        return Constant{lhs TOKEN rhs.value()};                            \
+    }                                                                      \
+                                                                           \
+    CELER_CEF friend Constant operator TOKEN(Constant lhs,                 \
+                                             Constant rhs) noexcept        \
+    {                                                                      \
+        return Constant{lhs.value() TOKEN rhs.value()};                    \
+    }
+
+    CELER_DEFINE_CONSTANT_OP(*)
+    CELER_DEFINE_CONSTANT_OP(/)
+    CELER_DEFINE_CONSTANT_OP(+)
+    CELER_DEFINE_CONSTANT_OP(-)
+    //!@!}
+
+#undef CELER_DEFINE_CONSTANT_OP
+
+//!@{
+//! In-place arithmetic
+#define CELER_DEFINE_CONSTANT_OP(TOKEN)                                \
+    template<class T, EnableIfFloating<T> = true>                      \
+    CELER_CEF friend T& operator TOKEN(T & lhs, Constant rhs) noexcept \
+    {                                                                  \
+        return lhs TOKEN static_cast<T>(rhs.value());                  \
+    }
+
+    CELER_DEFINE_CONSTANT_OP(*=)
+    CELER_DEFINE_CONSTANT_OP(/=)
+    CELER_DEFINE_CONSTANT_OP(+=)
+    CELER_DEFINE_CONSTANT_OP(-=)
+    //!@!}
+
+#undef CELER_DEFINE_CONSTANT_OP
+    //! \endcond
 
   private:
     real_type value_;
 };
 
-//! Unary negation
-CELER_CONSTEXPR_FUNCTION Constant operator-(Constant lhs) noexcept
-{
-    return Constant{-lhs.value()};
-}
-
-//---------------------------------------------------------------------------//
-//! \cond
-#define CELER_DEFINE_CONSTANT_CMP(TOKEN)                                          \
-    template<class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true> \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(Constant lhs, T rhs) noexcept    \
-    {                                                                             \
-        return static_cast<T>(lhs.value()) TOKEN rhs;                             \
-    }                                                                             \
-    template<class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true> \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(T lhs, Constant rhs) noexcept    \
-    {                                                                             \
-        return lhs TOKEN static_cast<T>(rhs.value());                             \
-    }                                                                             \
-    template<class T, std::enable_if_t<std::is_integral_v<T>, bool> = true>       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(Constant lhs, T rhs) noexcept    \
-    {                                                                             \
-        return lhs.value() TOKEN static_cast<Constant::real_type>(rhs);           \
-    }                                                                             \
-    template<class T, std::enable_if_t<std::is_integral_v<T>, bool> = true>       \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(T lhs, Constant rhs) noexcept    \
-    {                                                                             \
-        return static_cast<Constant::real_type>(lhs) TOKEN rhs.value();           \
-    }                                                                             \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(Constant lhs,                    \
-                                                 Constant rhs) noexcept           \
-    {                                                                             \
-        return lhs.value() TOKEN rhs.value();                                     \
-    }
-
-//!@{
-//! Comparison for Constant
-CELER_DEFINE_CONSTANT_CMP(==)
-CELER_DEFINE_CONSTANT_CMP(!=)
-CELER_DEFINE_CONSTANT_CMP(<)
-CELER_DEFINE_CONSTANT_CMP(>)
-CELER_DEFINE_CONSTANT_CMP(<=)
-CELER_DEFINE_CONSTANT_CMP(>=)
-//!@}
-
-#undef CELER_DEFINE_CONSTANT_CMP
-
-//!@{
-//! Arithmetic for Constant
-#define CELER_DEFINE_CONSTANT_OP(TOKEN)                                           \
-    template<class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true> \
-    CELER_CONSTEXPR_FUNCTION T operator TOKEN(Constant lhs, T rhs) noexcept       \
-    {                                                                             \
-        return static_cast<T>(lhs.value()) TOKEN rhs;                             \
-    }                                                                             \
-    template<class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true> \
-    CELER_CONSTEXPR_FUNCTION T operator TOKEN(T lhs, Constant rhs) noexcept       \
-    {                                                                             \
-        return lhs TOKEN static_cast<T>(rhs.value());                             \
-    }                                                                             \
-    template<class T, std::enable_if_t<std::is_integral_v<T>, bool> = true>       \
-    CELER_CONSTEXPR_FUNCTION Constant operator TOKEN(Constant lhs,                \
-                                                     T rhs) noexcept              \
-    {                                                                             \
-        return Constant{lhs.value() TOKEN rhs};                                   \
-    }                                                                             \
-    template<class T, std::enable_if_t<std::is_integral_v<T>, bool> = true>       \
-    CELER_CONSTEXPR_FUNCTION Constant operator TOKEN(T lhs,                       \
-                                                     Constant rhs) noexcept       \
-    {                                                                             \
-        return Constant{lhs TOKEN rhs.value()};                                   \
-    }                                                                             \
-    CELER_CONSTEXPR_FUNCTION Constant operator TOKEN(Constant lhs,                \
-                                                     Constant rhs) noexcept       \
-    {                                                                             \
-        return Constant{lhs.value() TOKEN rhs.value()};                           \
-    }
-
-CELER_DEFINE_CONSTANT_OP(*)
-CELER_DEFINE_CONSTANT_OP(/)
-CELER_DEFINE_CONSTANT_OP(+)
-CELER_DEFINE_CONSTANT_OP(-)
-//!@!}
-
-#undef CELER_DEFINE_CONSTANT_OP
-
-//!@{
-//! In-place arithmetic for Constant
-#define CELER_DEFINE_CONSTANT_OP(TOKEN)                                           \
-    template<class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true> \
-    CELER_CONSTEXPR_FUNCTION T& operator TOKEN(T & lhs, Constant rhs) noexcept    \
-    {                                                                             \
-        return lhs TOKEN static_cast<T>(rhs.value());                             \
-    }
-
-CELER_DEFINE_CONSTANT_OP(*=)
-CELER_DEFINE_CONSTANT_OP(/=)
-CELER_DEFINE_CONSTANT_OP(+=)
-CELER_DEFINE_CONSTANT_OP(-=)
-//!@!}
-
-#undef CELER_DEFINE_CONSTANT_OP
-
-//! \endcond
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -88,6 +88,12 @@ class Constant;
 template<class UnitT, class ValueT>
 class Quantity
 {
+    static_assert(std::is_arithmetic_v<ValueT>,
+                  "value type must be arithmetic");
+    static_assert(std::is_arithmetic_v<decltype(UnitT::value())>
+                      || std::is_same_v<decltype(UnitT::value()), Constant>,
+                  "unit value type must be arithmetic or constant");
+
   public:
     //!@{
     //! \name Type aliases

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -19,6 +19,7 @@
 
 namespace celeritas
 {
+class Constant;
 //---------------------------------------------------------------------------//
 /*!
  * A numerical value tagged with a unit.
@@ -137,6 +138,103 @@ class Quantity
     //! Access the underlying data for more efficient loading from memory
     CELER_CONSTEXPR_FUNCTION value_type const* data() const { return &value_; }
 
+    //// INLINE COMPARATOR FRIENDS ////
+
+#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                           \
+    template<class T2>                                             \
+    CELER_CONSTEXPR_FUNCTION friend bool operator TOKEN(           \
+        Quantity lhs, Quantity<UnitT, T2> rhs) noexcept            \
+    {                                                              \
+        return lhs.value() TOKEN rhs.value();                      \
+    }                                                              \
+    template<detail::QConstant QC>                                 \
+    CELER_CONSTEXPR_FUNCTION friend bool operator TOKEN(           \
+        Quantity lhs, detail::UnitlessQuantity<QC>) noexcept       \
+    {                                                              \
+        return lhs.value() TOKEN detail::get_constant<ValueT>(QC); \
+    }                                                              \
+    template<detail::QConstant QC>                                 \
+    CELER_CONSTEXPR_FUNCTION friend bool operator TOKEN(           \
+        detail::UnitlessQuantity<QC>, Quantity rhs) noexcept       \
+    {                                                              \
+        return detail::get_constant<ValueT>(QC) TOKEN rhs.value(); \
+    }
+
+    //!@{
+    //! Comparison for Quantity
+    CELER_DEFINE_QUANTITY_CMP(==)
+    CELER_DEFINE_QUANTITY_CMP(!=)
+    CELER_DEFINE_QUANTITY_CMP(<)
+    CELER_DEFINE_QUANTITY_CMP(>)
+    CELER_DEFINE_QUANTITY_CMP(<=)
+    CELER_DEFINE_QUANTITY_CMP(>=)
+    //!@}
+
+#undef CELER_DEFINE_QUANTITY_CMP
+
+  private:
+    template<class T2>
+    using OtherQuantity = Quantity<UnitT, std::common_type_t<ValueT, T2>>;
+
+  public:
+    //// INLINE OPERATOR FRIENDS ////
+
+    //!@{
+    //! Arithmetic with unitless scalars
+
+    template<class T2>
+    CELER_CONSTEXPR_FUNCTION friend auto
+    operator*(Quantity lhs, T2 rhs) noexcept
+    {
+        return OtherQuantity<T2>{lhs.value() * rhs};
+    }
+
+    template<class T2>
+    CELER_CONSTEXPR_FUNCTION friend auto
+    operator*(T2 lhs, Quantity rhs) noexcept
+    {
+        return OtherQuantity<T2>{lhs * rhs.value()};
+    }
+
+    template<class T2>
+    CELER_CONSTEXPR_FUNCTION friend auto
+    operator/(Quantity lhs, T2 rhs) noexcept
+    {
+        return OtherQuantity<T2>{lhs.value() / rhs};
+    }
+
+    //!@}
+
+    //!@{
+    //! Operators with same units
+    template<class T2>
+    CELER_CONSTEXPR_FUNCTION friend auto
+    operator+(Quantity lhs, Quantity<UnitT, T2> rhs) noexcept
+    {
+        return OtherQuantity<T2>{lhs.value() + rhs.value()};
+    }
+
+    template<class T2>
+    CELER_CONSTEXPR_FUNCTION friend auto
+    operator-(Quantity lhs, Quantity<UnitT, T2> rhs) noexcept
+    {
+        return OtherQuantity<T2>{lhs.value() - rhs.value()};
+    }
+
+    template<class T2>
+    CELER_CONSTEXPR_FUNCTION friend auto
+    operator/(Quantity lhs, Quantity<UnitT, T2> rhs) noexcept
+    {
+        return lhs.value() / rhs.value();
+    }
+
+    //!@}
+
+    CELER_CONSTEXPR_FUNCTION friend auto operator-(Quantity q) noexcept
+    {
+        return Quantity{-q.value()};
+    }
+
   private:
     value_type value_{};
 };
@@ -146,99 +244,6 @@ class Quantity
 template<class UnitT>
 using RealQuantity = Quantity<UnitT, real_type>;
 
-//---------------------------------------------------------------------------//
-//! \cond
-#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                           \
-    template<class U, class T, class T2>                           \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                  \
-        Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept          \
-    {                                                              \
-        return lhs.value() TOKEN rhs.value();                      \
-    }                                                              \
-    template<class U, class T, detail::QConstant QC>               \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                  \
-        Quantity<U, T> lhs, detail::UnitlessQuantity<QC>) noexcept \
-    {                                                              \
-        return lhs.value() TOKEN detail::get_constant<T>(QC);      \
-    }                                                              \
-    template<class U, class T, detail::QConstant QC>               \
-    CELER_CONSTEXPR_FUNCTION bool operator TOKEN(                  \
-        detail::UnitlessQuantity<QC>, Quantity<U, T> rhs) noexcept \
-    {                                                              \
-        return detail::get_constant<T>(QC) TOKEN rhs.value();      \
-    }                                                              \
-    namespace detail                                               \
-    {                                                              \
-    template<detail::QConstant C1, detail::QConstant C2>           \
-    CELER_CONSTEXPR_FUNCTION bool                                  \
-    operator TOKEN(detail::UnitlessQuantity<C1>,                   \
-                   detail::UnitlessQuantity<C2>) noexcept          \
-    {                                                              \
-        return static_cast<int>(C1) TOKEN static_cast<int>(C2);    \
-    }                                                              \
-    }
-
-//!@{
-//! Comparison for Quantity
-CELER_DEFINE_QUANTITY_CMP(==)
-CELER_DEFINE_QUANTITY_CMP(!=)
-CELER_DEFINE_QUANTITY_CMP(<)
-CELER_DEFINE_QUANTITY_CMP(>)
-CELER_DEFINE_QUANTITY_CMP(<=)
-CELER_DEFINE_QUANTITY_CMP(>=)
-//!@}
-
-#undef CELER_DEFINE_QUANTITY_CMP
-
-//!@{
-//! Math operator for Quantity
-template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto
-operator+(Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept
-{
-    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() + rhs.value()};
-}
-
-template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto
-operator-(Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept
-{
-    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() - rhs.value()};
-}
-
-template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto
-operator/(Quantity<U, T> lhs, Quantity<U, T2> rhs) noexcept
-{
-    return lhs.value() / rhs.value();
-}
-
-template<class U, class T>
-CELER_CONSTEXPR_FUNCTION auto operator-(Quantity<U, T> q) noexcept
-{
-    return Quantity<U, T>{-q.value()};
-}
-
-template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto operator*(Quantity<U, T> lhs, T2 rhs) noexcept
-{
-    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() * rhs};
-}
-
-template<class T, class U, class T2>
-CELER_CONSTEXPR_FUNCTION auto operator*(T rhs, Quantity<U, T2> lhs) noexcept
-{
-    return Quantity<U, std::common_type_t<T, T2>>{rhs * lhs.value()};
-}
-
-template<class U, class T, class T2>
-CELER_CONSTEXPR_FUNCTION auto operator/(Quantity<U, T> lhs, T2 rhs) noexcept
-{
-    return Quantity<U, std::common_type_t<T, T2>>{lhs.value() / rhs};
-}
-//!@!}
-
-//! \endcond
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/detail/QuantityImpl.hh
+++ b/src/corecel/math/detail/QuantityImpl.hh
@@ -52,6 +52,21 @@ CELER_CONSTEXPR_FUNCTION T get_constant(QConstant qc)
 template<QConstant QC>
 struct UnitlessQuantity
 {
+    // Define friend comparators
+#define CELER_DEFINE_QUANTITY_CMP(TOKEN)                        \
+    template<QConstant C2>                                      \
+    CELER_CONSTEXPR_FUNCTION bool friend operator TOKEN(        \
+        UnitlessQuantity, UnitlessQuantity<C2>) noexcept        \
+    {                                                           \
+        return static_cast<int>(QC) TOKEN static_cast<int>(C2); \
+    }
+    CELER_DEFINE_QUANTITY_CMP(==)
+    CELER_DEFINE_QUANTITY_CMP(!=)
+    CELER_DEFINE_QUANTITY_CMP(<)
+    CELER_DEFINE_QUANTITY_CMP(>)
+    CELER_DEFINE_QUANTITY_CMP(<=)
+    CELER_DEFINE_QUANTITY_CMP(>=)
+#undef CELER_DEFINE_QUANTITY_CMP
 };
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -106,6 +106,22 @@ class BoundingBox
     // Increase the bounding box's extent on both bounds
     CELER_CONSTEXPR_FUNCTION void grow(Axis axis, real_type position);
 
+    //// FRIENDLY COMPARATORS ////
+
+    //! Test equality of two bounding boxes
+    CELER_CONSTEXPR_FUNCTION friend bool
+    operator==(BoundingBox const& lhs, BoundingBox const& rhs)
+    {
+        return lhs.lower() == rhs.lower() && lhs.upper() == rhs.upper();
+    }
+
+    //! Test inequality of two bounding boxes
+    CELER_CONSTEXPR_FUNCTION friend bool
+    operator!=(BoundingBox const& lhs, BoundingBox const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
   private:
     Array<Real3, 2> points_;  //!< lo/hi points
 
@@ -123,28 +139,6 @@ using BBox = BoundingBox<>;
 
 //---------------------------------------------------------------------------//
 // INLINE FREE FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Test equality of two bounding boxes.
- */
-template<class T>
-CELER_CONSTEXPR_FUNCTION bool
-operator==(BoundingBox<T> const& lhs, BoundingBox<T> const& rhs)
-{
-    return lhs.lower() == rhs.lower() && lhs.upper() == rhs.upper();
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Test inequality of two bounding boxes.
- */
-template<class T>
-CELER_CONSTEXPR_FUNCTION bool
-operator!=(BoundingBox<T> const& lhs, BoundingBox<T> const& rhs)
-{
-    return !(lhs == rhs);
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Determine if a point is contained in a bounding box.

--- a/src/orange/OrangeInputIO.json.cc
+++ b/src/orange/OrangeInputIO.json.cc
@@ -301,7 +301,7 @@ void from_json(nlohmann::json const& j, UnitInput& value)
             DaughterInput daughter;
             daughter.univ_id = UnivId{daughters[i]};
             daughter.transform = std::move(transforms[i]);
-            value.daughter_map.emplace(LocalVolumeId{parent_vols[i]},
+            value.daughter_map.emplace(id_cast<LocalVolumeId>(parent_vols[i]),
                                        std::move(daughter));
         }
     }

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -32,7 +32,7 @@ class BoundingBox;
 using fast_real_type = float;
 
 //! Integer type for volume CSG tree representation
-using logic_int = size_type;
+using logic_int = ImplSurfaceId::size_type;
 
 //! Integer type for canonical volume level
 using vol_level_uint = VolumeLevelId::size_type;
@@ -62,10 +62,10 @@ using FastBBoxId = OpaqueId<FastBBox>;
 using FastReal3 = Array<float, 3>;
 
 //! Local identifier for a surface within a universe
-using LocalSurfaceId = OpaqueId<struct LocalSurface_>;
+using LocalSurfaceId = OpaqueId<struct LocalSurface_, ImplSurfaceId::size_type>;
 
 //! Local identifier for an ImplVolume within a universe
-using LocalVolumeId = OpaqueId<struct LocalVolume_>;
+using LocalVolumeId = OpaqueId<struct LocalVolume_, ImplVolumeId::size_type>;
 
 //! Identifier for an OrientedBoundingZone
 using OrientedBoundingZoneId = OpaqueId<struct OrientedBoundingZoneRecord>;

--- a/src/orange/orangeinp/detail/BuildLogic.cc
+++ b/src/orange/orangeinp/detail/BuildLogic.cc
@@ -112,7 +112,7 @@ void BaseLogicBuilder<Impl>::operator()(False const&)
 template<class Impl>
 void BaseLogicBuilder<Impl>::operator()(Surface const& s)
 {
-    CELER_EXPECT(s.id < logic::lbegin);
+    CELER_EXPECT(s.id < static_cast<SurfaceId::size_type>(logic::lbegin));
     // Get index of original surface or remapped
     logic_int sidx = [this, sid = s.id] {
         if (!mapping_)

--- a/src/orange/orangeinp/detail/BuildLogic.cc
+++ b/src/orange/orangeinp/detail/BuildLogic.cc
@@ -112,7 +112,7 @@ void BaseLogicBuilder<Impl>::operator()(False const&)
 template<class Impl>
 void BaseLogicBuilder<Impl>::operator()(Surface const& s)
 {
-    CELER_EXPECT(s.id < static_cast<SurfaceId::size_type>(logic::lbegin));
+    CELER_EXPECT(s.id < static_cast<logic_int>(logic::lbegin));
     // Get index of original surface or remapped
     logic_int sidx = [this, sid = s.id] {
         if (!mapping_)

--- a/src/orange/orangeinp/detail/CsgUnitBuilder.cc
+++ b/src/orange/orangeinp/detail/CsgUnitBuilder.cc
@@ -108,7 +108,7 @@ LocalVolumeId CsgUnitBuilder::insert_volume(NodeId n)
 {
     CELER_EXPECT(n < unit_->tree.size());
 
-    LocalVolumeId result{static_cast<size_type>(unit_->tree.volumes().size())};
+    auto result = id_cast<LocalVolumeId>(unit_->tree.volumes().size());
 
     unit_->tree.insert_volume(std::move(n));
     unit_->fills.resize(unit_->tree.volumes().size());

--- a/src/orange/orangeinp/detail/InfixStringBuilder.hh
+++ b/src/orange/orangeinp/detail/InfixStringBuilder.hh
@@ -115,7 +115,7 @@ void InfixStringBuilder::operator()(False const&)
  */
 void InfixStringBuilder::operator()(Surface const& s)
 {
-    CELER_EXPECT(s.id < logic::lbegin);
+    CELER_EXPECT(s.id < static_cast<SurfaceId::size_type>(logic::lbegin));
 
     static_assert(to_sense(true) == Sense::outside);
     *os_ << (negated_ ? '-' : '+') << s.id.unchecked_get();

--- a/src/orange/orangeinp/detail/InfixStringBuilder.hh
+++ b/src/orange/orangeinp/detail/InfixStringBuilder.hh
@@ -115,7 +115,7 @@ void InfixStringBuilder::operator()(False const&)
  */
 void InfixStringBuilder::operator()(Surface const& s)
 {
-    CELER_EXPECT(s.id < static_cast<SurfaceId::size_type>(logic::lbegin));
+    CELER_EXPECT(s.id < static_cast<logic_int>(logic::lbegin));
 
     static_assert(to_sense(true) == Sense::outside);
     *os_ << (negated_ ? '-' : '+') << s.id.unchecked_get();

--- a/src/orange/univ/RectArrayTracker.hh
+++ b/src/orange/univ/RectArrayTracker.hh
@@ -168,7 +168,7 @@ CELER_FUNCTION auto RectArrayTracker::initialize(LocalState const& state) const
     }
 
     VolumeIndexer to_index(record_.dims);
-    return {LocalVolumeId{to_index(coords)}, {}};
+    return {id_cast<LocalVolumeId>(to_index(coords)), {}};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/univ/detail/SurfaceFunctors.hh
+++ b/src/orange/univ/detail/SurfaceFunctors.hh
@@ -196,7 +196,7 @@ class CalcIntersections
     FaceId* const face_;
     real_type* const distance_;
     size_type* const isect_;
-    size_type face_idx_{0};
+    FaceId::size_type face_idx_{0};
     size_type isect_idx_{0};
 };
 

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -130,7 +130,7 @@ TEST_F(KernelContextExceptionTest, typical)
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             EXPECT_EQ(
-                R"(track slot 15 in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":null,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.67e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
+                R"(track slot {15} in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":null,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.67e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
                 simplified_str)
                 << repr(simplified_str);
         }
@@ -185,7 +185,7 @@ TEST_F(KernelContextExceptionTest, uninitialized_track)
     this->check_kce = [](KernelContextException const& e) {
         // Don't test this with vecgeom which has more assertions when
         // acquiring data
-        EXPECT_STREQ("track slot 1 in kernel 'test-kernel'", e.what());
+        EXPECT_STREQ("track slot {1} in kernel 'test-kernel'", e.what());
         EXPECT_EQ(TrackSlotId{1}, e.track_slot());
         EXPECT_EQ(EventId{}, e.event());
         EXPECT_EQ(TrackId{}, e.track());

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -341,7 +341,8 @@ TEST_F(SimpleComptonTest, max_steps)
         = {"debug", "debug", "debug", "debug"};
     EXPECT_VEC_EQ(expected_log_levels, scoped_log.levels());
     ASSERT_EQ(4, scoped_log.messages().size());
-    EXPECT_EQ("Track 62 exceeded maximum step count", scoped_log.messages()[0]);
+    EXPECT_EQ("Track {62} exceeded maximum step count",
+              scoped_log.messages()[0]);
     EXPECT_TRUE(scoped_log.messages()[2].find("\"num_steps\":2")
                 != std::string::npos);
 }

--- a/test/celeritas/random/ElementSelector.test.cc
+++ b/test/celeritas/random/ElementSelector.test.cc
@@ -97,7 +97,7 @@ class ElementSelectorTest : public Test
 // Return cross section proportional to the element ID offset by 1.
 auto mock_micro_xs(ElementId el_id) -> BarnXs
 {
-    CELER_EXPECT(el_id < 4);
+    CELER_EXPECT(el_id < ElementId{4});
     return BarnXs(static_cast<real_type>(el_id.get() + 1));
 }
 

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -90,6 +90,9 @@ TYPED_TEST(OpaqueIdTypedTest, operations)
     Id_t old{id++};
     EXPECT_EQ(Id_t{1}, id);
     EXPECT_EQ(Id_t{0}, old);
+
+    EXPECT_EQ("{1}", stream_to_string(Id_t{1}));
+    EXPECT_EQ("{}", stream_to_string(Id_t{}));
 }
 
 TEST(OpaqueIdTest, multi_int)

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -61,8 +61,21 @@ TYPED_TEST(OpaqueIdTypedTest, operations)
     EXPECT_EQ(assigned, assigned);
     EXPECT_EQ(std::hash<TypeParam>()(123), std::hash<Id_t>()(assigned));
 
-    EXPECT_EQ(10, Id_t{22} - Id_t{12});
+    EXPECT_TRUE(Id_t{22} <= Id_t{23});
     EXPECT_TRUE(Id_t{22} < Id_t{23});
+    EXPECT_TRUE(Id_t{22} < 23u);
+    EXPECT_TRUE(Id_t{23} > Id_t{22});
+    EXPECT_TRUE(Id_t{23} >= Id_t{22});
+    EXPECT_TRUE(Id_t{22} <= Id_t{23});
+    EXPECT_TRUE(Id_t{22} <= 23u);
+
+    EXPECT_FALSE(Id_t{23} <= Id_t{22});
+    EXPECT_FALSE(Id_t{23} < Id_t{22});
+    EXPECT_FALSE(Id_t{22} > Id_t{23});
+    EXPECT_FALSE(Id_t{22} >= Id_t{23});
+    EXPECT_FALSE(Id_t{23} <= Id_t{22});
+
+    EXPECT_EQ(10, Id_t{22} - Id_t{12});
     EXPECT_EQ(Id_t{24}, Id_t{22} + 2);
     EXPECT_EQ(Id_t{24}, 2 + Id_t{22});
     EXPECT_EQ(Id_t{24}, Id_t{22} + std::size_t(2));

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -65,6 +65,8 @@ TYPED_TEST(OpaqueIdTypedTest, operations)
     EXPECT_TRUE(Id_t{22} < Id_t{23});
     EXPECT_EQ(Id_t{24}, Id_t{22} + 2);
     EXPECT_EQ(Id_t{24}, 2 + Id_t{22});
+    EXPECT_EQ(Id_t{24}, Id_t{22} + std::size_t(2));
+    EXPECT_EQ(Id_t{20}, Id_t{22} + std::ptrdiff_t(-2));
     EXPECT_EQ(Id_t{24}, Id_t{22} - (-2));
     EXPECT_EQ(Id_t{22}, Id_t{22} + 0);
     EXPECT_EQ(Id_t{22}, Id_t{22} - 0);

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -97,7 +97,7 @@ TEST(OpaqueIdTest, multi_int)
     using limits_t = std::numeric_limits<Uint32>;
 
     // Unassigned is always out-of-range
-    EXPECT_FALSE(UId8{} < 0);
+    EXPECT_FALSE(UId8{} < 0u);
     EXPECT_FALSE(UId8{} < Uint32(limits_t::max()));
     EXPECT_FALSE(UId8{} < Uint32(255));
     EXPECT_FALSE(UId8{} < Uint32(256));

--- a/test/corecel/math/Constant.test.cc
+++ b/test/corecel/math/Constant.test.cc
@@ -28,6 +28,7 @@ TEST(ConstantTest, comparison)
     EXPECT_FALSE(pi == 3.0f);
     EXPECT_FALSE(pi == Constant{3});
     EXPECT_TRUE(pi != 3);
+    EXPECT_TRUE(pi != Constant{3});
     EXPECT_TRUE(pi == 3.14);
     EXPECT_TRUE(pi == 3.14f);
     EXPECT_TRUE(pi == Constant{3.14});

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -6,12 +6,13 @@
 //---------------------------------------------------------------------------//
 #include "corecel/math/Quantity.hh"
 
+#include <functional>
 #include <type_traits>
 
 #include "corecel/cont/Range.hh"
 #include "corecel/io/StreamUtils.hh"
 #include "corecel/math/ArrayQuantity.hh"
-#include "corecel/math/QuantityIO.json.hh"  //IWYU pragma: include
+#include "corecel/math/QuantityIO.json.hh"  // IWYU pragma: keep
 #include "corecel/math/Turn.hh"
 
 #include "celeritas_test.hh"

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -120,6 +120,15 @@ TEST(QuantityTest, mixed_precision)
     }
 }
 
+TEST(QuantityTest, ref)
+{
+    using DozenDbl = Quantity<DozenUnit, double>;
+    auto two_dozen = native_value_to<DozenDbl>(24);
+
+    auto td_ref = std::ref(two_dozen);
+    EXPECT_EQ(two_dozen * 2, td_ref * 2);
+}
+
 TEST(QuantityTest, comparators)
 {
     EXPECT_TRUE(zero_quantity() < Revolution{4});

--- a/test/corecel/random/Selector.test.cc
+++ b/test/corecel/random/Selector.test.cc
@@ -100,7 +100,7 @@ TEST_F(SelectorTest, selector_element)
     static double const macro_xs[] = {1.0, 2.0, 4.0};
     std::vector<int> evaluated;
     auto get_xs = [&evaluated](ElementId el) {
-        CELER_EXPECT(el < 3);
+        CELER_EXPECT(el < ElementId{3});
         evaluated.push_back(el.get());
         return macro_xs[el.get()];
     };


### PR DESCRIPTION
It turns out that many of the operators for Quantity, OpaqueId, etc. have a subtle but unfortunate oversight that, because they're declared as template functions, they don't participate in overload resolution when implicitly casting: this prevents `std::ref(value) + 2` from compiling. The fix is to declare them as inline friend functions, where they are reachable by ADL and where the RefWrapper can be automatically looked up via its implicit operator.

Moving the rest of the comparison operators into "inline" massively improves output from failed comparisons (e.g., if you try to test equality for a class that isn't convertible or doesn't have an equal sign). Such functions no longer are output in error messages from unrelated classes.

This change also improves the behavior of allowed comparison with OpaqueId: now `MatId{x} < 3` is forbidden; only `MatId{x} < y.size()` (since the RHS is an unsigned int) works.