### PR TITLE
Make NVTX range names consistent across kernels and apps

### DIFF
--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -193,14 +193,14 @@ void run(std::string_view filename, std::shared_ptr<SharedParams> params)
     {
         ScopedMem record_mem("run.initialize");
         ScopedTimeLog scoped_time;
-        ScopedProfiling profile_this{"celer-g4-setup"};
+        ScopedProfiling profile_this{"initialize"};
         CELER_LOG(status) << "Initializing run manager";
         run_manager->Initialize();
     }
     {
         ScopedMem record_mem("run.beamon");
         ScopedTimeLog scoped_time;
-        ScopedProfiling profile_this{"celer-g4-run"};
+        ScopedProfiling profile_this{"run"};
         CELER_LOG(status) << "Transporting " << num_events << " events";
         run_manager->BeamOn(num_events);
     }

--- a/app/celer-g4/celer-g4.cc
+++ b/app/celer-g4/celer-g4.cc
@@ -193,7 +193,7 @@ void run(std::string_view filename, std::shared_ptr<SharedParams> params)
     {
         ScopedMem record_mem("run.initialize");
         ScopedTimeLog scoped_time;
-        ScopedProfiling profile_this{"initialize"};
+        ScopedProfiling profile_this{"setup"};
         CELER_LOG(status) << "Initializing run manager";
         run_manager->Initialize();
     }

--- a/app/celer-optical/celer-optical.cc
+++ b/app/celer-optical/celer-optical.cc
@@ -29,7 +29,6 @@
 #include "corecel/sys/DeviceIO.json.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedMpiInit.hh"
-#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "corecel/sys/TracingSession.hh"
 #include "celeritas/Types.hh"
@@ -78,8 +77,6 @@ void run(std::shared_ptr<OutputRegistry>& output,
 
     // Start profiling
     TracingSession tracing_session{input.problem.perfetto_file};
-    ScopedProfiling profile_this{"celer-optical"};
-
     SimulationResult result;
 
     // Set up optical problem

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -8,6 +8,7 @@
 #include <exception>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <utility>
 #include <vector>

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -6,12 +6,9 @@
 //---------------------------------------------------------------------------//
 #include <cstdlib>
 #include <exception>
-#include <fstream>
-#include <initializer_list>
 #include <iostream>
 #include <memory>
 #include <string_view>
-#include <type_traits>
 #include <utility>
 #include <vector>
 #include <CLI/CLI.hpp>
@@ -22,8 +19,6 @@
 #endif
 
 #include "corecel/Config.hh"
-#include "corecel/DeviceRuntimeApi.hh"
-#include "corecel/Version.hh"
 
 #include "corecel/Assert.hh"
 #include "corecel/io/BuildOutput.hh"
@@ -34,7 +29,7 @@
 #include "corecel/io/OutputInterfaceAdapter.hh"
 #include "corecel/io/OutputRegistry.hh"
 #include "corecel/sys/Device.hh"
-#include "corecel/sys/DeviceIO.json.hh"
+#include "corecel/sys/DeviceIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/MultiExceptionHandler.hh"
 #include "corecel/sys/ScopedMem.hh"
 #include "corecel/sys/ScopedMpiInit.hh"
@@ -89,7 +84,7 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
 
     // Start profiling
     TracingSession tracing_session{run_input->tracing_file};
-    ScopedProfiling profile_this{"celer-sim"};
+    std::optional<ScopedProfiling> profile_this{std::in_place, "setup"};
 
     // Create runner and save setup time
     Stopwatch get_setup_time;
@@ -117,6 +112,7 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
     }
 
     // Start profiling *after* initialization and warmup are complete
+    profile_this.emplace("run");
     Stopwatch get_transport_time;
     if (run_input->merge_events)
     {
@@ -154,6 +150,7 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
         }
         log_and_rethrow(std::move(capture_exception));
     }
+    profile_this.reset();
 
     result.action_times = run_stream.get_action_times();
     result.total_time = get_transport_time();

--- a/doc/usage/execution/profiling.rst
+++ b/doc/usage/execution/profiling.rst
@@ -62,7 +62,7 @@ generate a timeline:
 
 Line 2 specifies the APIs to be captured: in this case, CUDA calls, NVTX
 ranges, and OS runtime libraries.
-To use the NVTX ranges, you must enable the ``CELER_ENABLE_PROFILING`` variable
+To use the NVTX ranges, you **must** enable the ``CELER_ENABLE_PROFILING`` variable
 in addition to using the NVTX "trace" option (lines 1 and 2).
 The capture domain in line 3 restricts profiling to the Celeritas application.
 (You can use, e.g., ``--nvtx-capture run@celeritas`` to capture only the main stepping execution inside Celeritas.)
@@ -146,7 +146,7 @@ gathered with the `NVIDIA Compute systems`_ profiler.
 
 .. _NVIDIA Compute systems: https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html
 
-This example gathers kernel statistics for 10 "propagate" kernels (for both
+This example gathers kernel statistics for 10 sets of "propagate" kernels (for both
 charged and uncharged particles) starting with the 300th launch.
 
 .. sourcecode::
@@ -154,7 +154,7 @@ charged and uncharged particles) starting with the 300th launch.
 
    $ CELER_ENABLE_PROFILING=1 \
    > ncu \
-   > --nvtx --nvtx-include "celeritas@celer-sim/step/*/propagate" \
+   > --nvtx --nvtx-include "celeritas@run/step/*/propagate" \
    > --launch-skip 300 --launch-count 10 \
    > -f -o propagate
    > celer-sim inp.json

--- a/doc/usage/execution/profiling.rst
+++ b/doc/usage/execution/profiling.rst
@@ -65,8 +65,7 @@ ranges, and OS runtime libraries.
 To use the NVTX ranges, you must enable the ``CELER_ENABLE_PROFILING`` variable
 in addition to using the NVTX "trace" option (lines 1 and 2).
 The capture domain in line 3 restricts profiling to the Celeritas application.
-(You can use, e.g., ``--nvtx-capture celer-sim@celeritas`` to capture a smaller
-range.)
+(You can use, e.g., ``--nvtx-capture run@celeritas`` to capture only the main stepping execution inside Celeritas.)
 Additional frame-pointer-based backtracing is specified in line 5; line 6
 writes (and overwrites) to a particular output file; the final line invokes the
 application.

--- a/src/celeritas/alongstep/AlongStepUniformMscAction.cu
+++ b/src/celeritas/alongstep/AlongStepUniformMscAction.cu
@@ -43,7 +43,8 @@ void AlongStepUniformMscAction::step(CoreParams const& params,
     }
     auto field = field_->ref<MemSpace::native>();
     {
-        ScopedProfiling profile_this{"propagate-uniform"};
+        ScopedProfiling profile_this{"propagate"};
+
         auto execute_thread = ConditionalTrackExecutor{
             params.ptr<MemSpace::native>(),
             state.ptr(),
@@ -51,22 +52,23 @@ void AlongStepUniformMscAction::step(CoreParams const& params,
             detail::PropagationApplier{
                 detail::FieldTrackPropagator<UniformField>{field}}};
         static ActionLauncher<decltype(execute_thread)> const launch_kernel(
-            *this, "propagate");
+            *this, "propagate-uniform");
         launch_kernel(*this, params, state, execute_thread);
+
+        if (!field_->in_all_volumes())
+        {
+            // Propagate tracks in volumes *without* field
+            auto execute_thread = ConditionalTrackExecutor{
+                params.ptr<MemSpace::native>(),
+                state.ptr(),
+                detail::IsAlongStepLinear{this->action_id(), field},
+                detail::PropagationApplier{detail::LinearTrackPropagator{}}};
+            static ActionLauncher<decltype(execute_thread)> const launch_kernel(
+                *this, "propagate-linear");
+            launch_kernel(*this, params, state, execute_thread);
+        }
     }
-    if (!field_->in_all_volumes())
-    {
-        // Launch linear propagation kernel for tracks in volumes without field
-        ScopedProfiling profile_this{"propagate-linear"};
-        auto execute_thread = ConditionalTrackExecutor{
-            params.ptr<MemSpace::native>(),
-            state.ptr(),
-            detail::IsAlongStepLinear{this->action_id(), field},
-            detail::PropagationApplier{detail::LinearTrackPropagator{}}};
-        static ActionLauncher<decltype(execute_thread)> const launch_kernel(
-            *this, "propagate-linear");
-        launch_kernel(*this, params, state, execute_thread);
-    }
+
     if (this->has_msc())
     {
         detail::launch_apply_msc(

--- a/src/celeritas/optical/CoreState.cc
+++ b/src/celeritas/optical/CoreState.cc
@@ -41,7 +41,7 @@ CoreState<M>::CoreState(CoreParams const& params,
                    << params.max_streams());
     CELER_VALIDATE(num_track_slots > 0, << "number of track slots is not set");
 
-    ScopedProfiling profile_this{"construct-optical-state"};
+    ScopedProfiling profile_this{"construct-state"};
 
     states_ = StateDataStore<CoreStateData, M>(
         params.host_ref(), stream_id, num_track_slots);

--- a/src/celeritas/optical/Runner.cc
+++ b/src/celeritas/optical/Runner.cc
@@ -10,6 +10,7 @@
 
 #include "corecel/io/OutputInterfaceAdapter.hh"
 #include "corecel/io/OutputRegistry.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/inp/StandaloneInputIO.json.hh"
 #include "celeritas/phys/GeneratorRegistry.hh"
 #include "celeritas/setup/Problem.hh"
@@ -30,6 +31,8 @@ Runner::Runner(Input&& osi)
 {
     CELER_VALIDATE(osi.problem.num_streams == 1,
                    << "standalone optical runner expects a single stream");
+
+    ScopedProfiling profile_this{"setup"};
     StreamId stream_id{0};
     auto num_tracks = osi.problem.capacity.tracks;
 
@@ -139,6 +142,7 @@ auto Runner::operator()(SpanConstGenDist data) -> Result
  */
 auto Runner::run() const -> Result
 {
+    ScopedProfiling profile_this{"run"};
     (*loaded_.problem.transporter)(*state_);
 
     Result result;

--- a/src/celeritas/optical/Transporter.cc
+++ b/src/celeritas/optical/Transporter.cc
@@ -77,7 +77,7 @@ void Transporter::transport_impl(CoreState<M>& state) const
     // Loop while photons are yet to be tracked
     while (counters.num_pending > 0 || counters.num_alive > 0)
     {
-        ScopedProfiling profile_this{"optical-step"};
+        ScopedProfiling profile_this{"step"};
         // Loop through actions
         for (auto const& action : actions_->step())
         {

--- a/src/celeritas/optical/gen/detail/GeneratorAlgorithms.cu
+++ b/src/celeritas/optical/gen/detail/GeneratorAlgorithms.cu
@@ -45,7 +45,7 @@ inclusive_scan_photons(ItemsRef<T, MemSpace::device> const& buffer,
     CELER_EXPECT(size > 0 && size <= buffer.size());
     CELER_EXPECT(offsets.size() == buffer.size());
 
-    ScopedProfiling profile_this{"inclusive-scan-photons"};
+    ScopedProfiling profile_this{"prefix-sum-counts"};
     auto data = thrust::device_pointer_cast(buffer.data().get());
     auto result = thrust::device_pointer_cast(offsets.data().get());
     auto stop = thrust::transform_inclusive_scan(thrust_execute_on(stream),

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -498,7 +498,7 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
     CELER_LOG(status) << "Initializing problem";
 
     ScopedMem record_mem("setup::problem");
-    ScopedProfiling profile_this{"setup::problem"};
+    ScopedProfiling profile_this{"problem"};
 
     CoreParams::Input params;
 
@@ -815,7 +815,7 @@ problem(inp::OpticalProblem const& p, ImportData const& imported)
     CELER_LOG(status) << "Initializing problem";
 
     ScopedMem record_mem("setup::problem");
-    ScopedProfiling profile_this{"setup::problem"};
+    ScopedProfiling profile_this{"problem"};
 
     CELER_VALIDATE(!imported.optical_materials.empty(),
                    << "an optical tracking loop was requested but no optical "

--- a/src/celeritas/track/detail/TrackInitAlgorithms.cu
+++ b/src/celeritas/track/detail/TrackInitAlgorithms.cu
@@ -144,7 +144,7 @@ size_type exclusive_scan_counts(
         counts,
     StreamId stream_id)
 {
-    ScopedProfiling profile_this{"exclusive-scan-counts"};
+    ScopedProfiling profile_this{"prefix-sum-counts"};
     auto& stream = device().stream(stream_id);
 #if CELER_USE_THRUST
     // Exclusive scan:


### PR DESCRIPTION
This splits the top-level `celer-sim`/`-optical` range for each app into separate *setup* and *run* ranges. It also fixes an inconsistency in the `propagate` range name for the uniform-along-step case.

cc @elliottbiondo @amandalund @LSchwiebert 