### PR TITLE
Add implicit constructor to Span

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Object files and tests may have different paths and test names than you expect (
 
 ## Documentation
 
-- Add Doxygen documentation to **definitions**, not declarations, when adding code
+- Add Doxygen documentation to **definitions**, not declarations, when adding code. Prefer doxygen-style markup `\c`, `<code>` to Markdown in such blocks.
 - Document equations and algorithmic descriptions, as applicable, in the class definition's docs, as those are often rendered in the user manual. All `operator()` behavior goes in the class definition's docs.
 - Always add `\sa {file}.test.cc` underneath `\file {file}.hh` to locate tests that break the `src/{path}.hh`→`test/{path}.test.cc` rule
 - Use **only** ASCII characters in CMake/C++/CUDA/shell files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,10 @@ successful commit):
 
 ```bash
 # Write message to file first, then commit (script handles add/format/rm)
-scripts/dev/agent-commit.sh <build>/commit_msg.txt
+scripts/dev/agent-commit.sh <build>/commit_msg.txt "<agentic-tool>" "<model-name>"
 ```
 
-The script runs `git add -A`, `pre-commit run`, `git commit --trailer
-"Assisted-by: GitHub Copilot"`, and `rm <build>/commit_msg.txt`. Pass
+The script runs `git add -A`, `pre-commit run`, `git commit --trailer "Assisted-by: <agentic-tool> (<model-name>)"`, and `rm <build>/commit_msg.txt`. Pass
 `--no-verify` as an extra argument only if pre-commit is already known to
 pass.
 

--- a/scripts/dev/agent-commit.sh
+++ b/scripts/dev/agent-commit.sh
@@ -6,31 +6,33 @@
 # Commit staged and unstaged changes using a pre-written commit message file.
 #
 # Usage:
-#   scripts/dev/agent-commit.sh <message-file> [--no-verify]
+#   scripts/dev/agent-commit.sh <message-file> "<agentic-tool>" "<model-name>" [--no-verify]
 #
 # Intended for use by AI coding agents that cannot reliably pass multi-line
 # strings via shell heredocs. The agent writes the commit message to a file
 # (e.g. build/commit_msg.txt), calls this script, and the file is deleted on
 # success so that create_file can be used again next time.
 #
-# The commit is tagged with an Assisted-by trailer whose value is taken from
-# the AGENT_TRAILER environment variable, defaulting to "GitHub Copilot".
+# The commit is tagged with an Assisted-by trailer of the form:
+#   Assisted-by: <agentic-tool> (<model-name>)
 #-----------------------------------------------------------------------------#
 
-if [ $# -lt 1 ]; then
-  printf "Usage: %s <message-file> [extra git-commit options...]\n" "$0" >&2
+if [ $# -lt 3 ]; then
+  printf "Usage: %s <message-file> <agentic-tool> <model-name> [extra git-commit options...]\n" "$0" >&2
   exit 1
 fi
 
 MSG_FILE="$1"
-shift
+AGENT_TOOL="$2"
+MODEL_NAME="$3"
+shift 3
 
 if [ ! -f "$MSG_FILE" ]; then
   printf "error: message file not found: %s\n" "$MSG_FILE" >&2
   exit 1
 fi
 
-TRAILER="${AGENT_TRAILER:-GitHub Copilot}"
+TRAILER="${AGENT_TOOL} (${MODEL_NAME})"
 
 # Stage all changes (including new files)
 git add -A

--- a/src/celeritas/neutron/model/detail/NuclearZoneBuilder.hh
+++ b/src/celeritas/neutron/model/detail/NuclearZoneBuilder.hh
@@ -280,12 +280,12 @@ auto NuclearZoneBuilder::calc_zones_heavy(AtomicMassNumber a) const
     if (a < AtomicMassNumber{100})
     {
         static real_type const alpha_i[] = {0.7, 0.3, 0.01};
-        alpha = make_span(alpha_i);
+        alpha = alpha_i;
     }
     else
     {
         static real_type const alpha_h[] = {0.9, 0.6, 0.4, 0.2, 0.1, 0.05};
-        alpha = make_span(alpha_h);
+        alpha = alpha_h;
     }
 
     VecZoneDensity result(alpha.size());

--- a/src/corecel/Macros.hh
+++ b/src/corecel/Macros.hh
@@ -227,6 +227,29 @@
 #    define CELER_CUDACC_BUGGY_IF_CONSTEXPR 0
 #endif
 
+/*!
+ * \def CELER_EXPLICIT_IF(COND)
+ *
+ * Conditionally explicit constructor or conversion operator annotation,
+ * analogous to \c std::span and other standard library types.
+ *
+ * In C++20 and later, this expands to <code>explicit(COND)</code>: when
+ * \c COND is \c false the constructor is implicit; when \c true it is
+ * explicit. In C++17 the condition is ignored and the annotated function
+ * is unconditionally explicit.
+ *
+ * Example usage mirroring \c std::span 's array constructor:
+ * \code
+ *   CELER_EXPLICIT_IF(Extent != dynamic_extent)
+ *   Span(Array<value_type, N>& arr);
+ * \endcode
+ */
+#if __cplusplus >= 202002L
+#    define CELER_EXPLICIT_IF(COND) explicit(COND)
+#else
+#    define CELER_EXPLICIT_IF(COND) explicit
+#endif
+
 //!@}
 //---------------------------------------------------------------------------//
 //!@{

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -64,11 +64,8 @@ class Array;
  * - Default: empty span
  * - Implicit: pointer and size
  * - Implicit: two \c contiguous_iterator \c (first,last)
- * - Implicit: C arrays and celeritas::Array (requires C++20; explicit in
- * C++17)
+ * - Implicit: C arrays and celeritas::Array when extents are compatible
  * - Implicit: fixed-to-dynamic Span
- * - Explicit: dynamic-to-fixed Span
- * - Explicit (always): fixed-extent Span from Array
  *
  * \par Data access
  *
@@ -133,11 +130,11 @@ class Span
     }
 
     /*!
-     * Construct from a mutable \c Array, implicit iff Extent is dynamic.
+     * Construct implicitly from a mutable \c Array.
      *
-     * Mirrors the \c std::span constructor from \c std::array. In C++20 the
-     * constructor is implicit when \c Extent is \c dynamic_extent and
-     * explicit otherwise; in C++17 it is always explicit.
+     * Enabled only when \c N matches \c Extent exactly or \c Extent is
+     * \c dynamic_extent, so the conversion is always statically safe and
+     * can be implicit unconditionally.
      */
     template<class U,
              std::size_t N,
@@ -145,18 +142,16 @@ class Span
                                   && (N == Extent || Extent == dynamic_extent),
                               bool>
              = true>
-    CELER_EXPLICIT_IF(Extent != dynamic_extent)
     CELER_CONSTEXPR_FUNCTION Span(Array<U, N>& arr) : s_(arr.data(), N)
     {
     }
 
     /*!
-     * Construct from a const \c Array, implicit iff Extent is dynamic.
+     * Construct implicitly from a const \c Array.
      *
-     * Mirrors the \c std::span constructor from <code>const std::array</code>.
-     * In C++20 the constructor is implicit when \c Extent is
-     * \c dynamic_extent and explicit otherwise; in C++17 it is always
-     * explicit.
+     * Enabled only when \c N matches \c Extent exactly or \c Extent is
+     * \c dynamic_extent, so the conversion is always statically safe and
+     * can be implicit unconditionally.
      */
     template<class U,
              std::size_t N,
@@ -164,7 +159,6 @@ class Span
                                   && (N == Extent || Extent == dynamic_extent),
                               bool>
              = true>
-    CELER_EXPLICIT_IF(Extent != dynamic_extent)
     CELER_CONSTEXPR_FUNCTION Span(Array<U, N> const& arr) : s_(arr.data(), N)
     {
     }

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -106,12 +106,12 @@ class Span
     constexpr Span() = default;
 
     //! Construct from data and size
-    CELER_CONSTEXPR_FUNCTION Span(pointer d, size_type s) : s_(d, s) {}
+    CELER_CONSTEXPR_FUNCTION Span(pointer d, std::size_t s) : s_(d, s) {}
 
     //! Construct from two contiguous random-access iterators
     template<class Iter>
     CELER_CONSTEXPR_FUNCTION Span(Iter first, Iter last)
-        : s_(&(*first), static_cast<size_type>(last - first))
+        : s_(&(*first), static_cast<std::size_t>(last - first))
     {
     }
 
@@ -173,7 +173,7 @@ class Span
 
     //!@{
     //! \name Element access
-    CELER_CONSTEXPR_FUNCTION reference operator[](size_type i) const
+    CELER_CONSTEXPR_FUNCTION reference operator[](std::size_t i) const
     {
         return s_.data[i];
     }
@@ -191,8 +191,8 @@ class Span
     //!@{
     //! \name Observers
     CELER_CONSTEXPR_FUNCTION bool empty() const { return s_.size == 0; }
-    CELER_CONSTEXPR_FUNCTION size_type size() const { return s_.size; }
-    CELER_CONSTEXPR_FUNCTION size_type size_bytes() const
+    CELER_CONSTEXPR_FUNCTION std::size_t size() const { return s_.size; }
+    CELER_CONSTEXPR_FUNCTION std::size_t size_bytes() const
     {
         return sizeof(element_type) * s_.size;
     }

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -109,10 +109,13 @@ class Span
     CELER_CONSTEXPR_FUNCTION Span(pointer d, std::size_t s) : s_(d, s) {}
 
     //! Construct from two contiguous random-access iterators
+    //! NOTE: should be explicit unless dynamic_span (requires C++20)
     template<class Iter>
     CELER_CONSTEXPR_FUNCTION Span(Iter first, Iter last)
-        : s_(&(*first), static_cast<std::size_t>(last - first))
+        : s_(first == last ? nullptr : &(*first),
+             static_cast<std::size_t>(last - first))
     {
+        CELER_EXPECT(last >= first);
     }
 
     //! Construct from a C array

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -312,23 +312,24 @@ class Span
 
 // Deduction guide for pointer and size
 template<class T>
-Span(T*, std::size_t) -> Span<T>;
+CELER_FUNCTION Span(T*, std::size_t) -> Span<T>;
 
 // Deduction guide for two iterators
 template<class Iter>
-Span(Iter, Iter) -> Span<typename std::iterator_traits<Iter>::value_type>;
+CELER_FUNCTION Span(Iter, Iter)
+    -> Span<typename std::iterator_traits<Iter>::value_type>;
 
 // Deduction guide for C array
 template<class T, std::size_t N>
-Span(T (&)[N]) -> Span<T, N>;
+CELER_FUNCTION Span(T (&)[N]) -> Span<T, N>;
 
 // Deduction guide for mutable Array
 template<class T, std::size_t N>
-Span(Array<T, N>&) -> Span<T, N>;
+CELER_FUNCTION Span(Array<T, N>&) -> Span<T, N>;
 
 // Deduction guide for const Array
 template<class T, std::size_t N>
-Span(Array<T, N> const&) -> Span<T const, N>;
+CELER_FUNCTION Span(Array<T, N> const&) -> Span<T const, N>;
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -25,21 +25,57 @@ constexpr std::size_t dynamic_extent = detail::dynamic_extent;
 
 //---------------------------------------------------------------------------//
 /*!
- * Non-owning reference to a contiguous span of data.
+ * Non-owning device-compatible reference to a contiguous span of data.
  * \tparam T value type
  * \tparam Extent fixed size; defaults to dynamic.
  *
- * This Span class is a modified backport of the C++20 \c std::span . In
- * Celeritas, it is often used as a return value from accessing elements in a
- * \c Collection.
+ * A \c Span, like \c std::string_view, provides access to externally managed
+ * data. In Celeritas, this class is typically used as a return result
+ * from accessing a range of elements in a \c Collection.
  *
- * Like the \ref celeritas::Array , this class is not 100% compatible
- * with the \c std::span class. The hope is that it will be complete and
- * correct for the use cases needed by Celeritas (and, as a bonus, it will be
- * device-compatible).
+ * This implementation is a \em nonconforming backport of the C++20 \c
+ * std::span. Improvements for standards compatibility are welcome as long as
+ * they retain the same behavior in device code. Important differences from
+ * the standard \c std::span include:
+ * - Supports a special marker/tag type `LdgValue<T>` which causes element
+ *   accessors and iterators to use value-semantics loads (optimized device
+ *   loads) instead of references.
+ * - Uses a restricted constructor for iterators: instead of two separate
+ *   iterator/end types, it uses only one.
+ * - Provides additional free helpers tailored to Celeritas: `make_span`
+ *   overloads for `Array<T,N>`, C arrays, and generic containers, plus
+ *   `to_array()` convenience and a host-only `operator<<` using
+ *   `StreamableContainer`.
+ * - All public methods are decorated with `CELER_CONSTEXPR_FUNCTION` for
+ *   host/device compatibility.
+ * - Some subview helpers use `CELER_EXPECT` to check for bounds validation in
+ *   debug builds.
+ * - Dynamic-to-fixed conversion performs runtime checks when `CELERITAS_DEBUG`
+ *   is on.
  *
- * See \c LdgSpan for a specialization optimized for on-device memory access of
- * immutable data.
+ * \par Synopsis
+ *
+ * Construction:
+ * - Default constructs to an empty span.
+ * - Construct from a pointer and size: `Span(pointer, size)`.
+ * - Construct from two contiguous random-access iterators: `Span(first,
+ *   last)` (non-standard convenience).
+ * - Construct from C arrays or `Array<T,N>` (fixed-size spans).
+ * - Converting constructor from a compatible `Span<U,N>` (e.g., mutable to
+ *   const element type) when extents are compatible.
+ *
+ * Data access:
+ * - Element access: `operator[]`, `front()`, `back()`.
+ * - Observers: `data()`, `size()`, `size_bytes()`, `empty()`.
+ * - Iteration: `begin()`, `end()`.
+ *
+ * Subviews and utilities:
+ * - `first<Count>()`, `first(count)`, `last<Count>()`, `last(count)`.
+ * - `subspan<Offset,Count>()` and `subspan(offset,count)` for compile-time
+ *   and runtime subviews.
+ * - Deduction guides are provided for pointer+size, iterator pairs and
+ *   C arrays; free functions `make_span(...)` and `to_array(...)` are
+ *   provided for convenience.
  */
 template<class T, std::size_t Extent = dynamic_extent>
 class Span
@@ -85,12 +121,45 @@ class Span
     {
     }
 
-    //! Construct from another span
-    template<class U, std::size_t N>
-    CELER_CONSTEXPR_FUNCTION Span(Span<U, N> const& other)
+    /*!
+     * Construct \c implicitly from convertible span and extent.
+     *
+     * Note that the enable-if prevents LdgSpan->Span conversion.
+     * Conversions that may require a runtime size check (dynamic-extent
+     * source to fixed-extent destination) are made explicit to avoid
+     * accidental UB, matching std::span's behavior.
+     *
+     * Implicit conversion for cases that are statically safe (e.g.,
+     * fixed->dynamic, fixed->same-fixed, or just element-type
+     * qualification changes).
+     */
+    template<class U,
+             std::size_t E2,
+             std::enable_if_t<detail::is_array_convertible_v<U, T>
+                                  && (E2 == Extent || Extent == dynamic_extent),
+                              bool>
+             = true>
+    CELER_CONSTEXPR_FUNCTION Span(Span<U, E2> const& other)
         : s_(other.data(), other.size())
     {
     }
+
+    /*!
+     * Require \em explicit conversion from dynamic to fixed extent.
+     *
+     * Runtime size compatibility is checked in \c detail::SpanImpl.
+     */
+    template<class U,
+             std::size_t E2,
+             std::enable_if_t<detail::is_array_convertible_v<U, T>
+                                  && Extent != dynamic_extent && E2 == dynamic_extent,
+                              bool>
+             = true>
+    CELER_CONSTEXPR_FUNCTION explicit Span(Span<U, E2> const& other)
+        : s_(other.data(), other.size())
+    {
+    }
+
     CELER_DEFAULT_COPY_MOVE(Span);
     ~Span() = default;
 

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -37,45 +37,44 @@ constexpr std::size_t dynamic_extent = detail::dynamic_extent;
  * std::span. Improvements for standards compatibility are welcome as long as
  * they retain the same behavior in device code. Important differences from
  * the standard \c std::span include:
- * - Supports a special marker/tag type `LdgValue<T>` which causes element
+ * - Supports a special marker/tag type \c LdgValue<T> which causes element
  *   accessors and iterators to use value-semantics loads (optimized device
  *   loads) instead of references.
  * - Uses a restricted constructor for iterators: instead of two separate
  *   iterator/end types, it uses only one.
- * - Provides additional free helpers tailored to Celeritas: `make_span`
- *   overloads for `Array<T,N>`, C arrays, and generic containers, plus
- *   `to_array()` convenience and a host-only `operator<<` using
- *   `StreamableContainer`.
- * - All public methods are decorated with `CELER_CONSTEXPR_FUNCTION` for
+ * - Provides additional free helpers tailored to Celeritas: \c make_span
+ *   overloads for \c Array<T,N>, C arrays, and generic containers, plus
+ *   \c to_array() convenience and a host-only \c operator<< using
+ *   \c StreamableContainer.
+ * - All public methods are decorated with \c CELER_CONSTEXPR_FUNCTION for
  *   host/device compatibility.
- * - Some subview helpers use `CELER_EXPECT` to check for bounds validation in
+ * - Some subview helpers use \c CELER_EXPECT to check for bounds validation in
  *   debug builds.
- * - Dynamic-to-fixed conversion performs runtime checks when `CELERITAS_DEBUG`
- *   is on.
+ * - Dynamic-to-fixed conversion performs runtime checks when \c
+ *   CELERITAS_DEBUG is on.
  *
- * \par Synopsis
+ * \par Construction
  *
- * Construction:
- * - Default constructs to an empty span.
- * - Construct from a pointer and size: `Span(pointer, size)`.
- * - Construct from two contiguous random-access iterators: `Span(first,
- *   last)` (non-standard convenience).
- * - Construct from C arrays or `Array<T,N>` (fixed-size spans).
- * - Converting constructor from a compatible `Span<U,N>` (e.g., mutable to
- *   const element type) when extents are compatible.
+ * - Default: empty span
+ * - Implicit: pointer and size
+ * - Implicit: two \c contiguous_iterator \c (first,last)
+ * - Implicit: C arrays and celeritas::Array
+ * - Implicit: fixed-to-dynamic Span
+ * - Explicit: dynamic-to-fixed Span
  *
- * Data access:
- * - Element access: `operator[]`, `front()`, `back()`.
- * - Observers: `data()`, `size()`, `size_bytes()`, `empty()`.
- * - Iteration: `begin()`, `end()`.
+ * \par Data access
  *
- * Subviews and utilities:
- * - `first<Count>()`, `first(count)`, `last<Count>()`, `last(count)`.
- * - `subspan<Offset,Count>()` and `subspan(offset,count)` for compile-time
- *   and runtime subviews.
- * - Deduction guides are provided for pointer+size, iterator pairs and
- *   C arrays; free functions `make_span(...)` and `to_array(...)` are
- *   provided for convenience.
+ * - Element access: \c operator[], \c front(), \c back()
+ * - Observers: \c data(), \c size(), \c size_bytes(), \c empty()
+ * - Iteration: \c begin(), \c end()
+ *
+ * \par Subviews and utilities
+ *
+ * - \c first<Count>(), \c first(count), \c last<Count>(), \c last(count)
+ * - \c subspan<Offset,Count>() and \c subspan(offset,count) for compile-time
+ *   and runtime subviews
+ * - Deduction guides for pointer+size, iterator pairs, and C arrays
+ * - Free functions \c make_span(...) and \c to_array(...)
  */
 template<class T, std::size_t Extent = dynamic_extent>
 class Span
@@ -119,6 +118,7 @@ class Span
     }
 
     //! Construct from a C array
+    // (FIXME: template enable only if N == Extent or Extent == dynamic)
     template<std::size_t N>
     CELER_CONSTEXPR_FUNCTION Span(element_type (&arr)[N]) : s_(arr, N)
     {

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -81,7 +81,7 @@ class Array;
  * - \c first<Count>(), \c first(count), \c last<Count>(), \c last(count)
  * - \c subspan<Offset,Count>() and \c subspan(offset,count) for compile-time
  *   and runtime subviews
- * - Deduction guides for pointer+size, iterator pairs, and C arrays
+ * - Deduction guides for pointer+size, iterator pairs, C arrays, and Array
  * - Free functions \c make_span(...) and \c to_array(...)
  */
 template<class T, std::size_t Extent = dynamic_extent>
@@ -314,6 +314,14 @@ Span(Iter, Iter) -> Span<typename std::iterator_traits<Iter>::value_type>;
 // Deduction guide for C array
 template<class T, std::size_t N>
 Span(T (&)[N]) -> Span<T, N>;
+
+// Deduction guide for mutable Array
+template<class T, std::size_t N>
+Span(Array<T, N>&) -> Span<T, N>;
+
+// Deduction guide for const Array
+template<class T, std::size_t N>
+Span(Array<T, N> const&) -> Span<T const, N>;
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -24,6 +24,12 @@ namespace celeritas
 constexpr std::size_t dynamic_extent = detail::dynamic_extent;
 
 //---------------------------------------------------------------------------//
+// FORWARD DECLARATIONS
+//---------------------------------------------------------------------------//
+template<class T, std::size_t N>
+class Array;
+
+//---------------------------------------------------------------------------//
 /*!
  * Non-owning device-compatible reference to a contiguous span of data.
  * \tparam T value type
@@ -58,9 +64,11 @@ constexpr std::size_t dynamic_extent = detail::dynamic_extent;
  * - Default: empty span
  * - Implicit: pointer and size
  * - Implicit: two \c contiguous_iterator \c (first,last)
- * - Implicit: C arrays and celeritas::Array
+ * - Implicit: C arrays and celeritas::Array (requires C++20; explicit in
+ * C++17)
  * - Implicit: fixed-to-dynamic Span
  * - Explicit: dynamic-to-fixed Span
+ * - Explicit (always): fixed-extent Span from Array
  *
  * \par Data access
  *
@@ -121,6 +129,43 @@ class Span
     // (FIXME: template enable only if N == Extent or Extent == dynamic)
     template<std::size_t N>
     CELER_CONSTEXPR_FUNCTION Span(element_type (&arr)[N]) : s_(arr, N)
+    {
+    }
+
+    /*!
+     * Construct from a mutable \c Array, implicit iff Extent is dynamic.
+     *
+     * Mirrors the \c std::span constructor from \c std::array. In C++20 the
+     * constructor is implicit when \c Extent is \c dynamic_extent and
+     * explicit otherwise; in C++17 it is always explicit.
+     */
+    template<class U,
+             std::size_t N,
+             std::enable_if_t<detail::is_array_convertible_v<U, T>
+                                  && (N == Extent || Extent == dynamic_extent),
+                              bool>
+             = true>
+    CELER_EXPLICIT_IF(Extent != dynamic_extent)
+    CELER_CONSTEXPR_FUNCTION Span(Array<U, N>& arr) : s_(arr.data(), N)
+    {
+    }
+
+    /*!
+     * Construct from a const \c Array, implicit iff Extent is dynamic.
+     *
+     * Mirrors the \c std::span constructor from <code>const std::array</code>.
+     * In C++20 the constructor is implicit when \c Extent is
+     * \c dynamic_extent and explicit otherwise; in C++17 it is always
+     * explicit.
+     */
+    template<class U,
+             std::size_t N,
+             std::enable_if_t<detail::is_array_convertible_v<U const, T>
+                                  && (N == Extent || Extent == dynamic_extent),
+                              bool>
+             = true>
+    CELER_EXPLICIT_IF(Extent != dynamic_extent)
+    CELER_CONSTEXPR_FUNCTION Span(Array<U, N> const& arr) : s_(arr.data(), N)
     {
     }
 
@@ -269,12 +314,6 @@ Span(Iter, Iter) -> Span<typename std::iterator_traits<Iter>::value_type>;
 // Deduction guide for C array
 template<class T, std::size_t N>
 Span(T (&)[N]) -> Span<T, N>;
-
-//---------------------------------------------------------------------------//
-// FORWARD DECLARATIONS
-//---------------------------------------------------------------------------//
-template<class T, std::size_t N>
-class Array;
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS

--- a/src/corecel/cont/Span.hh
+++ b/src/corecel/cont/Span.hh
@@ -85,6 +85,8 @@ template<class T, std::size_t Extent = dynamic_extent>
 class Span
 {
     using SpanTraitsT = detail::SpanTraits<T>;
+    static constexpr bool ndebug = !CELERITAS_DEBUG;
+    static constexpr bool ndebug_or_dyn = (ndebug || Extent == dynamic_extent);
 
   public:
     //!@{
@@ -110,12 +112,18 @@ class Span
     constexpr Span() = default;
 
     //! Construct from data and size
-    CELER_CONSTEXPR_FUNCTION Span(pointer d, std::size_t s) : s_(d, s) {}
+    CELER_CONSTEXPR_FUNCTION
+    Span(pointer d, std::size_t s) noexcept(ndebug_or_dyn) : s_(d, s) {}
 
-    //! Construct from two contiguous random-access iterators
-    //! NOTE: should be explicit unless dynamic_span (requires C++20)
+    /*!
+     * Construct from two contiguous random-access iterators.
+     *
+     * \note If \c Extent is fixed-size, the \c SpanImpl will fire an assertion
+     * in debug mode if the size does not match.
+     * \todo should be explicit unless dynamic size (requires C++20)
+     */
     template<class Iter>
-    CELER_CONSTEXPR_FUNCTION Span(Iter first, Iter last)
+    CELER_CONSTEXPR_FUNCTION Span(Iter first, Iter last) noexcept(ndebug_or_dyn)
         : s_(first == last ? nullptr : &(*first),
              static_cast<std::size_t>(last - first))
     {
@@ -123,9 +131,9 @@ class Span
     }
 
     //! Construct from a C array
-    // (FIXME: template enable only if N == Extent or Extent == dynamic)
-    template<std::size_t N>
-    CELER_CONSTEXPR_FUNCTION Span(element_type (&arr)[N]) : s_(arr, N)
+    template<std::size_t N,
+             std::enable_if_t<N == Extent || Extent == dynamic_extent, bool> = true>
+    CELER_CONSTEXPR_FUNCTION Span(element_type (&arr)[N]) noexcept : s_(arr, N)
     {
     }
 
@@ -142,7 +150,8 @@ class Span
                                   && (N == Extent || Extent == dynamic_extent),
                               bool>
              = true>
-    CELER_CONSTEXPR_FUNCTION Span(Array<U, N>& arr) : s_(arr.data(), N)
+    CELER_CONSTEXPR_FUNCTION Span(Array<U, N>& arr) noexcept
+        : s_(arr.data(), N)
     {
     }
 
@@ -159,7 +168,8 @@ class Span
                                   && (N == Extent || Extent == dynamic_extent),
                               bool>
              = true>
-    CELER_CONSTEXPR_FUNCTION Span(Array<U, N> const& arr) : s_(arr.data(), N)
+    CELER_CONSTEXPR_FUNCTION Span(Array<U, N> const& arr) noexcept
+        : s_(arr.data(), N)
     {
     }
 
@@ -181,7 +191,8 @@ class Span
                                   && (E2 == Extent || Extent == dynamic_extent),
                               bool>
              = true>
-    CELER_CONSTEXPR_FUNCTION Span(Span<U, E2> const& other)
+    CELER_CONSTEXPR_FUNCTION
+    Span(Span<U, E2> const& other) noexcept(ndebug_or_dyn)
         : s_(other.data(), other.size())
     {
     }
@@ -197,7 +208,8 @@ class Span
                                   && Extent != dynamic_extent && E2 == dynamic_extent,
                               bool>
              = true>
-    CELER_CONSTEXPR_FUNCTION explicit Span(Span<U, E2> const& other)
+    CELER_CONSTEXPR_FUNCTION explicit Span(Span<U, E2> const& other) noexcept(
+        ndebug_or_dyn)
         : s_(other.data(), other.size())
     {
     }
@@ -243,13 +255,13 @@ class Span
     //!@{
     //! \name Subviews
     template<std::size_t Count>
-    CELER_CONSTEXPR_FUNCTION Span<T, Count> first() const
+    CELER_CONSTEXPR_FUNCTION Span<T, Count> first() const noexcept(ndebug)
     {
         CELER_EXPECT(Count == 0 || Count <= this->size());
         return {this->data(), Count};
     }
     CELER_CONSTEXPR_FUNCTION
-    Span<T, dynamic_extent> first(std::size_t count) const
+    Span<T, dynamic_extent> first(std::size_t count) const noexcept(ndebug)
     {
         CELER_EXPECT(count <= this->size());
         return {this->data(), count};
@@ -258,7 +270,7 @@ class Span
     template<std::size_t Offset, std::size_t Count = dynamic_extent>
     CELER_CONSTEXPR_FUNCTION
         Span<T, detail::subspan_extent(Extent, Offset, Count)>
-        subspan() const
+        subspan() const noexcept(ndebug)
     {
         CELER_EXPECT((Count == dynamic_extent) || (Offset == 0 && Count == 0)
                      || (Offset + Count <= this->size()));
@@ -268,6 +280,7 @@ class Span
     CELER_CONSTEXPR_FUNCTION
     Span<T, dynamic_extent>
     subspan(std::size_t offset, std::size_t count = dynamic_extent) const
+        noexcept(ndebug)
     {
         CELER_EXPECT(offset + count <= this->size());
         return {this->data() + offset,
@@ -275,13 +288,13 @@ class Span
     }
 
     template<std::size_t Count>
-    CELER_CONSTEXPR_FUNCTION Span<T, Count> last() const
+    CELER_CONSTEXPR_FUNCTION Span<T, Count> last() const noexcept(ndebug)
     {
         CELER_EXPECT(Count == 0 || Count <= this->size());
         return {this->data() + this->size() - Count, Count};
     }
     CELER_CONSTEXPR_FUNCTION
-    Span<T, dynamic_extent> last(std::size_t count) const
+    Span<T, dynamic_extent> last(std::size_t count) const noexcept(ndebug)
     {
         CELER_EXPECT(count <= this->size());
         return {this->data() + this->size() - count, count};
@@ -289,7 +302,7 @@ class Span
     //!@}
 
   private:
-    //! Storage
+    //// DATA ////
     detail::SpanImpl<T, Extent> s_;
 };
 

--- a/src/corecel/cont/VariantUtils.hh
+++ b/src/corecel/cont/VariantUtils.hh
@@ -118,8 +118,9 @@ class ContainerVisitor
 };
 
 //---------------------------------------------------------------------------//
-// TEMPLATE DEDUCTION
+// DEDUCTION GUIDES
 //---------------------------------------------------------------------------//
+
 template<class T>
 ContainerVisitor(T&&) -> ContainerVisitor<T>;
 

--- a/src/corecel/cont/detail/LdgSpanImpl.hh
+++ b/src/corecel/cont/detail/LdgSpanImpl.hh
@@ -283,10 +283,10 @@ class LdgIterator
 // DEDUCTION GUIDES
 //---------------------------------------------------------------------------//
 template<class T>
-LdgWrapper(T&) -> LdgWrapper<std::add_const_t<T>>;
+CELER_FUNCTION LdgWrapper(T&) -> LdgWrapper<std::add_const_t<T>>;
 
 template<class T>
-LdgIterator(T*) -> LdgIterator<std::add_const_t<T>>;
+CELER_FUNCTION LdgIterator(T*) -> LdgIterator<std::add_const_t<T>>;
 
 //---------------------------------------------------------------------------//
 //! Get the item that's wrapped

--- a/src/corecel/cont/detail/SpanImpl.hh
+++ b/src/corecel/cont/detail/SpanImpl.hh
@@ -31,12 +31,12 @@ template<class T>
 struct SpanTraits
 {
     using element_type = T;
-    using pointer = std::add_pointer_t<element_type>;
-    using const_pointer = std::add_pointer_t<element_type const>;
+    using pointer = std::add_pointer_t<T>;
+    using const_pointer = std::add_pointer_t<std::add_const_t<T>>;
     using iterator = pointer;
     using const_iterator = const_pointer;
-    using reference = std::add_lvalue_reference_t<element_type>;
-    using const_reference = std::add_lvalue_reference_t<element_type const>;
+    using reference = std::add_lvalue_reference_t<T>;
+    using const_reference = std::add_lvalue_reference_t<std::add_const_t<T>>;
 };
 
 //---------------------------------------------------------------------------//
@@ -52,7 +52,7 @@ struct SpanTraits<LdgWrapper<T>>
 {
     static_assert(std::is_const_v<T>);
 
-    using element_type = T;
+    using element_type = T;  //!< Underlying type
     using pointer = std::add_pointer_t<T>;
     using const_pointer = pointer;
     using iterator = LdgIterator<T>;
@@ -63,7 +63,13 @@ struct SpanTraits<LdgWrapper<T>>
 
 //---------------------------------------------------------------------------//
 //! Sentinel value for span of dynamic type
-inline constexpr std::size_t dynamic_extent = std::size_t(-1);
+inline constexpr std::size_t dynamic_extent = static_cast<std::size_t>(-1);
+
+//---------------------------------------------------------------------------//
+//! Whether one type array is convertible to another
+template<class T, class U>
+inline constexpr bool is_array_convertible_v
+    = std::is_convertible_v<T (*)[], U (*)[]>;
 
 //---------------------------------------------------------------------------//
 //! Calculate the return type for a subspan
@@ -85,7 +91,7 @@ subspan_size(std::size_t size, std::size_t offset, std::size_t count)
 
 //---------------------------------------------------------------------------//
 /*!
- * Storage for a Span.
+ * Storage for a fixed-size nonzero Span.
  */
 template<class T, std::size_t Extent>
 struct SpanImpl

--- a/src/corecel/cont/detail/SpanImpl.hh
+++ b/src/corecel/cont/detail/SpanImpl.hh
@@ -66,10 +66,15 @@ struct SpanTraits<LdgWrapper<T>>
 inline constexpr std::size_t dynamic_extent = static_cast<std::size_t>(-1);
 
 //---------------------------------------------------------------------------//
+//! Pointer to a fixed-size array
+template<class T>
+using array_ptr_t = T (*)[];
+
+//---------------------------------------------------------------------------//
 //! Whether one type array is convertible to another
 template<class T, class U>
 inline constexpr bool is_array_convertible_v
-    = std::is_convertible_v<T (*)[], U (*)[]>;
+    = std::is_convertible_v<array_ptr_t<T>, array_ptr_t<U>>;
 
 //---------------------------------------------------------------------------//
 //! Calculate the return type for a subspan

--- a/src/corecel/data/Collection.hh
+++ b/src/corecel/data/Collection.hh
@@ -388,10 +388,10 @@ class Collection
 
     //!@{
     //! Access all data as a span (memspace-safe)
-    CELER_FIF auto operator[](AllItemsT) { return SpanT{this->raw_span()}; }
-    CELER_FIF auto operator[](AllItemsT) const
+    CELER_FIF SpanT operator[](AllItemsT) { return {s_.data(), s_.size()}; }
+    CELER_FIF SpanConstT operator[](AllItemsT) const
     {
-        return SpanConstT{this->raw_span()};
+        return {s_.data(), s_.size()};
     }
     //!@}
 

--- a/src/corecel/math/detail/SpanUtilsImpl.hh
+++ b/src/corecel/math/detail/SpanUtilsImpl.hh
@@ -28,15 +28,6 @@ CELER_FUNCTION Array<T, N> load_array(Span<T const, N> s)
     return result;
 }
 
-//! Load a const span into a fixed-size array.
-//! \todo Delete in follow-up PR when implicit const conversion works.
-template<class T, std::size_t N>
-CELER_FUNCTION Array<T, N> load_array(Span<T, N> s)
-{
-    static_assert(N != dynamic_extent);
-    return load_array(make_span(const_cast<T const>(s.data()), s.size()));
-}
-
 //---------------------------------------------------------------------------//
 //! Store a fixed-size array into a span.
 template<class T, std::size_t N>

--- a/src/corecel/random/engine/detail/RanluxppImpl.hh
+++ b/src/corecel/random/engine/detail/RanluxppImpl.hh
@@ -443,10 +443,10 @@ CELER_FUNCTION RanluxppArray9 compute_modulus(RanluxppArray18 const& mul)
     }
 
     // Make a subspan of the last 9 elements of mul
-    auto mul_end = celeritas::make_span(mul).subspan<9, 9>();
+    auto mul_end = Span{mul}.subspan<9, 9>();
     static_assert(mul_end.size() == 9);
 
-    int64_t c = compute_remainder(mul_end, celeritas::make_span(r));
+    int64_t c = compute_remainder(mul_end, r);
 
     // To update r = r - c * m, it suffices to know c * (-2 ** 240 + 1)
     // because the 2 ** 576 will cancel out. Also note that c may be zero, but

--- a/src/corecel/random/engine/detail/RanluxppImpl.hh
+++ b/src/corecel/random/engine/detail/RanluxppImpl.hh
@@ -633,8 +633,7 @@ CELER_FUNCTION RanluxppArray9 to_lcg(RanluxppNumber const& ranlux)
 CELER_FUNCTION RanluxppNumber to_ranlux(RanluxppArray9 const& lcg)
 {
     RanluxppNumber result;
-    int64_t c = compute_remainder(celeritas::make_span(lcg),
-                                  celeritas::make_span(result.number));
+    int64_t c = compute_remainder(lcg, result.number);
 
     // ranlux = t1 + t2 + c
     unsigned int carry = 0;

--- a/src/orange/surf/SurfaceSimplifier.cc
+++ b/src/orange/surf/SurfaceSimplifier.cc
@@ -216,7 +216,7 @@ ORANGE_INSTANTIATE_OP(ConeAligned, ConeAligned);
 auto SurfaceSimplifier::operator()(Plane const& p) const
     -> Optional<PlaneX, PlaneY, PlaneZ, Plane>
 {
-    auto signs = SignCounter{tol_}(make_span(p.normal()));
+    auto signs = SignCounter{tol_}(p.normal());
     CELER_ASSERT(signs);
 
     if (signs.should_flip())

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -122,7 +122,7 @@ CELER_FUNCTION T
 TransformVisitor::make_transform(OpaqueId<real_type> data_offset) const
 {
     CELER_EXPECT(data_offset <= reals_.size());
-    using SpanT = T::StorageSpan;
+    using SpanT = typename T::StorageSpan;
     constexpr size_type size{SpanT::extent};
     CELER_ASSERT(data_offset + size <= reals_.size());
 

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -122,10 +122,16 @@ CELER_FUNCTION T
 TransformVisitor::make_transform(OpaqueId<real_type> data_offset) const
 {
     CELER_EXPECT(data_offset <= reals_.size());
-    constexpr size_type size{T::StorageSpan::extent};
+    using SpanT = T::StorageSpan;
+    constexpr size_type size{SpanT::extent};
     CELER_ASSERT(data_offset + size <= reals_.size());
 
-    return T{reals_[Reals::ItemRangeT{data_offset, data_offset + size}]};
+    // ItemRangeT returns a Span<Ldg..., dynamic>
+    // but each Transform class expects Span<..., N>, which requires an
+    // explicit cast
+    // TODO: templated 'subspan' for collection?
+    auto dynspan = reals_[Reals::ItemRangeT{data_offset, data_offset + size}];
+    return T{SpanT{dynspan}};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/transform/TransformVisitor.hh
+++ b/src/orange/transform/TransformVisitor.hh
@@ -126,12 +126,11 @@ TransformVisitor::make_transform(OpaqueId<real_type> data_offset) const
     constexpr size_type size{SpanT::extent};
     CELER_ASSERT(data_offset + size <= reals_.size());
 
-    // ItemRangeT returns a Span<Ldg..., dynamic>
-    // but each Transform class expects Span<..., N>, which requires an
-    // explicit cast
-    // TODO: templated 'subspan' for collection?
+    // ItemRangeT returns a LdgSpan<Ldg..., dynamic>
+    // but each Transform class expects LdgSpan<..., N>,
+    // which requires an explicit cast
     auto dynspan = reals_[Reals::ItemRangeT{data_offset, data_offset + size}];
-    return T{SpanT{dynspan}};
+    return T{SpanT{dynspan.data(), dynspan.size()}};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/grid/GridIdFinder.test.cc
+++ b/test/celeritas/grid/GridIdFinder.test.cc
@@ -35,7 +35,7 @@ TEST_F(GridIdFinderTest, all)
     grid = {1e-3, 1, 10, 11};
     ids = {IdT{5}, IdT{3}, IdT{7}};
 
-    FinderT find_id(make_span(grid), make_span(ids));
+    FinderT find_id(make_ldg_span(grid), make_ldg_span(ids));
     EXPECT_EQ(invalid, find_id(Energy{1e-6}).unchecked_get());
     EXPECT_EQ(5, find_id(Energy{1e-3}).unchecked_get());
     EXPECT_EQ(5, find_id(Energy{0.1}).unchecked_get());

--- a/test/celeritas/grid/UniformLogGridCalculator.test.cc
+++ b/test/celeritas/grid/UniformLogGridCalculator.test.cc
@@ -124,7 +124,7 @@ TEST_F(UniformLogGridCalculatorTest, spline_deriv)
             EXPECT_SOFT_EQ(x[i], std::exp(loge_grid[i]));
             EXPECT_SOFT_EQ(y[i], calc[i]);
         }
-        auto deriv = calc_deriv(make_span(x), make_span(y));
+        auto deriv = calc_deriv(make_ldg_span(x), make_ldg_span(y));
         EXPECT_VEC_SOFT_EQ(expected_deriv, deriv);
     }
 }

--- a/test/celeritas/track/MockInteractAction.cc
+++ b/test/celeritas/track/MockInteractAction.cc
@@ -64,7 +64,8 @@ void MockInteractAction::step(CoreParams const& params,
  */
 Span<size_type const> MockInteractAction::num_secondaries() const
 {
-    return data_.host_ref().num_secondaries[AllItems<size_type>{}];
+    return remove_ldg_wrapper(
+        data_.host_ref().num_secondaries[AllItems<size_type>{}]);
 }
 
 //---------------------------------------------------------------------------//
@@ -73,7 +74,7 @@ Span<size_type const> MockInteractAction::num_secondaries() const
  */
 Span<char const> MockInteractAction::alive() const
 {
-    return data_.host_ref().alive[AllItems<char>{}];
+    return remove_ldg_wrapper(data_.host_ref().alive[AllItems<char>{}]);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/OpaqueIdUtils.hh
+++ b/test/corecel/OpaqueIdUtils.hh
@@ -54,7 +54,7 @@ inline auto id_to_int(Span<OpaqueId<I, T> const> vals)
 template<class I, class T>
 inline auto id_to_int(LdgSpan<OpaqueId<I, T> const> vals)
 {
-    return id_to_int(Span<OpaqueId<I, T> const>(vals));
+    return id_to_int(remove_ldg_wrapper(vals));
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/cont/LdgSpan.test.cc
+++ b/test/corecel/cont/LdgSpan.test.cc
@@ -51,8 +51,8 @@ TEST_F(LdgWrapperTest, equality)
 
     // std::equal triggers LdgWrapper == LdgWrapper comparison internally
     static double const same_vals[] = {1.0, 2.0};
-    LdgSpan<double const> span1{vals};
-    LdgSpan<double const> span2{same_vals};
+    auto span1 = make_ldg_span(vals);
+    auto span2 = make_ldg_span(same_vals);
     EXPECT_TRUE(std::equal(span1.begin(), span1.end(), span2.begin()));
     static double const diff_vals[] = {1.0, 3.0};
     LdgSpan<double const> span3{diff_vals};
@@ -259,11 +259,14 @@ TEST_F(LdgSpanTest, pod)
     using LdgWrap = detail::LdgWrapper<int const>;
     using LdgIter = detail::LdgIterator<int const>;
 
-    int local_data[] = {123, 456, 789};
-    Span<int> mutable_span(local_data);
-    EXPECT_TRUE((is_same_v<decltype(mutable_span[0]), int&>));
+    // LdgSpan must not be implicitly convertible to Span
+    EXPECT_FALSE((std::is_constructible_v<Span<int const>, LdgSpan<int const>>))
+        << "LdgSpan->Span conversion is prohibited";
 
-    Span<LdgWrap> ldg_span(mutable_span);
+    int const local_data[] = {123, 456, 789};
+    Span<int const> basic_span(local_data);
+    EXPECT_TRUE((is_same_v<decltype(basic_span[0]), int const&>));
+
     Span<LdgWrap> local_span(local_data);
     EXPECT_TRUE((is_same_v<typename Span<LdgWrap>::element_type, int const>));
     EXPECT_TRUE((is_same_v<decltype(local_span.data()), int const*>));
@@ -298,7 +301,6 @@ TEST_F(LdgSpanTest, opaque_id)
     Span<TestId> mutable_span(local_data);
     EXPECT_TRUE((is_same_v<decltype(mutable_span[0]), TestId&>));
 
-    Span<LdgWrap> ldg_span(mutable_span);
     Span<LdgWrap> s(local_data);
     EXPECT_TRUE(
         (is_same_v<typename Span<LdgWrap>::element_type, TestId const>));

--- a/test/corecel/cont/Span.test.cc
+++ b/test/corecel/cont/Span.test.cc
@@ -323,59 +323,34 @@ TEST(SpanTest, array_conversion)
     ArrInt3 arr = {1, 2, 3};
     ArrInt3 const carr = {4, 5, 6};
 
-    // Direct (explicit) construction always works
-    Span<int, 3> fixed{arr};
+    // Implicit copy-initialization for both fixed and dynamic extents
+    Span<int, 3> fixed = arr;
     EXPECT_EQ(arr.data(), fixed.data());
     EXPECT_EQ(3, fixed.size());
 
-    Span<int const, 3> cfixed{arr};
+    Span<int const, 3> cfixed = arr;
     EXPECT_EQ(arr.data(), cfixed.data());
 
-    Span<int const, 3> cfixed2{carr};
+    Span<int const, 3> cfixed2 = carr;
     EXPECT_EQ(carr.data(), cfixed2.data());
 
-    // Dynamic extent: explicit construction always works
-    Span<int> dyn{arr};
+    Span<int> dyn = arr;
     EXPECT_EQ(arr.data(), dyn.data());
     EXPECT_EQ(3, dyn.size());
 
-    Span<int const> cdyn{carr};
+    Span<int const> cdyn = carr;
     EXPECT_EQ(carr.data(), cdyn.data());
     EXPECT_EQ(3, cdyn.size());
 
-    // In C++20, construction is implicit for dynamic-extent spans
-#if __cplusplus >= 202002L
-    // Implicit copy-initialization only works if constructor is not explicit
-    Span<int> implicit_dyn = arr;
-    EXPECT_EQ(arr.data(), implicit_dyn.data());
-    EXPECT_EQ(3, implicit_dyn.size());
+    // All size-compatible conversions are implicit in all standards
+    EXPECT_TRUE((std::is_convertible_v<ArrInt3&, Span<int, 3>>));
+    EXPECT_TRUE((std::is_convertible_v<ArrInt3&, Span<int>>));
+    EXPECT_TRUE((std::is_convertible_v<ArrInt3 const&, Span<int const, 3>>));
+    EXPECT_TRUE((std::is_convertible_v<ArrInt3 const&, Span<int const>>));
 
-    Span<int const> implicit_cdyn = carr;
-    EXPECT_EQ(carr.data(), implicit_cdyn.data());
-    EXPECT_EQ(3, implicit_cdyn.size());
-
-    // Dynamic extent is implicitly constructible from Array
-    EXPECT_TRUE((std::is_convertible_v<ArrInt3&, Span<int>>))
-        << "Array to dynamic Span must be implicit in C++20";
-    EXPECT_TRUE((std::is_convertible_v<ArrInt3 const&, Span<int const>>))
-        << "const Array to dynamic const Span must be implicit in C++20";
-
-    // Fixed extent is NOT implicitly constructible from Array
-    EXPECT_FALSE((std::is_convertible_v<ArrInt3&, Span<int, 3>>))
-        << "Array to fixed Span must be explicit in C++20";
-#else
-    // In C++17 all Array-to-Span constructors are explicit
-    EXPECT_FALSE((std::is_convertible_v<ArrInt3&, Span<int>>))
-        << "Array to dynamic Span must be explicit in C++17";
-    EXPECT_FALSE((std::is_convertible_v<ArrInt3 const&, Span<int const>>))
-        << "const Array to dynamic const Span must be explicit in C++17";
-#endif
-
-    // Constructible (explicit) in all standards
-    EXPECT_TRUE((std::is_constructible_v<Span<int>, ArrInt3&>));
-    EXPECT_TRUE((std::is_constructible_v<Span<int, 3>, ArrInt3&>));
-    EXPECT_TRUE((std::is_constructible_v<Span<int const>, ArrInt3 const&>));
-    EXPECT_TRUE((std::is_constructible_v<Span<int const, 3>, ArrInt3 const&>));
+    // Wrong fixed extent: not constructible
+    EXPECT_FALSE((std::is_constructible_v<Span<int, 2>, ArrInt3&>))
+        << "Array to fixed Span with different extent is prohibited";
 
     // Removing const must not be allowed
     EXPECT_FALSE((std::is_constructible_v<Span<int>, ArrInt3 const&>))

--- a/test/corecel/cont/Span.test.cc
+++ b/test/corecel/cont/Span.test.cc
@@ -317,6 +317,73 @@ TEST(SpanTest, make_span)
     }
 }
 
+TEST(SpanTest, array_conversion)
+{
+    using ArrInt3 = Array<int, 3>;
+    ArrInt3 arr = {1, 2, 3};
+    ArrInt3 const carr = {4, 5, 6};
+
+    // Direct (explicit) construction always works
+    Span<int, 3> fixed{arr};
+    EXPECT_EQ(arr.data(), fixed.data());
+    EXPECT_EQ(3, fixed.size());
+
+    Span<int const, 3> cfixed{arr};
+    EXPECT_EQ(arr.data(), cfixed.data());
+
+    Span<int const, 3> cfixed2{carr};
+    EXPECT_EQ(carr.data(), cfixed2.data());
+
+    // Dynamic extent: explicit construction always works
+    Span<int> dyn{arr};
+    EXPECT_EQ(arr.data(), dyn.data());
+    EXPECT_EQ(3, dyn.size());
+
+    Span<int const> cdyn{carr};
+    EXPECT_EQ(carr.data(), cdyn.data());
+    EXPECT_EQ(3, cdyn.size());
+
+    // In C++20, construction is implicit for dynamic-extent spans
+#if __cplusplus >= 202002L
+    // Implicit copy-initialization only works if constructor is not explicit
+    Span<int> implicit_dyn = arr;
+    EXPECT_EQ(arr.data(), implicit_dyn.data());
+    EXPECT_EQ(3, implicit_dyn.size());
+
+    Span<int const> implicit_cdyn = carr;
+    EXPECT_EQ(carr.data(), implicit_cdyn.data());
+    EXPECT_EQ(3, implicit_cdyn.size());
+
+    // Dynamic extent is implicitly constructible from Array
+    EXPECT_TRUE((std::is_convertible_v<ArrInt3&, Span<int>>))
+        << "Array to dynamic Span must be implicit in C++20";
+    EXPECT_TRUE((std::is_convertible_v<ArrInt3 const&, Span<int const>>))
+        << "const Array to dynamic const Span must be implicit in C++20";
+
+    // Fixed extent is NOT implicitly constructible from Array
+    EXPECT_FALSE((std::is_convertible_v<ArrInt3&, Span<int, 3>>))
+        << "Array to fixed Span must be explicit in C++20";
+#else
+    // In C++17 all Array-to-Span constructors are explicit
+    EXPECT_FALSE((std::is_convertible_v<ArrInt3&, Span<int>>))
+        << "Array to dynamic Span must be explicit in C++17";
+    EXPECT_FALSE((std::is_convertible_v<ArrInt3 const&, Span<int const>>))
+        << "const Array to dynamic const Span must be explicit in C++17";
+#endif
+
+    // Constructible (explicit) in all standards
+    EXPECT_TRUE((std::is_constructible_v<Span<int>, ArrInt3&>));
+    EXPECT_TRUE((std::is_constructible_v<Span<int, 3>, ArrInt3&>));
+    EXPECT_TRUE((std::is_constructible_v<Span<int const>, ArrInt3 const&>));
+    EXPECT_TRUE((std::is_constructible_v<Span<int const, 3>, ArrInt3 const&>));
+
+    // Removing const must not be allowed
+    EXPECT_FALSE((std::is_constructible_v<Span<int>, ArrInt3 const&>))
+        << "const Array to mutable Span is prohibited";
+    EXPECT_FALSE((std::is_constructible_v<Span<int, 3>, ArrInt3 const&>))
+        << "const Array to mutable fixed Span is prohibited";
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/cont/Span.test.cc
+++ b/test/corecel/cont/Span.test.cc
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <type_traits>
 
-#include "corecel/OpaqueId.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/io/StreamUtils.hh"
 #include "corecel/sys/TypeDemangler.hh"
@@ -67,6 +66,15 @@ TEST(SpanTest, fixed_size_zero)
     Span<int const> const_dynamic{empty_span};
     EXPECT_EQ(0, const_dynamic.size());
 
+    // Removing const must not be allowed
+    EXPECT_FALSE((std::is_constructible_v<Span<int, 0>, Span<int const, 0>>))
+        << "const->mutable span is prohibited";
+    EXPECT_FALSE((std::is_constructible_v<Span<int>, Span<int const>>))
+        << "const->mutable dynamic span is prohibited";
+    // Incompatible fixed extents must not be allowed
+    EXPECT_FALSE((std::is_constructible_v<Span<int, 2>, Span<int, 3>>))
+        << "fixed span with different extent is prohibited";
+
     // Test pointer constructor
     Span<int, 0> ptr_span(empty_span.begin(), empty_span.end());
     EXPECT_EQ(0, ptr_span.size());
@@ -121,6 +129,30 @@ TEST(SpanTest, fixed_size)
     // Test pointer constructor
     Span<int, 2> ptr_span(local_data, local_data + 2);
     EXPECT_EQ(local_data, ptr_span.data());
+}
+
+TEST(SpanTest, implicit_const_conversion)
+{
+    // Test that Span<int, 3> implicitly converts to Span<int const>
+    // (i.e., the converting constructor is not explicit)
+    int local_data[] = {1, 2, 3};
+    Span<int, 3> span(local_data);
+
+    Span<int const> const_span = span;
+    EXPECT_EQ(local_data, const_span.data());
+    EXPECT_EQ(3, const_span.size());
+
+    // Should be able to convert back *explicitly* to fixed-size
+    Span<int const, 3> const_fixed_span{const_span};
+    EXPECT_EQ(local_data, const_fixed_span.data());
+    EXPECT_EQ(3, const_fixed_span.size());
+
+    // Converting dynamic to wrong size should result in assertion failure
+    if constexpr (CELERITAS_DEBUG)
+    {
+        EXPECT_THROW((Span<int const, 2>{const_span}), DebugError);
+        EXPECT_THROW((Span<int const, 4>{const_span}), DebugError);
+    }
 }
 
 TEST(SpanTest, dynamic_size)

--- a/test/corecel/cont/Span.test.cc
+++ b/test/corecel/cont/Span.test.cc
@@ -12,6 +12,7 @@
 
 #include "corecel/OpaqueId.hh"
 #include "corecel/cont/Array.hh"
+#include "corecel/io/StreamUtils.hh"
 #include "corecel/sys/TypeDemangler.hh"
 
 #include "celeritas_test.hh"
@@ -20,20 +21,7 @@ namespace celeritas
 {
 namespace test
 {
-namespace
-{
 //---------------------------------------------------------------------------//
-
-template<class T, std::size_t E>
-std::string span_to_string(Span<T, E> const& s)
-{
-    std::ostringstream os;
-    os << s;
-    return os.str();
-}
-
-//---------------------------------------------------------------------------//
-}  // namespace
 
 TEST(SpanTest, fixed_size_zero)
 {
@@ -42,7 +30,7 @@ TEST(SpanTest, fixed_size_zero)
     EXPECT_EQ(0, empty_span.size());
     EXPECT_TRUE(empty_span.empty());
     EXPECT_EQ(sizeof(int*), sizeof(empty_span));
-    EXPECT_EQ("{}", span_to_string(empty_span));
+    EXPECT_EQ("{}", stream_to_string(empty_span));
 
     {
         auto templ_subspan = empty_span.subspan<0, 0>();
@@ -89,7 +77,7 @@ TEST(SpanTest, fixed_size)
     int local_data[] = {123, 456};
     Span<int, 2> local_span(local_data);
     EXPECT_EQ(sizeof(int*), sizeof(local_span));
-    EXPECT_EQ("{123,456}", span_to_string(local_span));
+    EXPECT_EQ("{123,456}", stream_to_string(local_span));
 
     EXPECT_EQ(local_data, local_span.begin());
     EXPECT_EQ(local_data + 2, local_span.end());
@@ -140,7 +128,7 @@ TEST(SpanTest, dynamic_size)
     int local_data[] = {123, 456, 789};
     Span<int> local_span(local_data);
     EXPECT_EQ(sizeof(int*) + sizeof(std::size_t), sizeof(local_span));
-    EXPECT_EQ("{123,456,789}", span_to_string(local_span));
+    EXPECT_EQ("{123,456,789}", stream_to_string(local_span));
 
     EXPECT_EQ(local_data, local_span.begin());
     EXPECT_EQ(local_data + 3, local_span.end());

--- a/test/corecel/cont/Span.test.cc
+++ b/test/corecel/cont/Span.test.cc
@@ -65,6 +65,8 @@ TEST(SpanTest, fixed_size_zero)
     // Test type conversion
     Span<int const> const_dynamic{empty_span};
     EXPECT_EQ(0, const_dynamic.size());
+    Span<int const, 0> also_fixed{const_dynamic};
+    EXPECT_EQ(0, also_fixed.size());
 
     // Removing const must not be allowed
     EXPECT_FALSE((std::is_constructible_v<Span<int, 0>, Span<int const, 0>>))
@@ -75,9 +77,10 @@ TEST(SpanTest, fixed_size_zero)
     EXPECT_FALSE((std::is_constructible_v<Span<int, 2>, Span<int, 3>>))
         << "fixed span with different extent is prohibited";
 
-    // Test pointer constructor
-    Span<int, 0> ptr_span(empty_span.begin(), empty_span.end());
-    EXPECT_EQ(0, ptr_span.size());
+    // Test empty iterator construction
+    int const* null_int{nullptr};
+    Span<int const, 0> null_span(null_int, null_int);
+    EXPECT_EQ(0, null_span.size());
 }
 
 TEST(SpanTest, fixed_size)

--- a/test/corecel/cont/Span.test.cc
+++ b/test/corecel/cont/Span.test.cc
@@ -384,6 +384,24 @@ TEST(SpanTest, array_conversion)
         << "const Array to mutable fixed Span is prohibited";
 }
 
+TEST(SpanTest, array_deduction)
+{
+    Array<int, 3> arr = {1, 2, 3};
+    Array<int, 3> const carr = {4, 5, 6};
+
+    // Mutable Array -> Span<T, N>
+    Span mspan{arr};
+    EXPECT_TRUE((std::is_same_v<Span<int, 3>, decltype(mspan)>));
+    EXPECT_EQ(arr.data(), mspan.data());
+    EXPECT_EQ(3, mspan.size());
+
+    // Const Array -> Span<T const, N>
+    Span cspan{carr};
+    EXPECT_TRUE((std::is_same_v<Span<int const, 3>, decltype(cspan)>));
+    EXPECT_EQ(carr.data(), cspan.data());
+    EXPECT_EQ(3, cspan.size());
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/corecel/grid/SplineDerivCalculator.test.cc
+++ b/test/corecel/grid/SplineDerivCalculator.test.cc
@@ -26,6 +26,14 @@ class SplineDerivativeTest : public Test
   protected:
     using BC = SplineDerivCalculator::BoundaryCondition;
     using VecReal = std::vector<real_type>;
+
+    auto calc_with_bc(BC bc)
+    {
+        return SplineDerivCalculator(bc)(make_ldg_span(x), make_ldg_span(y));
+    }
+
+    VecReal x;
+    VecReal y;
 };
 
 //---------------------------------------------------------------------------//
@@ -34,42 +42,31 @@ class SplineDerivativeTest : public Test
 
 TEST_F(SplineDerivativeTest, simple)
 {
-    VecReal x{0, 1, 2, 3, 4};
-    VecReal y{0, 2, 1, 2, 0};
-    {
-        auto result
-            = SplineDerivCalculator(BC::natural)(make_span(x), make_span(y));
-        EXPECT_VEC_SOFT_EQ(VecReal({0, -6, 6, -6, 0}), result);
-    }
-    {
-        auto result = SplineDerivCalculator(BC::not_a_knot)(make_span(x),
-                                                            make_span(y));
-        EXPECT_VEC_SOFT_EQ(VecReal({-10.5, -3, 4.5, -3, -10.5}), result);
-    }
-    {
-        auto result
-            = SplineDerivCalculator(BC::geant)(make_span(x), make_span(y));
-        EXPECT_VEC_SOFT_EQ(VecReal({-4.3125, 0, 4.3125, -3, -10.3125}), result);
-    }
+    x = {0, 1, 2, 3, 4};
+    y = {0, 2, 1, 2, 0};
+
+    EXPECT_VEC_SOFT_EQ(VecReal({0, -6, 6, -6, 0}),
+                       this->calc_with_bc(BC::natural));
+    EXPECT_VEC_SOFT_EQ(VecReal({-10.5, -3, 4.5, -3, -10.5}),
+                       this->calc_with_bc(BC::not_a_knot));
+    EXPECT_VEC_SOFT_EQ(VecReal({-4.3125, 0, 4.3125, -3, -10.3125}),
+                       this->calc_with_bc(BC::geant));
 }
 
 TEST_F(SplineDerivativeTest, constant)
 {
-    VecReal x{0, 1, 3, 7, 15};
-    VecReal y{3, 3, 3, 3, 3};
+    x = {0, 1, 3, 7, 15};
+    y = {3, 3, 3, 3, 3};
     {
-        auto result
-            = SplineDerivCalculator(BC::natural)(make_span(x), make_span(y));
+        auto result = this->calc_with_bc(BC::natural);
         EXPECT_VEC_SOFT_EQ(VecReal({0, 0, 0, 0, 0}), result);
     }
     {
-        auto result = SplineDerivCalculator(BC::not_a_knot)(make_span(x),
-                                                            make_span(y));
+        auto result = this->calc_with_bc(BC::not_a_knot);
         EXPECT_VEC_SOFT_EQ(VecReal({0, 0, 0, 0, 0}), result);
     }
     {
-        auto result
-            = SplineDerivCalculator(BC::geant)(make_span(x), make_span(y));
+        auto result = this->calc_with_bc(BC::geant);
         EXPECT_VEC_SOFT_EQ(VecReal({0, 0, 0, 0, 0}), result);
     }
 }
@@ -77,8 +74,8 @@ TEST_F(SplineDerivativeTest, constant)
 TEST_F(SplineDerivativeTest, sin)
 {
     size_type num_points = 10;
-    VecReal x(num_points);
-    VecReal y(num_points);
+    x.resize(num_points);
+    y.resize(num_points);
 
     for (size_type i = 0; i < num_points; ++i)
     {
@@ -99,15 +96,14 @@ TEST_F(SplineDerivativeTest, sin)
         -0.9096114092862184,
         -1.061828271062575,
     };
-    auto result
-        = SplineDerivCalculator(BC::not_a_knot)(make_span(x), make_span(y));
+    auto result = this->calc_with_bc(BC::not_a_knot);
     EXPECT_VEC_SOFT_EQ(expected_result, result);
 }
 
 TEST_F(SplineDerivativeTest, nonuniform)
 {
-    VecReal x{0, 7, 16, 20, 24, 25, 29, 31};
-    VecReal y{13, 12, 10, 2, 5, 8, 12, 15};
+    x = {0, 7, 16, 20, 24, 25, 29, 31};
+    y = {13, 12, 10, 2, 5, 8, 12, 15};
     {
         // Values from scipy.interpolate.CubicSpline with bc_type='natural'
         static double const expected_result[] = {
@@ -120,8 +116,7 @@ TEST_F(SplineDerivativeTest, nonuniform)
             0.7944766477725745,
             -1.110223024625157e-16,
         };
-        auto result
-            = SplineDerivCalculator(BC::natural)(make_span(x), make_span(y));
+        auto result = this->calc_with_bc(BC::natural);
         EXPECT_VEC_SOFT_EQ(expected_result, result);
     }
     {
@@ -136,8 +131,7 @@ TEST_F(SplineDerivativeTest, nonuniform)
             0.5032201626285102,
             1.512880650514041,
         };
-        auto result = SplineDerivCalculator(BC::not_a_knot)(make_span(x),
-                                                            make_span(y));
+        auto result = this->calc_with_bc(BC::not_a_knot);
         EXPECT_VEC_SOFT_EQ(expected_result, result);
     }
     {
@@ -151,8 +145,7 @@ TEST_F(SplineDerivativeTest, nonuniform)
             0.54085090248942,
             1.5705078953168,
         };
-        auto result
-            = SplineDerivCalculator(BC::geant)(make_span(x), make_span(y));
+        auto result = this->calc_with_bc(BC::geant);
         EXPECT_VEC_SOFT_EQ(expected_result, result);
     }
 }
@@ -160,9 +153,8 @@ TEST_F(SplineDerivativeTest, nonuniform)
 TEST_F(SplineDerivativeTest, log)
 {
     // Trimmed energy loss grid
-    VecReal x
-        = {1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7};
-    VecReal y = {
+    x = {1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7};
+    y = {
         839.668353354807,
         430.530096695467,
         111.600220710967,
@@ -193,8 +185,7 @@ TEST_F(SplineDerivativeTest, log)
             -0.0001057475269338493,
             6.776263578034403e-21,
         };
-        auto result
-            = SplineDerivCalculator(BC::natural)(make_span(x), make_span(y));
+        auto result = this->calc_with_bc(BC::natural);
         EXPECT_VEC_SOFT_EQ(expected_result, result);
 
         SplineInterpolator interpolate({x[0], y[0], result[0]},
@@ -218,8 +209,7 @@ TEST_F(SplineDerivativeTest, log)
             0.00119268423306982,
             -0.002782929877162913,
         };
-        auto result = SplineDerivCalculator(BC::not_a_knot)(make_span(x),
-                                                            make_span(y));
+        auto result = this->calc_with_bc(BC::not_a_knot);
         EXPECT_VEC_SOFT_EQ(expected_result, result);
 
         SplineInterpolator interpolate({x[0], y[0], result[0]},
@@ -242,8 +232,7 @@ TEST_F(SplineDerivativeTest, log)
             0.0011561116748754,
             -0.0026975939080425,
         };
-        auto result
-            = SplineDerivCalculator(BC::geant)(make_span(x), make_span(y));
+        auto result = this->calc_with_bc(BC::geant);
         EXPECT_VEC_SOFT_EQ(expected_result, result);
 
         SplineInterpolator interpolate({x[0], y[0], result[0]},

--- a/test/orange/univ/detail/InfixEvaluator.test.cc
+++ b/test/orange/univ/detail/InfixEvaluator.test.cc
@@ -51,11 +51,11 @@ TEST(InfixEvaluatorTest, evaluate)
 
     //// CREATE ////
 
-    InfixEvaluator eval_alpha(make_span(alpha_logic));
-    InfixEvaluator eval_beta(make_span(beta_logic));
-    InfixEvaluator eval_gamma(make_span(gamma_logic));
-    InfixEvaluator eval_delta(make_span(delta_logic));
-    InfixEvaluator eval_everywhere(make_span(everywhere_logic));
+    InfixEvaluator eval_alpha(make_ldg_span(alpha_logic));
+    InfixEvaluator eval_beta(make_ldg_span(beta_logic));
+    InfixEvaluator eval_gamma(make_ldg_span(gamma_logic));
+    InfixEvaluator eval_delta(make_ldg_span(delta_logic));
+    InfixEvaluator eval_everywhere(make_ldg_span(everywhere_logic));
 
     //// EVALUATE ////
 

--- a/test/orange/univ/detail/LogicEvaluator.test.cc
+++ b/test/orange/univ/detail/LogicEvaluator.test.cc
@@ -72,11 +72,11 @@ TEST(LogicEvaluatorTest, evaluate)
 
     //// CREATE ////
 
-    LogicEvaluator eval_alpha(make_span(alpha_logic));
-    LogicEvaluator eval_beta(make_span(beta_logic));
-    LogicEvaluator eval_gamma(make_span(gamma_logic));
-    LogicEvaluator eval_delta(make_span(delta_logic));
-    LogicEvaluator eval_everywhere(make_span(everywhere_logic));
+    LogicEvaluator eval_alpha(make_ldg_span(alpha_logic));
+    LogicEvaluator eval_beta(make_ldg_span(beta_logic));
+    LogicEvaluator eval_gamma(make_ldg_span(gamma_logic));
+    LogicEvaluator eval_delta(make_ldg_span(delta_logic));
+    LogicEvaluator eval_everywhere(make_ldg_span(everywhere_logic));
 
     //// EVALUATE ////
 


### PR DESCRIPTION
This closes the loop on #2336. The change to use more standards-compliant implicit constructors is the proximate cause of the LDG refactoring (#2343) which led to the friend stuff (#2347). Adding the implicit cast with conversion checking allows us to integrate the span utils for vecgeom usage, but it prevents `LdgSpan` from being implicitly cast to `Span`. This is good because we want to not accidentally lose `ldg` acceleration, which we *were* currently doing in a couple of places (#2354).