### PR TITLE
Optimize BIH/bounding box to improve DUNE performance

### DIFF
--- a/doc/usage/execution/profiling.rst
+++ b/doc/usage/execution/profiling.rst
@@ -55,20 +55,20 @@ generate a timeline:
    $ CELER_ENABLE_PROFILING=1 \
    > nsys profile \
    >   --trace=cuda,nvtx,osrt \
-   >   --capture-range nvtx --nvtx-domain celeritas \
+   >   --nvtx-capture="celeritas" \
    >   --osrt-backtrace-stack-size=16384 --backtrace=fp \
-   >   -o report.qdrep -f true \
+   >   -o report.nsys-rep -f true \
    >   celer-sim inp.json
 
 Line 2 specifies the APIs to be captured: in this case, CUDA calls, NVTX
 ranges, and OS runtime libraries.
-To use the NVTX ranges, you **must** enable the ``CELER_ENABLE_PROFILING`` variable
-in addition to using the NVTX "trace" option (lines 1 and 2).
-The capture domain in line 3 restricts profiling to the Celeritas application.
-(You can use, e.g., ``--nvtx-capture run@celeritas`` to capture only the main stepping execution inside Celeritas.)
-Additional frame-pointer-based backtracing is specified in line 5; line 6
-writes (and overwrites) to a particular output file; the final line invokes the
-application.
+To use the NVTX ranges, which is strongly recommended for kernel annotations,
+you **must** enable the ``CELER_ENABLE_PROFILING`` variable
+in addition to using the NVTX "trace" option (line 3).
+The capture domain in line 4 restricts profiling to the Celeritas application.
+Additional frame-pointer-based backtracing is specified in line 5;
+line 6 writes (and overwrites) to a particular output file;
+the final line invokes the application.
 
 On AMD hardware using the ROCProfiler_, here's an example that writes out timeline information:
 
@@ -144,7 +144,7 @@ Kernel profiling
 Detailed kernel diagnostics including occupancy and memory bandwidth can be
 gathered with the `NVIDIA Nsight Compute`_ profiler.
 
-.. _NVIDIA Compute systems: https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
+.. _NVIDIA Nsight Compute: https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
 
 The ``Source`` tab is especially useful, as it maps diagnostics such as number
 of instructions executed and number of stalls to individual lines in the source
@@ -187,7 +187,7 @@ method is:
 3. Click ``Display the command line to use NVIDIA Nsight Compute CLI``
 4. Copy the ``launch-skip`` from the supplied ``ncu`` command.
 
-A final option is to profile a kernel within a particular NVTX domain via:
+A final option is to profile a kernel using NVTX annotations:
 
 .. sourcecode::
    :linenos:
@@ -195,12 +195,12 @@ A final option is to profile a kernel within a particular NVTX domain via:
    $ CELER_ENABLE_PROFILING=1 \
    > ncu \
    > --set full \
-   > --nvtx --nvtx-include "celeritas@DOMAIN" \
-   > --launch-skip 300 --launch-count 10 \
+   > --nvtx --nvtx-include "celeritas@{RANGE}" \
+   > --launch-skip 100 --launch-count 1 \
    > -f -o output \
    > celer-sim inp.json
 
-where DOMAIN is the name of the NVTX domain (e.g.
-``celer-optical/optical-step/.../...``). Note that the domain and range are
-flipped compared to ``nsys`` since the kernel profiling allows detailed
-top-down stack specification.
+Here, :samp:`celeritas@{RANGE}` is the name of the NVTX domain and
+slash-separated range, (e.g. ``run/step/*/propagate``).
+Note that the domain and range are flipped compared to ``nsys`` since the
+kernel profiling allows detailed top-down stack specification.

--- a/doc/usage/execution/profiling.rst
+++ b/doc/usage/execution/profiling.rst
@@ -46,7 +46,7 @@ can be gathered, the example below illustrates how to do it using `NVIDIA Nsight
 
 .. _NVIDIA Nsight systems: https://docs.nvidia.com/nsight-systems/UserGuide/index.html
 
-Here is an example invoking the ``celer-sim`` app through the Nvidia utility to
+Here is an example invoking the ``celer-sim`` app through the NVIDIA utility to
 generate a timeline:
 
 .. sourcecode::
@@ -142,23 +142,65 @@ Kernel profiling
 ----------------
 
 Detailed kernel diagnostics including occupancy and memory bandwidth can be
-gathered with the `NVIDIA Compute systems`_ profiler.
+gathered with the `NVIDIA Nsight Compute`_ profiler.
 
 .. _NVIDIA Compute systems: https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
 
-This example gathers kernel statistics for 10 sets of "propagate" kernels (for both
-charged and uncharged particles) starting with the 300th launch.
+The ``Source`` tab is especially useful, as it maps diagnostics such as number
+of instructions executed and number of stalls to individual lines in the source
+code. To obtain this mapping, Celeritas must be compiled with ``-lineinfo`` in
+``CMAKE_CUDA_FLAGS``. The following ``ncu`` command can be run to obtain an
+``.ncu-rep`` for use with NVIDIA Nsight Compute.
+
+.. sourcecode::
+   :linenos:
+
+    $ ncu \
+    > --set full \
+    > --kernel-name launch_action_impl \
+    > --launch-skip 254 --launch-count 1 \
+    > -f -o output \
+    > celer-sim inp.json
+
+The metric set must be ``full`` for detailed source-level profiling
+information.  Note that full metrics require 30+ passes and thus are very
+time-consuming; use ``basic`` to rapidly obtain coarse-grained profiling
+information.  This command will force-overwrite an output file named
+``output.ncu-rep``.  In this example, only a single kernel is profiled: the
+255th launch of the ``launch_action_impl``. Selecting how many kernels must be
+skipped before reaching the kernel of interest can be done in NVIDIA Nsight
+Systems prior to running NVIDIA Nsight Compute. This can be done in two ways. The
+first method is:
+
+1. Click ``CUDA HW`` then ``[All Streams]`` then ``Kernels``
+2. Right-click ``launch_action_impl`` and click ``Show in Events View``
+3. Select any kernel in the event view
+4. Obtain the launch number of the kernel in the ``#`` column
+5. Use ``#`` minus 1 as the ``launch-skip``
+
+This method can be used to profile the most expensive kernel by sorting the
+event view by duration and finding the ``#`` of the top kernel.  The second
+method is:
+
+1. Right-click the kernel of interest in the timeline
+2. Click ``Analyze the selected kernel with NVIDIA Nsight Compute``
+3. Click ``Display the command line to use NVIDIA Nsight Compute CLI``
+4. Copy the ``launch-skip`` from the supplied ``ncu`` command.
+
+A final option is to profile a kernel within a particular NVTX domain via:
 
 .. sourcecode::
    :linenos:
 
    $ CELER_ENABLE_PROFILING=1 \
    > ncu \
-   > --nvtx --nvtx-include "celeritas@run/step/*/propagate" \
+   > --set full \
+   > --nvtx --nvtx-include "celeritas@DOMAIN" \
    > --launch-skip 300 --launch-count 10 \
-   > -f -o propagate
+   > -f -o output \
    > celer-sim inp.json
 
-It will write to :file:`propagate.ncu-rep` output file. Note that the domain
-and range are flipped compared to ``nsys`` since the kernel profiling allows
-detailed top-down stack specification.
+where DOMAIN is the name of the NVTX domain (e.g.
+``celer-optical/optical-step/.../...``). Note that the domain and range are
+flipped compared to ``nsys`` since the kernel profiling allows detailed
+top-down stack specification.

--- a/scripts/user/orange-bih-to-dot.py
+++ b/scripts/user/orange-bih-to-dot.py
@@ -33,7 +33,7 @@ from pathlib import Path
 def make_dot(universe_id, tree):
     lines = []
     lines.append('digraph "bih_{}" {{'.format(universe_id))
-    lines.append("  rankdir=TB")
+    lines.append("  rankdir=LR")
     lines.append("  node [shape=box]")
 
     for i, node in enumerate(tree):

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -279,18 +279,21 @@ inline CELER_FUNCTION T calc_dist_to_inside(BoundingBox<T> const& bbox,
 
     // Loop over all 6 planes to find the minimum intersection
     T min_dist = numeric_limits<T>::infinity();
-    for (auto bound : range(Bound::size_))
+    for (auto ax : range(to_int(Axis::size_)))
     {
-        for (auto ax : range(to_int(Axis::size_)))
+        if (dir[ax] == 0)
         {
-            if (dir[ax] == 0)
-            {
-                // Short circuit if there is not movement in this dir
-                continue;
-            }
+            // Short circuit if there is not movement in this dir
+            continue;
+        }
 
+        T inv_dir = 1 / dir[ax];
+
+        for (auto bound : range(Bound::size_))
+        {
             T dist = (bbox.point(static_cast<Bound>(bound))[ax] - pos[ax])
-                     / dir[ax];
+                     * inv_dir;
+
             if (dist <= 0)
             {
                 // Short circuit if the plane is behind us

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -29,7 +29,7 @@ class BoundingBox;
 //---------------------------------------------------------------------------//
 
 //! Real type used for acceleration
-using fast_real_type = float;
+using fast_real_type = double;
 
 //! Integer type for volume CSG tree representation
 using logic_int = ImplSurfaceId::size_type;

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -68,12 +68,6 @@ class BIHIntersectingVolFinder
 
     //// HELPER FUNCTIONS ////
 
-    // Get the ID of the next node in the traversal sequence
-    inline CELER_FUNCTION BIHNodeId next_node(BIHNodeId current_id,
-                                              BIHNodeId previous_id,
-                                              Ray ray,
-                                              real_type min_dist) const;
-
     // Determine if the intersection with an edge/vol bbox is less than
     // min_dist
     inline CELER_FUNCTION bool
@@ -126,86 +120,59 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
                                      real_type max_search_dist) const
     -> Intersection
 {
-    BIHNodeId previous_node;
-    BIHNodeId current_node{0};
+    // Stack of deferred nodes
+    BIHNodeId stack[17];  // max tree depth
+    int stack_ptr = 0;
 
     Intersection intersection{OnLocalSurface{}, max_search_dist};
 
-    do
+    BIHNodeId current_node{0};
+
+    while (current_node)
     {
         if (!view_.is_inner(current_node))
         {
             intersection = this->visit_leaf(
                 view_.leaf_node(current_node), ray, intersection, visit_vol);
+
+            // Pop or stop
+            current_node = stack_ptr > 0 ? stack[--stack_ptr] : BIHNodeId{};
+            continue;
         }
 
-        previous_node = exchange(
-            current_node,
-            this->next_node(
-                current_node, previous_node, ray, intersection.distance));
+        auto const& node = view_.inner_node(current_node);
+        auto const& l_edge = node.edges[BIHInnerNode::Side::left];
+        auto const& r_edge = node.edges[BIHInnerNode::Side::right];
 
-    } while (current_node);
+        bool hit_left
+            = this->visit_bbox(l_edge.bbox, ray, intersection.distance);
+        bool hit_right
+            = this->visit_bbox(r_edge.bbox, ray, intersection.distance);
+
+        if (hit_left && hit_right)
+        {
+            stack[stack_ptr++] = r_edge.child;
+            current_node = l_edge.child;
+        }
+        else if (hit_left)
+        {
+            current_node = l_edge.child;
+        }
+        else if (hit_right)
+        {
+            current_node = r_edge.child;
+        }
+        else
+        {
+            current_node = stack_ptr > 0 ? stack[--stack_ptr] : BIHNodeId{};
+        }
+    }
 
     return this->visit_inf_vols(intersection, visit_vol);
 }
 
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- *  Get the ID of the next node in the traversal sequence.
- */
-CELER_FUNCTION
-BIHNodeId BIHIntersectingVolFinder::next_node(BIHNodeId current_id,
-                                              BIHNodeId previous_id,
-                                              Ray ray,
-                                              real_type min_dist) const
-{
-    using Side = BIHInnerNode::Side;
-
-    if (!view_.is_inner(current_id))
-    {
-        // Leaf node; return to parent
-        CELER_EXPECT(previous_id == view_.leaf_node(current_id).parent);
-        return previous_id;
-    }
-
-    auto const& current_node = view_.inner_node(current_id);
-    auto const& l_edge = current_node.edges[Side::left];
-    auto const& r_edge = current_node.edges[Side::right];
-
-    if (previous_id == current_node.parent)
-    {
-        // Visiting this inner node for the first time; go down either left
-        // edge, right edge, or return to the parent
-        if (this->visit_bbox(l_edge.bbox, ray, min_dist))
-        {
-            return l_edge.child;
-        }
-        else if (this->visit_bbox(r_edge.bbox, ray, min_dist))
-        {
-            return r_edge.child;
-        }
-        else
-        {
-            return current_node.parent;
-        }
-    }
-
-    if (previous_id == current_node.edges[Side::left].child)
-    {
-        // Visiting this inner node for the second time; go down right edge
-        // or return to parent
-        return this->visit_bbox(r_edge.bbox, ray, min_dist)
-                   ? r_edge.child
-                   : current_node.parent;
-    }
-
-    // Visiting this inner node for the third time; return to parent
-    CELER_ASSERT(previous_id == current_node.edges[Side::right].child);
-    return current_node.parent;
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Determine if the intersection with an edge/vol bbox is less than min_dist.

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -11,6 +11,7 @@
 #include "BIHView.hh"
 #include "../BoundingBoxUtils.hh"
 #include "../OrangeData.hh"
+#include "../inp/Bih.hh"
 #include "../univ/detail/Types.hh"
 
 namespace celeritas
@@ -121,7 +122,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
     -> Intersection
 {
     // Stack of deferred nodes
-    BIHNodeId stack[17];  // max tree depth
+    BIHNodeId stack[inp::BIHBuilder::max_depth_limit - 1];  // max tree depth
     int stack_ptr = 0;
 
     Intersection intersection{OnLocalSurface{}, max_search_dist};

--- a/src/orange/inp/Bih.hh
+++ b/src/orange/inp/Bih.hh
@@ -24,7 +24,7 @@ struct BIHBuilder
 
     //! Hard limit on the depth of most the embedded node (where 1 is the root
     //! node)
-    size_type depth_limit = 32;
+    size_type depth_limit = 18;
 
     //! The number of partition candidates to check per axis when partitioning
     //! a node during BIH construction

--- a/src/orange/inp/Bih.hh
+++ b/src/orange/inp/Bih.hh
@@ -18,13 +18,17 @@ namespace inp
  */
 struct BIHBuilder
 {
+    //! The maximum value the \p depth_limit parameter can be, as to not
+    //! overstep the BIH stack
+    static constexpr size_type max_depth_limit = 18;
+
     //! Maximum number of bboxes that can reside on a leaf node without
     //! triggering a partitioning attempt
     size_type max_leaf_size = 1;
 
     //! Hard limit on the depth of most the embedded node (where 1 is the root
     //! node)
-    size_type depth_limit = 18;
+    size_type depth_limit = max_depth_limit;
 
     //! The number of partition candidates to check per axis when partitioning
     //! a node during BIH construction

--- a/src/orange/orangeinp/InputBuilder.cc
+++ b/src/orange/orangeinp/InputBuilder.cc
@@ -164,6 +164,7 @@ auto InputBuilder::operator()(ProtoInterface const& global) const -> result_type
     {
         size_type dl = std::stoul(var);
         CELER_EXPECT(dl > 0);
+        CELER_EXPECT(dl <= inp::BIHBuilder::max_depth_limit);
         result.construction_opts.bih_options.depth_limit = dl;
     }
 


### PR DESCRIPTION
This MR implements several changes that results in a ~2x reduction in runtime for the simplified (Rice) version of the DUNE model with minor benefits to the ATLAS lower end cap performance as well. These changes were informed by profiling with Nvidia Nsight Compute. Results at each stage are shown below, on an H100:

<img width="934" height="131" alt="Screenshot 2026-04-16 at 12 29 02 PM" src="https://github.com/user-attachments/assets/c4bf7f49-5b38-4611-b5d2-39a2d3755d86" />

### Loop order

The first hot spot was found in`BoundingBoxUtiils`:

<img width="1252" height="222" alt="Screenshot 2026-04-10 at 5 54 12 PM" src="https://github.com/user-attachments/assets/e2736a53-274c-4253-b9d5-d6c689ce7013" />

The was fixed by switching the loop order and storing `inv_dir`, resulting in half the number of divide operations.

### Stack

The second hotspot was found in `BIHIntersectingVolumeFinder`:

<img width="1118" height="776" alt="Screenshot 2026-04-14 at 11 45 37 AM" src="https://github.com/user-attachments/assets/b004e681-aa9a-4000-bfc5-52cb3dcf002c" />

These results show that the number of active threads decreases from 12 to 2 within this loop. This thread divergence is somewhat inherit to the random walk process, so this hot spot is more difficult to remedy. We are currently using a pointer-based approach to tree traversal. When a traversal starts going back up the tree, `next_node` can only step back a single level at a time via a pointer to the node's parent, even if the next node is many levels up. A stack-based approach doesn't have this problem. I have implemented a simple stack-based approach here, which requires trees have a max depth of 18 (stack size of 17; root can't be on the stack). This limitation can be easily met by enforcing this depth during BIH construction (as done in the MR, but as a punt). This limitation is also temporary. The next thing I will try will be a "short stack with restart trail" approach:

https://users.aalto.fi/~laines9/publications/laine2010hpg_paper.pdf

This will 1) eliminate the tree depth limitation, no matter what the stack size is, and 2) possibly improve performance by using a "short" stack size of 4-5.

### Fast real type

Bounding boxes current use a reduced-precision `fast_real_type`, of `float`. It seems like converting to `double`, essentially not using a fast real type, provides better performance. It is possible that using `float` and explicitly static casting positions and directions to `float` once per function call will be faster, but I haven't tried this yet. I figured I'd keep this in because it provides and improvement, but I can take it out until I test the other case.