### PR TITLE
Add a helper for sampling polarization orthogonal to direction

### DIFF
--- a/src/celeritas/optical/gen/PrimaryGenerator.hh
+++ b/src/celeritas/optical/gen/PrimaryGenerator.hh
@@ -13,7 +13,7 @@
 #include "corecel/Types.hh"
 #include "corecel/random/data/DistributionData.hh"
 #include "corecel/random/distribution/DistributionVisitor.hh"
-#include "corecel/random/distribution/IsotropicDistribution.hh"
+#include "celeritas/phys/InteractionUtils.hh"
 
 #include "PrimaryGeneratorData.hh"
 #include "../TrackInitializer.hh"
@@ -48,7 +48,6 @@ class PrimaryGenerator
   private:
     NativeCRef<DistributionParamsData> const& params_;
     PrimaryDistributionData const& data_;
-    IsotropicDistribution<real_type> sample_polarization_;
 };
 
 //---------------------------------------------------------------------------//
@@ -70,10 +69,6 @@ PrimaryGenerator::PrimaryGenerator(
 //---------------------------------------------------------------------------//
 /*!
  * Sample an optical photon from the energy, angular and spatial distributions.
- *
- * \todo There are a couple places in the code where we resample the
- * polarization if orthogonality fails: possibly add a helper function to
- * reduce duplication
  */
 template<class Generator>
 CELER_FUNCTION optical::TrackInitializer
@@ -88,12 +83,7 @@ PrimaryGenerator::operator()(Generator& rng)
     result.direction = sample_with(visit, data_.angle, rng);
     CELER_ASSERT(is_soft_unit_vector(result.direction));
     result.primary = {};  // No associated Geant4 primary
-    do
-    {
-        result.polarization = make_unit_vector(
-            make_orthogonal(sample_polarization_(rng), result.direction));
-    } while (CELER_UNLIKELY(
-        !is_soft_orthogonal(result.polarization, result.direction)));
+    result.polarization = TransversePolarizationSampler{result.direction}(rng);
 
     return result;
 }

--- a/src/celeritas/optical/gen/ScintillationGenerator.hh
+++ b/src/celeritas/optical/gen/ScintillationGenerator.hh
@@ -20,6 +20,7 @@
 #include "corecel/random/distribution/TruncatedDistribution.hh"
 #include "corecel/random/distribution/UniformRealDistribution.hh"
 #include "celeritas/optical/detail/OpticalUtils.hh"
+#include "celeritas/phys/InteractionUtils.hh"
 
 #include "GeneratorData.hh"
 #include "ScintillationData.hh"
@@ -68,19 +69,8 @@ class ScintillationGenerator
     inline CELER_FUNCTION TrackInitializer operator()(Generator& rng);
 
   private:
-    //// TYPES ////
-
-    using UniformRealDist = UniformRealDistribution<real_type>;
-    using ExponentialDist = ExponentialDistribution<real_type>;
-
-    //// DATA ////
-
     GeneratorDistributionData const& dist_;
     NativeCRef<ScintillationData> const& shared_;
-
-    UniformRealDist sample_cost_;
-    UniformRealDist sample_phi_;
-
     units::LightSpeed delta_speed_{};
     Real3 delta_pos_{};
 };
@@ -95,10 +85,7 @@ CELER_FUNCTION
 ScintillationGenerator::ScintillationGenerator(
     NativeCRef<ScintillationData> const& shared,
     GeneratorDistributionData const& dist)
-    : dist_(dist)
-    , shared_(shared)
-    , sample_cost_(-1, 1)
-    , sample_phi_(0, real_type(2 * constants::pi))
+    : dist_(dist), shared_(shared)
 {
     CELER_EXPECT(dist_);
     CELER_EXPECT(shared_);
@@ -141,8 +128,7 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(Generator& rn
         CELER_ASSERT(component.lambda_mean > 0);
         auto wavelength = TruncatedDistribution<NormalDistribution<real_type>>{
             0, inf, component.lambda_mean, component.lambda_sigma}(rng);
-        energy_val = value_as<units::MevEnergy>(
-            detail::wavelength_to_energy(wavelength));
+        energy_val = value_as<Energy>(detail::wavelength_to_energy(wavelength));
     }
     else
     {
@@ -154,31 +140,14 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(Generator& rn
         energy_val = calc_energy(generate_canonical(rng));
     }
 
-    ExponentialDist sample_time(real_type{1} / component.fall_time);
+    ExponentialDistribution sample_time(real_type{1} / component.fall_time);
 
     TrackInitializer photon;
     photon.energy = Energy{energy_val};
 
-    // Sample direction
-    real_type cost = sample_cost_(rng);
-    real_type phi = sample_phi_(rng);
-    photon.direction = from_spherical(cost, phi);
-
-    // Sample polarization perpendicular to the photon direction
-    photon.polarization = [&] {
-        Real3 pol = from_spherical(
-            (cost > 0 ? -1 : 1) * std::sqrt(1 - ipow<2>(cost)), phi);
-        Real3 perp = {-std::sin(phi), std::cos(phi), 0};
-        real_type sinphi, cosphi;
-        sincospi(UniformRealDist{}(rng), &sinphi, &cosphi);
-        for (auto j : range(3))
-        {
-            pol[j] = cosphi * pol[j] + sinphi * perp[j];
-        }
-        // Enforce orthogonality
-        return make_unit_vector(make_orthogonal(pol, photon.direction));
-    }();
-    CELER_ASSERT(is_soft_orthogonal(photon.polarization, photon.direction));
+    // Sample the photon direction and polarization perpendicular to direction
+    photon.direction = IsotropicDistribution{}(rng);
+    photon.polarization = TransversePolarizationSampler{photon.direction}(rng);
 
     // Sample the position
     real_type u = [&rng, &p = dist_.continuous_edep_fraction] {
@@ -195,7 +164,7 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(Generator& rn
         if (p == 1 || (p != 0 && BernoulliDistribution{p}(rng)))
         {
             // Sample uniformly along the step
-            return UniformRealDist{}(rng);
+            return UniformRealDistribution<real_type>{}(rng);
         }
         // Generate the photon at the discrete interaction site
         return real_type(1);

--- a/src/celeritas/optical/gen/WavelengthShiftGenerator.hh
+++ b/src/celeritas/optical/gen/WavelengthShiftGenerator.hh
@@ -64,7 +64,6 @@ class WavelengthShiftGenerator
     real_type time_constant_;
     WlsDistribution time_profile_;
     NonuniformGridCalculator calc_cdf_;
-    IsotropicDistribution<real_type> sample_polarization_;
 };
 
 //---------------------------------------------------------------------------//
@@ -118,12 +117,7 @@ CELER_FUNCTION TrackInitializer WavelengthShiftGenerator::operator()(Engine& rng
 
     // Sample the emitted photon (incoherent) direction and polarization
     result.direction = IsotropicDistribution{}(rng);
-    do
-    {
-        result.polarization = make_unit_vector(
-            make_orthogonal(sample_polarization_(rng), result.direction));
-    } while (CELER_UNLIKELY(
-        !is_soft_orthogonal(result.polarization, result.direction)));
+    result.polarization = TransversePolarizationSampler{result.direction}(rng);
 
     // Sample the delta time (based on the exponential relaxation)
     result.time

--- a/src/celeritas/phys/InteractionUtils.hh
+++ b/src/celeritas/phys/InteractionUtils.hh
@@ -8,6 +8,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/math/ArrayUtils.hh"
+#include "corecel/random/distribution/IsotropicDistribution.hh"
 #include "corecel/random/distribution/UniformRealDistribution.hh"
 #include "geocel/Types.hh"
 #include "celeritas/Constants.hh"
@@ -60,6 +61,28 @@ struct ExitingDirectionSampler
         UniformRealDistribution<real_type> sample_phi(
             0, real_type(2 * constants::pi));
         return rotate(from_spherical(costheta, sample_phi(rng)), direction);
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Sample a polarization uniformly in the plane orthogonal to the direction.
+ */
+struct TransversePolarizationSampler
+{
+    Real3 const& direction;
+
+    template<class Engine>
+    inline CELER_FUNCTION Real3 operator()(Engine& rng)
+    {
+        IsotropicDistribution<real_type> sample_polarization;
+        Real3 polarization;
+        do
+        {
+            polarization = make_unit_vector(
+                make_orthogonal(sample_polarization(rng), direction));
+        } while (CELER_UNLIKELY(!is_soft_orthogonal(polarization, direction)));
+        return polarization;
     }
 };
 

--- a/test/celeritas/optical/Generator.test.cc
+++ b/test/celeritas/optical/Generator.test.cc
@@ -233,8 +233,8 @@ TEST_F(LArSphereGeneratorTest, offload)
     if (reference_configuration)
     {
         EXPECT_EQ(51226, gen.num_generated);
-        EXPECT_EQ(53459, result.counters.steps);
-        EXPECT_EQ(15, result.counters.step_iters);
+        EXPECT_EQ(53439, result.counters.steps);
+        EXPECT_EQ(14, result.counters.step_iters);
     }
 
     // Check accumulated action times

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -474,8 +474,8 @@ TEST_F(LArSphereOffloadTest, host_generate_small)
 
     if (reference_configuration)
     {
-        constexpr unsigned int expected_steps = 117;
-        constexpr unsigned int expected_step_iters = 5;
+        constexpr unsigned int expected_steps = 114;
+        constexpr unsigned int expected_step_iters = 4;
         EXPECT_EQ(expected_steps, result.accum.steps);
         EXPECT_EQ(expected_step_iters, result.accum.step_iters);
         EXPECT_EQ(1, result.accum.flushes);
@@ -502,8 +502,8 @@ TEST_F(LArSphereOffloadTest, host_generate)
 
     if (reference_configuration)
     {
-        unsigned int expected_steps = 19283;
-        unsigned int expected_step_iters = 3;
+        unsigned int expected_steps = 19311;
+        unsigned int expected_step_iters = 2;
         EXPECT_EQ(expected_steps, static_cast<double>(result.accum.steps));
         EXPECT_EQ(expected_step_iters, result.accum.step_iters);
         EXPECT_EQ(1, result.accum.flushes);
@@ -541,7 +541,7 @@ TEST_F(LArSphereOffloadTest, TEST_IF_CELER_DEVICE(device_generate))
 
     if (reference_configuration)
     {
-        constexpr int ref_steps = 59;
+        constexpr int ref_steps = 60;
         EXPECT_EQ(ref_steps, result.accum.step_iters);
         EXPECT_EQ(1, result.accum.flushes);
         ASSERT_EQ(1, result.accum.generators.size());

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -340,50 +340,50 @@ TEST_F(MaterialScintillationGaussianTest, basic)
 
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        EXPECT_SOFT_EQ(1.8455823106866e-05, avg_lambda);
-        EXPECT_SOFT_EQ(869.57091905169, avg_time);
-        EXPECT_SOFT_EQ(0.023544714177305, avg_cosine);
-        EXPECT_EQ(8250, rng.exchange_count());
+        EXPECT_SOFT_EQ(1.939220574857e-05, avg_lambda);
+        EXPECT_SOFT_EQ(1143.994787854, avg_time);
+        EXPECT_SOFT_EQ(0.00023285021811913, avg_cosine);
+        EXPECT_EQ(8992, rng.exchange_count());
 
         static double const expected_energy[] = {
             6.1650902874689e-06,
-            5.3609823654525e-06,
-            1.1892383769681e-05,
+            1.2359597158853e-05,
             6.0546751413336e-06,
-            1.3582229285385e-05,
-            6.1392669704928e-06,
-            3.1773246015197e-06,
-            2.9038196053521e-06,
+            5.8329374922145e-06,
+            3.2255409151959e-06,
+            3.0888032280851e-06,
+            1.2486685087625e-05,
+            6.4735856383819e-06,
         };
         static double const expected_time[] = {
-            3312.8806914137,
-            338.64626300081,
-            10.532092321203,
-            404.28257965362,
-            35.26357244485,
-            295.4003690722,
-            4407.0565774611,
-            138.14745536841,
+            338.28022906717,
+            10.527016296506,
+            1068.2865021538,
+            346.09571919691,
+            1666.7247712873,
+            5534.4360660306,
+            16.241055894704,
+            1358.7806326338,
         };
         static double const expected_cos_theta[] = {
             0.99292265109602,
-            -0.77507096788764,
-            -0.20252296017542,
+            0.27952671419631,
             -0.70177204718526,
-            -0.57958185096199,
-            0.14750933319318,
-            -0.15366976713254,
-            -0.97292174666956,
+            -0.89756714842957,
+            -0.99436313487603,
+            0.64168156835022,
+            -0.33510343532344,
+            0.35963958142597,
         };
         static double const expected_polarization_x[] = {
-            -0.48061717648891,
-            0.74609610658139,
-            0.99419460248005,
-            -0.57457399792055,
-            0.5101014413042,
-            0.30947392565286,
-            0.11400602132643,
-            -0.47137697798179,
+            0.98676014710283,
+            -0.53225191336739,
+            0.60041678770806,
+            -0.8766193034968,
+            -0.97032602989238,
+            -0.50785369457567,
+            0.22953263774201,
+            0.61705838755229,
         };
         EXPECT_VEC_SOFT_EQ(expected_energy, energy);
         EXPECT_VEC_SOFT_EQ(expected_time, time);
@@ -432,14 +432,14 @@ TEST_F(MaterialScintillationGaussianTest, time)
         if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
             static double const expected_time[] = {
-                7.3670494614798,
-                10.58035645366,
-                3117.0542454245,
-                4968.1642964938,
-                2.1742646282647,
-                319.54758544355,
-                3.3419800716698,
-                6453.3407764283,
+                32.139021771616,
+                1379.2576287607,
+                204.79482025888,
+                12.517269999399,
+                35.31295179735,
+                295.48239066317,
+                4407.0764816682,
+                138.16011685841,
             };
             EXPECT_VEC_SOFT_EQ(expected_time, time);
         }
@@ -457,14 +457,14 @@ TEST_F(MaterialScintillationGaussianTest, time)
         if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
         {
             static double const expected_time[] = {
-                7.367041567676,
-                10.580348559856,
-                3117.0542375307,
-                4968.1642886,
-                2.1742567344609,
-                319.54757754975,
-                3.341972177866,
-                6453.3407685345,
+                32.139013877813,
+                1379.2576208669,
+                204.79481236507,
+                12.517262105595,
+                35.312943903546,
+                295.48238276936,
+                4407.0764737744,
+                138.16010896461,
             };
             EXPECT_VEC_SOFT_EQ(expected_time, time);
         }
@@ -513,7 +513,7 @@ TEST_F(MaterialScintillationGaussianTest, stress_test)
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         EXPECT_SOFT_NEAR(
-            20.71518597719,
+            22.6292,
             rng.exchange_count() / static_cast<real_type>(num_photons),
             1e-2);
     }

--- a/test/celeritas/phys/InteractionUtils.test.cc
+++ b/test/celeritas/phys/InteractionUtils.test.cc
@@ -66,7 +66,7 @@ TEST(InteractionUtilsTest, sample_exiting_direction)
     }
 }
 
-TEST(InteractionUtilsTest, TEST_IF_CELERITAS_DOUBLE(sample_polarization))
+TEST(InteractionUtilsTest, sample_polarization)
 {
     DiagnosticRngEngine<std::mt19937> rng;
 
@@ -81,14 +81,17 @@ TEST(InteractionUtilsTest, TEST_IF_CELERITAS_DOUBLE(sample_polarization))
     {
         result.push_back(TransversePolarizationSampler{dir}(rng));
     }
-    static Real3 const expected_result[] = {
-        {0, -0.6285203911562, -0.77779310738837},
-        {0.18099540215833, 0.98348394211474, 0},
-        {-0.96349621318245, 0.13467426584993, 0.2313825604942},
-        {0.99896510069951, -0.045471273756906, -0.0010444363744566},
-    };
-    EXPECT_VEC_SOFT_EQ(expected_result, result);
-    EXPECT_EQ(4, rng.exchange_count() / real_type(direction.size()));
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
+    {
+        static Real3 const expected_result[] = {
+            {0, -0.6285203911562, -0.77779310738837},
+            {0.18099540215833, 0.98348394211474, 0},
+            {-0.96349621318245, 0.13467426584993, 0.2313825604942},
+            {0.99896510069951, -0.045471273756906, -0.0010444363744566},
+        };
+        EXPECT_VEC_SOFT_EQ(expected_result, result);
+        EXPECT_EQ(4, rng.exchange_count() / real_type(direction.size()));
+    }
 
     size_type num_samples = 10000;
     for (size_type i = 0; i < num_samples; ++i)
@@ -97,19 +100,10 @@ TEST(InteractionUtilsTest, TEST_IF_CELERITAS_DOUBLE(sample_polarization))
         auto pol = TransversePolarizationSampler{dir}(rng);
         EXPECT_TRUE(is_soft_orthogonal(dir, pol));
     }
-    EXPECT_EQ(8, rng.exchange_count() / real_type(num_samples));
-
-#if 0
-    // The following takes O(1e9) iterations in the rejection loop
-
-    // Direction nearly along +z
-    auto direction = make_unit_vector(Real3{1e-3, -1e-3, 1});
-    Real3 polarization;
-    do
+    if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
-        polarization = ExitingDirectionSampler{0, direction}(rng);
-    } while (CELER_UNLIKELY(!is_soft_orthogonal(polarization, direction)));
-#endif
+        EXPECT_EQ(8, rng.exchange_count() / real_type(num_samples));
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/phys/InteractionUtils.test.cc
+++ b/test/celeritas/phys/InteractionUtils.test.cc
@@ -10,6 +10,9 @@
 #include <random>
 #include <vector>
 
+#include "corecel/random/DiagnosticRngEngine.hh"
+#include "corecel/random/distribution/IsotropicDistribution.hh"
+
 #include "TestMacros.hh"
 #include "celeritas_test.hh"
 
@@ -61,6 +64,52 @@ TEST(InteractionUtilsTest, sample_exiting_direction)
                0.26726124191242,  0.53452248382485,  0.80178372573727};
         EXPECT_VEC_SOFT_EQ(expected_out_dir, out_dir);
     }
+}
+
+TEST(InteractionUtilsTest, TEST_IF_CELERITAS_DOUBLE(sample_polarization))
+{
+    DiagnosticRngEngine<std::mt19937> rng;
+
+    std::vector<Real3> direction = {
+        {1, 0, 0},
+        {0, 0, 1},
+        make_unit_vector(Real3{1, 2, 3}),
+        make_unit_vector(Real3{1e-3, -1e-3, 1}),
+    };
+    std::vector<Real3> result;
+    for (auto const& dir : direction)
+    {
+        result.push_back(TransversePolarizationSampler{dir}(rng));
+    }
+    static Real3 const expected_result[] = {
+        {0, -0.6285203911562, -0.77779310738837},
+        {0.18099540215833, 0.98348394211474, 0},
+        {-0.96349621318245, 0.13467426584993, 0.2313825604942},
+        {0.99896510069951, -0.045471273756906, -0.0010444363744566},
+    };
+    EXPECT_VEC_SOFT_EQ(expected_result, result);
+    EXPECT_EQ(4, rng.exchange_count() / real_type(direction.size()));
+
+    size_type num_samples = 10000;
+    for (size_type i = 0; i < num_samples; ++i)
+    {
+        auto dir = IsotropicDistribution{}(rng);
+        auto pol = TransversePolarizationSampler{dir}(rng);
+        EXPECT_TRUE(is_soft_orthogonal(dir, pol));
+    }
+    EXPECT_EQ(8, rng.exchange_count() / real_type(num_samples));
+
+#if 0
+    // The following takes O(1e9) iterations in the rejection loop
+
+    // Direction nearly along +z
+    auto direction = make_unit_vector(Real3{1e-3, -1e-3, 1});
+    Real3 polarization;
+    do
+    {
+        polarization = ExitingDirectionSampler{0, direction}(rng);
+    } while (CELER_UNLIKELY(!is_soft_orthogonal(polarization, direction)));
+#endif
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This adds a helper function for sampling a polarization orthogonal to the direction (see https://github.com/celeritas-project/celeritas/pull/2339#discussion_r3009969149). I think we can use this for scintillation too (7f8f93e3e53cba6ac8f5e881cd7be087a5fcb972) but wanted to double check before I go ahead and update the tests.