### PR TITLE
Use real_type UDL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,16 @@ State collections need `resize(size)` operators for track slots.
 | `CELER_ENSURE` | Postconditions at function exit |
 | `CELER_VALIDATE` | User input validation (always active) |
 
+### Literal UDLs
+
+- When converting numeric literals to `_r`, replace explicit `real_type{...}` wrappers or equivalent explicit casts that were written only to force a literal to `real_type`.
+- When doing an `_r` sweep, audit for missed explicit wrappers with a regex search such as `real_type[\{\(][0-9\-\.e]*[\}\)]` over `src`, `test`, and `doc/example`, then resolve each match or consciously leave it because `_r` is not legal there (for example namespace-scope public-header initializers or non-literal expressions).
+- Before closing an `_r` sweep, rerun that regex over the full user-requested tree, not just the files already touched, and verify that every remaining match is an intentional exception with a concrete reason.
+- Do **not** treat every public-header match as an exception. If the explicit cast is inside a function body in a public header, including a `static` member helper like `default_light()`, it is still eligible for `_r` with a function-scope `using namespace celeritas::literals;`.
+- Do **not** rewrite standalone initializers whose target type is already explicit at the declaration site, such as `real_type x = 1.5;`, `real_type const tol = 1e-4;`, or `static constexpr real_type eps = 1e-4;`.
+- In `test/`, do **not** rewrite ordinary expressions to use `_r` unless the old code explicitly cast that literal to `real_type`. For example, leave `0.5 * value`, `find_root(0.5, 1.5)`, and `pi * 0.5` unchanged; replace `real_type{0.5} * value`, `real_type{1e-6}`, or similar explicit casts.
+- In public headers, function/block-scope `using namespace celeritas::literals;` is allowed. Never introduce namespace-scope `using namespace` there.
+
 ### Type-Safe Indices & Collections
 
 | Type | Purpose |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,12 +178,6 @@ State collections need `resize(size)` operators for track slots.
 
 ### Literal UDLs
 
-- When converting numeric literals to `_r`, replace explicit `real_type{...}` wrappers or equivalent explicit casts that were written only to force a literal to `real_type`.
-- When doing an `_r` sweep, audit for missed explicit wrappers with a regex search such as `real_type[\{\(][0-9\-\.e]*[\}\)]` over `src`, `test`, and `doc/example`, then resolve each match or consciously leave it because `_r` is not legal there (for example namespace-scope public-header initializers or non-literal expressions).
-- Before closing an `_r` sweep, rerun that regex over the full user-requested tree, not just the files already touched, and verify that every remaining match is an intentional exception with a concrete reason.
-- Do **not** treat every public-header match as an exception. If the explicit cast is inside a function body in a public header, including a `static` member helper like `default_light()`, it is still eligible for `_r` with a function-scope `using namespace celeritas::literals;`.
-- Do **not** rewrite standalone initializers whose target type is already explicit at the declaration site, such as `real_type x = 1.5;`, `real_type const tol = 1e-4;`, or `static constexpr real_type eps = 1e-4;`.
-- In `test/`, do **not** rewrite ordinary expressions to use `_r` unless the old code explicitly cast that literal to `real_type`. For example, leave `0.5 * value`, `find_root(0.5, 1.5)`, and `pi * 0.5` unchanged; replace `real_type{0.5} * value`, `real_type{1e-6}`, or similar explicit casts.
 - In public headers, function/block-scope `using namespace celeritas::literals;` is allowed. Never introduce namespace-scope `using namespace` there.
 
 ### Type-Safe Indices & Collections

--- a/src/celeritas/decay/interactor/MuDecayInteractor.hh
+++ b/src/celeritas/decay/interactor/MuDecayInteractor.hh
@@ -147,6 +147,8 @@ MuDecayInteractor::MuDecayInteractor(MuDecayData const& shared,
 template<class Engine>
 CELER_FUNCTION Interaction MuDecayInteractor::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     // Allocate secondaries
     Secondary* secondaries = allocate_(1);
     if (secondaries == nullptr)
@@ -163,11 +165,11 @@ CELER_FUNCTION Interaction MuDecayInteractor::operator()(Engine& rng)
         {
             electron_nu_energy_frac = generate_canonical(rng);
         } while (RejectionSampler(
-            electron_nu_energy_frac * (real_type{1} - electron_nu_energy_frac),
-            real_type{0.25})(rng));
+            electron_nu_energy_frac * (1_r - electron_nu_energy_frac),
+            0.25_r)(rng));
 
         electron_energy_frac = generate_canonical(rng);
-    } while (electron_nu_energy_frac + electron_energy_frac < real_type{1});
+    } while (electron_nu_energy_frac + electron_energy_frac < 1_r);
 
     // Decay isotropically in rest frame and boost secondaries to the lab frame
     auto charged_lep_fv = this->to_lab_frame(

--- a/src/celeritas/em/distribution/EnergyLossUrbanDistribution.hh
+++ b/src/celeritas/em/distribution/EnergyLossUrbanDistribution.hh
@@ -136,6 +136,8 @@ CELER_FUNCTION EnergyLossUrbanDistribution::EnergyLossUrbanDistribution(
     real_type beta_sq)
     : max_energy_(max_energy.value())
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(unscaled_mean_loss > zero_quantity());
     CELER_EXPECT(two_mebsgs > zero_quantity());
     CELER_EXPECT(beta_sq > 0);
@@ -146,10 +148,8 @@ CELER_FUNCTION EnergyLossUrbanDistribution::EnergyLossUrbanDistribution(
     // rescaling the energy levels and number of excitations. The width
     // correction algorithm is discussed (though not in much detail) in PRM
     // section 7.3.3
-    loss_scaling_
-        = real_type(0.5)
-              * min(this->fwhm_min_energy() / max_energy_, real_type(1))
-          + real_type(1);
+    loss_scaling_ = 0.5_r * min(this->fwhm_min_energy() / max_energy_, 1.0_r)
+                    + 1.0_r;
     real_type const mean_loss = unscaled_mean_loss.value() / loss_scaling_;
 
     // Material-dependent data
@@ -194,8 +194,8 @@ CELER_FUNCTION EnergyLossUrbanDistribution::EnergyLossUrbanDistribution(
             real_type scaling = 4;
             if (xs_exc_[0] < this->exc_thresh())
             {
-                scaling = real_type(0.5)
-                          + (scaling - real_type(0.5))
+                scaling = 0.5_r
+                          + (scaling - 0.5_r)
                                 * std::sqrt(xs_exc_[0] / this->exc_thresh());
             }
             binding_energy_[0] *= scaling;

--- a/src/celeritas/em/distribution/MuAngularDistribution.hh
+++ b/src/celeritas/em/distribution/MuAngularDistribution.hh
@@ -78,9 +78,11 @@ MuAngularDistribution::MuAngularDistribution(Energy inc_energy,
                                              Energy energy)
     : gamma_(1 + value_as<Energy>(inc_energy) / value_as<Mass>(inc_mass))
 {
+    using namespace celeritas::literals;
+
     real_type r_max_sq = ipow<2>(
-        real_type(0.5) * constants::pi * gamma_
-        * min(real_type(1),
+        0.5_r * constants::pi * gamma_
+        * min(1.0_r,
               gamma_ * value_as<Mass>(inc_mass) / value_as<Energy>(energy) - 1));
     sample_a_ = {0, r_max_sq / (1 + r_max_sq)};
 }

--- a/src/celeritas/em/distribution/MuBBEnergyDistribution.hh
+++ b/src/celeritas/em/distribution/MuBBEnergyDistribution.hh
@@ -151,6 +151,8 @@ MuBBEnergyDistribution::MuBBEnergyDistribution(ParticleTrackView const& particle
 template<class Engine>
 CELER_FUNCTION auto MuBBEnergyDistribution::operator()(Engine& rng) -> Energy
 {
+    using namespace celeritas::literals;
+
     InverseSquareDistribution sample_energy(value_as<Energy>(min_energy_),
                                             value_as<Energy>(max_energy_));
     real_type energy;
@@ -159,7 +161,7 @@ CELER_FUNCTION auto MuBBEnergyDistribution::operator()(Engine& rng) -> Energy
     {
         energy = sample_energy(rng);
         target = 1 - (beta_sq_ / value_as<Energy>(max_energy_)) * energy
-                 + real_type(0.5) * ipow<2>(energy / total_energy_);
+                 + 0.5_r * ipow<2>(energy / total_energy_);
 
         if (use_rad_correction_
             && energy > value_as<Energy>(kin_energy_limit()))

--- a/src/celeritas/em/distribution/MuPPEnergyDistribution.hh
+++ b/src/celeritas/em/distribution/MuPPEnergyDistribution.hh
@@ -161,6 +161,8 @@ MuPPEnergyDistribution::MuPPEnergyDistribution(
     , min_energy_(max(value_as<Energy>(cutoffs.energy(shared.ids.positron)),
                       min_pair_energy_))
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(max_pair_energy_ > min_energy_);
 
     NonuniformGrid logz_grid(table_.logz_grid, table_.reals);
@@ -190,6 +192,8 @@ template<class Engine>
 CELER_FUNCTION auto MuPPEnergyDistribution::operator()(Engine& rng)
     -> PairEnergy
 {
+    using namespace celeritas::literals;
+
     // Sample the energy transfer
     real_type pair_energy
         = inc_energy_ * std::exp(coeff_ * this->sample_scaled_energy(rng));
@@ -204,7 +208,7 @@ CELER_FUNCTION auto MuPPEnergyDistribution::operator()(Engine& rng)
 
     // Calculate the electron and positron energies
     PairEnergy result;
-    real_type half_energy = pair_energy * real_type(0.5);
+    real_type half_energy = pair_energy * 0.5_r;
     result.electron = Energy((1 - r) * half_energy - electron_mass_);
     result.positron = Energy((1 + r) * half_energy - electron_mass_);
 

--- a/src/celeritas/em/distribution/MuPPEnergyDistribution.hh
+++ b/src/celeritas/em/distribution/MuPPEnergyDistribution.hh
@@ -161,8 +161,6 @@ MuPPEnergyDistribution::MuPPEnergyDistribution(
     , min_energy_(max(value_as<Energy>(cutoffs.energy(shared.ids.positron)),
                       min_pair_energy_))
 {
-    using namespace celeritas::literals;
-
     CELER_EXPECT(max_pair_energy_ > min_energy_);
 
     NonuniformGrid logz_grid(table_.logz_grid, table_.reals);

--- a/src/celeritas/em/distribution/TsaiUrbanDistribution.hh
+++ b/src/celeritas/em/distribution/TsaiUrbanDistribution.hh
@@ -78,14 +78,14 @@ TsaiUrbanDistribution::TsaiUrbanDistribution(Energy energy, Mass mass)
 template<class Engine>
 CELER_FUNCTION real_type TsaiUrbanDistribution::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     real_type u;
     do
     {
         real_type uu
             = -std::log(generate_canonical(rng) * generate_canonical(rng));
-        u = uu
-            * (BernoulliDistribution(0.25)(rng) ? real_type(1.6)
-                                                : real_type(1.6 / 3));
+        u = uu * (BernoulliDistribution(0.25)(rng) ? 1.6_r : 1.6_r / 3.0);
     } while (u > umax_);
 
     return 1 - 2 * ipow<2>(u / umax_);

--- a/src/celeritas/em/distribution/TsaiUrbanDistribution.hh
+++ b/src/celeritas/em/distribution/TsaiUrbanDistribution.hh
@@ -85,7 +85,7 @@ CELER_FUNCTION real_type TsaiUrbanDistribution::operator()(Engine& rng)
     {
         real_type uu
             = -std::log(generate_canonical(rng) * generate_canonical(rng));
-        u = uu * (BernoulliDistribution(0.25)(rng) ? 1.6_r : 1.6_r / 3.0);
+        u = uu * (BernoulliDistribution(0.25)(rng) ? 1.6_r : 1.6_r / 3.0_r);
     } while (u > umax_);
 
     return 1 - 2 * ipow<2>(u / umax_);

--- a/src/celeritas/em/distribution/UrbanLargeAngleDistribution.hh
+++ b/src/celeritas/em/distribution/UrbanLargeAngleDistribution.hh
@@ -103,12 +103,14 @@ class UrbanLargeAngleDistribution
 CELER_FUNCTION
 UrbanLargeAngleDistribution::UrbanLargeAngleDistribution(real_type tau)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(tau > 0);
     // Eq. 8.2 and \f$ \cos^2\theta \f$ term in Eq. 8.3 in PRM
     real_type mumean = std::exp(-tau);
     // NOTE: tau_big = 8 -> ~0.0003 < mumean < 1
 
-    real_type musqmean = (1 + 2 * std::exp(real_type(-2.5) * tau)) / 3;
+    real_type musqmean = (1 + 2 * std::exp(-2.5_r * tau)) / 3;
     real_type a = (2 * mumean + 9 * musqmean - 3)
                   / (2 * mumean - 3 * musqmean + 1);
 

--- a/src/celeritas/em/distribution/WentzelDistribution.hh
+++ b/src/celeritas/em/distribution/WentzelDistribution.hh
@@ -295,9 +295,11 @@ template<class Engine>
 CELER_FUNCTION real_type WentzelDistribution::sample_costheta(
     real_type cos_thetamin, real_type cos_thetamax, Engine& rng) const
 {
+    using namespace celeritas::literals;
+
     // Sample scattering angle [fern] eqn 92, where cos(theta) = 1 - 2*mu
-    real_type const mu1 = real_type{0.5} * (1 - cos_thetamin);
-    real_type const mu2 = real_type{0.5} * (1 - cos_thetamax);
+    real_type const mu1 = 0.5_r * (1 - cos_thetamin);
+    real_type const mu2 = 0.5_r * (1 - cos_thetamax);
     real_type const w = generate_canonical(rng) * (mu2 - mu1);
     real_type const sc = helper_.screening_coefficient();
 

--- a/src/celeritas/em/interactor/AtomicRelaxation.hh
+++ b/src/celeritas/em/interactor/AtomicRelaxation.hh
@@ -121,6 +121,8 @@ template<class Engine>
 CELER_FUNCTION AtomicRelaxation::result_type
 AtomicRelaxation::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     AtomicRelaxElement const& el = shared_.elements[el_id_];
     auto const& shells = shared_.shells[el.shells];
     MiniStack<SubshellId> vacancies(vacancies_);
@@ -150,7 +152,7 @@ AtomicRelaxation::operator()(Engine& rng)
                 return transitions[i.unchecked_get()].probability;
             },
             id_cast<TransitionId>(transitions.size()),
-            real_type{1})(rng);
+            1_r)(rng);
 
         if (trans_id == id_cast<TransitionId>(transitions.size()))
         {

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -166,7 +166,7 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     else
     {
         screen_delta_ = epsilon0_ * 136 / element.cbrt_z();
-        f_z_ = 8.0_r / 3.0 * element.log_z();
+        f_z_ = 8.0_r / 3.0_r * element.log_z();
         if (inc_energy_ > coulomb_corr_threshold())
         {
             // Apply Coulomb correction function

--- a/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
+++ b/src/celeritas/em/interactor/BetheHeitlerInteractor.hh
@@ -148,6 +148,8 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     , calc_lpm_functions_(
           material, element, shared_.dielectric_suppression(), inc_energy_)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(particle.particle_id() == shared_.ids.gamma);
     CELER_EXPECT(value_as<Energy>(inc_energy_)
                  >= 2 * value_as<Mass>(shared_.electron_mass));
@@ -164,7 +166,7 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
     else
     {
         screen_delta_ = epsilon0_ * 136 / element.cbrt_z();
-        f_z_ = real_type(8) / real_type(3) * element.log_z();
+        f_z_ = 8.0_r / 3.0 * element.log_z();
         if (inc_energy_ > coulomb_corr_threshold())
         {
             // Apply Coulomb correction function
@@ -180,6 +182,8 @@ CELER_FUNCTION BetheHeitlerInteractor::BetheHeitlerInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     // Allocate space for the electron/positron pair
     Secondary* secondaries = allocate_(2);
     if (secondaries == nullptr)
@@ -204,9 +208,8 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // \epsilon = \epsilon_1) values of screening variable, \delta. Above
         // 50 MeV, a Coulomb correction function is introduced.
         real_type const delta_min = 4 * screen_delta_;
-        real_type const delta_max
-            = std::exp((real_type(42.038) - f_z_) / real_type(8.29))
-              - real_type(0.958);
+        real_type const delta_max = std::exp((42.038_r - f_z_) / 8.29_r)
+                                    - 0.958_r;
         CELER_ASSERT(delta_min <= delta_max);
 
         // Calculate the lower limit of epsilon. Due to the Coulomb correction,
@@ -224,7 +227,7 @@ CELER_FUNCTION Interaction BetheHeitlerInteractor::operator()(Engine& rng)
         // c.f. Eq. 6.6 of Geant4 Physics Reference 10.6)
         Real2 const fmin = this->screening_f(delta_min) - f_z_;
         BernoulliDistribution choose_f1g1(
-            ipow<2>(half - epsilon_min) * fmin[0], real_type(1.5) * fmin[1]);
+            ipow<2>(half - epsilon_min) * fmin[0], 1.5_r * fmin[1]);
 
         // Rejection function g_1 or g_2. Note the it's possible for g to be
         // greater than one

--- a/src/celeritas/em/interactor/KleinNishinaInteractor.hh
+++ b/src/celeritas/em/interactor/KleinNishinaInteractor.hh
@@ -102,6 +102,8 @@ CELER_FUNCTION KleinNishinaInteractor::KleinNishinaInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction KleinNishinaInteractor::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     using Energy = units::MevEnergy;
 
     // Allocate space for the single electron to be emitted
@@ -119,7 +121,7 @@ CELER_FUNCTION Interaction KleinNishinaInteractor::operator()(Engine& rng)
 
     // Probability of alpha_1 to choose f_1 (sample epsilon)
     BernoulliDistribution choose_f1(-std::log(epsilon_0),
-                                    real_type(0.5) * (1 - ipow<2>(epsilon_0)));
+                                    0.5_r * (1 - ipow<2>(epsilon_0)));
     // Sample f_1(\eps) \propto 1/\eps on [\eps_0, 1]
     ReciprocalDistribution<real_type> sample_f1(epsilon_0);
     // Sample square of f_2(\eps^2) \propto 1 on [\eps_0^2, 1]

--- a/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
+++ b/src/celeritas/em/interactor/detail/SBPositronXsCorrector.hh
@@ -111,6 +111,8 @@ SBPositronXsCorrector::SBPositronXsCorrector(Mass positron_mass,
  */
 CELER_FUNCTION real_type SBPositronXsCorrector::operator()(Energy energy) const
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(energy > zero_quantity());
     CELER_EXPECT(energy.value() < inc_energy_);
     real_type delta = cutoff_invbeta_ - this->calc_invbeta(energy.value());
@@ -118,7 +120,7 @@ CELER_FUNCTION real_type SBPositronXsCorrector::operator()(Energy energy) const
     // Avoid positive delta values due to floating point inaccuracies
     // See https://github.com/celeritas-project/celeritas/issues/617
     CELER_ASSERT(delta < 100 * numeric_limits<real_type>::epsilon());
-    real_type result = std::exp(alpha_z_ * celeritas::min(delta, real_type{0}));
+    real_type result = std::exp(alpha_z_ * celeritas::min(delta, 0_r));
     CELER_ENSURE(result <= 1);
     return result;
 }

--- a/src/celeritas/em/model/RelativisticBremModel.cc
+++ b/src/celeritas/em/model/RelativisticBremModel.cc
@@ -27,6 +27,8 @@
 #include "celeritas/phys/ParticleParams.hh"
 #include "celeritas/phys/ParticleView.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -179,7 +181,7 @@ auto RelativisticBremModel::compute_element_data(ElementView const& elem,
     }
 
     real_type fc = elem.coulomb_correction();
-    real_type invz = real_type(1) / z.unchecked_get();
+    real_type invz = 1.0_r / z.unchecked_get();
 
     data.fz = elem.log_z() / 3 + fc;
     data.factor1 = (ff_el - fc) + ff_inel * invz;

--- a/src/celeritas/em/msc/detail/MscStepFromGeo.hh
+++ b/src/celeritas/em/msc/detail/MscStepFromGeo.hh
@@ -98,6 +98,8 @@ CELER_FUNCTION MscStepFromGeo::MscStepFromGeo(MscParameters const& params,
  */
 CELER_FUNCTION real_type MscStepFromGeo::operator()(real_type gstep) const
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(gstep >= 0 && gstep <= true_step_);
 
     if (gstep < params_.min_step_transform)
@@ -129,7 +131,7 @@ CELER_FUNCTION real_type MscStepFromGeo::operator()(real_type gstep) const
         // ending MFP of zero is correct when the step is the range. Precision
         // loss means this conversion also may result in x > 1, which we guard
         // against.
-        x = min(x, real_type(1));
+        x = min(x, 1.0_r);
         // Near x=1, (1 - (1-x)^(1/w)) suffers from numerical precision loss;
         // the maximum value of the expression should be range_.
         // TODO: we should use the action ID to avoid applying this

--- a/src/celeritas/em/msc/detail/UrbanMscMinimalStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscMinimalStepLimit.hh
@@ -116,6 +116,8 @@ UrbanMscMinimalStepLimit::UrbanMscMinimalStepLimit(
 template<class Engine>
 CELER_FUNCTION real_type UrbanMscMinimalStepLimit::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     if (max_step_ <= limit_)
     {
         // Skip sampling if the physics step is limiting
@@ -128,8 +130,8 @@ CELER_FUNCTION real_type UrbanMscMinimalStepLimit::operator()(Engine& rng)
     }
 
     // Randomize the limit if this step should be determined by MSC
-    NormalDistribution<real_type> sample_gauss(
-        limit_, real_type(0.1) * (limit_ - limit_min_));
+    NormalDistribution<real_type> sample_gauss(limit_,
+                                               0.1_r * (limit_ - limit_min_));
     real_type sampled_limit = sample_gauss(rng);
 
     // Keep sampled limit between the minimum value and maximum step

--- a/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscSafetyStepLimit.hh
@@ -190,6 +190,8 @@ UrbanMscSafetyStepLimit::UrbanMscSafetyStepLimit(
 template<class Engine>
 CELER_FUNCTION real_type UrbanMscSafetyStepLimit::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     // TODO: if start energy is below min_energy, also skip since we won't
     // sample MSC
     if (max_step_ <= limit_)
@@ -204,8 +206,8 @@ CELER_FUNCTION real_type UrbanMscSafetyStepLimit::operator()(Engine& rng)
     }
 
     // Randomize the limit if this step should be determined by msc
-    NormalDistribution<real_type> sample_gauss(
-        limit_, real_type(0.1) * (limit_ - limit_min_));
+    NormalDistribution<real_type> sample_gauss(limit_,
+                                               0.1_r * (limit_ - limit_min_));
     real_type sampled_limit = sample_gauss(rng);
 
     // Keep sampled limit between the minimum value and maximum step
@@ -221,6 +223,8 @@ CELER_FUNCTION real_type UrbanMscSafetyStepLimit::operator()(Engine& rng)
 CELER_FUNCTION real_type UrbanMscSafetyStepLimit::calc_limit_min(
     UrbanMscMaterialData const& msc, Energy const inc_energy) const
 {
+    using namespace celeritas::literals;
+
     using PolyQuad = PolyEvaluator<real_type, 2>;
 
     // Calculate minimum step
@@ -233,8 +237,8 @@ CELER_FUNCTION real_type UrbanMscSafetyStepLimit::calc_limit_min(
     if (inc_energy < shared_.params.min_scaling_energy)
     {
         // Energy is below a pre-defined limit
-        xm *= (real_type(0.5)
-               + real_type(0.5) * value_as<Energy>(inc_energy)
+        xm *= (0.5_r
+               + 0.5_r * value_as<Energy>(inc_energy)
                      / value_as<Energy>(shared_.params.min_scaling_energy));
     }
 

--- a/src/celeritas/em/msc/detail/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscScatter.hh
@@ -225,8 +225,6 @@ UrbanMscScatter::UrbanMscScatter(UrbanMscRef const& shared,
     {
         // Calculate number of mean free paths traveled
         tau_ = true_path_ / [this, &helper] {
-            using namespace celeritas::literals;
-
             // Calculate the average MFP assuming the cross section varies
             // linearly over the step
             real_type lambda = helper_.msc_mfp();
@@ -381,8 +379,6 @@ CELER_FUNCTION real_type UrbanMscScatter::sample_cos_theta(Engine& rng) const
 
     // Evaluate parameters for the tail distribution
     real_type xsi = [this] {
-        using namespace celeritas::literals;
-
         using PolyQuad = PolyEvaluator<real_type, 2>;
 
         real_type maxtau
@@ -422,8 +418,6 @@ CELER_FUNCTION real_type UrbanMscScatter::sample_cos_theta(Engine& rng) const
 
     // From continuity of derivatives
     real_type c = [xsi] {
-        using namespace celeritas::literals;
-
         if (std::fabs(xsi - 3) < 0.001_r)
         {
             return 3.001_r;

--- a/src/celeritas/em/msc/detail/UrbanMscScatter.hh
+++ b/src/celeritas/em/msc/detail/UrbanMscScatter.hh
@@ -175,6 +175,8 @@ UrbanMscScatter::UrbanMscScatter(UrbanMscRef const& shared,
     , true_path_(input.true_path)
     , limit_min_(physics.msc_range().limit_min)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(safety_ >= 0);
     CELER_EXPECT(geom_path_ > 0);
     CELER_EXPECT(true_path_ >= geom_path_);
@@ -223,11 +225,13 @@ UrbanMscScatter::UrbanMscScatter(UrbanMscRef const& shared,
     {
         // Calculate number of mean free paths traveled
         tau_ = true_path_ / [this, &helper] {
+            using namespace celeritas::literals;
+
             // Calculate the average MFP assuming the cross section varies
             // linearly over the step
             real_type lambda = helper_.msc_mfp();
             real_type lambda_end = helper.calc_msc_mfp(Energy{end_energy_});
-            if (std::fabs(lambda - lambda_end) < lambda * real_type(0.01))
+            if (std::fabs(lambda - lambda_end) < lambda * 0.01_r)
             {
                 // Cross section is almost constant over the step: avoid
                 // numerical explosion
@@ -253,7 +257,7 @@ UrbanMscScatter::UrbanMscScatter(UrbanMscRef const& shared,
             // many of the class member data
             theta0_ = this->compute_theta0(particle);
 
-            if (theta0_ < real_type(1e-8))
+            if (theta0_ < 1e-8_r)
             {
                 // Arbitrarily (?) small angle change (theta_0^2 < 1e-16):
                 // skip sampling angular distribution if width of direction
@@ -280,6 +284,8 @@ UrbanMscScatter::UrbanMscScatter(UrbanMscRef const& shared,
 template<class Engine>
 CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
 {
+    using namespace celeritas::literals;
+
     if (skip_sampling_)
     {
         // Do not sample scattering at the last or at a small step
@@ -291,7 +297,7 @@ CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
         if (theta0_ <= 0)
         {
             // Very small outgoing angular distribution
-            return real_type{1};
+            return 1_r;
         }
         if (tau_ >= shared_.params.tau_big)
         {
@@ -311,8 +317,8 @@ CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
     CELER_ASSERT(std::fabs(costheta) <= 1);
 
     // Sample azimuthal angle, used for displacement and exiting angle
-    real_type phi = UniformRealDistribution<real_type>(
-        0, real_type{2 * constants::pi})(rng);
+    real_type phi
+        = UniformRealDistribution<real_type>(0, 2_r * constants::pi)(rng);
 
     MscInteraction result;
     result.action = MscInteraction::Action::scattered;
@@ -371,14 +377,18 @@ CELER_FUNCTION auto UrbanMscScatter::operator()(Engine& rng) -> MscInteraction
 template<class Engine>
 CELER_FUNCTION real_type UrbanMscScatter::sample_cos_theta(Engine& rng) const
 {
+    using namespace celeritas::literals;
+
     // Evaluate parameters for the tail distribution
     real_type xsi = [this] {
+        using namespace celeritas::literals;
+
         using PolyQuad = PolyEvaluator<real_type, 2>;
 
         real_type maxtau
             = true_path_ < limit_min_ ? limit_min_ / helper_.msc_mfp() : tau_;
         // note: 0 < u <= sqrt(2) when shared_.params.tau_big == 8
-        real_type u = fastpow(maxtau, 1 / real_type(6));
+        real_type u = fastpow(maxtau, 1.0_r / 6.0_r);
         // Number of radiation lengths traveled by the average MFP over this
         // step
         real_type radlen_mfp = true_path_
@@ -386,14 +396,14 @@ CELER_FUNCTION real_type UrbanMscScatter::sample_cos_theta(Engine& rng) const
         real_type result = PolyQuad(msc_.tail_coeff)(u)
                            + msc_.tail_corr * std::log(radlen_mfp);
         // The tail should not be too big
-        return max(result, real_type(1.9));
+        return max(result, 1.9_r);
     }();
 
     // Mean of cos\theta computed from the distribution g_1(cos\theta)
     // small theta => x = theta0^2
     // large xsi => xmean_1 = 1 - x
     // small tau => xmean = 1
-    real_type x = ipow<2>(2 * std::sin(real_type(0.5) * theta0_));
+    real_type x = ipow<2>(2 * std::sin(0.5_r * theta0_));
 
     // Calculate intermediate values for the mean of cos(theta)
     // Since xsi is not near zero (thanks to max), no need to use expm1
@@ -405,20 +415,22 @@ CELER_FUNCTION real_type UrbanMscScatter::sample_cos_theta(Engine& rng) const
     real_type xmean = std::exp(-tau_);
 
     // 0.0003 (max tau before assuming isotropic scattering) < xmean < 1
-    if (xmean_1 <= real_type(0.999) * xmean)
+    if (xmean_1 <= 0.999_r * xmean)
     {
         return this->simple_scattering(rng);
     }
 
     // From continuity of derivatives
     real_type c = [xsi] {
-        if (std::fabs(xsi - 3) < real_type(0.001))
+        using namespace celeritas::literals;
+
+        if (std::fabs(xsi - 3) < 0.001_r)
         {
-            return real_type(3.001);
+            return 3.001_r;
         }
-        else if (std::fabs(xsi - 2) < real_type(0.001))
+        else if (std::fabs(xsi - 2) < 0.001_r)
         {
-            return real_type(2.001);
+            return 2.001_r;
         }
         return xsi;
     }();
@@ -457,11 +469,10 @@ CELER_FUNCTION real_type UrbanMscScatter::sample_cos_theta(Engine& rng) const
     {
         // Sample \f$ \cos\theta \f$ from \f$ g_2(\cos\theta) \f$
         real_type var = (1 - d) * generate_canonical(rng);
-        if (var < real_type(0.01) * d)
+        if (var < 0.01_r * d)
         {
             var /= (d * (c - 1));
-            return -1
-                   + var * (1 - real_type(0.5) * var * c) * (2 + (c - xsi) * x);
+            return -1 + var * (1 - 0.5_r * var * c) * (2 + (c - xsi) * x);
         }
         else
         {

--- a/src/celeritas/em/msc/detail/UrbanPositronCorrector.hh
+++ b/src/celeritas/em/msc/detail/UrbanPositronCorrector.hh
@@ -40,6 +40,8 @@ class UrbanPositronCorrector
  */
 CELER_FUNCTION UrbanPositronCorrector::UrbanPositronCorrector(real_type zeff)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(zeff >= 1);
     using PolyLin = PolyEvaluator<real_type, 1>;
     using PolyQuad = PolyEvaluator<real_type, 2>;
@@ -47,7 +49,7 @@ CELER_FUNCTION UrbanPositronCorrector::UrbanPositronCorrector(real_type zeff)
     a_ = PolyLin(0.994, -4.08e-3)(zeff);
     b_ = PolyQuad(7.16, 52.6, 365)(1 / zeff);
     c_ = PolyLin(1, -4.47e-3)(zeff);
-    d_ = real_type(1.21e-3) * zeff;
+    d_ = 1.21e-3_r * zeff;
     mult_ = PolyQuad(1.41125, -1.86427e-2, 1.84035e-4)(zeff);
 }
 

--- a/src/celeritas/em/params/AtomicRelaxationParams.cc
+++ b/src/celeritas/em/params/AtomicRelaxationParams.cc
@@ -31,6 +31,8 @@
 #include "celeritas/phys/PDGNumber.hh"
 #include "celeritas/phys/ParticleParams.hh"  // IWYU pragma: keep
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -130,7 +132,7 @@ void AtomicRelaxationParams::append_element(ImportAtomicRelaxation const& inp,
             designators.insert(transition.initial_shell);
             designators.insert(transition.auger_shell);
         }
-        CELER_ASSERT(soft_equal(real_type(1), norm));
+        CELER_ASSERT(soft_equal(1.0_r, norm));
     }
 
     // Create a mapping of subshell designator to index in the shells array (it

--- a/src/celeritas/em/params/WentzelOKVIParams.cc
+++ b/src/celeritas/em/params/WentzelOKVIParams.cc
@@ -17,6 +17,8 @@
 #include "celeritas/mat/MaterialParams.hh"
 #include "celeritas/phys/ParticleParams.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -49,7 +51,7 @@ WentzelOKVIParams::from_import(ImportData const& data,
         if (!wentzel)
         {
             // Set the minimum scattering angle for Coulomb single scattering
-            return real_type(0);
+            return 0.0_r;
         }
         // Polar angle limit between single and multiple scattering if both
         // models are present
@@ -79,7 +81,7 @@ WentzelOKVIParams::WentzelOKVIParams(SPConstMaterials materials,
     host_data.params.is_combined = options.is_combined;
     host_data.params.costheta_limit = std::cos(options.polar_angle_limit);
     host_data.params.a_sq_factor
-        = real_type(0.5)
+        = 0.5_r
           * ipow<2>(native_value_to<units::MevEnergy>(
                         options.angle_limit_factor * constants::hbar_planck
                         * constants::c_light / units::femtometer)
@@ -150,7 +152,7 @@ void WentzelOKVIParams::build_data(HostVal<WentzelOKVIData>& host_data,
                 auto atomic_mass = mat.element_record(elcomp_id).atomic_mass();
                 inv_mass_cbrt_sq[mat_id.get()]
                     += el_comp.fraction
-                       / std::pow(atomic_mass.value(), real_type(2) / 3);
+                       / std::pow(atomic_mass.value(), 2.0_r / 3.0);
             }
         }
         make_builder(&host_data.inv_mass_cbrt_sq)

--- a/src/celeritas/em/params/WentzelOKVIParams.cc
+++ b/src/celeritas/em/params/WentzelOKVIParams.cc
@@ -152,7 +152,7 @@ void WentzelOKVIParams::build_data(HostVal<WentzelOKVIData>& host_data,
                 auto atomic_mass = mat.element_record(elcomp_id).atomic_mass();
                 inv_mass_cbrt_sq[mat_id.get()]
                     += el_comp.fraction
-                       / std::pow(atomic_mass.value(), 2.0_r / 3.0);
+                       / std::pow(atomic_mass.value(), 2.0_r / 3.0_r);
             }
         }
         make_builder(&host_data.inv_mass_cbrt_sq)

--- a/src/celeritas/em/xs/LPMCalculator.hh
+++ b/src/celeritas/em/xs/LPMCalculator.hh
@@ -122,11 +122,13 @@ LPMCalculator::LPMCalculator(MaterialView const& material,
  */
 CELER_FUNCTION auto LPMCalculator::operator()(real_type epsilon) -> LPMFunctions
 {
+    using namespace celeritas::literals;
+
     real_type const s_prime = std::sqrt(
         lpm_energy_ / (8 * epsilon * gamma_energy_ * std::fabs(epsilon - 1)));
 
     // Stanev Eq 17, constant revised down from 191
-    real_type const s1 = ipow<2>(element_.cbrt_z() / real_type(184.15));
+    real_type const s1 = ipow<2>(element_.cbrt_z() / 184.15_r);
 
     // Stanev Eq 21
     real_type xi = 2;
@@ -138,7 +140,7 @@ CELER_FUNCTION auto LPMCalculator::operator()(real_type epsilon) -> LPMFunctions
     {
         real_type const log_s1 = std::log(constants::sqrt_two * s1);
         real_type const h = std::log(s_prime) / log_s1;
-        xi = 1 + h - real_type(0.08) * (1 - h) * h * (2 - h) / log_s1;
+        xi = 1 + h - 0.08_r * (1 - h) * h * (2 - h) / log_s1;
     }
     real_type s = s_prime / std::sqrt(xi);
 
@@ -172,7 +174,7 @@ CELER_FUNCTION auto LPMCalculator::operator()(real_type epsilon) -> LPMFunctions
     // Make sure suppression is less than 1 (due to Migdal's approximation on
     // \f$ xi \f$)
     real_type phi = this->calc_phi(s);
-    if (xi * phi > 1 || s > real_type(0.57))
+    if (xi * phi > 1 || s > 0.57_r)
     {
         xi = 1 / phi;
     }
@@ -199,14 +201,16 @@ CELER_FUNCTION auto LPMCalculator::operator()(real_type epsilon) -> LPMFunctions
  */
 CELER_FUNCTION real_type LPMCalculator::calc_phi(real_type s) const
 {
+    using namespace celeritas::literals;
+
     using PolyLin = PolyEvaluator<real_type, 1>;
     using PolyQuad = PolyEvaluator<real_type, 2>;
 
-    if (s < real_type(0.01))
+    if (s < 0.01_r)
     {
         return s * PolyLin(6, -6 * constants::pi)(s);
     }
-    else if (s < real_type(1.55))
+    else if (s < 1.55_r)
     {
         real_type a = PolyQuad{0.623, 0.796, 0.658}(s);
         real_type b = PolyQuad{-6, -6 * (3 - constants::pi), 1 / a}(s);
@@ -214,7 +218,7 @@ CELER_FUNCTION real_type LPMCalculator::calc_phi(real_type s) const
     }
     else
     {
-        return 1 - real_type(0.01190476) / ipow<4>(s);
+        return 1 - 0.01190476_r / ipow<4>(s);
     }
 }
 
@@ -224,28 +228,30 @@ CELER_FUNCTION real_type LPMCalculator::calc_phi(real_type s) const
  */
 CELER_FUNCTION real_type LPMCalculator::calc_g(real_type s, real_type phi) const
 {
+    using namespace celeritas::literals;
+
     using PolyLin = PolyEvaluator<real_type, 1>;
     using PolyQuart = PolyEvaluator<real_type, 4>;
 
-    if (s < real_type(0.01))
+    if (s < 0.01_r)
     {
         return PolyLin(-2 * phi, 12)(s);
     }
-    else if (s < real_type(0.415827))
+    else if (s < 0.415827_r)
     {
         real_type a = PolyQuart{1, 3.936, 4.97, -0.05, 7.5}(s);
         real_type b = PolyLin{-4, -8 / a}(s);
         real_type psi = 1 - std::exp(s * b);
         return 3 * psi - 2 * phi;
     }
-    else if (s < real_type(1.9156))
+    else if (s < 1.9156_r)
     {
         return std::tanh(
             PolyQuart{-0.160723, 3.755030, -1.798138, 0.672827, -0.120772}(s));
     }
     else
     {
-        return 1 - real_type(0.0230655) / ipow<4>(s);
+        return 1 - 0.0230655_r / ipow<4>(s);
     }
 }
 

--- a/src/celeritas/em/xs/MuBremsDiffXsCalculator.hh
+++ b/src/celeritas/em/xs/MuBremsDiffXsCalculator.hh
@@ -127,13 +127,15 @@ MuBremsDiffXsCalculator::MuBremsDiffXsCalculator(ElementView const& element,
     , total_energy_(inc_energy_ + inc_mass_)
     , electron_mass_(value_as<Mass>(electron_mass))
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(inc_energy_ > 0);
 
-    d_n_ = real_type(1.54) * std::pow(atomic_mass_, real_type(0.27));
+    d_n_ = 1.54_r * std::pow(atomic_mass_, 0.27_r);
     if (atomic_number_ == 1)
     {
         // Constants calculated calculated analytically
-        b_ = real_type(202.4);
+        b_ = 202.4_r;
         b_prime_ = 446;
     }
     else
@@ -141,7 +143,7 @@ MuBremsDiffXsCalculator::MuBremsDiffXsCalculator(ElementView const& element,
         // Constants calculated using the Thomas-Fermi model
         b_ = 183;
         b_prime_ = 1429;
-        d_n_ = std::pow(d_n_, 1 - real_type(1) / atomic_number_);
+        d_n_ = std::pow(d_n_, 1 - 1.0_r / atomic_number_);
     }
 }
 
@@ -152,6 +154,8 @@ MuBremsDiffXsCalculator::MuBremsDiffXsCalculator(ElementView const& element,
 CELER_FUNCTION
 real_type MuBremsDiffXsCalculator::operator()(Energy energy)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(energy > zero_quantity());
 
     using namespace celeritas::constants;
@@ -165,7 +169,7 @@ real_type MuBremsDiffXsCalculator::operator()(Energy energy)
     real_type v = value_as<Energy>(energy) / total_energy_;
 
     // Calculate the minimum momentum transfer
-    real_type delta = real_type(0.5) * inc_mass_sq_ * v
+    real_type delta = 0.5_r * inc_mass_sq_ * v
                       / (total_energy_ - value_as<Energy>(energy));
 
     // Calculate the contribution to the cross section from the nucleus
@@ -174,10 +178,9 @@ real_type MuBremsDiffXsCalculator::operator()(Energy energy)
         / (d_n_ * (electron_mass_ + delta * sqrt_euler * b_ * inv_cbrt_z_))));
 
     // Photon energy above which there is no contribution from electrons
-    real_type energy_max_prime = total_energy_
-                                 / (1
-                                    + real_type(0.5) * inc_mass_sq_
-                                          / (electron_mass_ * total_energy_));
+    real_type energy_max_prime
+        = total_energy_
+          / (1 + 0.5_r * inc_mass_sq_ / (electron_mass_ * total_energy_));
 
     // Calculate the contribution to the cross section from electrons
     real_type phi_e = 0;
@@ -194,8 +197,7 @@ real_type MuBremsDiffXsCalculator::operator()(Energy energy)
     // Calculate the differential cross section
     return 16 * alpha_fine_structure * na_avogadro
            * ipow<2>(electron_mass_ * r_electron) * atomic_number_
-           * (atomic_number_ * phi_n + phi_e)
-           * (1 - v * (1 - real_type(0.75) * v))
+           * (atomic_number_ * phi_n + phi_e) * (1 - v * (1 - 0.75_r * v))
            / (3 * inc_mass_sq_ * value_as<Energy>(energy) * atomic_mass_);
 }
 

--- a/src/celeritas/em/xs/NuclearFormFactors.hh
+++ b/src/celeritas/em/xs/NuclearFormFactors.hh
@@ -174,18 +174,19 @@ class UUNuclearFormFactor : public NuclearFormFactorTraits
 CELER_FUNCTION
 ExpNuclearFormFactor::ExpNuclearFormFactor(AtomicMassNumber a_mass)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(a_mass);
     real_type nucl_radius_fm = [a_mass] {
         if (CELER_UNLIKELY(a_mass == AtomicMassNumber{1}))
         {
             // Special case for proton radius
-            return real_type{0.85};
+            return 0.85_r;
         }
-        return real_type{1.27}
-               * fastpow(real_type(a_mass.get()), real_type{0.27});
+        return 1.27_r * fastpow(real_type(a_mass.get()), 0.27_r);
     }();
     prefactor_ = ipow<2>(nucl_radius_fm * value_as<InvMomentum>(fm_par_hbar()))
-                 * (real_type{1} / 12);
+                 * (1_r / 12);
     CELER_ENSURE(prefactor_ > 0);
 }
 
@@ -248,9 +249,10 @@ GaussianNuclearFormFactor::operator()(Momentum target_mom) const
  */
 CELER_FUNCTION UUNuclearFormFactor::UUNuclearFormFactor(AtomicMassNumber a_mass)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(a_mass);
-    nucl_radius_fm_ = real_type{1.2}
-                      * fastpow(real_type(a_mass.get()), real_type{1} / 3);
+    nucl_radius_fm_ = 1.2_r * fastpow(real_type(a_mass.get()), 1_r / 3);
 }
 
 //---------------------------------------------------------------------------//
@@ -279,9 +281,10 @@ CELER_FUNCTION real_type UUNuclearFormFactor::operator()(Momentum target_mom) co
     };
 
     // Due to catastrophic error for small x, clamp the result to 1
+    using namespace celeritas::literals;
     return min(sphere_ff(nucl_radius_fm_)
                    * sphere_ff(UUNuclearFormFactor::skin_radius_fm()),
-               real_type{1});
+               1_r);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/em/xs/WentzelHelper.hh
+++ b/src/celeritas/em/xs/WentzelHelper.hh
@@ -207,9 +207,11 @@ CELER_FUNCTION real_type WentzelHelper::calc_xs_factor(
 CELER_FUNCTION real_type WentzelHelper::calc_screening_coefficient(
     ParticleTrackView const& particle, CoulombIds const& ids) const
 {
+    using namespace celeritas::literals;
+
     // TODO: Reference for just proton correction?
     real_type correction = 1;
-    real_type sq_cbrt_z = fastpow(real_type(target_z_.get()), real_type{2} / 3);
+    real_type sq_cbrt_z = fastpow(real_type(target_z_.get()), 2_r / 3);
     if (target_z_.get() > 1)
     {
         // TODO: tau correction factor and "min" value are of unknown
@@ -229,11 +231,11 @@ CELER_FUNCTION real_type WentzelHelper::calc_screening_coefficient(
         {
             // Muons and hadrons
             factor = ipow<2>(value_as<Charge>(particle.charge()));
-            z_factor += std::exp(-ipow<2>(target_z_.get()) * real_type(0.001));
+            z_factor += std::exp(-ipow<2>(target_z_.get()) * 0.001_r);
         }
-        correction = min(target_z_.get() * real_type{1.13},
-                         real_type{1.13}
-                             + real_type{3.76}
+        correction = min(target_z_.get() * 1.13_r,
+                         1.13_r
+                             + 3.76_r
                                    * ipow<2>(target_z_.get()
                                              * constants::alpha_fine_structure)
                                    * factor / particle.beta_sq())
@@ -306,6 +308,8 @@ WentzelHelper::calc_cos_thetamax_electron(ParticleTrackView const& particle,
                                           Energy cutoff,
                                           Mass electron_mass)
 {
+    using namespace celeritas::literals;
+
     real_type result = 0;
     real_type inc_energy = value_as<Energy>(particle.energy());
     real_type mass = value_as<Mass>(particle.mass());
@@ -315,7 +319,7 @@ WentzelHelper::calc_cos_thetamax_electron(ParticleTrackView const& particle,
     {
         // Electrons and positrons
         real_type max_energy = particle.particle_id() == ids.electron
-                                   ? real_type{0.5} * inc_energy
+                                   ? 0.5_r * inc_energy
                                    : inc_energy;
         real_type final_energy = inc_energy
                                  - min(value_as<Energy>(cutoff), max_energy);

--- a/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
+++ b/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
@@ -117,10 +117,10 @@ CELER_FUNCTION real_type WentzelTransportXsCalculator::calc_xs_contribution(
     if (x < WentzelTransportXsCalculator::limit())
     {
         real_type x_sq = ipow<2>(x);
-        result
-            = 0.5_r * x_sq
-              * ((1 - 4.0_r / 3.0_r * x + 1.5_r * x_sq)
-                 - screening_coeff_ * spin * beta_sq_ * x * (2.0_r / 3.0_r - x));
+        result = 0.5_r * x_sq
+                 * ((1 - 4.0_r / 3.0_r * x + 1.5_r * x_sq)
+                    - screening_coeff_ * spin * beta_sq_ * x
+                          * (2.0_r / 3.0_r - x));
     }
     else
     {

--- a/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
+++ b/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
@@ -109,16 +109,18 @@ WentzelTransportXsCalculator::operator()(real_type cos_thetamax) const
 CELER_FUNCTION real_type WentzelTransportXsCalculator::calc_xs_contribution(
     real_type cos_thetamax) const
 {
+    using namespace celeritas::literals;
+
     real_type result;
-    real_type const spin = real_type(0.5);
+    real_type const spin = 0.5_r;
     real_type x = (1 - cos_thetamax) / screening_coeff_;
     if (x < WentzelTransportXsCalculator::limit())
     {
         real_type x_sq = ipow<2>(x);
-        result = real_type(0.5) * x_sq
-                 * ((1 - real_type(4) / 3 * x + real_type(1.5) * x_sq)
-                    - screening_coeff_ * spin * beta_sq_ * x
-                          * (real_type(2) / 3 - x));
+        result
+            = 0.5_r * x_sq
+              * ((1 - 4.0_r / 3.0 * x + 1.5_r * x_sq)
+                 - screening_coeff_ * spin * beta_sq_ * x * (2.0_r / 3.0 - x));
     }
     else
     {

--- a/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
+++ b/src/celeritas/em/xs/WentzelTransportXsCalculator.hh
@@ -119,8 +119,8 @@ CELER_FUNCTION real_type WentzelTransportXsCalculator::calc_xs_contribution(
         real_type x_sq = ipow<2>(x);
         result
             = 0.5_r * x_sq
-              * ((1 - 4.0_r / 3.0 * x + 1.5_r * x_sq)
-                 - screening_coeff_ * spin * beta_sq_ * x * (2.0_r / 3.0 - x));
+              * ((1 - 4.0_r / 3.0_r * x + 1.5_r * x_sq)
+                 - screening_coeff_ * spin * beta_sq_ * x * (2.0_r / 3.0_r - x));
     }
     else
     {

--- a/src/celeritas/field/CylMapFieldParams.cc
+++ b/src/celeritas/field/CylMapFieldParams.cc
@@ -22,6 +22,8 @@
 #include "CylMapFieldData.hh"
 #include "CylMapFieldInput.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -57,10 +59,9 @@ CylMapFieldParams::CylMapFieldParams(CylMapFieldInput const& inp)
     CELER_VALIDATE(soft_zero(inp.grid_phi.front().value()),
                    << "Phi grid must be a complete circle (grid_phi min="
                    << inp.grid_phi.front().value() << "): should be 0");
-    CELER_VALIDATE(
-        soft_equal(celeritas::real_type{1}, inp.grid_phi.back().value()),
-        << "Phi grid must be a complete circle (grid_phi max="
-        << inp.grid_phi.back().value() << "): should be 1");
+    CELER_VALIDATE(soft_equal(1_r, inp.grid_phi.back().value()),
+                   << "Phi grid must be a complete circle (grid_phi max="
+                   << inp.grid_phi.back().value() << "): should be 1");
 
     CELER_VALIDATE(
         inp.field.size()

--- a/src/celeritas/field/DormandPrinceIntegrator.hh
+++ b/src/celeritas/field/DormandPrinceIntegrator.hh
@@ -106,6 +106,8 @@ DormandPrinceIntegrator<E>::operator()(real_type step,
                                        OdeState const& beg_state) const
     -> result_type
 {
+    using namespace celeritas::literals;
+
     using celeritas::axpy;
     using R = real_type;
 
@@ -210,7 +212,7 @@ DormandPrinceIntegrator<E>::operator()(real_type step,
     axpy(d77 * step, k7, &result.err_state);
 
     // The mid point
-    real_type half_step = step / real_type(2);
+    real_type half_step = step / 2.0_r;
     result.mid_state = beg_state;
     axpy(c71 * half_step, k1, &result.mid_state);
     axpy(c73 * half_step, k3, &result.mid_state);

--- a/src/celeritas/field/FieldPropagator.hh
+++ b/src/celeritas/field/FieldPropagator.hh
@@ -357,7 +357,9 @@ CELER_FUNCTION real_type FieldPropagator<SubstepperT, GTV>::minimum_substep() co
 template<class SubstepperT, class GTV>
 CELER_FUNCTION real_type FieldPropagator<SubstepperT, GTV>::bump_distance() const
 {
-    return this->delta_intersection() * real_type(0.1);
+    using namespace celeritas::literals;
+
+    return this->delta_intersection() * 0.1_r;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/field/RungeKuttaIntegrator.hh
+++ b/src/celeritas/field/RungeKuttaIntegrator.hh
@@ -92,9 +92,11 @@ RungeKuttaIntegrator<E>::operator()(real_type step,
                                     OdeState const& beg_state) const
     -> result_type
 {
+    using namespace celeritas::literals;
+
     using celeritas::axpy;
-    real_type half_step = step / real_type(2);
-    constexpr real_type fourth_order_correction = 1 / real_type(15);
+    real_type half_step = step / 2.0_r;
+    constexpr real_type fourth_order_correction = 1.0_r / 15.0_r;
 
     result_type result;
     OdeState beg_slope = calc_rhs_(beg_state);
@@ -109,7 +111,7 @@ RungeKuttaIntegrator<E>::operator()(real_type step,
 
     // Integrator error: difference between the full step and two half steps
     result.err_state = result.end_state;
-    axpy(real_type(-1), yt, &result.err_state);
+    axpy(-1.0_r, yt, &result.err_state);
 
     // Output correction with the 4th order coefficient (1/15)
     axpy(fourth_order_correction, result.err_state, &result.end_state);
@@ -127,9 +129,11 @@ RungeKuttaIntegrator<E>::do_step(real_type step,
                                  OdeState const& beg_state,
                                  OdeState const& beg_slope) const -> OdeState
 {
+    using namespace celeritas::literals;
+
     using celeritas::axpy;
-    real_type half_step = step / real_type(2);
-    constexpr real_type sixth = 1 / real_type(6);
+    real_type half_step = step / 2.0_r;
+    constexpr real_type sixth = 1.0_r / 6.0_r;
 
     // 1st step k1 = (step/2)*beg_slope
     OdeState mid_est = beg_state;
@@ -147,9 +151,9 @@ RungeKuttaIntegrator<E>::do_step(real_type step,
     OdeState end_slope = calc_rhs_(end_est);
 
     // Average slope at all 4 points
-    axpy(real_type(1), beg_slope, &end_slope);
-    axpy(real_type(2), mid_slope, &end_slope);
-    axpy(real_type(2), mid_est_slope, &end_slope);
+    axpy(1.0_r, beg_slope, &end_slope);
+    axpy(2.0_r, mid_slope, &end_slope);
+    axpy(2.0_r, mid_est_slope, &end_slope);
 
     // 4th Step k4 = h*dydxt and the final RK4 output: k1/6+k4/6+(k2+k3)/3
     OdeState end_state = beg_state;

--- a/src/celeritas/field/ZHelixIntegrator.hh
+++ b/src/celeritas/field/ZHelixIntegrator.hh
@@ -104,6 +104,8 @@ CELER_FUNCTION auto
 ZHelixIntegrator<E>::operator()(real_type step, OdeState const& beg_state) const
     -> result_type
 {
+    using namespace celeritas::literals;
+
     result_type result;
 
     // Evaluate the right hand side of the equation
@@ -119,7 +121,7 @@ ZHelixIntegrator<E>::operator()(real_type step, OdeState const& beg_state) const
 
     // State after the half step
     result.mid_state
-        = this->move(real_type(0.5) * step, radius, helicity, beg_state, rhs);
+        = this->move(0.5_r * step, radius, helicity, beg_state, rhs);
 
     // State after the full step
     result.end_state = this->move(step, radius, helicity, beg_state, rhs);

--- a/src/celeritas/grid/InverseCdfFinder.hh
+++ b/src/celeritas/grid/InverseCdfFinder.hh
@@ -51,9 +51,11 @@ CELER_FUNCTION InverseCdfFinder<G, C>::InverseCdfFinder(G&& grid, C&& calc_cdf)
     : grid_(celeritas::forward<G>(grid))
     , calc_cdf_(celeritas::forward<C>(calc_cdf))
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(grid_.size() >= 2);
     CELER_EXPECT(calc_cdf_[0] == 0
-                 && soft_equal(calc_cdf_[grid_.size() - 1], real_type(1)));
+                 && soft_equal(calc_cdf_[grid_.size() - 1], 1.0_r));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/grid/RangeCalculator.hh
+++ b/src/celeritas/grid/RangeCalculator.hh
@@ -79,6 +79,8 @@ RangeCalculator::RangeCalculator(UniformGridRecord const& grid,
  */
 CELER_FUNCTION real_type RangeCalculator::operator()(Energy energy) const
 {
+    using namespace celeritas::literals;
+
     CELER_ASSERT(energy > zero_quantity());
     UniformGrid loge_grid(data_.grid);
     real_type const loge = std::log(energy.value());
@@ -87,7 +89,7 @@ CELER_FUNCTION real_type RangeCalculator::operator()(Energy energy) const
     {
         real_type result = this->get(0);
         // Scale by sqrt(E/Emin) = exp(.5 (log E - log Emin))
-        result *= std::exp(real_type(.5) * (loge - loge_grid.front()));
+        result *= std::exp(0.5_r * (loge - loge_grid.front()));
         return result;
     }
     else if (loge >= loge_grid.back())

--- a/src/celeritas/mat/MaterialParams.cc
+++ b/src/celeritas/mat/MaterialParams.cc
@@ -28,6 +28,8 @@
 
 namespace celeritas
 {
+using namespace celeritas::literals;
+
 namespace
 {
 //---------------------------------------------------------------------------//
@@ -440,7 +442,7 @@ MaterialParams::extend_elcomponents(MaterialInput const& inp,
     }
 
     // Renormalize component fractions that are not unity and log them
-    if (!inp.elements_fractions.empty() && !soft_equal(norm, real_type(1)))
+    if (!inp.elements_fractions.empty() && !soft_equal(norm, 1.0_r))
     {
         CELER_LOG(warning) << "Element component fractions for `" << inp.label
                            << "` should sum to 1 but instead sum to " << norm
@@ -454,7 +456,7 @@ MaterialParams::extend_elcomponents(MaterialInput const& inp,
             comp.fraction *= norm;
             total_fractions += comp.fraction;
         }
-        CELER_ASSERT(soft_equal(total_fractions, real_type(1)));
+        CELER_ASSERT(soft_equal(total_fractions, 1.0_r));
     }
 
     // Sort elements by increasing element ID for improved access

--- a/src/celeritas/mucf/executor/detail/MuonicAtomSelector.hh
+++ b/src/celeritas/mucf/executor/detail/MuonicAtomSelector.hh
@@ -65,11 +65,12 @@ class MuonicAtomSelector
 CELER_FUNCTION
 MuonicAtomSelector::MuonicAtomSelector(real_type deuterium_fraction)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(deuterium_fraction >= 0 && deuterium_fraction <= 1);
 
-    real_type tritium_fraction = real_type{1} - deuterium_fraction;
-    real_type const q1s = real_type{1}
-                          / (real_type{1} + real_type{2.9} * tritium_fraction);
+    real_type tritium_fraction = 1_r - deuterium_fraction;
+    real_type const q1s = 1_r / (1_r + 2.9_r * tritium_fraction);
     deuterium_probability_ = deuterium_fraction * q1s;
 
     CELER_ENSURE(deuterium_probability_ >= 0 && deuterium_probability_ <= 1);

--- a/src/celeritas/mucf/executor/detail/MuonicAtomSpinSelector.hh
+++ b/src/celeritas/mucf/executor/detail/MuonicAtomSpinSelector.hh
@@ -43,13 +43,15 @@ class MuonicAtomSpinSelector
     // Muonic deuterium spin probabilities: 2/3 for spin 3/2; 1/3 for spin 1/2
     constexpr CELER_FUNCTION real_type deuterium_spin_probability()
     {
-        return real_type{2} / real_type{3};
+        using namespace celeritas::literals;
+        return 2_r / 3;
     }
 
     // Muonic tritium spin probabilities: 3/4 for spin 1; 1/4 for spin 0
     constexpr CELER_FUNCTION real_type tritium_spin_probability()
     {
-        return real_type{0.75};
+        using namespace celeritas::literals;
+        return 0.75_r;
     }
 };
 

--- a/src/celeritas/mucf/model/detail/EquilibrateDensitiesSolver.cc
+++ b/src/celeritas/mucf/model/detail/EquilibrateDensitiesSolver.cc
@@ -12,6 +12,8 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/math/Algorithms.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace detail
@@ -58,7 +60,7 @@ EquilibrateDensitiesSolver::EquilibrateDensitiesSolver(
                      + lhd_densities_[Iso::deuterium]
                      + lhd_densities_[Iso::tritium];
     CELER_ENSURE(total_density_ > 0);
-    inv_tot_density_ = real_type{1} / total_density_;
+    inv_tot_density_ = 1_r / total_density_;
 }
 
 //---------------------------------------------------------------------------//
@@ -248,11 +250,9 @@ void EquilibrateDensitiesSolver::equilibrate_pair(
     CELER_EXPECT(eq_constant_ab > 0);
 
     // AA + AB / 2
-    real_type const mix_a = input[molecule_aa]
-                            + input[molecule_ab] * real_type{0.5};
+    real_type const mix_a = input[molecule_aa] + input[molecule_ab] * 0.5_r;
     // BB + AB / 2
-    real_type const mix_b = input[molecule_bb]
-                            + input[molecule_ab] * real_type{0.5};
+    real_type const mix_b = input[molecule_bb] + input[molecule_ab] * 0.5_r;
 
     real_type sigma
         = ((mix_a + mix_b)

--- a/src/celeritas/mucf/model/detail/MucfMaterialInserter.cc
+++ b/src/celeritas/mucf/model/detail/MucfMaterialInserter.cc
@@ -8,6 +8,8 @@
 
 #include "corecel/Assert.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace detail
@@ -143,10 +145,10 @@ MucfMaterialInserter::calc_dd_cycle(EquilibriumArray const& eq_dens,
         = this->interpolator(CTT::deuterium_deuterium, HalfSpinInt{3});
 
     MoleculeCycles result;
-    result[0] = real_type{1}
-                / (dd_dens * dd_1_over_2_interpolate(temperature));  // F = 1/2
-    result[1] = real_type{1}
-                / (dd_dens * dd_3_over_2_interpolate(temperature));  // F = 3/2
+    result[0] = 1_r / (dd_dens * dd_1_over_2_interpolate(temperature));  // F =
+                                                                         // 1/2
+    result[1] = 1_r / (dd_dens * dd_3_over_2_interpolate(temperature));  // F =
+                                                                         // 3/2
 
     CELER_ENSURE(result[0] >= 0 && result[1] >= 0);
     return result;
@@ -189,11 +191,11 @@ MucfMaterialInserter::calc_dt_cycle(EquilibriumArray const& eq_dens,
 
     // Interpolate over rates, store final cycle time (1/rate)
     MoleculeCycles result;
-    result[0] = real_type{1}
+    result[0] = 1_r
                 / (hd_dens * hd0_interpolate(temperature)
                    + dd_dens * dd0_interpolate(temperature)
                    + dt_dens * dt0_interpolate(temperature));  // F = 0
-    result[1] = real_type{1}
+    result[1] = 1_r
                 / (hd_dens * hd1_interpolate(temperature)
                    + dd_dens * dd1_interpolate(temperature)
                    + dt_dens * dt1_interpolate(temperature));  // F = 1
@@ -221,7 +223,7 @@ MucfMaterialInserter::calc_tt_cycle(EquilibriumArray const& eq_dens,
         = this->interpolator(CTT::tritium_tritium, HalfSpinInt{1});
 
     MoleculeCycles result;
-    result[0] = real_type{1} / (tt_dens * tt_interpolate(temperature));
+    result[0] = 1_r / (tt_dens * tt_interpolate(temperature));
 
     CELER_ENSURE(result[0] >= 0 && result[1] == 0);
     return result;

--- a/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
+++ b/src/celeritas/neutron/interactor/ChipsNeutronElasticInteractor.hh
@@ -114,6 +114,8 @@ CELER_FUNCTION ChipsNeutronElasticInteractor::ChipsNeutronElasticInteractor(
 template<class Engine>
 CELER_FUNCTION Interaction ChipsNeutronElasticInteractor::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     // Scattered neutron with respect to the axis of incident direction
     Interaction result;
 
@@ -127,7 +129,7 @@ CELER_FUNCTION Interaction ChipsNeutronElasticInteractor::operator()(Engine& rng
     // Sample the scattered direction from the invariant momentum transfer
     // squared (\f$ -t = Q^{2} \f$) in the c.m. frame
     real_type cos_theta
-        = 1 - real_type(0.5) * sample_momentum_square_(rng) / ipow<2>(cm_p);
+        = 1 - 0.5_r * sample_momentum_square_(rng) / ipow<2>(cm_p);
     CELER_ASSERT(std::fabs(cos_theta) <= 1);
 
     // Boost to the center of mass (c.m.) frame

--- a/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
+++ b/src/celeritas/neutron/interactor/detail/CascadeCollider.hh
@@ -93,7 +93,8 @@ class CascadeCollider
     //! A criteria [1/c] for coplanarity in the Lorentz transformation
     static CELER_CONSTEXPR_FUNCTION real_type epsilon()
     {
-        return real_type{1e-10};
+        using namespace celeritas::literals;
+        return 1e-10_r;
     }
 
     //// HELPER FUNCTIONS ////

--- a/src/celeritas/neutron/interactor/detail/MomentumTransferSampler.hh
+++ b/src/celeritas/neutron/interactor/detail/MomentumTransferSampler.hh
@@ -170,10 +170,12 @@ CELER_FUNCTION auto MomentumTransferSampler::operator()(Engine& rng)
     }
     else
     {
+        using namespace celeritas::literals;
+
         // Sample \f$ Q^{2} \f$ for \f$ n + A \rightarrow n + A \f$
-        constexpr real_type one_third = 1 / real_type(3);
+        constexpr real_type one_third = 1.0_r / 3.0_r;
         constexpr real_type one_fifth{0.2};
-        constexpr real_type one_seventh = 1 / real_type(7);
+        constexpr real_type one_seventh = 1.0_r / 7.0_r;
 
         real_type const r[4]
             = {-std::expm1(-max_q_sq_
@@ -231,7 +233,8 @@ CELER_FUNCTION auto MomentumTransferSampler::operator()(Engine& rng)
             }
         }
     }
-    return clamp(q_sq, real_type{0}, max_q_sq_) / ipow<2>(this->to_gev());
+    using namespace celeritas::literals;
+    return clamp(q_sq, 0_r, max_q_sq_) / ipow<2>(this->to_gev());
 }
 
 //---------------------------------------------------------------------------//
@@ -317,17 +320,19 @@ auto MomentumTransferSampler::calc_par_q_sq(Momentum neutron_p) const
     }
     else
     {
+        using namespace celeritas::literals;
+
         real_type p5 = p4 * p;
         real_type p6 = p5 * p;
         real_type p8 = p6 * p2;
         real_type p10 = p8 * p2;
         real_type p12 = p10 * p2;
         real_type p16 = ipow<2>(p8);
-        real_type dl = lp - real_type(5);
+        real_type dl = lp - 5.0_r;
 
         if (!heavy_target_)
         {
-            real_type pah = std::pow(p, real_type(0.5) * amass_.get());
+            real_type pah = std::pow(p, 0.5_r * amass_.get());
             real_type pa = ipow<2>(pah);
             real_type pa2 = ipow<2>(pa);
             result.expnt[0] = par_[0] / (1 + par_[1] * p4 * pa)

--- a/src/celeritas/neutron/model/detail/NuclearZoneBuilder.hh
+++ b/src/celeritas/neutron/model/detail/NuclearZoneBuilder.hh
@@ -156,7 +156,8 @@ auto NuclearZoneBuilder::calc_zone_components(IsotopeView const& target) const
     CELER_ASSERT(!zone_dens.empty());
 
     // Fill the differential nuclear volume by each zone
-    constexpr real_type four_thirds_pi = 4 * constants::pi / real_type{3};
+    using namespace celeritas::literals;
+    constexpr real_type four_thirds_pi = 4.0_r * constants::pi / 3.0;
 
     ComponentVec components(zone_dens.size());
     real_type prev_volume{0};
@@ -182,7 +183,7 @@ auto NuclearZoneBuilder::calc_zone_components(IsotopeView const& target) const
     real_type const total_integral
         = std::accumulate(zone_dens.begin(),
                           zone_dens.end(),
-                          real_type{0},
+                          0_r,
                           [](real_type sum, ZoneDensity const& zone) {
                               return sum + zone.integral;
                           });
@@ -228,10 +229,12 @@ auto NuclearZoneBuilder::calc_zones_light(AtomicMassNumber a) const
 auto NuclearZoneBuilder::calc_zones_small(AtomicMassNumber a) const
     -> VecZoneDensity
 {
+    using namespace celeritas::literals;
+
     real_type const nuclear_radius = this->calc_nuclear_radius(a);
     real_type gauss_radius = std::sqrt(
         ipow<2>(nuclear_radius) * (1 - 1 / static_cast<real_type>(a.get()))
-        + real_type{6.4});
+        + 6.4_r);
 
     Integrator integrate_gauss{
         [](real_type r) { return ipow<2>(r) * std::exp(-ipow<2>(r)); }};

--- a/src/celeritas/neutron/model/detail/NuclearZoneBuilder.hh
+++ b/src/celeritas/neutron/model/detail/NuclearZoneBuilder.hh
@@ -157,7 +157,7 @@ auto NuclearZoneBuilder::calc_zone_components(IsotopeView const& target) const
 
     // Fill the differential nuclear volume by each zone
     using namespace celeritas::literals;
-    constexpr real_type four_thirds_pi = 4.0_r * constants::pi / 3.0;
+    constexpr real_type four_thirds_pi = 4.0_r * constants::pi / 3.0_r;
 
     ComponentVec components(zone_dens.size());
     real_type prev_volume{0};

--- a/src/celeritas/neutron/xs/NucleonNucleonXsCalculator.hh
+++ b/src/celeritas/neutron/xs/NucleonNucleonXsCalculator.hh
@@ -98,9 +98,9 @@ auto NucleonNucleonXsCalculator::operator()(ChannelId ch_id,
         }
         else
         {
+            using namespace celeritas::literals;
             using StepanovFunction = PolyEvaluator<real_type, 2>;
-            result
-                = StepanovFunction(par.coeffs)(real_type{1} / energy.value());
+            result = StepanovFunction(par.coeffs)(1_r / energy.value());
         }
     }
     else

--- a/src/celeritas/optical/gen/CherenkovGenerator.hh
+++ b/src/celeritas/optical/gen/CherenkovGenerator.hh
@@ -174,6 +174,8 @@ CELER_FUNCTION TrackInitializer CherenkovGenerator::operator()(Generator& rng)
     CELER_ASSERT(is_soft_orthogonal(photon.polarization, photon.direction));
 
     // Sample fraction along the step
+    using namespace celeritas::literals;
+
     UniformRealDistribution<> sample_step_fraction;
     real_type u;
     do
@@ -184,7 +186,7 @@ CELER_FUNCTION TrackInitializer CherenkovGenerator::operator()(Generator& rng)
     real_type delta_time
         = u * dist_.step_length
           / (native_value_from(dist_.points[StepPoint::pre].speed)
-             + u * real_type(0.5) * native_value_from(delta_speed_));
+             + u * 0.5_r * native_value_from(delta_speed_));
     photon.time = dist_.points[StepPoint::pre].time + delta_time;
     photon.position = dist_.points[StepPoint::pre].pos;
     axpy(u, delta_pos_, &photon.position);

--- a/src/celeritas/optical/gen/CherenkovOffload.hh
+++ b/src/celeritas/optical/gen/CherenkovOffload.hh
@@ -94,8 +94,10 @@ CherenkovOffload::CherenkovOffload(units::ElementaryCharge charge,
     CELER_EXPECT(step_length_ > 0);
     CELER_EXPECT(pre_step_);
 
+    using namespace celeritas::literals;
+
     units::LightSpeed beta(
-        real_type{0.5} * (pre_step_.speed.value() + post_step_.speed.value()));
+        0.5_r * (pre_step_.speed.value() + post_step_.speed.value()));
 
     CherenkovDndxCalculator calculate_dndx(pre_mat, shared, charge_);
     num_photons_per_len_ = calculate_dndx(beta);

--- a/src/celeritas/optical/gen/ScintillationGenerator.hh
+++ b/src/celeritas/optical/gen/ScintillationGenerator.hh
@@ -141,7 +141,8 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(Generator& rn
         energy_val = calc_energy(generate_canonical(rng));
     }
 
-    ExponentialDistribution sample_time(real_type{1} / component.fall_time);
+    using namespace celeritas::literals;
+    ExponentialDistribution sample_time(1_r / component.fall_time);
 
     TrackInitializer photon;
     photon.energy = Energy{energy_val};
@@ -152,6 +153,8 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(Generator& rn
 
     // Sample the position
     real_type u = [&rng, &p = dist_.continuous_edep_fraction] {
+        using namespace celeritas::literals;
+
         // The number of photons generated along the step (continuous energy
         // loss) and at the interaction site (local energy deposition) is
         // proportional to their respective energy contributions. If both
@@ -168,7 +171,7 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(Generator& rn
             return UniformRealDistribution<real_type>{}(rng);
         }
         // Generate the photon at the discrete interaction site
-        return real_type(1);
+        return 1.0_r;
     }();
     photon.position = dist_.points[StepPoint::pre].pos;
     axpy(u, delta_pos_, &photon.position);
@@ -179,7 +182,7 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(Generator& rn
         {
             return dist_.step_length
                    / (native_value_from(dist_.points[StepPoint::pre].speed)
-                      + u * real_type(0.5) * native_value_from(delta_speed_));
+                      + u * 0.5_r * native_value_from(delta_speed_));
         }
         // Fall back to using pre- and post-step time if speed isn't available
         // (e.g. with the LArSoft SimEnergyDeposit)

--- a/src/celeritas/optical/gen/ScintillationOffload.hh
+++ b/src/celeritas/optical/gen/ScintillationOffload.hh
@@ -127,11 +127,13 @@ ScintillationOffload::operator()(Generator& rng)
     optical::GeneratorDistributionData result;
     if (mean_num_photons_ > poisson_threshold())
     {
+        using namespace celeritas::literals;
+
         real_type sigma = shared_.resolution_scale[pre_step_.material]
                           * std::sqrt(mean_num_photons_);
         result.num_photons = static_cast<size_type>(clamp_to_nonneg(
             NormalDistribution<real_type>(mean_num_photons_, sigma)(rng)
-            + real_type{0.5}));
+            + 0.5_r));
     }
     else if (mean_num_photons_ > 0)
     {

--- a/src/celeritas/optical/gen/WavelengthShiftGenerator.hh
+++ b/src/celeritas/optical/gen/WavelengthShiftGenerator.hh
@@ -94,6 +94,8 @@ WavelengthShiftGenerator::WavelengthShiftGenerator(
 template<class Engine>
 CELER_FUNCTION TrackInitializer WavelengthShiftGenerator::operator()(Engine& rng)
 {
+    using namespace celeritas::literals;
+
     // Sample wavelength shifted optical photon
     TrackInitializer result;
 
@@ -120,11 +122,10 @@ CELER_FUNCTION TrackInitializer WavelengthShiftGenerator::operator()(Engine& rng
     result.polarization = TransversePolarizationSampler{result.direction}(rng);
 
     // Sample the delta time (based on the exponential relaxation)
-    result.time
-        = distribution_.time
-          + (time_profile_ == WlsDistribution::delta
-                 ? time_constant_
-                 : ExponentialDistribution(real_type{1} / time_constant_)(rng));
+    result.time = distribution_.time
+                  + (time_profile_ == WlsDistribution::delta
+                         ? time_constant_
+                         : ExponentialDistribution(1_r / time_constant_)(rng));
     result.primary = distribution_.primary;
 
     return result;

--- a/src/celeritas/optical/interactor/MieInteractor.hh
+++ b/src/celeritas/optical/interactor/MieInteractor.hh
@@ -91,6 +91,8 @@ MieInteractor::MieInteractor(NativeCRef<MieData> const& shared,
 template<class Engine>
 CELER_FUNCTION Interaction MieInteractor::operator()(Engine& rng) const
 {
+    using namespace celeritas::literals;
+
     Interaction result;
     Real3& new_dir = result.direction;
     Real3& new_pol = result.polarization;
@@ -113,7 +115,7 @@ CELER_FUNCTION Interaction MieInteractor::operator()(Engine& rng) const
         real_type costheta = 2 * r * ipow<2>((1 + g) / (1 - g + 2 * g * r))
                                  * (1 - g + g * r)
                              - 1;
-        costheta = celeritas::min(costheta, real_type{1});
+        costheta = celeritas::min(costheta, 1_r);
 
         CELER_ASSERT(costheta >= -1 && costheta <= 1);
 

--- a/src/celeritas/optical/surface/model/FresnelCalculator.hh
+++ b/src/celeritas/optical/surface/model/FresnelCalculator.hh
@@ -138,9 +138,9 @@ FresnelCalculator::FresnelCalculator(Real3 const& direction,
 
     // Sometimes dot product of normalized parallel vectors is the next
     // representation after 1. Round down to exactly 1 to avoid errors.
-    CELER_EXPECT(-dot_product(direction_, normal_)
-                 <= std::nextafter(real_type{1}, real_type{2}));
-    cos_theta_ = min(-dot_product(direction_, normal_), real_type{1});
+    using namespace celeritas::literals;
+    CELER_EXPECT(-dot_product(direction_, normal_) <= std::nextafter(1_r, 2_r));
+    cos_theta_ = min(-dot_product(direction_, normal_), 1_r);
 
     // Snell's law
     real_type sin_phi = sqrt(1 - ipow<2>(cos_theta_)) / relative_r_index_;

--- a/src/celeritas/optical/surface/model/GridReflectivityExecutor.hh
+++ b/src/celeritas/optical/surface/model/GridReflectivityExecutor.hh
@@ -111,6 +111,8 @@ GridReflectivityCalculator::operator()(ReflectivityAction action) const
 CELER_FUNCTION ReflectivityAction
 GridReflectivityExecutor::operator()(CoreTrackView const& track) const
 {
+    using namespace celeritas::literals;
+
     auto s_phys = track.surface_physics();
     auto sub_model_id = s_phys.interface(SurfacePhysicsOrder::reflectivity)
                             .internal_surface_id();
@@ -122,7 +124,7 @@ GridReflectivityExecutor::operator()(CoreTrackView const& track) const
         GridReflectivityCalculator{
             data, sub_model_id, track.particle().energy()},
         ReflectivityAction::size_,
-        real_type{1})(rng);
+        1.0_r)(rng);
 
     if (action == ReflectivityAction::absorb)
     {

--- a/src/celeritas/phys/FourVector.hh
+++ b/src/celeritas/phys/FourVector.hh
@@ -103,8 +103,10 @@ inline CELER_FUNCTION FourVector operator+(FourVector const& lhs,
  */
 inline CELER_FUNCTION Real3 boost_vector(FourVector const& p)
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(p.energy > 0);
-    return (real_type{1} / p.energy) * p.mom;
+    return (1_r / p.energy) * p.mom;
 }
 
 //---------------------------------------------------------------------------//
@@ -121,11 +123,13 @@ inline CELER_FUNCTION Real3 boost_vector(FourVector const& p)
  */
 inline CELER_FUNCTION void boost(Real3 const& v, FourVector* p)
 {
+    using namespace celeritas::literals;
+
     real_type const v_sq = dot_product(v, v);
-    CELER_EXPECT(v_sq < real_type{1});
+    CELER_EXPECT(v_sq < 1_r);
 
     real_type const vp = dot_product(v, p->mom);
-    real_type const gamma = real_type{1} / std::sqrt(1 - v_sq);
+    real_type const gamma = 1_r / std::sqrt(1 - v_sq);
     real_type const lambda = (v_sq > 0 ? (gamma - 1) * vp / v_sq : 0)
                              + gamma * p->energy;
 

--- a/src/celeritas/phys/PhysicsOptions.hh
+++ b/src/celeritas/phys/PhysicsOptions.hh
@@ -63,8 +63,10 @@ struct ParticleOptions
     //! Default options for light particles (electrons/positrons)
     static ParticleOptions default_light()
     {
+        using namespace celeritas::literals;
+
         ParticleOptions opts;
-        opts.min_range = real_type{1} * units::millimeter;
+        opts.min_range = 1.0_r * units::millimeter;
         opts.max_step_over_range = 0.2;
         opts.lowest_energy = ParticleOptions::Energy{0.001};
         opts.displaced = true;

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -23,6 +23,8 @@
 
 #include "detail/SimpleCaloImpl.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -172,7 +174,7 @@ auto SimpleCalo::energy_deposition(StreamId stream_id) const
  */
 auto SimpleCalo::calc_total_energy_deposition() const -> VecReal
 {
-    VecReal result(this->num_detectors(), real_type{0});
+    VecReal result(this->num_detectors(), 0_r);
 
     accumulate_over_streams(
         store_, [](auto& state) { return state.energy_deposition; }, &result);
@@ -185,9 +187,8 @@ auto SimpleCalo::calc_total_energy_deposition() const -> VecReal
  */
 void SimpleCalo::clear()
 {
-    apply_to_all_streams(store_, [](auto& state) {
-        fill(real_type(0), &state.energy_deposition);
-    });
+    apply_to_all_streams(
+        store_, [](auto& state) { fill(0.0_r, &state.energy_deposition); });
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/SimpleCaloData.cc
+++ b/src/celeritas/user/SimpleCaloData.cc
@@ -12,6 +12,8 @@
 
 namespace celeritas
 {
+using namespace celeritas::literals;
+
 //---------------------------------------------------------------------------//
 /*!
  * Resize based on the number of detectors.
@@ -24,7 +26,7 @@ void resize(SimpleCaloStateData<Ownership::value, M>* state,
 {
     CELER_EXPECT(params);
     resize(&state->energy_deposition, params.num_detectors);
-    fill(real_type(0), &state->energy_deposition);
+    fill(0.0_r, &state->energy_deposition);
     state->num_track_slots = num_track_slots;
     CELER_ENSURE(*state);
 }

--- a/src/corecel/math/ArraySoftUnit.hh
+++ b/src/corecel/math/ArraySoftUnit.hh
@@ -114,12 +114,14 @@ template<std::size_t N>
 CELER_CONSTEXPR_FUNCTION bool
 ArraySoftUnit<T>::operator()(Array<T, N> const& arr) const
 {
+    using namespace celeritas::literals;
+
     T length_sq{};
     for (size_type i = 0; i != N; ++i)
     {
         length_sq = std::fma(arr[i], arr[i], length_sq);
     }
-    return std::fabs(length_sq - 1) < tol_ * std::fmax(real_type(1), length_sq);
+    return std::fabs(length_sq - 1) < tol_ * std::fmax(1.0_r, length_sq);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/BisectionRootFinder.hh
+++ b/src/corecel/math/BisectionRootFinder.hh
@@ -80,6 +80,8 @@ template<class F>
 CELER_FUNCTION real_type BisectionRootFinder<F>::operator()(real_type left,
                                                             real_type right)
 {
+    using namespace celeritas::literals;
+
     // Initialize Iteration parameters
     real_type f_left = func_(left);
     real_type f_root = 1;
@@ -90,7 +92,7 @@ CELER_FUNCTION real_type BisectionRootFinder<F>::operator()(real_type left,
     do
     {
         // Estimate root and update value
-        root = real_type(0.5) * (left + right);
+        root = 0.5_r * (left + right);
         f_root = func_(root);
 
         // Update the bound which produces the same sign as the root

--- a/src/corecel/math/FerrariSolver.hh
+++ b/src/corecel/math/FerrariSolver.hh
@@ -133,6 +133,8 @@ FerrariSolver::FerrariSolver(real_type tolerance) : soft_zero_{tolerance} {}
 CELER_FUNCTION auto FerrariSolver::operator()(Real5 const& abcde) const
     -> result_type
 {
+    using namespace celeritas::literals;
+
     CELER_EXPECT(abcde[0] != 0);
     auto [a, b, c, d, e] = abcde;
 
@@ -140,7 +142,7 @@ CELER_FUNCTION auto FerrariSolver::operator()(Real5 const& abcde) const
     real_type ba = b / a, ca = c / a, da = d / a, ea = e / a;
 
     constexpr real_type half{0.5};
-    real_type qb = real_type{0.25} * ba;
+    real_type qb = 0.25_r * ba;
 
     // Incomplete quartic
     real_type p = PolyEvaluator{-half * ca, 0, 3}(qb);
@@ -294,8 +296,10 @@ FerrariSolver::real_roots_normalized_cubic(real_type b,
                                            real_type c,
                                            real_type d) const -> Real3
 {
-    constexpr real_type half = real_type{0.5};
-    constexpr real_type third = real_type{1} / real_type{3};
+    using namespace celeritas::literals;
+
+    constexpr real_type half = 0.5_r;
+    constexpr real_type third = 1_r / 3;
     real_type third_b = b * third;
 
     // Intermediate values
@@ -314,15 +318,15 @@ FerrariSolver::real_roots_normalized_cubic(real_type b,
     else if (discrim <= 0)  // All roots real, calculate with trigomonetry
     {
         real_type theta = std::acos(r / std::sqrt(q3));
-        real_type n2_root_q = real_type{-2} * std::sqrt(q);
-        real_type twth_pi = constants::pi * real_type{2} * third;
+        real_type n2_root_q = -2_r * std::sqrt(q);
+        real_type twth_pi = constants::pi * 2_r * third;
         real_type third_theta = theta * third;
 
         real_type z0 = n2_root_q * std::cos(third_theta) - third_b;
         real_type z1 = n2_root_q * std::cos(third_theta + twth_pi) - third_b;
         real_type z2 = n2_root_q * std::cos(third_theta - twth_pi) - third_b;
 
-        if (real_type{2} * theta < constants::pi)
+        if (2_r * theta < constants::pi)
         {
             return Real3(z0, z1, z2);
         }

--- a/src/corecel/math/IllinoisRootFinder.hh
+++ b/src/corecel/math/IllinoisRootFinder.hh
@@ -81,6 +81,8 @@ template<class F>
 CELER_FUNCTION real_type IllinoisRootFinder<F>::operator()(real_type xl,
                                                            real_type xr)
 {
+    using namespace celeritas::literals;
+
     //! Enum defining side of approximated root to true root
     enum class Side
     {
@@ -111,7 +113,7 @@ CELER_FUNCTION real_type IllinoisRootFinder<F>::operator()(real_type xl,
             fl = fx;
             if (side == Side::left)
             {
-                fr *= real_type(0.5);
+                fr *= 0.5_r;
             }
             side = Side::left;
         }
@@ -121,7 +123,7 @@ CELER_FUNCTION real_type IllinoisRootFinder<F>::operator()(real_type xl,
             fr = fx;
             if (side == Side::right)
             {
-                fl *= real_type(0.5);
+                fl *= 0.5_r;
             }
             side = Side::right;
         }

--- a/src/corecel/random/distribution/ExponentialDistribution.hh
+++ b/src/corecel/random/distribution/ExponentialDistribution.hh
@@ -71,9 +71,7 @@ CELER_FUNCTION
 ExponentialDistribution<RT>::ExponentialDistribution(real_type lambda)
     : neg_inv_lambda_(real_type{-1} / lambda)
 {
-    using namespace celeritas::literals;
-
-    CELER_EXPECT(lambda > 0.0_r);
+    CELER_EXPECT(lambda > real_type{0});
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/random/distribution/ExponentialDistribution.hh
+++ b/src/corecel/random/distribution/ExponentialDistribution.hh
@@ -71,7 +71,9 @@ CELER_FUNCTION
 ExponentialDistribution<RT>::ExponentialDistribution(real_type lambda)
     : neg_inv_lambda_(real_type{-1} / lambda)
 {
-    CELER_EXPECT(lambda > real_type{0});
+    using namespace celeritas::literals;
+
+    CELER_EXPECT(lambda > 0.0_r);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/random/distribution/GammaDistribution.hh
+++ b/src/corecel/random/distribution/GammaDistribution.hh
@@ -99,6 +99,8 @@ template<class Generator>
 CELER_FUNCTION auto GammaDistribution<RealType>::operator()(Generator& rng)
     -> result_type
 {
+    using namespace celeritas::literals;
+
     real_type u, v, z;
     do
     {
@@ -109,9 +111,8 @@ CELER_FUNCTION auto GammaDistribution<RealType>::operator()(Generator& rng)
         } while (v <= 0);
         v = ipow<3>(v);
         u = generate_canonical<real_type>(rng);
-    } while (u > 1 - real_type(0.0331) * ipow<4>(z)
-             && std::log(u) > real_type(0.5) * ipow<2>(z)
-                                  + d_ * (1 - v + std::log(v)));
+    } while (u > 1 - 0.0331_r * ipow<4>(z)
+             && std::log(u) > 0.5_r * ipow<2>(z) + d_ * (1 - v + std::log(v)));
 
     result_type result = d_ * v * beta_;
     if (alpha_ != alpha_p_)

--- a/src/corecel/random/distribution/GammaDistribution.hh
+++ b/src/corecel/random/distribution/GammaDistribution.hh
@@ -99,8 +99,6 @@ template<class Generator>
 CELER_FUNCTION auto GammaDistribution<RealType>::operator()(Generator& rng)
     -> result_type
 {
-    using namespace celeritas::literals;
-
     real_type u, v, z;
     do
     {
@@ -111,8 +109,9 @@ CELER_FUNCTION auto GammaDistribution<RealType>::operator()(Generator& rng)
         } while (v <= 0);
         v = ipow<3>(v);
         u = generate_canonical<real_type>(rng);
-    } while (u > 1 - 0.0331_r * ipow<4>(z)
-             && std::log(u) > 0.5_r * ipow<2>(z) + d_ * (1 - v + std::log(v)));
+    } while (u > 1 - real_type(0.0331) * ipow<4>(z)
+             && std::log(u) > real_type(0.5) * ipow<2>(z)
+                                  + d_ * (1 - v + std::log(v)));
 
     result_type result = d_ * v * beta_;
     if (alpha_ != alpha_p_)

--- a/src/corecel/random/distribution/PoissonDistribution.hh
+++ b/src/corecel/random/distribution/PoissonDistribution.hh
@@ -98,6 +98,8 @@ template<class Generator>
 CELER_FUNCTION auto PoissonDistribution<RealType>::operator()(Generator& rng)
     -> result_type
 {
+    using namespace celeritas::literals;
+
     if (lambda_ <= PoissonDistribution::lambda_threshold())
     {
         // Use direct method
@@ -111,7 +113,7 @@ CELER_FUNCTION auto PoissonDistribution<RealType>::operator()(Generator& rng)
         return static_cast<result_type>(k - 1);
     }
     // Use Gaussian approximation rounded to nearest integer
-    return result_type(sample_normal_(rng) + real_type(0.5));
+    return result_type(sample_normal_(rng) + 0.5_r);
 }
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/random/distribution/PoissonDistribution.hh
+++ b/src/corecel/random/distribution/PoissonDistribution.hh
@@ -98,8 +98,6 @@ template<class Generator>
 CELER_FUNCTION auto PoissonDistribution<RealType>::operator()(Generator& rng)
     -> result_type
 {
-    using namespace celeritas::literals;
-
     if (lambda_ <= PoissonDistribution::lambda_threshold())
     {
         // Use direct method
@@ -113,7 +111,7 @@ CELER_FUNCTION auto PoissonDistribution<RealType>::operator()(Generator& rng)
         return static_cast<result_type>(k - 1);
     }
     // Use Gaussian approximation rounded to nearest integer
-    return result_type(sample_normal_(rng) + 0.5_r);
+    return result_type(sample_normal_(rng) + real_type(0.5));
 }
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/rasterize/Image.cc
+++ b/src/geocel/rasterize/Image.cc
@@ -15,6 +15,8 @@
 #include "corecel/math/ArraySoftUnit.hh"
 #include "corecel/math/ArrayUtils.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -27,7 +29,7 @@ namespace celeritas
  */
 ImageParams::ImageParams(ImageInput const& inp)
 {
-    CELER_VALIDATE(ArraySoftUnit{real_type{0.001}}(inp.rightward),
+    CELER_VALIDATE(ArraySoftUnit{0.001_r}(inp.rightward),
                    << "rightward axis " << repr(inp.rightward)
                    << " is not a unit vector");
     CELER_VALIDATE(inp.vertical_pixels > 0,

--- a/src/geocel/rasterize/ImageLineView.hh
+++ b/src/geocel/rasterize/ImageLineView.hh
@@ -87,8 +87,9 @@ ImageLineView::ImageLineView(ParamsRef const& params,
  */
 CELER_FUNCTION auto ImageLineView::start_pos() const -> Real3
 {
-    real_type down_offset = (row_index_ + real_type(0.5))
-                            * scalars_.pixel_width;
+    using namespace celeritas::literals;
+
+    real_type down_offset = (row_index_ + 0.5_r) * scalars_.pixel_width;
     Real3 result = scalars_.origin;
     axpy(down_offset, scalars_.down, &result);
     return result;

--- a/src/geocel/rasterize/detail/SafetyCalculator.hh
+++ b/src/geocel/rasterize/detail/SafetyCalculator.hh
@@ -83,9 +83,11 @@ template<class GTV>
 CELER_FUNCTION real_type SafetyCalculator<GTV>::operator()(size_type x,
                                                            size_type y)
 {
+    using namespace celeritas::literals;
+
     geo_ = [&] {
         auto calc_offset = [pw = scalars_.pixel_width](size_type i) {
-            return pw * (static_cast<real_type>(i) + real_type(0.5));
+            return pw * (static_cast<real_type>(i) + 0.5_r);
         };
 
         GeoTrackInitializer init;

--- a/src/orange/BoundingBoxUtils.cc
+++ b/src/orange/BoundingBoxUtils.cc
@@ -15,8 +15,6 @@
 #include "transform/Transformation.hh"
 #include "transform/Translation.hh"
 
-using namespace celeritas::literals;
-
 namespace celeritas
 {
 //---------------------------------------------------------------------------//

--- a/src/orange/BoundingBoxUtils.cc
+++ b/src/orange/BoundingBoxUtils.cc
@@ -60,7 +60,7 @@ BBox calc_transform(Transformation const& tr, BBox const& a)
             result[i] = 0;
             for (auto j : range(3))
             {
-                if (r[i][j] != 0_r)
+                if (r[i][j] != real_type(0))
                 {
                     result[i] += r[i][j] * x[j];
                 }

--- a/src/orange/BoundingBoxUtils.cc
+++ b/src/orange/BoundingBoxUtils.cc
@@ -15,6 +15,8 @@
 #include "transform/Transformation.hh"
 #include "transform/Translation.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -58,7 +60,7 @@ BBox calc_transform(Transformation const& tr, BBox const& a)
             result[i] = 0;
             for (auto j : range(3))
             {
-                if (r[i][j] != real_type{0})
+                if (r[i][j] != 0_r)
                 {
                     result[i] += r[i][j] * x[j];
                 }

--- a/src/orange/MatrixUtils.cc
+++ b/src/orange/MatrixUtils.cc
@@ -15,6 +15,7 @@
 #include "corecel/math/SoftEqual.hh"
 
 using Mat3 = celeritas::SquareMatrixReal3;
+using namespace celeritas::literals;
 
 namespace celeritas
 {
@@ -172,7 +173,7 @@ void orthonormalize(SquareMatrix<T, N>* mat)
 Mat3 make_rotation(Real3 const& ax, Turn theta)
 {
     CELER_EXPECT(is_soft_unit_vector(ax));
-    CELER_EXPECT(theta >= Turn{0} && theta <= Turn{real_type(0.5)});
+    CELER_EXPECT(theta >= Turn{0} && theta <= Turn{0.5_r});
 
     // Axis/direction enumeration
     enum
@@ -196,7 +197,7 @@ Mat3 make_rotation(Real3 const& ax, Turn theta)
            Real3{ax[X] * ax[Z] * (1 - cost) - ax[Y] * sint,
                  ax[Y] * ax[Z] * (1 - cost) + ax[X] * sint,
                  cost + ipow<2>(ax[Z]) * (1 - cost)}};
-    CELER_ENSURE(soft_equal(std::fabs(determinant(r)), real_type{1}));
+    CELER_ENSURE(soft_equal(std::fabs(determinant(r)), 1_r));
     return r;
 }
 

--- a/src/orange/g4org/Converter.cc
+++ b/src/orange/g4org/Converter.cc
@@ -22,6 +22,8 @@
 #include "PhysicalVolumeConverter.hh"
 #include "ProtoConstructor.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace g4org
@@ -65,7 +67,7 @@ Converter::Converter(Options&& opts) : opts_{std::move(opts)}
         opts_.tol = Tolerance<>::from_default(opts_.unit_length);
     }
 
-    if (real_type{1} - ipow<2>(opts_.tol.rel) == real_type{1})
+    if (1_r - ipow<2>(opts_.tol.rel) == 1_r)
     {
         CELER_LOG(warning)
             << "Requested relative tolerance (" << opts_.tol.rel

--- a/src/orange/g4org/SolidConverter.cc
+++ b/src/orange/g4org/SolidConverter.cc
@@ -70,6 +70,7 @@
 #include "Scaler.hh"
 #include "Transformer.hh"
 
+using namespace celeritas::literals;
 using namespace celeritas::orangeinp;
 
 namespace celeritas
@@ -90,10 +91,10 @@ auto enclosed_azi_radians(double start_rad, double stop_rad)
     auto start = native_value_to<RealTurn>(start_rad);
     auto stop = native_value_to<RealTurn>(stop_rad);
     auto delta_turn = value_as<RealTurn>(stop - start);
-    CELER_VALIDATE(delta_turn <= 1 || soft_equal(delta_turn, real_type{1}),
+    CELER_VALIDATE(delta_turn <= 1 || soft_equal(delta_turn, 1_r),
                    << "azimuthal restriction [" << start.value() << ", "
                    << stop.value() << "] [turn] exceeds 1 turn");
-    if (delta_turn >= real_type{1} || soft_equal(delta_turn, real_type{1}))
+    if (delta_turn >= 1_r || soft_equal(delta_turn, 1_r))
     {
         // Avoid roundoff error: return full region
         return EnclosedAzi{};
@@ -769,8 +770,7 @@ auto SolidConverter::polyhedra(arg_type solid_base) -> result_type
     // there are only two sides, the opening angle must be less than 2pi.
     CELER_VALIDATE(
         num_sides > 2
-            || (azi
-                && azi.stop() - azi.start() < Turn{real_type{0.5} * num_sides}),
+            || (azi && azi.stop() - azi.start() < Turn{0.5_r * num_sides}),
         << "invalid number of sizes for the opening angle");
 
     // Scale input values

--- a/src/orange/orangeinp/IntersectRegion.cc
+++ b/src/orange/orangeinp/IntersectRegion.cc
@@ -32,6 +32,8 @@
 
 #include "detail/PolygonUtils.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace orangeinp
@@ -206,7 +208,7 @@ void Cone::build(IntersectSurfaceBuilder& insert_surface) const
     if (CELER_UNLIKELY(make_soft_equal(insert_surface)(radii_[0], radii_[1])))
     {
         // Degenerate cone: build a cylinder instead
-        Cylinder cyl{real_type{0.5} * (radii_[0] + radii_[1]), hh_};
+        Cylinder cyl{0.5_r * (radii_[0] + radii_[1]), hh_};
         return cyl.build(insert_surface);
     }
 
@@ -1631,8 +1633,7 @@ void Prism::build(IntersectSurfaceBuilder& insert_surface) const
     // the +x axis. An offset of 1 would produce a shape congruent with an
     // offset of zero, except that every face has an index that's decremented
     // by 1. We prevent this by using fmod.
-    real_type const offset
-        = std::fmod(orientation_ + real_type{0.5}, real_type{1});
+    real_type const offset = std::fmod(orientation_ + 0.5_r, 1_r);
     CELER_ASSERT(offset >= 0 && offset < 1);
 
     // Change of angle in radians per side

--- a/src/orange/orangeinp/RevolvedPolygon.cc
+++ b/src/orange/orangeinp/RevolvedPolygon.cc
@@ -16,6 +16,8 @@
 #include "detail/BuildIntersectRegion.hh"
 #include "detail/ConvexHullFinder.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace orangeinp
@@ -251,7 +253,7 @@ NodeId RevolvedPolygon::make_cone(detail::VolumeBuilder& vb,
         std::swap(p_bot, p_top);
     }
 
-    real_type hh = 0.5 * (p_top[Z] - p_bot[Z]);
+    real_type hh = 0.5_r * (p_top[Z] - p_bot[Z]);
     Real2 radii{p_bot[R], p_top[R]};
 
     auto scoped_transform

--- a/src/orange/surf/Involute.hh
+++ b/src/orange/surf/Involute.hh
@@ -243,8 +243,8 @@ CELER_FUNCTION SignedSense Involute::calc_sense(Real3 const& pos) const
         theta = 2 * pi - theta;
     }
     // Count number of positive rotations around involute
-    theta += max<real_type>(real_type{0},
-                            std::floor((tmax_ + a_ - theta) / (2 * pi)))
+    using namespace celeritas::literals;
+    theta += max<real_type>(0_r, std::floor((tmax_ + a_ - theta) / (2 * pi)))
              * 2 * pi;
 
     // Calculate the displacement angle of the point

--- a/src/orange/surf/SimpleQuadric.cc
+++ b/src/orange/surf/SimpleQuadric.cc
@@ -18,6 +18,8 @@
 
 namespace celeritas
 {
+using namespace celeritas::literals;
+
 //---------------------------------------------------------------------------//
 /*!
  * Construct with coefficients.
@@ -99,7 +101,7 @@ SimpleQuadric::SimpleQuadric(Sphere const& other) noexcept(!CELERITAS_DEBUG)
         zeroth += ipow<2>(origin[ax]);
     }
 
-    *this = SimpleQuadric{{1, 1, 1}, real_type{-2} * origin, zeroth};
+    *this = SimpleQuadric{{1, 1, 1}, -2.0_r * origin, zeroth};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/Sphere.hh
+++ b/src/orange/surf/Sphere.hh
@@ -139,9 +139,11 @@ CELER_FUNCTION auto Sphere::calc_intersections(Real3 const& pos,
                                                SurfaceState on_surface) const
     -> Intersections
 {
+    using namespace celeritas::literals;
+
     Real3 tpos{pos[0] - origin_[0], pos[1] - origin_[1], pos[2] - origin_[2]};
 
-    detail::QuadraticSolver solve_quadric(real_type(1), dot_product(tpos, dir));
+    detail::QuadraticSolver solve_quadric(1.0_r, dot_product(tpos, dir));
     if (on_surface == SurfaceState::off)
     {
         return solve_quadric(dot_product(tpos, tpos) - radius_sq_);

--- a/src/orange/surf/SphereCentered.hh
+++ b/src/orange/surf/SphereCentered.hh
@@ -137,7 +137,9 @@ SphereCentered::calc_intersections(Real3 const& pos,
                                    SurfaceState on_surface) const
     -> Intersections
 {
-    detail::QuadraticSolver solve_quadric(real_type(1), dot_product(pos, dir));
+    using namespace celeritas::literals;
+
+    detail::QuadraticSolver solve_quadric(1.0_r, dot_product(pos, dir));
     if (on_surface == SurfaceState::off)
     {
         return solve_quadric(dot_product(pos, pos) - radius_sq_);

--- a/src/orange/surf/SurfaceSimplifier.cc
+++ b/src/orange/surf/SurfaceSimplifier.cc
@@ -134,10 +134,12 @@ template<Axis T>
 auto SurfaceSimplifier::operator()(PlaneAligned<T> const& p) const
     -> Optional<PlaneAligned<T>>
 {
-    if (p.position() != real_type{0} && SoftZero{tol_}(p.position()))
+    using namespace celeritas::literals;
+
+    if (p.position() != 0_r && SoftZero{tol_}(p.position()))
     {
         // Snap to zero since it's not already zero
-        return PlaneAligned<T>{real_type{0}};
+        return PlaneAligned<T>{0_r};
     }
     // No simplification performed
     return {};

--- a/src/orange/surf/detail/InvoluteSolver.hh
+++ b/src/orange/surf/detail/InvoluteSolver.hh
@@ -179,7 +179,8 @@ CELER_FUNCTION auto InvoluteSolver::operator()(Real3 const& pos,
     real_type t_upper = angle - a_;
 
     // Round t_upper to the first positive multiple of pi
-    t_upper += max<real_type>(real_type{0}, -std::floor(t_upper / pi)) * pi;
+    using namespace celeritas::literals;
+    t_upper += max<real_type>(0_r, -std::floor(t_upper / pi)) * pi;
 
     // Slow down factor to increment bounds when a root cannot be found
     int i = 1;

--- a/src/orange/surf/detail/QuadricConeConverter.hh
+++ b/src/orange/surf/detail/QuadricConeConverter.hh
@@ -120,7 +120,8 @@ QuadricConeConverter::operator()(AxisTag<T>, SimpleQuadric const& sq) const
     }
 
     // Clear potential signed zeros before returning
-    origin += real_type{0};
+    using namespace celeritas::literals;
+    origin += 0_r;
     return ConeAligned<T>::from_tangent_sq(origin, tsq);
 }
 

--- a/src/orange/surf/detail/QuadricCylConverter.hh
+++ b/src/orange/surf/detail/QuadricCylConverter.hh
@@ -107,9 +107,10 @@ QuadricCylConverter::operator()(AxisTag<T>, SimpleQuadric const& sq) const
     auto const inv_norm = 2 / (second[to_int(U)] + second[to_int(V)]);
 
     // Calculate origin from first-order coefficients
+    using namespace celeritas::literals;
     Real3 origin{0, 0, 0};
-    origin[to_int(U)] = real_type{-0.5} * inv_norm * sq.first()[to_int(U)];
-    origin[to_int(V)] = real_type{-0.5} * inv_norm * sq.first()[to_int(V)];
+    origin[to_int(U)] = -0.5_r * inv_norm * sq.first()[to_int(U)];
+    origin[to_int(V)] = -0.5_r * inv_norm * sq.first()[to_int(V)];
 
     real_type radius_sq = ipow<2>(origin[to_int(U)])
                           + ipow<2>(origin[to_int(V)]) - sq.zeroth() * inv_norm;
@@ -121,7 +122,7 @@ QuadricCylConverter::operator()(AxisTag<T>, SimpleQuadric const& sq) const
     }
 
     // Clear potential signed zeros before returning
-    origin += real_type{0};
+    origin += 0_r;
     return CylAligned<T>::from_radius_sq(origin, radius_sq);
 }
 

--- a/src/orange/surf/detail/QuadricSphereConverter.hh
+++ b/src/orange/surf/detail/QuadricSphereConverter.hh
@@ -93,8 +93,9 @@ QuadricSphereConverter::operator()(SimpleQuadric const& sq) const
     real_type const inv_norm = 3 / (second[0] + second[1] + second[2]);
     CELER_ASSERT(inv_norm > 0);
 
+    using namespace celeritas::literals;
     Real3 origin = to_array(sq.first());
-    origin *= real_type{-0.5} * inv_norm;
+    origin *= -0.5_r * inv_norm;
 
     real_type radius_sq = dot_product(origin, origin) - sq.zeroth() * inv_norm;
     if (radius_sq <= 0)
@@ -104,7 +105,7 @@ QuadricSphereConverter::operator()(SimpleQuadric const& sq) const
     }
 
     // Clear potential signed zeros before returning
-    origin += real_type{0};
+    origin += 0_r;
     return Sphere::from_radius_sq(origin, radius_sq);
 }
 

--- a/src/orange/surf/detail/SurfaceTransformer.cc
+++ b/src/orange/surf/detail/SurfaceTransformer.cc
@@ -193,13 +193,15 @@ GeneralQuadric SurfaceTransformer::operator()(GeneralQuadric const& other) const
     }();
 
     auto calc_q = [&other] {
+        using namespace celeritas::literals;
+
         constexpr auto X = to_int(Axis::x);
         constexpr auto Y = to_int(Axis::y);
         constexpr auto Z = to_int(Axis::z);
 
         Real3 const second = to_array(other.second());
-        Real3 const cross = to_array(other.cross()) / real_type(2);
-        Real3 const first = to_array(other.first()) / real_type(2);
+        Real3 const cross = to_array(other.cross()) / 2.0_r;
+        Real3 const first = to_array(other.first()) / 2.0_r;
         real_type const zeroth = other.zeroth();
 
         return Mat4{Vec4{zeroth, first[X], first[Y], first[Z]},

--- a/src/orange/surf/detail/SurfaceTranslator.cc
+++ b/src/orange/surf/detail/SurfaceTranslator.cc
@@ -152,13 +152,15 @@ SimpleQuadric SurfaceTranslator::operator()(SimpleQuadric const& other) const
  */
 GeneralQuadric SurfaceTranslator::operator()(GeneralQuadric const& other) const
 {
+    using namespace celeritas::literals;
+
     constexpr auto X = to_int(Axis::x);
     constexpr auto Y = to_int(Axis::y);
     constexpr auto Z = to_int(Axis::z);
 
     Real3 const second = to_array(other.second());
-    Real3 const cross = to_array(other.cross()) / real_type(2);
-    Real3 const first = to_array(other.first()) / real_type(2);
+    Real3 const cross = to_array(other.cross()) / 2.0_r;
+    Real3 const first = to_array(other.first()) / 2.0_r;
 
     // Nonlinear components of the quadric matrix
     SquareMatrix<real_type, 3> nonl{Real3{second[X], cross[X], cross[Z]},
@@ -166,8 +168,7 @@ GeneralQuadric SurfaceTranslator::operator()(GeneralQuadric const& other) const
                                     Real3{cross[Z], cross[Y], second[Z]}};
 
     // Calculate q' = - Q t + q
-    Real3 newfirst
-        = gemv(real_type(-1), nonl, tr_.translation(), real_type(1), first);
+    Real3 newfirst = gemv(-1.0_r, nonl, tr_.translation(), 1.0_r, first);
 
     // Update constant:
     // j' = j - t*(q' + q)
@@ -175,7 +176,7 @@ GeneralQuadric SurfaceTranslator::operator()(GeneralQuadric const& other) const
                           - dot_product(tr_.translation(), newfirst + first);
 
     return GeneralQuadric{
-        second, to_array(other.cross()), real_type(2) * newfirst, newzeroth};
+        second, to_array(other.cross()), 2.0_r * newfirst, newzeroth};
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/transform/Transformation.cc
+++ b/src/orange/transform/Transformation.cc
@@ -14,6 +14,8 @@
 
 #include "Translation.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -26,7 +28,7 @@ Transformation Transformation::from_inverse(Mat3 const& rot, Real3 const& trans)
     Mat3 const rinv = make_transpose(rot);
 
     // Calculate the updated position
-    Real3 tinv = gemv(real_type{-1}, rinv, trans, real_type{0}, {});
+    Real3 tinv = gemv(-1_r, rinv, trans, 0_r, {});
     return Transformation{rinv, tinv};
 }
 
@@ -84,7 +86,7 @@ Transformation::Properties Transformation::calc_properties() const
     result.scales = !std::all_of(rot_.begin(), rot_.end(), [](Real3 const& row) {
         return is_soft_unit_vector(row);
     });
-    CELER_ENSURE(soft_equal(std::fabs(det), real_type{1}) || result.scales);
+    CELER_ENSURE(soft_equal(std::fabs(det), 1_r) || result.scales);
     return result;
 }
 

--- a/src/orange/transform/Transformation.hh
+++ b/src/orange/transform/Transformation.hh
@@ -176,7 +176,8 @@ CELER_FUNCTION Transformation::Transformation(StorageSpan s)
  */
 CELER_FUNCTION Real3 Transformation::transform_up(Real3 const& pos) const
 {
-    return gemv(real_type{1}, rot_, pos, real_type{1}, tra_);
+    using namespace celeritas::literals;
+    return gemv(1_r, rot_, pos, 1_r, tra_);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/JsonComparer.test.cc
+++ b/test/JsonComparer.test.cc
@@ -31,7 +31,7 @@ TEST_F(JsonComparerTest, parse_errors)
 
 TEST_F(JsonComparerTest, scalars)
 {
-    JsonComparer compare{real_type(0.001)};
+    JsonComparer compare{0.001_r};
 
     EXPECT_TRUE(compare("null", "null"));
 
@@ -60,7 +60,7 @@ TEST_F(JsonComparerTest, array)
 
 TEST_F(JsonComparerTest, object)
 {
-    JsonComparer compare{real_type(0.001)};
+    JsonComparer compare{0.001_r};
 
     EXPECT_TRUE(compare(R"json({"a": 1, "b": 2})json"));
     EXPECT_TRUE(
@@ -74,7 +74,7 @@ TEST_F(JsonComparerTest, object)
 
 TEST_F(JsonComparerTest, stringification)
 {
-    JsonComparer compare{real_type(0.001)};
+    JsonComparer compare{0.001_r};
     auto r = compare(R"json({"a": 1, "b": [1, 2, [0]]})json",
                      R"json({"a": 2, "b": [2, 3, [4, 5]]})json");
     EXPECT_STREQ(R"(JSON objects differ:

--- a/test/celeritas/Units.test.cc
+++ b/test/celeritas/Units.test.cc
@@ -43,7 +43,7 @@ TEST(UnitsTest, equivalence)
     {
         constexpr auto erg = gram * centimeter * centimeter / (second * second);
 
-        EXPECT_EQ(real_type(1), erg);
+        EXPECT_EQ(1_r, erg);
         EXPECT_EQ(1e7 * erg, joule);
         EXPECT_REAL_EQ(1e4, tesla);
         EXPECT_REAL_EQ(0.1, coulomb);

--- a/test/celeritas/decay/MuDecay.test.cc
+++ b/test/celeritas/decay/MuDecay.test.cc
@@ -75,7 +75,7 @@ TEST_F(MuDecayInteractorTest, basic)
 {
     auto const& params = *this->particle_params();
     auto const at_rest = MevEnergy{0};
-    auto const max_lepton_energy = real_type{0.5} * data_.muon_mass.value()
+    auto const max_lepton_energy = 0.5_r * data_.muon_mass.value()
                                    - data_.electron_mass.value();
 
     // Anti-muon decay

--- a/test/celeritas/em/CoulombScattering.test.cc
+++ b/test/celeritas/em/CoulombScattering.test.cc
@@ -417,7 +417,7 @@ TEST_F(CoulombScatteringTest, simple_scattering)
     {
         for (auto log_energy : range(-4, 6).step(2))
         {
-            real_type energy = std::pow(real_type{10}, log_energy);
+            real_type energy = std::pow(10_r, log_energy);
             this->set_inc_particle(particle, MevEnergy{energy});
             for (auto i : range(all_wentzel.size()))
             {
@@ -458,10 +458,8 @@ TEST_F(CoulombScatteringTest, simple_scattering)
                     accum_costheta += ct;
                     accum_eloss += eloss;
                 }
-                cos_theta.push_back(accum_costheta
-                                    * (real_type{1} / num_samples));
-                eloss_frac.push_back(accum_eloss
-                                     * (real_type{1} / num_samples));
+                cos_theta.push_back(accum_costheta * (1_r / num_samples));
+                eloss_frac.push_back(accum_eloss * (1_r / num_samples));
             }
         }
     }

--- a/test/celeritas/em/LivermorePE.test.cc
+++ b/test/celeritas/em/LivermorePE.test.cc
@@ -553,7 +553,7 @@ TEST_F(LivermorePEUtilsTest, one_neighbor)
     for (auto i : range(num_shells))
     {
         std::vector<AtomicRelaxTransition> transitions
-            = {{SubshellId{i + 1}, SubshellId{}, real_type{1}, MevEnergy{1}}};
+            = {{SubshellId{i + 1}, SubshellId{}, 1_r, MevEnergy{1}}};
         shells[i].transitions
             = make_builder(&data.transitions)
                   .insert_back(transitions.begin(), transitions.end());
@@ -589,7 +589,7 @@ TEST_F(LivermorePEUtilsTest, one_per_previous)
         {
             transitions.push_back({SubshellId{j + 1},
                                    SubshellId{j + 1},
-                                   real_type{1} / (num_shells - i),
+                                   1_r / (num_shells - i),
                                    MevEnergy{1}});
         }
         shells[i].transitions

--- a/test/celeritas/em/SeltzerBerger.test.cc
+++ b/test/celeritas/em/SeltzerBerger.test.cc
@@ -183,7 +183,7 @@ TEST_F(SeltzerBergerTest, sb_positron_xs_scaling)
         0.99999599590292, 0.99994914123134, 0.99844428624414, 0.0041293798201,
         0.99999995934326, 0.99999948043882, 0.99998298916928, 0.33428689072689};
     // clang-format on
-    EXPECT_VEC_NEAR(expected_scaling_frac, scaling_frac, real_type{1e-11});
+    EXPECT_VEC_NEAR(expected_scaling_frac, scaling_frac, 1e-11_r);
 }
 
 TEST_F(SeltzerBergerTest, sb_energy_dist)

--- a/test/celeritas/em/UrbanMsc.test.cc
+++ b/test/celeritas/em/UrbanMsc.test.cc
@@ -50,10 +50,10 @@ TEST(Distributions, UrbanLargeAngleDistribution)
     {
         accumulate_n(
             [](real_type mu) {
-                EXPECT_LT(real_type(0.9999), mu);
-                EXPECT_LE(mu, real_type(1));
+                EXPECT_LT(0.9999_r, mu);
+                EXPECT_LE(mu, 1_r);
             },
-            UrbanLargeAngleDistribution{real_type(1e-14)},
+            UrbanLargeAngleDistribution{1e-14_r},
             rng,
             num_samples);
         EXPECT_EQ(2 * samples_per_real * num_samples, rng.exchange_count());
@@ -256,7 +256,7 @@ TEST_F(UrbanMscTest, step_conversion)
         MscStepToGeo calc_geom_path(
             msc_params_->host_ref(), helper, energy, lambda, range);
 
-        LogInterp calc_pstep({0, real_type{0.9} * params.min_step},
+        LogInterp calc_pstep({0, 0.9_r * params.min_step},
                              {static_cast<real_type>(pstep_points), range});
         for (auto ppt : celeritas::range(pstep_points + 1))
         {
@@ -280,7 +280,7 @@ TEST_F(UrbanMscTest, step_conversion)
             MscStepFromGeo geo_to_true(
                 msc_params_->host_ref().params, msc_step, range, lambda);
             LogInterp calc_gstep(
-                {0, real_type{0.9} * params.min_step},
+                {0, 0.9_r * params.min_step},
                 {static_cast<real_type>(gstep_points), gp.step});
             for (auto gpt : celeritas::range(gstep_points + 1))
             {
@@ -598,7 +598,7 @@ TEST_F(UrbanMscTest, msc_scattering)
         auto par = this->make_par_view(ptype, MevEnergy{energy[i]});
         auto phys = this->make_phys_view(
             par, "G4_STAINLESS-STEEL", this->physics()->host_ref());
-        auto geo = this->make_geo_view(from_cm(i * 2 - real_type(1e-4)));
+        auto geo = this->make_geo_view(from_cm(i * 2 - 1e-4_r));
         MaterialView mat = this->material()->get(phys.material_id());
         real_type this_pstep = get_pstep(i, phys);
 

--- a/test/celeritas/ext/detail/HitProcessor.test.cc
+++ b/test/celeritas/ext/detail/HitProcessor.test.cc
@@ -148,9 +148,9 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
         TrackId{4},
     };
     dso.weight = {
-        real_type{1.0},  // si_tracker
-        real_type{0.5},  // em_calorimeter
-        real_type{0.8},  // had_calorimeter
+        1.0_r,  // si_tracker
+        0.5_r,  // em_calorimeter
+        0.8_r,  // had_calorimeter
     };
     if (selection_.energy_deposition)
     {

--- a/test/celeritas/field/CMSParameterizedField.hh
+++ b/test/celeritas/field/CMSParameterizedField.hh
@@ -91,6 +91,7 @@ CELER_FUNCTION
 auto CMSParameterizedField::evaluate_field(real_type r, real_type z) const
     -> Real3
 {
+    using namespace celeritas::literals;
     using units::meter;
 
     real_type const prm[9] = {4.24326,
@@ -104,7 +105,7 @@ auto CMSParameterizedField::evaluate_field(real_type r, real_type z) const
                               1.77436};
 
     real_type ap2 = 4 * ipow<2>(prm[0] / prm[1]);
-    real_type hb0 = real_type(0.5) * prm[2] * std::sqrt(1 + ap2);
+    real_type hb0 = 0.5_r * prm[2] * std::sqrt(1 + ap2);
     real_type hlova = 1 / std::sqrt(ap2);
     real_type ainv = 2 * hlova / prm[1];
     real_type coeff = 1 / ipow<2>(prm[8]);
@@ -123,7 +124,7 @@ auto CMSParameterizedField::evaluate_field(real_type r, real_type z) const
     Real4 fu = this->evaluate_parameters(u);
     Real4 gv = this->evaluate_parameters(v);
 
-    real_type rat = real_type(0.5) * r * ainv;
+    real_type rat = 0.5_r * r * ainv;
     real_type rat2 = ipow<2>(rat);
 
     Real3 bw;

--- a/test/celeritas/field/FieldPropagator.test.cc
+++ b/test/celeritas/field/FieldPropagator.test.cc
@@ -461,10 +461,10 @@ TEST_F(TwoBoxesTest, electron_super_small_step)
         {
             SCOPED_TRACE("Bump distance intersects boundary");
             real_type const bump_distance
-                = (driver_options.delta_intersection * real_type{0.1});
-            real_type const eps = bump_distance * real_type{0.99};
-            auto geo = this->make_geo_track_view({real_type{5.0} + eps, 0, 0},
-                                                 {-1, 0, 0});
+                = (driver_options.delta_intersection * 0.1_r);
+            real_type const eps = bump_distance * 0.99_r;
+            auto geo
+                = this->make_geo_track_view({5.0_r + eps, 0, 0}, {-1, 0, 0});
             EXPECT_EQ("world", this->volume_name(geo));
             auto integrate = make_mag_field_integrator<DiagnosticDPIntegrator>(
                 field, particle.charge());
@@ -592,7 +592,7 @@ TEST_F(TwoBoxesTest, electron_tangent)
         EXPECT_SOFT_EQ(quarter, result.distance);
         EXPECT_LT(distance(Real3({std::cos(quarter), 4 + std::sin(quarter), 0}),
                            geo.pos()),
-                  real_type{2e-6});
+                  2e-6_r);
     }
     {
         SCOPED_TRACE("Short step tangent to boundary");
@@ -601,13 +601,13 @@ TEST_F(TwoBoxesTest, electron_tangent)
         auto geo = this->make_checked_track_view();
         auto propagate = make_mag_field_propagator<DormandPrinceIntegrator>(
             field, driver_options, particle, geo);
-        auto result = propagate(real_type{0.02 * pi});
+        auto result = propagate(0.02_r * pi);
 
         EXPECT_FALSE(result.boundary);
-        EXPECT_SOFT_EQ(real_type{0.02 * pi}, result.distance);
+        EXPECT_SOFT_EQ(0.02_r * pi, result.distance);
         EXPECT_LT(distance(Real3({std::cos(quarter), 4 + std::sin(quarter), 0}),
                            geo.pos()),
-                  real_type{2e-6});
+                  2e-6_r);
     }
 }
 
@@ -768,7 +768,7 @@ TEST_F(TwoBoxesTest, electron_corner_hit)
         EXPECT_TRUE(result.boundary);
         EXPECT_LT(distance(Real3({-5 + x, 5, 0}), geo.pos()), 1e-5)
             << "Actually stopped at " << geo.pos();
-        EXPECT_LT(distance(Real3({dy - 1, x, 0}), geo.dir()), real_type{1.5e-5})
+        EXPECT_LT(distance(Real3({dy - 1, x, 0}), geo.dir()), 1.5e-5_r)
             << "Ending direction at " << geo.dir();
 
         if (geo.check_normal())
@@ -851,7 +851,7 @@ TEST_F(TwoBoxesTest, TEST_IF_CELERITAS_DOUBLE(electron_step_endpoint))
         field, particle.charge());
     auto propagate = [&](real_type start_delta, real_type move_delta) {
         Real3 start_pos{-5 + start_delta, 0, 0};
-        axpy(real_type(-1), first_pos, &start_pos);
+        axpy(-1.0_r, first_pos, &start_pos);
 
         geo = GeoTrackInitializer{start_pos, {0, 1, 0}};
         auto propagate
@@ -990,8 +990,7 @@ TEST_F(TwoBoxesTest,
     std::vector<int> substeps;
     std::vector<std::string> volumes;
 
-    for (real_type dtheta :
-         {pi / 4, pi / 7, real_type{1e-3}, real_type{1e-6}, real_type{1e-9}})
+    for (real_type dtheta : {pi / 4, pi / 7, 1e-3_r, 1e-6_r, 1e-9_r})
     {
         SCOPED_TRACE(dtheta);
         {
@@ -1082,7 +1081,7 @@ TEST_F(TwoBoxesTest,
     };
 
     EXPECT_VEC_EQ(expected_boundary, boundary) << repr(boundary);
-    EXPECT_VEC_NEAR(expected_distances, distances, real_type{.1} * coarse_eps)
+    EXPECT_VEC_NEAR(expected_distances, distances, 0.1_r * coarse_eps)
         << repr(distances);
     EXPECT_VEC_EQ(expected_substeps, substeps) << repr(substeps);
     EXPECT_VEC_EQ(expected_volumes, volumes) << repr(volumes);
@@ -1464,8 +1463,8 @@ TEST_F(CmseTest, coarse)
     {
         ScopedLogStorer scoped_log_{&celeritas::self_logger(),
                                     LogLevel::warning};
-        auto geo = this->make_geo_track_view(
-            {2 * radius + real_type{0.01}, 0, -300}, {0, 1, 1});
+        auto geo = this->make_geo_track_view({2 * radius + 0.01_r, 0, -300},
+                                             {0, 1, 1});
         // TODO: define a "reentrant" different propagation status: see
         // CheckedGeoTrackView, OrangeTrackView
         geo.check_zero_distance(false);

--- a/test/celeritas/field/FieldSubstepper.test.cc
+++ b/test/celeritas/field/FieldSubstepper.test.cc
@@ -245,8 +245,7 @@ TEST_F(FieldSubstepperTest, pathological_chord)
 
     OdeState state;
     state.pos = {radius, 0, 0};
-    state.mom = this->calc_momentum(
-        e, {0, std::sqrt(1 - ipow<2>(real_type{0.2})), 0.2});
+    state.mom = this->calc_momentum(e, {0, std::sqrt(1 - ipow<2>(0.2_r)), 0.2});
 
     DiagnosticIntegrator integrate{ZHelixIntegrator{MagFieldEquation{
         UniformZField{field_strength}, units::ElementaryCharge{-1}}}};
@@ -291,7 +290,7 @@ TEST_F(FieldSubstepperTest, step_counts)
     // 10 TeV.
     for (int loge : range(-7, 7).step(2))
     {
-        MevEnergy e{std::pow(real_type{10}, static_cast<real_type>(loge))};
+        MevEnergy e{std::pow(10_r, static_cast<real_type>(loge))};
         real_type radius = this->calc_curvature(e, field_strength);
         radii.push_back(radius);
 

--- a/test/celeritas/field/Fields.test.cc
+++ b/test/celeritas/field/Fields.test.cc
@@ -163,7 +163,7 @@ TEST_F(RZMapFieldTest, all)
     };
     // clang-format on
     // Float32 covfie interpolation; allow for AVX2 rounding variation
-    EXPECT_VEC_NEAR(expected_field, actual, real_type{2e-7});
+    EXPECT_VEC_NEAR(expected_field, actual, 2e-7_r);
 }
 
 TEST_F(RZMapFieldTest, interp_validation)
@@ -365,7 +365,7 @@ TEST_F(CylMapFieldTest, all)
     };
     // clang-format on
 
-    EXPECT_VEC_NEAR(expected_field, actual, real_type{1e-7});
+    EXPECT_VEC_NEAR(expected_field, actual, 1e-7_r);
 }
 
 //---------------------------------------------------------------------------//
@@ -641,7 +641,7 @@ TEST_F(CartMapFieldTest, host)
         -0.54941475391388,
         0.33834865689278,
     };
-    EXPECT_VEC_NEAR(expected_field, actual, real_type{1e-6});
+    EXPECT_VEC_NEAR(expected_field, actual, 1e-6_r);
 }
 
 TEST_F(CartMapFieldTest, TEST_IF_CELER_DEVICE(device))

--- a/test/celeritas/field/Integrators.test.cc
+++ b/test/celeritas/field/Integrators.test.cc
@@ -89,7 +89,7 @@ class IntegratorsTest : public Test
         {
             // Initial state and the expected state after revolutions
             OdeState y;
-            y.pos = {param.radius, 0, i * real_type{1e-6}};
+            y.pos = {param.radius, 0, i * 1e-6_r};
             y.mom = {0, param.momentum_y, param.momentum_z};
 
             OdeState expected_y = y;
@@ -100,8 +100,7 @@ class IntegratorsTest : public Test
             for (int nr : range(param.revolutions))
             {
                 // Travel hstep for num_steps times in the field
-                expected_y.pos[2] = param.delta_z * (nr + 1)
-                                    + i * real_type{1e-6};
+                expected_y.pos[2] = param.delta_z * (nr + 1) + i * 1e-6_r;
                 for ([[maybe_unused]] int j : range(param.nsteps))
                 {
                     FieldIntegration result = integrate(hstep, y);
@@ -128,8 +127,7 @@ class IntegratorsTest : public Test
         {
             real_type error = std::sqrt(output.error[i]);
             EXPECT_SOFT_NEAR(output.pos_x[i], param.radius, error);
-            EXPECT_SOFT_NEAR(
-                output.pos_z[i], zstep + i * real_type{1e-6}, error);
+            EXPECT_SOFT_NEAR(output.pos_z[i], zstep + i * 1e-6_r, error);
             EXPECT_SOFT_NEAR(output.mom_y[i], param.momentum_y, error);
             EXPECT_SOFT_NEAR(output.mom_z[i], param.momentum_z, error);
             EXPECT_LT(output.error[i], param.epsilon);

--- a/test/celeritas/field/MagFieldEquation.test.cc
+++ b/test/celeritas/field/MagFieldEquation.test.cc
@@ -22,9 +22,9 @@ Real3 dummy_field(Real3 const& pos)
 {
     // Rotate and scale
     Real3 result;
-    result[0] = real_type(0.5) * to_cm(pos[1]) * units::gauss;
-    result[1] = real_type(1.0) * to_cm(pos[2]) * units::gauss;
-    result[2] = real_type(2.0) * to_cm(pos[0]) * units::gauss;
+    result[0] = 0.5_r * to_cm(pos[1]) * units::gauss;
+    result[1] = 1.0_r * to_cm(pos[2]) * units::gauss;
+    result[2] = 2.0_r * to_cm(pos[0]) * units::gauss;
     return result;
 }
 

--- a/test/celeritas/geo/HeuristicGeoData.hh
+++ b/test/celeritas/geo/HeuristicGeoData.hh
@@ -18,6 +18,8 @@
 #include "celeritas/Units.hh"
 #include "celeritas/geo/GeoData.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace test
@@ -161,7 +163,7 @@ inline void resize(HeuristicGeoStateData<Ownership::value, M>* state,
     fill(LifeStatus::unborn, &state->status);
 
     resize(&state->accum_path, params.s.num_volumes);
-    fill(real_type{0}, &state->accum_path);
+    fill(0.0_r, &state->accum_path);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/geo/HeuristicGeoData.hh
+++ b/test/celeritas/geo/HeuristicGeoData.hh
@@ -18,8 +18,6 @@
 #include "celeritas/Units.hh"
 #include "celeritas/geo/GeoData.hh"
 
-using namespace celeritas::literals;
-
 namespace celeritas
 {
 namespace test
@@ -157,6 +155,7 @@ inline void resize(HeuristicGeoStateData<Ownership::value, M>* state,
 {
     CELER_EXPECT(params);
     CELER_EXPECT(size > 0);
+    using namespace celeritas::literals;
     resize(&state->geometry, params.geometry, size);
     resize(&state->rng, params.rng, StreamId{0}, size);
     resize(&state->status, size);

--- a/test/celeritas/geo/HeuristicGeoExecutor.hh
+++ b/test/celeritas/geo/HeuristicGeoExecutor.hh
@@ -177,12 +177,14 @@ CELER_FUNCTION void HeuristicGeoExecutor::operator()(TrackSlotId tid) const
     BernoulliDistribution do_scatter(0.1);
     if (do_scatter(rng))
     {
+        using namespace celeritas::literals;
+
         // Forward scatter: anything up to a 90 degree angle if not on a
         // boundary, otherwise pretty close to forward peaked
-        real_type min_angle = (geo.is_on_boundary() ? real_type(0.9) : 0);
+        real_type min_angle = (geo.is_on_boundary() ? 0.9_r : 0);
         real_type mu = UniformRealDistribution<>{min_angle, 1}(rng);
         real_type phi
-            = UniformRealDistribution<>{0, real_type(2 * constants::pi)}(rng);
+            = UniformRealDistribution<>{0, 2.0_r * constants::pi}(rng);
 
         Real3 dir = rotate(from_spherical(mu, phi), geo.dir());
         geo.set_dir(dir);

--- a/test/celeritas/grid/NonuniformGridInserter.test.cc
+++ b/test/celeritas/grid/NonuniformGridInserter.test.cc
@@ -95,8 +95,8 @@ TEST_F(NonuniformGridInserterTest, many_no_repeats)
     for (size_t i = 0; i < num_grids; i++)
     {
         inp::Grid grid;
-        grid.x = build_random_array(count, real_type{-100} * i);
-        grid.y = build_random_array(count, real_type{300} * i);
+        grid.x = build_random_array(count, -100_r * i);
+        grid.y = build_random_array(count, 300_r * i);
         grids.push_back(grid);
 
         grid_ids.push_back(insert(grid));
@@ -126,7 +126,7 @@ TEST_F(NonuniformGridInserterTest, many_with_repeats)
     size_t const num_grids = 20;
     for (size_t i = 0; i < num_grids; i++)
     {
-        grid.y = build_random_array(count, real_type{300} * i);
+        grid.y = build_random_array(count, 300_r * i);
         grids.push_back(grid);
 
         grid_ids.push_back(insert(grid));

--- a/test/celeritas/grid/SplineCalculator.test.cc
+++ b/test/celeritas/grid/SplineCalculator.test.cc
@@ -76,7 +76,7 @@ TEST_F(SplineCalculatorTest, simple)
 
 TEST_F(SplineCalculatorTest, quadratic)
 {
-    auto xs = [](real_type energy) { return real_type{0.1} * ipow<2>(energy); };
+    auto xs = [](real_type energy) { return 0.1_r * ipow<2>(energy); };
 
     inp::UniformGrid grid;
     grid.x = {1e-3, 1e2};
@@ -115,8 +115,7 @@ TEST_F(SplineCalculatorTest, quadratic)
 
 TEST_F(SplineCalculatorTest, cubic)
 {
-    auto xs
-        = [](real_type energy) { return real_type{0.01} * ipow<3>(energy); };
+    auto xs = [](real_type energy) { return 0.01_r * ipow<3>(energy); };
 
     inp::UniformGrid grid;
     grid.x = {1e-3, 1e4};

--- a/test/celeritas/io/EventIOTestBase.cc
+++ b/test/celeritas/io/EventIOTestBase.cc
@@ -16,6 +16,7 @@
 
 #include "TestMacros.hh"
 
+using namespace celeritas::literals;
 using celeritas::units::MevEnergy;
 
 namespace celeritas
@@ -192,13 +193,13 @@ void EventIOTestBase::read_check_test_event(Reader& read_event) const
     static int const expected_event[] = {0, 0, 0, 0, 1, 1, 1, 1, 1, 2};
     // clang-format on
 
-    real_type energy_tol = real_type{0.1} * coarse_eps;
+    real_type energy_tol = 0.1_r * coarse_eps;
 
     EXPECT_VEC_EQ(expected_pdg, result.pdg);
     EXPECT_VEC_NEAR(expected_energy, result.energy, energy_tol);
     EXPECT_VEC_SOFT_EQ(expected_pos, result.pos);
     EXPECT_VEC_SOFT_EQ(expected_dir, result.dir);
-    EXPECT_VEC_NEAR(expected_time, result.time, real_type(1e-6));
+    EXPECT_VEC_NEAR(expected_time, result.time, 1e-6_r);
     EXPECT_VEC_EQ(expected_event, result.event);
 }
 

--- a/test/celeritas/neutron/NeutronElastic.test.cc
+++ b/test/celeritas/neutron/NeutronElastic.test.cc
@@ -240,7 +240,7 @@ TEST_F(NeutronElasticTest, extended)
     for (auto i : range(10))
     {
         MevEnergy const inc_energy{
-            std::pow(real_type{10}, static_cast<real_type>(-5 + 1 * i))};
+            std::pow(10_r, static_cast<real_type>(-5 + 1 * i))};
         this->set_inc_particle(pdg::neutron(), inc_energy);
         ChipsNeutronElasticInteractor interact(
             shared, this->particle_track(), this->direction(), isotope_he4);

--- a/test/celeritas/optical/Cherenkov.test.cc
+++ b/test/celeritas/optical/Cherenkov.test.cc
@@ -535,10 +535,8 @@ TEST_F(CherenkovAirTest, dndx)
         params->host_ref(),
         this->particle_params()->get(ParticleId{0}).charge());
 
-    std::vector<real_type> betas{real_type{1.0 / 1.2},
-                                 real_type{1.0 / 1.3},
-                                 1 / 1.31,
-                                 real_type{1.0 / 1.4}};
+    std::vector<real_type> betas{
+        1.0_r / 1.2, 1.0_r / 1.3, 1 / 1.31, 1.0_r / 1.4};
 
     std::vector<real_type> dndx;
     for (real_type beta : betas)

--- a/test/celeritas/optical/Fresnel.test.cc
+++ b/test/celeritas/optical/Fresnel.test.cc
@@ -116,9 +116,8 @@ ScatteringResult scan_refraction(CoordinateAxes const& axes,
         EXPECT_EQ(SurfaceInteraction::Action::refracted, refract.action);
         EXPECT_SOFT_EQ(0, dot_product(refract.direction, axes.p_hat));
 
-        real_type cos_theta = clamp(-dot_product(refract.direction, axes.n_hat),
-                                    real_type{0},
-                                    real_type{1});
+        real_type cos_theta
+            = clamp(-dot_product(refract.direction, axes.n_hat), 0_r, 1_r);
         real_type theta = std::acos(cos_theta);
 
         result.cos_theta.push_back(cos_theta);

--- a/test/celeritas/optical/Physics.test.cc
+++ b/test/celeritas/optical/Physics.test.cc
@@ -301,7 +301,7 @@ TEST_F(OpticalPhysicsTest, calc_step_limits)
 
         auto const& expected_model_xs = expected_model_xs_per_energy[i];
         real_type expected_total_xs = std::accumulate(
-            expected_model_xs.begin(), expected_model_xs.end(), real_type{0});
+            expected_model_xs.begin(), expected_model_xs.end(), 0_r);
 
         StepLimit limits = calc_physics_step_limit(particle, physics);
 

--- a/test/celeritas/optical/SurfacePhysicsInteractionIntegration.test.cc
+++ b/test/celeritas/optical/SurfacePhysicsInteractionIntegration.test.cc
@@ -16,7 +16,7 @@ namespace optical
 {
 namespace test
 {
-constexpr Turn degree{real_type{1} / 360};
+constexpr Turn degree{1_r / 360};
 //---------------------------------------------------------------------------//
 /*!
  * Counters for photon status after a run at a single angle.

--- a/test/celeritas/phys/InteractorHostTestBase.cc
+++ b/test/celeritas/phys/InteractorHostTestBase.cc
@@ -17,6 +17,8 @@
 
 namespace celeritas
 {
+using namespace celeritas::literals;
+
 namespace test
 {
 //---------------------------------------------------------------------------//
@@ -363,9 +365,8 @@ void InteractorHostBase::check_momentum_conservation(
             parent_momentum_mag, exit_momentum_mag, default_tol * 10000);
 
         exit_momentum = make_unit_vector(exit_momentum);
-        EXPECT_SOFT_NEAR(real_type(1),
-                         dot_product(inc_direction_, exit_momentum),
-                         3 * default_tol)
+        EXPECT_SOFT_NEAR(
+            1.0_r, dot_product(inc_direction_, exit_momentum), 3 * default_tol)
             << "Incident direction: " << inc_direction_
             << "; exiting momentum direction: " << exit_momentum;
     }

--- a/test/celeritas/phys/Physics.test.cc
+++ b/test/celeritas/phys/Physics.test.cc
@@ -343,19 +343,19 @@ TEST_F(PhysicsTrackViewHostTest, track_view)
     std::vector<real_type> step;
     real_type const eps = std::numeric_limits<real_type>::epsilon();
 
-    for (real_type r : {real_type(0.1) * rho,
-                        real_type(1 - 1000 * eps) * rho,
-                        real_type(1 - 100 * eps) * rho,
-                        real_type(1 + 10 * eps) * rho,
-                        real_type(1 + 100 * eps) * rho,
-                        real_type(1.00000001) * rho,
-                        real_type(1.000001) * rho,
-                        real_type{1.5} * rho,
+    for (real_type r : {0.1_r * rho,
+                        (1.0_r - 1000 * eps) * rho,
+                        (1.0_r - 100 * eps) * rho,
+                        (1.0_r + 10 * eps) * rho,
+                        (1.0_r + 100 * eps) * rho,
+                        1.00000001_r * rho,
+                        1.000001_r * rho,
+                        1.5_r * rho,
                         10 * rho,
                         100 * rho})
     {
         auto s = celer.range_to_step(r);
-        EXPECT_GT(s, real_type(0));
+        EXPECT_GT(s, 0.0_r);
         EXPECT_LE(s, r) << "s - r == " << s - r;
         step.push_back(to_cm(s));
     }

--- a/test/celeritas/phys/Physics.test.hh
+++ b/test/celeritas/phys/Physics.test.hh
@@ -59,6 +59,8 @@ inline CELER_FUNCTION real_type calc_step(PhysicsTrackView& phys,
                                           MaterialView const& mat,
                                           units::MevEnergy energy)
 {
+    using namespace celeritas::literals;
+
     // Calc total macro_xs over processes
     real_type total_xs = 0;
     for (auto ppid : range(ParticleProcessId{phys.num_particle_processes()}))
@@ -95,7 +97,7 @@ inline CELER_FUNCTION real_type calc_step(PhysicsTrackView& phys,
     }
 
     // Take minimum of step and half the MFP
-    step = min(step, real_type{0.5} * phys.interaction_mfp());
+    step = min(step, 0.5_r * phys.interaction_mfp());
     return step;
 }
 

--- a/test/corecel/grid/TwodGridCalculator.test.cc
+++ b/test/corecel/grid/TwodGridCalculator.test.cc
@@ -76,8 +76,8 @@ TEST_F(TwodGridCalculatorTest, whole_grid)
     // Outer extrema
     real_type const eps = 1e-6;
     EXPECT_SOFT_EQ(calc_expected(-1, 0), interpolate({-1, 0}));
-    EXPECT_SOFT_EQ(calc_expected(3 - eps, real_type(3.5) - eps),
-                   interpolate({3 - eps, real_type(3.5) - eps}));
+    EXPECT_SOFT_EQ(calc_expected(3 - eps, 3.5_r - eps),
+                   interpolate({3 - eps, 3.5_r - eps}));
 
     // Interior points
     for (real_type x : {-1.0, -0.5, -0.9, 2.25})

--- a/test/corecel/grid/UniformGrid.test.cc
+++ b/test/corecel/grid/UniformGrid.test.cc
@@ -73,8 +73,8 @@ TEST_F(UniformGridTest, from_bounds)
 
 TEST_F(UniformGridTest, TEST_IF_CELERITAS_DOUBLE(from_logbounds))
 {
-    real_type const log_emin = std::log(real_type{1.0});
-    real_type const log_emax = std::log(real_type{1e5});
+    real_type const log_emin = std::log(1.0_r);
+    real_type const log_emax = std::log(1e5_r);
     input = UniformGridData::from_bounds({log_emin, log_emax}, 6);
 
     UniformGrid grid(input);

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -141,7 +141,7 @@ TEST(AlgorithmsTest, clamp)
     }
 
     constexpr auto nan = std::numeric_limits<real_type>::quiet_NaN();
-    EXPECT_TRUE(std::isnan(clamp(nan, real_type{-1}, real_type{1})));
+    EXPECT_TRUE(std::isnan(clamp(nan, -1_r, 1_r)));
 }
 
 TEST(AlgorithmsTest, clamp_to_nonneg)
@@ -284,10 +284,10 @@ TEST(AlgorithmsTest, minmax)
     EXPECT_EQ(2, max<int>(1, 2));
 
     constexpr auto nan = std::numeric_limits<real_type>::quiet_NaN();
-    EXPECT_EQ(real_type{1}, min(real_type{1}, nan));
-    EXPECT_EQ(real_type{1}, min(nan, real_type{1}));
-    EXPECT_EQ(real_type{1}, max(real_type{1}, nan));
-    EXPECT_EQ(real_type{1}, max(nan, real_type{1}));
+    EXPECT_EQ(1_r, min(1_r, nan));
+    EXPECT_EQ(1_r, min(nan, 1_r));
+    EXPECT_EQ(1_r, max(1_r, nan));
+    EXPECT_EQ(1_r, max(nan, 1_r));
 }
 
 TEST(AlgorithmsTest, min_element)

--- a/test/corecel/math/Integrator.test.cc
+++ b/test/corecel/math/Integrator.test.cc
@@ -20,7 +20,7 @@ namespace test
 //---------------------------------------------------------------------------//
 TEST(IntegratorTest, constant)
 {
-    DiagnosticRealFunc f{[](real_type) { return real_type{10}; }};
+    DiagnosticRealFunc f{[](real_type) { return 10_r; }};
     {
         Integrator integrate{f};
         EXPECT_SOFT_EQ(10.0, integrate(1, 2));

--- a/test/corecel/random/Selector.test.cc
+++ b/test/corecel/random/Selector.test.cc
@@ -166,7 +166,7 @@ TEST_F(UnnormSelectorTest, make_selector)
     static double const prob[] = {0.1, 0.3, 0.5};
 
     auto sample_prob = make_unnormalized_selector(
-        [](int i) { return prob[i]; }, std::size(prob), real_type{1});
+        [](int i) { return prob[i]; }, std::size(prob), 1_r);
 
     auto rng = make_rng(0.0);
     EXPECT_EQ(0, sample_prob(rng));

--- a/test/geocel/CheckedGeoTrackView.cc
+++ b/test/geocel/CheckedGeoTrackView.cc
@@ -17,6 +17,8 @@
 #include "geocel/GeoParamsInterface.hh"
 #include "geocel/VolumeParams.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace test
@@ -472,7 +474,7 @@ void CheckedGeoTrackView::cross_boundary()
         CGTV_VALIDATE(
             *this,
             soft_equal(std::fabs(dot_product(*pre_crossing_normal, post_norm)),
-                       real_type{1}),
+                       1_r),
             << "inconsistent surface normal: pre-crossing "
             << *pre_crossing_normal << ", post-crossing " << post_norm);
 

--- a/test/geocel/GenericGeoResults.cc
+++ b/test/geocel/GenericGeoResults.cc
@@ -19,6 +19,8 @@
 #include "GenericGeoTestInterface.hh"
 #include "TestMacros.hh"
 
+using namespace celeritas::literals;
+
 namespace celeritas
 {
 namespace test
@@ -78,7 +80,7 @@ void GenericGeoTrackingResult::clear_boring_normals()
 {
     auto& dn = this->dot_normal;
     if (std::all_of(dn.begin(), dn.end(), [](real_type n) {
-            return soft_equal(n, real_type{1});
+            return soft_equal(n, 1_r);
         }))
     {
         dn.clear();

--- a/test/geocel/GeoTests.cc
+++ b/test/geocel/GeoTests.cc
@@ -30,6 +30,8 @@
 #include "TestMacros.hh"
 #include "UnitUtils.hh"
 
+using namespace celeritas::literals;
+
 /*!
  * Allow a statement to skip the test when using a certain geometry.
  *
@@ -265,7 +267,7 @@ void AtlasHgtdGeoTest::test_trace() const
         Real3 pos{24.097769534015998, 17.956803215217408, 344.45};
         Real3 dir{
             0.5784236876658104, 0.8157365000698582, -9.290358099212079e-7};
-        axpy(real_type{-1}, dir, &pos);
+        axpy(-1_r, dir, &pos);
 
         if (test_->geometry_type() == "VecGeom" && !CELERITAS_VECGEOM_SURFACE)
         {
@@ -806,7 +808,7 @@ void FourLevelsGeoTest::test_reentrant() const
     EXPECT_EQ("Shape1", test_->volume_name(geo));
 
     // Test relocation without direction change on surface
-    constexpr auto dx = real_type{1} / constants::sqrt_two;
+    constexpr auto dx = 1_r / constants::sqrt_two;
 
     // Check non-reentrant direction
     geo.set_dir(Real3{dx, dx, 0});
@@ -2855,7 +2857,7 @@ void TwoBoxesGeoTest::test_detailed_tracking() const
 void TwoBoxesGeoTest::test_reentrant() const
 {
     auto geo = test_->make_checked_track_view();
-    constexpr auto dx = real_type{1} / constants::sqrt_two;
+    constexpr auto dx = 1_r / constants::sqrt_two;
 
     // Starting left of edge (-), headed down right (+,-)
     geo = test_->make_initializer({5 - dx, dx, 0}, {dx, -dx, 0});
@@ -2932,7 +2934,7 @@ void TwoBoxesGeoTest::test_reentrant() const
 void TwoBoxesGeoTest::test_reentrant_undo() const
 {
     auto geo = test_->make_checked_track_view();
-    constexpr auto dx = real_type{1} / constants::sqrt_two;
+    constexpr auto dx = 1_r / constants::sqrt_two;
 
     // Starting left of edge (-), headed down right (+,-)
     geo = test_->make_initializer({5 - dx, dx, 0}, {dx, -dx, 0});
@@ -2987,7 +2989,7 @@ void TwoBoxesGeoTest::test_reentrant_undo() const
  */
 void TwoBoxesGeoTest::test_tangent() const
 {
-    constexpr auto dx = real_type{1} / constants::sqrt_two;
+    constexpr auto dx = 1_r / constants::sqrt_two;
 
     // Starting left of edge (-), headed down right (+,-)
     auto geo = test_->make_checked_track_view();

--- a/test/geocel/rasterize/Image.test.cc
+++ b/test/geocel/rasterize/Image.test.cc
@@ -104,9 +104,9 @@ TEST_F(ImageTest, inexact)
     auto const& scalars = params->scalars();
     EXPECT_VEC_SOFT_EQ((Real3{6, 2, -1}), scalars.origin);
     EXPECT_VEC_SOFT_EQ((Real3{-1, 0, 0}), scalars.down);
-    EXPECT_SOFT_EQ(real_type{7} / 256, scalars.pixel_width);
+    EXPECT_SOFT_EQ(7_r / 256, scalars.pixel_width);
     EXPECT_VEC_EQ((Size2{256, 192}), scalars.dims);
-    EXPECT_SOFT_EQ(real_type{5}, scalars.max_length);
+    EXPECT_SOFT_EQ(5_r, scalars.max_length);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/MatrixUtils.test.cc
+++ b/test/orange/MatrixUtils.test.cc
@@ -274,7 +274,7 @@ TEST_F(MatrixUtilsTest, make_arb_rotation)
     }
     {
         auto r = make_rotation(make_unit_vector(Real3{-3, -4, -5}),
-                               Turn{1 / real_type{6}});
+                               Turn{1 / 6_r});
         static double const expected_r[] = {
             0.59,
             0.73237243569579,
@@ -295,13 +295,13 @@ TEST_F(MatrixUtilsTest, make_arb_rotation)
 TEST_F(MatrixUtilsTest, make_scaling)
 {
     {
-        auto r = make_scaling(real_type{2.0});
+        auto r = make_scaling(2.0_r);
 
         static double const expected_r[] = {2, 0, 0, 0, 2, 0, 0, 0, 2};
         EXPECT_VEC_SOFT_EQ(expected_r, flattened(r));
     }
     {
-        auto r = make_scaling(Axis::z, real_type{2.0});
+        auto r = make_scaling(Axis::z, 2.0_r);
 
         static double const expected_r[] = {1, 0, 0, 0, 1, 0, 0, 0, 2};
         EXPECT_VEC_SOFT_EQ(expected_r, flattened(r));

--- a/test/orange/orangeinp/IntersectRegion.test.cc
+++ b/test/orange/orangeinp/IntersectRegion.test.cc
@@ -820,8 +820,7 @@ class GenPrismTest : public IntersectRegionTest
             auto twist_cosine = pri.calc_twist_cosine(i);
             EXPECT_GT(twist_cosine, 0);
             EXPECT_LT(twist_cosine, 1 + SoftEqual<>{}.abs());
-            real_type twist_angle
-                = std::acos(std::fmin(twist_cosine, real_type(1)));
+            real_type twist_angle = std::acos(std::fmin(twist_cosine, 1_r));
             result.push_back(native_value_to<Turn>(twist_angle).value());
         }
         return result;
@@ -1247,7 +1246,7 @@ TEST_F(GenPrismTest, trap_thetaphi)
 
 TEST_F(GenPrismTest, trap_g4)
 {
-    constexpr Turn degree{real_type{1} / 360};
+    constexpr Turn degree{1_r / 360};
 
     auto pri = GenPrism::from_trap(4,
                                    5 * degree,
@@ -1668,11 +1667,11 @@ TEST_F(GenPrismTest, variable_twisted)
     };
     for (auto logeps : range(-6, -1))
     {
-        build_prism(std::pow(real_type{10}, static_cast<real_type>(logeps)));
+        build_prism(std::pow(10_r, static_cast<real_type>(logeps)));
     }
     for (auto fraceps : range(0, 5))
     {
-        build_prism(0.1 + real_type{0.025} * fraceps);
+        build_prism(0.1 + 0.025_r * fraceps);
     }
 
     auto const& u = this->unit();

--- a/test/orange/orangeinp/Solid.test.cc
+++ b/test/orange/orangeinp/Solid.test.cc
@@ -373,7 +373,7 @@ TEST_F(SolidTest, sphere_polar)
 {
     using SS = SphereSolid;
     using EP = EnclosedPolar;
-    constexpr real_type one_third = 1 / real_type{3};
+    constexpr real_type one_third = 1 / 3_r;
     {
         this->build_volume(
             SS("top", Sphere{10.0}, {}, {}, EP{Turn{0.0}, Turn{0.125}}));

--- a/test/orange/orangeinp/UnitProto.test.cc
+++ b/test/orange/orangeinp/UnitProto.test.cc
@@ -774,7 +774,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
         using VR2 = GenPrism::VecReal2;
         auto trd
             = make_shape<GenPrism>("turd",
-                                   real_type{3},
+                                   3_r,
                                    VR2{{-1, -1}, {1, -1}, {1, 1}, {-1, 1}},
                                    VR2{{-2, -2}, {2, -2}, {2, 2}, {-2, 2}});
         append_material(inp,

--- a/test/orange/orangeinp/detail/PolygonUtils.test.cc
+++ b/test/orange/orangeinp/detail/PolygonUtils.test.cc
@@ -278,7 +278,7 @@ TEST(PolygonUtilsTest, calc_extrema)
 
 TEST(PolygonUtilsTest, normal_from_triangle)
 {
-    constexpr auto dir = real_type{1} / constants::sqrt_three;
+    constexpr auto dir = 1_r / constants::sqrt_three;
 
     // Construct from three points, in this case a plane passing through the
     // point (1, 2, 3) with slope (1, 1, 1). Specifying the points in clockwise

--- a/test/orange/surf/ConeAligned.test.cc
+++ b/test/orange/surf/ConeAligned.test.cc
@@ -111,7 +111,7 @@ TEST(ConeAlignedTest, intersection_along_surface)
     if (CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
     {
         // Move to calculated endpoint
-        axpy(distances[0] - real_type(1e-10), dir, &pos);
+        axpy(distances[0] - 1e-10_r, dir, &pos);
         // Calculate inward direction (near cone, normal is outward dir)
         auto tempdir = cone.calc_normal(pos);
         for (auto& d : tempdir)

--- a/test/orange/surf/CylAligned.test.cc
+++ b/test/orange/surf/CylAligned.test.cc
@@ -380,17 +380,13 @@ TEST_F(CylZTest, calc_intersections_degenerate)
     {
         CylZ cyl{{1.23, 2.34, 0}, 3.45};
 
-        auto distances = calc_intersections(cyl,
-                                            {real_type{4.68} - eps, 2.34, 1.23},
-                                            {-1, 0, 0},
-                                            SurfaceState::off);
+        auto distances = calc_intersections(
+            cyl, {4.68_r - eps, 2.34, 1.23}, {-1, 0, 0}, SurfaceState::off);
         EXPECT_SOFT_EQ(6.9 - eps, distances[0]);
         EXPECT_EQ(no_intersection(), distances[1]);
 
-        distances = calc_intersections(cyl,
-                                       {real_type{4.68} - eps, 2.34, 1.23},
-                                       {1, 0, 0},
-                                       SurfaceState::off);
+        distances = calc_intersections(
+            cyl, {4.68_r - eps, 2.34, 1.23}, {1, 0, 0}, SurfaceState::off);
         EXPECT_SOFT_NEAR(eps, distances[0], eps);
         EXPECT_EQ(no_intersection(), distances[1]);
     }
@@ -412,7 +408,7 @@ TEST_F(CylZTest, TEST_IF_CELERITAS_DOUBLE(degenerate_boundary))
         for (real_type xdir : {-1.0, 1.0})
         {
             SCOPED_TRACE(xdir < 0 ? "leftward" : "rightward");
-            for (real_type eps : {-coarse_eps, real_type{0}, coarse_eps})
+            for (real_type eps : {-coarse_eps, 0_r, coarse_eps})
             {
                 SCOPED_TRACE(eps < 0 ? "neg" : eps > 0 ? "pos" : "zero");
 

--- a/test/orange/surf/CylCentered.test.cc
+++ b/test/orange/surf/CylCentered.test.cc
@@ -324,7 +324,7 @@ TEST_F(CCylZTest, TEST_IF_CELERITAS_DOUBLE(multi_tangent_intersect))
     {
         for (real_type v : {-1.0, 1.0})
         {
-            Real3 pos{x, real_type{-10 - 100 * coarse_eps} * v, 0};
+            Real3 pos{x, (-10_r - 100 * coarse_eps) * v, 0};
             Real3 dir{0, v, 0};
 
             real_type d;
@@ -399,8 +399,7 @@ TEST_F(CCylZTest, TEST_IF_CELERITAS_DOUBLE(multi_along_intersect))
                 // Move the solved distance and make sure we're close to the
                 // actual cylinder surface
                 axpy(d, dir, &pos);
-                real_type boundary_error = std::hypot(pos[0], pos[1])
-                                           - real_type(30);
+                real_type boundary_error = std::hypot(pos[0], pos[1]) - 30_r;
 
                 // Calculate relative to the distance traveled and floating
                 // point precision
@@ -432,8 +431,7 @@ TEST_F(CCylZTest, TEST_IF_CELERITAS_DOUBLE(multi_along_intersect))
         inf, inf, inf, inf, inf, inf, inf, inf, inf};
     // clang-format on
 
-    EXPECT_VEC_NEAR(
-        expected_all_first_distances, all_first_distances, real_type{1e-5});
+    EXPECT_VEC_NEAR(expected_all_first_distances, all_first_distances, 1e-5_r);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/surf/Plane.test.cc
+++ b/test/orange/surf/Plane.test.cc
@@ -15,7 +15,7 @@ namespace celeritas
 {
 namespace test
 {
-constexpr auto sqrt_two = real_type{constants::sqrt_two};
+constexpr auto inv_sqrt_two = 1.0_r / constants::sqrt_two;
 
 //---------------------------------------------------------------------------//
 // TEST HARNESS
@@ -40,8 +40,9 @@ class PlaneTest : public Test
 TEST_F(PlaneTest, construction)
 {
     // Make a rotated plane in the xy axis
-    Plane p{{1 / sqrt_two, 1 / sqrt_two, 0.0}, {2 / sqrt_two, 2 / sqrt_two, 2}};
-    EXPECT_VEC_SOFT_EQ((Real3{1 / sqrt_two, 1 / sqrt_two, 0}), p.normal());
+    Plane p{{inv_sqrt_two, inv_sqrt_two, 0.0},
+            {2 * inv_sqrt_two, 2 * inv_sqrt_two, 2}};
+    EXPECT_VEC_SOFT_EQ((Real3{inv_sqrt_two, inv_sqrt_two, 0}), p.normal());
     EXPECT_SOFT_EQ(2, p.displacement());
 
     Plane px{PlaneX{1.25}};
@@ -55,7 +56,7 @@ TEST_F(PlaneTest, construction)
 TEST_F(PlaneTest, tracking)
 {
     // Make a rotated plane in the xy axis
-    Plane p{{1 / sqrt_two, 1 / sqrt_two, 0.0}, 2 * sqrt_two};
+    Plane p{{inv_sqrt_two, inv_sqrt_two, 0.0}, 2.0_r * constants::sqrt_two};
 
     // Get a point that should have positive sense
     Real3 x{{5.41421356, 1.41421356, 0.0}};

--- a/test/orange/surf/Sphere.test.cc
+++ b/test/orange/surf/Sphere.test.cc
@@ -18,7 +18,7 @@ namespace celeritas
 namespace test
 {
 //---------------------------------------------------------------------------//
-constexpr auto sqrt_third = real_type{1} / constants::sqrt_three;
+constexpr auto sqrt_third = 1_r / constants::sqrt_three;
 
 class SphereTest : public Test
 {

--- a/test/orange/surf/SphereCentered.test.cc
+++ b/test/orange/surf/SphereCentered.test.cc
@@ -21,7 +21,7 @@ class SphereCenteredTest : public Test
   protected:
     using Intersections = SphereCentered::Intersections;
 
-    static constexpr auto sqrt_third = real_type{1} / constants::sqrt_three;
+    static constexpr auto sqrt_third = 1_r / constants::sqrt_three;
     static constexpr Real3 inward{-sqrt_third, -sqrt_third, -sqrt_third};
     static constexpr Real3 outward{sqrt_third, sqrt_third, sqrt_third};
 };

--- a/test/orange/transform/Transformation.test.cc
+++ b/test/orange/transform/Transformation.test.cc
@@ -108,9 +108,8 @@ TEST_F(TransformationTest, transform)
 
         auto const daughter = Real3{-3.4, 2.1, 0.4};
         auto const parent = tr.transform_up(daughter);
-        EXPECT_VEC_NEAR((Real3{0.81191836, -4.5042777, 3.31300032}),
-                        parent,
-                        real_type(1e-6));
+        EXPECT_VEC_NEAR(
+            (Real3{0.81191836, -4.5042777, 3.31300032}), parent, 1e-6_r);
         EXPECT_VEC_SOFT_EQ(daughter, tr.transform_down(parent));
     }
 }

--- a/test/orange/univ/SimpleUnitTracker.test.cc
+++ b/test/orange/univ/SimpleUnitTracker.test.cc
@@ -34,7 +34,7 @@ namespace test
 {
 constexpr real_type sqrt_three{constants::sqrt_three};
 constexpr real_type sqrt_two{constants::sqrt_two};
-constexpr real_type sqrt_half = sqrt_two / real_type{2};
+constexpr real_type sqrt_half = sqrt_two / 2_r;
 
 //---------------------------------------------------------------------------//
 // TEST FIXTURES
@@ -623,7 +623,7 @@ TEST_F(TwoVolumeTest, normal)
         for (auto i : range(3))
         {
             expected_normal[i] = pos[i] * invnorm;
-            pos[i] = expected_normal[i] * real_type(1.5);  // radius
+            pos[i] = expected_normal[i] * 1.5_r;  // radius
         }
 
         auto actual_normal = tracker.normal(pos, LocalSurfaceId{0});
@@ -691,7 +691,7 @@ TEST_F(FieldLayersTest, cross_boundary)
         {
             // From background to volume
             auto init = tracker.cross_boundary(
-                this->make_state_crossing({0, real_type{-1.5} + eps, 0},
+                this->make_state_crossing({0, -1.5_r + eps, 0},
                                           {0, -1, 0},
                                           "world.bg",
                                           "layerbox1.py",
@@ -702,12 +702,8 @@ TEST_F(FieldLayersTest, cross_boundary)
         }
         {
             // From volume to background
-            auto init = tracker.cross_boundary(
-                this->make_state_crossing({0, real_type{-2.5} - eps, 0},
-                                          {0, -1, 0},
-                                          "layer1",
-                                          "layerbox1.my",
-                                          '+'));
+            auto init = tracker.cross_boundary(this->make_state_crossing(
+                {0, -2.5_r - eps, 0}, {0, -1, 0}, "layer1", "layerbox1.my", '+'));
             EXPECT_EQ("world.bg", this->id_to_label(init.volume));
             EXPECT_EQ("layerbox1.my", this->id_to_label(init.surface.id()));
             EXPECT_EQ(Sense::inside, init.surface.unchecked_sense());

--- a/test/orange/univ/detail/SurfaceFunctors.test.cc
+++ b/test/orange/univ/detail/SurfaceFunctors.test.cc
@@ -76,27 +76,27 @@ TEST_F(SurfaceFunctorsTest, calc_safety_distance)
     CalcSafetyDistance calc_distance{pos};
 
     real_type eps = 1e-4;
-    pos = {real_type{1.25} + eps, 1, 0};
+    pos = {1.25_r + eps, 1, 0};
     EXPECT_SOFT_EQ(eps, calc_distance(px_));
     EXPECT_SOFT_EQ(0.25 + eps, calc_distance(s_));
 
-    pos = {real_type{1.25}, 1, 0};
+    pos = {1.25_r, 1, 0};
     EXPECT_SOFT_EQ(0, calc_distance(px_));
     EXPECT_SOFT_EQ(0.25, calc_distance(s_));
 
-    pos = {real_type{1.25} - eps, 1, 0};
+    pos = {1.25_r - eps, 1, 0};
     EXPECT_SOFT_EQ(eps, calc_distance(px_));
     EXPECT_SOFT_EQ(0.25 - eps, calc_distance(s_));
 
-    pos = {real_type{1} - eps, 1, 0};
+    pos = {1_r - eps, 1, 0};
     EXPECT_SOFT_EQ(0.25 + eps, calc_distance(px_));
     EXPECT_SOFT_EQ(eps, calc_distance(s_));
 
-    pos = {real_type{3.5} + eps, 1, 0};
+    pos = {3.5_r + eps, 1, 0};
     EXPECT_SOFT_EQ(2.25 + eps, calc_distance(px_));
     EXPECT_SOFT_NEAR(0.0 + eps, calc_distance(s_), coarse_eps);
 
-    pos = {real_type{3.5}, 1, 0};
+    pos = {3.5_r, 1, 0};
     EXPECT_SOFT_EQ(2.25, calc_distance(px_));
     EXPECT_SOFT_EQ(0.0, calc_distance(s_));
 }


### PR DESCRIPTION
Goes over the codebase and replace explicit `real_type{<literal>}` with `<literal>_r`, avoiding replacement when:

- in public headers
- shadowed `real_type` is present