### PR TITLE
Step death record restore handover

### DIFF
--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -272,15 +272,15 @@ void LocalTransporter::Push(G4Track& g4track)
 
     Primary track;
 
+    track.energy = gtv.energy();
+    track.particle_id = particles_->find(gtv.particle().pdg());
+
     // Generate Celeritas-specific PrimaryID and capture user info
     if (hit_processor_)
     {
-        track.primary_id
-            = hit_processor_->track_reconstruction().acquire(g4track);
+        track.primary_id = hit_processor_->track_reconstruction().acquire(
+            g4track, track.particle_id);
     }
-
-    track.energy = gtv.energy();
-    track.particle_id = particles_->find(gtv.particle().pdg());
     track.position = static_array_cast<real_type>(native_value_from(gtv.pos()));
     track.direction = static_array_cast<real_type>(gtv.dir());
     track.time = static_cast<real_type>(native_value_from(gtv.time()));

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -237,10 +237,6 @@ void LocalTransporter::InitializeEvent(int id)
             step_->reseed(event_id_);
         }
     }
-    if (hit_processor_)
-    {
-        hit_processor_->track_reconstruction().init_event();
-    }
 }
 
 //---------------------------------------------------------------------------//
@@ -285,8 +281,6 @@ void LocalTransporter::Push(G4Track& g4track)
     track.direction = static_array_cast<real_type>(gtv.dir());
     track.time = static_cast<real_type>(native_value_from(gtv.time()));
     track.weight = gtv.weight();
-    track.primary_id = celeritas::id_cast<PrimaryId>(
-        track.primary_id.unchecked_get() + g4track.GetTrackID());
 
     CELER_VALIDATE(track.particle_id,
                    << "cannot offload '" << gtv.particle().name()

--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -144,6 +144,7 @@ auto GeantSd::filters() const -> Filters
     }
 
     result.nonzero_energy_deposition = nonzero_energy_deposition_;
+    result.track_death = true;
 
     return result;
 }

--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -75,6 +75,7 @@ GeantSd::GeantSd(ParticleParams const& par,
 
     // Convert setup options to step data
     selection_.particle = setup.track;
+    selection_.primary_id = setup.track;
     selection_.weight = setup.track;
     selection_.energy_deposition = setup.energy_deposition;
     selection_.step_length = setup.step_length;

--- a/src/celeritas/ext/GeantTrackReconstruction.cc
+++ b/src/celeritas/ext/GeantTrackReconstruction.cc
@@ -60,7 +60,7 @@ void GeantTrackReconstruction::AcquiredData::restore(G4Track& track) const
  */
 GeantTrackReconstruction::GeantTrackReconstruction(VecParticle const& particles,
                                                    SPStep step)
-    : step_(std::move(step)), start_(0)
+    : step_(std::move(step))
 {
     CELER_EXPECT(step_);
 
@@ -105,8 +105,6 @@ GeantTrackReconstruction::~GeantTrackReconstruction()
  */
 void GeantTrackReconstruction::clear()
 {
-    // Set starting primary id
-    start_ = celeritas::id_cast<PrimaryId>(g4_track_data_.size());
     for (auto& track : tracks_)
     {
         // Clear the user information to prevent double deletion:
@@ -118,22 +116,13 @@ void GeantTrackReconstruction::clear()
 
 //---------------------------------------------------------------------------//
 /*!
- * At the start of an event, reset the primary ID counter.
- */
-void GeantTrackReconstruction::init_event()
-{
-    start_ = PrimaryId(0);
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Register mapping from Celeritas PrimaryID to Geant4 TrackID. This will take
  * ownership of the G4VUserTrackInformation and unset it in the primary track.
  */
 PrimaryId
 GeantTrackReconstruction::acquire(G4Track& primary, ParticleId particle_id)
 {
-    auto primary_id = start_ + g4_track_data_.size();
+    auto primary_id = celeritas::id_cast<PrimaryId>(g4_track_data_.size());
     g4_track_data_.emplace_back(AcquiredData{primary, particle_id});
     return primary_id;
 }
@@ -155,13 +144,9 @@ G4Track& GeantTrackReconstruction::view(ParticleId particle_id,
 
     if (primary_id)
     {
-        // primary_id is an absolute event-scoped ID; subtract the flush-local
-        // start offset to get the index into g4_track_data_ for this flush.
-        CELER_ASSERT(primary_id.unchecked_get() >= start_.unchecked_get());
-        size_type local_idx = primary_id.unchecked_get()
-                              - start_.unchecked_get();
-        CELER_ASSERT(local_idx < g4_track_data_.size());
-        g4_track_data_[local_idx].restore(track);
+        // primary_id is flush-local: direct index into g4_track_data_
+        CELER_ASSERT(primary_id.unchecked_get() < g4_track_data_.size());
+        g4_track_data_[primary_id.unchecked_get()].restore(track);
     }
     return track;
 }

--- a/src/celeritas/ext/GeantTrackReconstruction.cc
+++ b/src/celeritas/ext/GeantTrackReconstruction.cc
@@ -8,6 +8,7 @@
 
 #include <G4DynamicParticle.hh>
 #include <G4ParticleDefinition.hh>
+#include <G4PrimaryParticle.hh>
 #include <G4Step.hh>
 #include <G4ThreeVector.hh>
 #include <G4Track.hh>
@@ -31,10 +32,21 @@ GeantTrackReconstruction::AcquiredData::AcquiredData(G4Track& track,
     : track_id_{track.GetTrackID()}
     , parent_id_{track.GetParentID()}
     , particle_id_{particle_id}
+    , kinetic_energy_{track.GetKineticEnergy()}
+    , time_{track.GetGlobalTime()}
+    , primary_particle_{track.GetDynamicParticle()->GetPrimaryParticle()}
     , user_info_{track.GetUserInformation()}
     , creator_process_{track.GetCreatorProcess()}
 {
     CELER_EXPECT(*this);
+    auto const& pos = track.GetPosition();
+    pos_[0] = pos.x();
+    pos_[1] = pos.y();
+    pos_[2] = pos.z();
+    auto const& dir = track.GetMomentumDirection();
+    dir_[0] = dir.x();
+    dir_[1] = dir.y();
+    dir_[2] = dir.z();
     // Clear user information so that it doesn't get deleted with the G4Track
     track.SetUserInformation(nullptr);
 }
@@ -52,6 +64,42 @@ void GeantTrackReconstruction::AcquiredData::restore(G4Track& track) const
     track.SetParentID(parent_id_);
     track.SetUserInformation(user_info_.get());
     track.SetCreatorProcess(creator_process_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Restore the initial kinematic state for PreUserTrackingAction dispatch.
+ *
+ * Sets position, momentum direction, kinetic energy, global time, and the
+ * G4PrimaryParticle pointer on the dynamic particle so that MC-truth
+ * frameworks that check GetPrimaryParticle() in PreUserTrackingAction
+ * correctly identify the track as a generator-level primary.
+ */
+void GeantTrackReconstruction::AcquiredData::restore_initial(G4Track& track) const
+{
+    CELER_EXPECT(*this);
+    restore(track);
+    track.SetPosition(G4ThreeVector(pos_[0], pos_[1], pos_[2]));
+    track.SetMomentumDirection(G4ThreeVector(dir_[0], dir_[1], dir_[2]));
+    track.SetGlobalTime(time_);
+    auto* dp = const_cast<G4DynamicParticle*>(track.GetDynamicParticle());
+    dp->SetKineticEnergy(kinetic_energy_);
+    dp->SetPrimaryParticle(const_cast<G4PrimaryParticle*>(primary_particle_));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Return true if the given primary was created by the event generator.
+ *
+ * Generator-level primaries have parent ID 0. Geant4-tracked secondaries that
+ * were re-offloaded to Celeritas via HandOverOneTrack have a non-zero parent
+ * ID, so Pre/PostUserTrackingAction should not be fired for them here.
+ */
+bool GeantTrackReconstruction::is_generator_primary(PrimaryId primary_id) const
+{
+    CELER_EXPECT(primary_id);
+    CELER_ASSERT(primary_id.unchecked_get() < g4_track_data_.size());
+    return g4_track_data_[primary_id.unchecked_get()].is_generator_primary();
 }
 
 //---------------------------------------------------------------------------//
@@ -148,6 +196,29 @@ G4Track& GeantTrackReconstruction::view(ParticleId particle_id,
         CELER_ASSERT(primary_id.unchecked_get() < g4_track_data_.size());
         g4_track_data_[primary_id.unchecked_get()].restore(track);
     }
+    return track;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Restore the track with its initial (handover) state.
+ *
+ * Used to prepare the track for PreUserTrackingAction in Flush(), where the
+ * track must look exactly as it did when first handed over to Celeritas.
+ */
+G4Track& GeantTrackReconstruction::view_initial(ParticleId particle_id,
+                                                PrimaryId primary_id) const
+{
+    CELER_EXPECT(particle_id < tracks_.size());
+    CELER_EXPECT(primary_id);
+
+    G4Track& track = *tracks_[particle_id.unchecked_get()];
+    step_->SetTrack(&track);
+
+    // primary_id is flush-local: direct index into g4_track_data_
+    CELER_ASSERT(primary_id.unchecked_get() < g4_track_data_.size());
+    g4_track_data_[primary_id.unchecked_get()].restore_initial(track);
+
     return track;
 }
 

--- a/src/celeritas/ext/GeantTrackReconstruction.cc
+++ b/src/celeritas/ext/GeantTrackReconstruction.cc
@@ -22,12 +22,15 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Restore the G4Track from the reconstruction data. Takes ownership of the
- * user information by unsetting it in the original track.
+ * Save G4Track reconstruction data along with the Celeritas particle type.
+ * Takes ownership of the user information by unsetting it in the original
+ * track.
  */
-GeantTrackReconstruction::AcquiredData::AcquiredData(G4Track& track)
+GeantTrackReconstruction::AcquiredData::AcquiredData(G4Track& track,
+                                                     ParticleId particle_id)
     : track_id_{track.GetTrackID()}
     , parent_id_{track.GetParentID()}
+    , particle_id_{particle_id}
     , user_info_{track.GetUserInformation()}
     , creator_process_{track.GetCreatorProcess()}
 {
@@ -127,10 +130,11 @@ void GeantTrackReconstruction::init_event()
  * Register mapping from Celeritas PrimaryID to Geant4 TrackID. This will take
  * ownership of the G4VUserTrackInformation and unset it in the primary track.
  */
-PrimaryId GeantTrackReconstruction::acquire(G4Track& primary)
+PrimaryId
+GeantTrackReconstruction::acquire(G4Track& primary, ParticleId particle_id)
 {
     auto primary_id = start_ + g4_track_data_.size();
-    g4_track_data_.emplace_back(AcquiredData{primary});
+    g4_track_data_.emplace_back(AcquiredData{primary, particle_id});
     return primary_id;
 }
 
@@ -151,8 +155,13 @@ G4Track& GeantTrackReconstruction::view(ParticleId particle_id,
 
     if (primary_id)
     {
-        CELER_ASSERT(primary_id < g4_track_data_.size());
-        g4_track_data_[primary_id.unchecked_get()].restore(track);
+        // primary_id is an absolute event-scoped ID; subtract the flush-local
+        // start offset to get the index into g4_track_data_ for this flush.
+        CELER_ASSERT(primary_id.unchecked_get() >= start_.unchecked_get());
+        size_type local_idx = primary_id.unchecked_get()
+                              - start_.unchecked_get();
+        CELER_ASSERT(local_idx < g4_track_data_.size());
+        g4_track_data_[local_idx].restore(track);
     }
     return track;
 }

--- a/src/celeritas/ext/GeantTrackReconstruction.hh
+++ b/src/celeritas/ext/GeantTrackReconstruction.hh
@@ -55,9 +55,6 @@ class GeantTrackReconstruction
     template<class F>
     void for_each_primary(F&& func) const;
 
-    // Reset primary ID at each event start
-    void init_event();
-
     // Restore track information for given primary and particle IDs
     [[nodiscard]] G4Track& view(ParticleId, PrimaryId) const;
 
@@ -94,8 +91,6 @@ class GeantTrackReconstruction
     std::vector<std::unique_ptr<G4Track>> tracks_;
     //! Shared step object
     SPStep step_;
-    //! Starting primary id
-    PrimaryId start_;
 };
 
 //---------------------------------------------------------------------------//
@@ -114,8 +109,7 @@ void GeantTrackReconstruction::for_each_primary(F&& func) const
     for (size_type i = 0; i < g4_track_data_.size(); ++i)
     {
         auto const& data = g4_track_data_[i];
-        PrimaryId pid
-            = celeritas::id_cast<PrimaryId>(start_.unchecked_get() + i);
+        auto pid = celeritas::id_cast<PrimaryId>(i);
         G4Track& track = this->view(data.particle_id(), pid);
         func(track);
     }

--- a/src/celeritas/ext/GeantTrackReconstruction.hh
+++ b/src/celeritas/ext/GeantTrackReconstruction.hh
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "corecel/Macros.hh"
+#include "corecel/Types.hh"
 #include "celeritas/Types.hh"
 
 class G4ParticleDefinition;
@@ -48,7 +49,11 @@ class GeantTrackReconstruction
     void clear();
 
     // Register mapping from Celeritas PrimaryID to Geant4 track ID
-    [[nodiscard]] PrimaryId acquire(G4Track&);
+    [[nodiscard]] PrimaryId acquire(G4Track&, ParticleId);
+
+    // Iterate over all acquired primaries, calling func(G4Track&) for each
+    template<class F>
+    void for_each_primary(F&& func) const;
 
     // Reset primary ID at each event start
     void init_event();
@@ -61,18 +66,22 @@ class GeantTrackReconstruction
     class AcquiredData
     {
       public:
-        //! Save the G4Track reconstruction data
-        explicit AcquiredData(G4Track&);
+        //! Save the G4Track reconstruction data along with ParticleId
+        AcquiredData(G4Track&, ParticleId);
         //! Whether the data is valid
         explicit operator bool() const { return track_id_ >= 0; }
         //! Restore the G4Track from the reconstruction data
         void restore(G4Track&) const;
+        //! Celeritas particle type for this primary
+        ParticleId particle_id() const { return particle_id_; }
 
       private:
         //! Original Geant4 track ID
         int track_id_{-1};
         //! Original Geant4 parent ID
         int parent_id_{0};
+        //! Celeritas particle type
+        ParticleId particle_id_{};
         //! User track information
         std::unique_ptr<G4VUserTrackInformation> user_info_;
         //! Process that created the track
@@ -88,6 +97,29 @@ class GeantTrackReconstruction
     //! Starting primary id
     PrimaryId start_;
 };
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Iterate over all acquired primaries, calling func(G4Track&) for each.
+ *
+ * The track is restored (track ID, parent ID, user info, creator process)
+ * before the callback is invoked. This is used in Flush() to fire
+ * PostUserTrackingAction for all offloaded primaries.
+ */
+template<class F>
+void GeantTrackReconstruction::for_each_primary(F&& func) const
+{
+    for (size_type i = 0; i < g4_track_data_.size(); ++i)
+    {
+        auto const& data = g4_track_data_[i];
+        PrimaryId pid
+            = celeritas::id_cast<PrimaryId>(start_.unchecked_get() + i);
+        G4Track& track = this->view(data.particle_id(), pid);
+        func(track);
+    }
+}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/ext/GeantTrackReconstruction.hh
+++ b/src/celeritas/ext/GeantTrackReconstruction.hh
@@ -14,6 +14,7 @@
 #include "celeritas/Types.hh"
 
 class G4ParticleDefinition;
+class G4PrimaryParticle;
 class G4Step;
 class G4Track;
 class G4VProcess;
@@ -55,8 +56,15 @@ class GeantTrackReconstruction
     template<class F>
     void for_each_primary(F&& func) const;
 
-    // Restore track information for given primary and particle IDs
+    // Restore track with terminal state for given primary and particle IDs
     [[nodiscard]] G4Track& view(ParticleId, PrimaryId) const;
+
+    // Restore track with initial (handover) state for given primary and
+    // particle IDs (for PreUserTrackingAction dispatch)
+    [[nodiscard]] G4Track& view_initial(ParticleId, PrimaryId) const;
+
+    // True if the given primary was created by the event generator
+    bool is_generator_primary(PrimaryId) const;
 
   private:
     //! Data needed to reconstruct a G4Track from Celeritas transport
@@ -69,8 +77,21 @@ class GeantTrackReconstruction
         explicit operator bool() const { return track_id_ >= 0; }
         //! Restore the G4Track from the reconstruction data
         void restore(G4Track&) const;
+        //! Restore initial kinematic state (for PreUserTrackingAction)
+        void restore_initial(G4Track&) const;
         //! Celeritas particle type for this primary
         ParticleId particle_id() const { return particle_id_; }
+        //! Original Geant4 track ID
+        int track_id() const { return track_id_; }
+        //! Original Geant4 parent ID
+        int parent_id() const { return parent_id_; }
+        //! Generator-level G4PrimaryParticle pointer (null for secondaries)
+        G4PrimaryParticle const* primary_particle() const
+        {
+            return primary_particle_;
+        }
+        //! True if this track was created by the event generator (parent ID 0)
+        bool is_generator_primary() const { return parent_id_ == 0; }
 
       private:
         //! Original Geant4 track ID
@@ -79,6 +100,17 @@ class GeantTrackReconstruction
         int parent_id_{0};
         //! Celeritas particle type
         ParticleId particle_id_{};
+        //! Initial kinetic energy [MeV]
+        double kinetic_energy_{0};
+        //! Initial global time [ns]
+        double time_{0};
+        //! Initial position [mm]
+        double pos_[3]{0, 0, 0};
+        //! Initial momentum direction (unit vector)
+        double dir_[3]{0, 0, 1};
+        //! Generator-level primary particle pointer (non-owning, valid until
+        //! end of event)
+        G4PrimaryParticle const* primary_particle_{nullptr};
         //! User track information
         std::unique_ptr<G4VUserTrackInformation> user_info_;
         //! Process that created the track
@@ -101,7 +133,7 @@ class GeantTrackReconstruction
  *
  * The track is restored (track ID, parent ID, user info, creator process)
  * before the callback is invoked. This is used in Flush() to fire
- * PostUserTrackingAction for all offloaded primaries.
+ * Pre/PostUserTrackingAction for all offloaded primaries.
  */
 template<class F>
 void GeantTrackReconstruction::for_each_primary(F&& func) const

--- a/src/celeritas/ext/detail/HitProcessor.cc
+++ b/src/celeritas/ext/detail/HitProcessor.cc
@@ -167,6 +167,9 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
 void HitProcessor::operator()(StepStateHostRef const& states)
 {
     copy_steps(&steps_, states);
+    copy_deaths(&steps_, states);
+    accumulated_deaths_.insert(
+        accumulated_deaths_.end(), steps_.deaths.begin(), steps_.deaths.end());
     if (steps_)
     {
         num_hits_ += steps_.size();
@@ -181,6 +184,9 @@ void HitProcessor::operator()(StepStateHostRef const& states)
 void HitProcessor::operator()(StepStateDeviceRef const& states)
 {
     copy_steps(&steps_, states);
+    copy_deaths(&steps_, states);
+    accumulated_deaths_.insert(
+        accumulated_deaths_.end(), steps_.deaths.begin(), steps_.deaths.end());
     if (steps_)
     {
         num_hits_ += steps_.size();

--- a/src/celeritas/ext/detail/HitProcessor.hh
+++ b/src/celeritas/ext/detail/HitProcessor.hh
@@ -106,6 +106,15 @@ class HitProcessor
     // Get and reset the hits counted (generally once per event)
     inline size_type exchange_hits();
 
+    //! Death records accumulated across all stepper iterations in this flush
+    std::vector<TrackDeathRecord> const& last_deaths() const
+    {
+        return accumulated_deaths_;
+    }
+
+    //! Clear accumulated death records (call after consuming last_deaths)
+    void clear_deaths() { accumulated_deaths_.clear(); }
+
     //! Access Geant4 track metadata reconstruction
     GeantTrackReconstruction& track_reconstruction()
     {
@@ -135,6 +144,8 @@ class HitProcessor
     //! Whether geometry-related step status can be updated
     bool step_post_status_{false};
 
+    //! Death records accumulated across stepper iterations within a flush
+    std::vector<TrackDeathRecord> accumulated_deaths_;
     //! Accumulated number of hits
     size_type num_hits_{0};
 };

--- a/src/celeritas/user/DetectorSteps.cc
+++ b/src/celeritas/user/DetectorSteps.cc
@@ -182,32 +182,19 @@ void copy_deaths<MemSpace::host>(
 
     ScopedProfiling profile_this{"copy-deaths"};
 
-    auto const& death_track_id = state.data.death_track_id;
-
-    // Count deaths this step
-    size_type num_deaths = 0;
-    for (TrackSlotId tid : range(TrackSlotId{death_track_id.size()}))
-    {
-        if (death_track_id[tid])
-            ++num_deaths;
-    }
-
-    // Compact death records
+    // Compact death records from sparse slots into contiguous output
     output->deaths.clear();
-    output->deaths.reserve(num_deaths);
-    for (TrackSlotId tid : range(TrackSlotId{death_track_id.size()}))
+    for (TrackSlotId tid : range(TrackSlotId{state.data.death_track_id.size()}))
     {
-        if (!death_track_id[tid])
+        if (!state.data.death_track_id[tid])
             continue;
-        TrackDeathRecord rec;
-        rec.track_id = state.data.death_track_id[tid];
-        rec.primary_id = state.data.death_primary_id[tid];
-        rec.particle = state.data.death_particle[tid];
-        rec.final_pos = state.data.death_pos[tid];
-        rec.final_dir = state.data.death_dir[tid];
-        rec.final_energy = state.data.death_energy[tid];
-        rec.final_time = state.data.death_time[tid];
-        output->deaths.push_back(rec);
+        output->deaths.push_back({state.data.death_track_id[tid],
+                                  state.data.death_primary_id[tid],
+                                  state.data.death_particle[tid],
+                                  state.data.death_pos[tid],
+                                  state.data.death_dir[tid],
+                                  state.data.death_energy[tid],
+                                  state.data.death_time[tid]});
     }
 }
 

--- a/src/celeritas/user/DetectorSteps.cc
+++ b/src/celeritas/user/DetectorSteps.cc
@@ -164,4 +164,52 @@ void copy_steps<MemSpace::host>(
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Consolidate results from tracks that died (killed) this step.
+ */
+template<>
+void copy_deaths<MemSpace::host>(
+    DetectorStepOutput* output,
+    StepStateData<Ownership::reference, MemSpace::host> const& state)
+{
+    CELER_EXPECT(output);
+
+    if (state.data.death_track_id.empty())
+    {
+        output->deaths.clear();
+        return;
+    }
+
+    ScopedProfiling profile_this{"copy-deaths"};
+
+    auto const& death_track_id = state.data.death_track_id;
+
+    // Count deaths this step
+    size_type num_deaths = 0;
+    for (TrackSlotId tid : range(TrackSlotId{death_track_id.size()}))
+    {
+        if (death_track_id[tid])
+            ++num_deaths;
+    }
+
+    // Compact death records
+    output->deaths.clear();
+    output->deaths.reserve(num_deaths);
+    for (TrackSlotId tid : range(TrackSlotId{death_track_id.size()}))
+    {
+        if (!death_track_id[tid])
+            continue;
+        TrackDeathRecord rec;
+        rec.track_id = state.data.death_track_id[tid];
+        rec.primary_id = state.data.death_primary_id[tid];
+        rec.particle = state.data.death_particle[tid];
+        rec.final_pos = state.data.death_pos[tid];
+        rec.final_dir = state.data.death_dir[tid];
+        rec.final_energy = state.data.death_energy[tid];
+        rec.final_time = state.data.death_time[tid];
+        output->deaths.push_back(rec);
+    }
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/user/DetectorSteps.cu
+++ b/src/celeritas/user/DetectorSteps.cu
@@ -40,20 +40,13 @@ using ItemRef
     = celeritas::Collection<T, Ownership::reference, MemSpace::native>;
 
 //---------------------------------------------------------------------------//
-struct HasDetector
+//! Predicate: true if the OpaqueId is valid (non-null).
+template<class T>
+struct IsValid
 {
-    CELER_FORCEINLINE_FUNCTION bool operator()(DetectorId const& d)
+    CELER_FORCEINLINE_FUNCTION bool operator()(T const& id)
     {
-        return static_cast<bool>(d);
-    }
-};
-
-//---------------------------------------------------------------------------//
-struct HasDeath
-{
-    CELER_FORCEINLINE_FUNCTION bool operator()(TrackId const& t)
-    {
-        return static_cast<bool>(t);
+        return static_cast<bool>(id);
     }
 };
 
@@ -68,7 +61,7 @@ size_type count_num_valid(
                                thrust::make_counting_iterator(state.size()),
                                device_pointer_cast(state.data.detector.data()),
                                start,
-                               HasDetector{});
+                               IsValid<DetectorId>{});
     return end - start;
 }
 
@@ -210,7 +203,7 @@ void copy_deaths<MemSpace::device>(
         thrust::make_counting_iterator(state.size()),
         device_pointer_cast(state.data.death_track_id.data()),
         start,
-        HasDeath{});
+        IsValid<TrackId>{});
     size_type const num_deaths = end - start;
 
     if (num_deaths == 0)

--- a/src/celeritas/user/DetectorSteps.cu
+++ b/src/celeritas/user/DetectorSteps.cu
@@ -49,6 +49,15 @@ struct HasDetector
 };
 
 //---------------------------------------------------------------------------//
+struct HasDeath
+{
+    CELER_FORCEINLINE_FUNCTION bool operator()(TrackId const& t)
+    {
+        return static_cast<bool>(t);
+    }
+};
+
+//---------------------------------------------------------------------------//
 size_type count_num_valid(
     StepStateData<Ownership::reference, MemSpace::device> const& state)
 {
@@ -172,6 +181,97 @@ void copy_steps<MemSpace::device>(
 
     CELER_ENSURE(output->detector.size() == num_valid);
     CELER_ENSURE(output->track_id.size() == num_valid);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Copy to host results from tracks that died (killed) this step.
+ */
+template<>
+void copy_deaths<MemSpace::device>(
+    DetectorStepOutput* output,
+    StepStateData<Ownership::reference, MemSpace::device> const& state)
+{
+    CELER_EXPECT(output);
+
+    if (state.data.death_track_id.empty())
+    {
+        output->deaths.clear();
+        return;
+    }
+
+    ScopedProfiling profile_this{"copy-deaths"};
+
+    // Compact dying-track slot indices into death_valid_id
+    auto start = device_pointer_cast(state.death_valid_id.data());
+    auto end = thrust::copy_if(
+        thrust_execute_on(state.stream_id),
+        thrust::make_counting_iterator(0_sz),
+        thrust::make_counting_iterator(state.size()),
+        device_pointer_cast(state.data.death_track_id.data()),
+        start,
+        HasDeath{});
+    size_type const num_deaths = end - start;
+
+    if (num_deaths == 0)
+    {
+        output->deaths.clear();
+        return;
+    }
+
+    // Gather death fields into scratch indexed by death_valid_id
+    {
+        auto execute_thread
+            = detail::DeathScratchCopyExecutor{state, num_deaths};
+        static KernelLauncher<decltype(execute_thread)> const launch_kernel(
+            "gather-death-scratch");
+        launch_kernel(num_deaths, state.stream_id, execute_thread);
+    }
+
+    // Copy compacted scratch to pinned host memory
+    output->deaths.resize(num_deaths);
+
+    auto copy_death_field = [&](auto* dst_begin, auto const& src_col) {
+        using T = std::remove_reference_t<decltype(*dst_begin)>;
+        Copier<T, MemSpace::host> copy{{dst_begin, num_deaths},
+                                       state.stream_id};
+        copy(MemSpace::device, {src_col.data().get(), num_deaths});
+    };
+
+    // Extract fields one at a time into a temporary, then fill records
+    // Use per-field device->host copies with the stream synchronization
+    // deferred until after all copies are enqueued.
+    {
+        std::vector<TrackId> h_track_id(num_deaths);
+        std::vector<PrimaryId> h_primary_id(num_deaths);
+        std::vector<ParticleId> h_particle(num_deaths);
+        std::vector<Real3> h_pos(num_deaths);
+        std::vector<Real3> h_dir(num_deaths);
+        std::vector<TrackDeathRecord::Energy> h_energy(num_deaths);
+        std::vector<real_type> h_time(num_deaths);
+
+        copy_death_field(h_track_id.data(), state.scratch.death_track_id);
+        copy_death_field(h_primary_id.data(), state.scratch.death_primary_id);
+        copy_death_field(h_particle.data(), state.scratch.death_particle);
+        copy_death_field(h_pos.data(), state.scratch.death_pos);
+        copy_death_field(h_dir.data(), state.scratch.death_dir);
+        copy_death_field(h_energy.data(), state.scratch.death_energy);
+        copy_death_field(h_time.data(), state.scratch.death_time);
+
+        CELER_DEVICE_API_CALL(StreamSynchronize(
+            celeritas::device().stream(state.stream_id).get()));
+
+        for (size_type i = 0; i < num_deaths; ++i)
+        {
+            output->deaths[i] = {h_track_id[i],
+                                 h_primary_id[i],
+                                 h_particle[i],
+                                 h_pos[i],
+                                 h_dir[i],
+                                 h_energy[i],
+                                 h_time[i]};
+        }
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/DetectorSteps.hh
+++ b/src/celeritas/user/DetectorSteps.hh
@@ -50,6 +50,31 @@ struct DetectorStepPointOutput
 
 //---------------------------------------------------------------------------//
 /*!
+ * CPU results for a single track that reached a terminal state (killed).
+ *
+ * Populated when \c StepParamsData::track_death is true. Used to fire
+ * \c PostUserTrackingAction with the correct GPU endpoint state.
+ */
+struct TrackDeathRecord
+{
+    //// TYPES ////
+
+    using Energy = units::MevEnergy;
+
+    //// DATA ////
+
+    TrackId track_id;
+    PrimaryId primary_id;  //!< Valid for offloaded primaries; invalid for
+                           //!< secondaries
+    ParticleId particle;
+    Real3 final_pos;
+    Real3 final_dir;
+    Energy final_energy;
+    real_type final_time;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * CPU results for many in-detector tracks at a single step iteration.
  *
  * This convenience class can be used to postprocess the results from sensitive
@@ -90,6 +115,9 @@ struct DetectorStepOutput
     // 2D size for volume instances
     size_type num_volume_levels{0};
 
+    // Track death records (populated when StepParamsData::track_death is true)
+    std::vector<TrackDeathRecord> deaths;
+
     //// METHODS ////
 
     //! Number of elements in the detector output.
@@ -114,9 +142,32 @@ void copy_steps<MemSpace::device>(
     StepStateData<Ownership::reference, MemSpace::device> const&);
 
 //---------------------------------------------------------------------------//
+// Copy death records for all terminal tracks to the output.
+template<MemSpace M>
+void copy_deaths(DetectorStepOutput* output,
+                 StepStateData<Ownership::reference, M> const& state);
+
+template<>
+void copy_deaths<MemSpace::host>(
+    DetectorStepOutput*,
+    StepStateData<Ownership::reference, MemSpace::host> const&);
+template<>
+void copy_deaths<MemSpace::device>(
+    DetectorStepOutput*,
+    StepStateData<Ownership::reference, MemSpace::device> const&);
+
+//---------------------------------------------------------------------------//
 #if !CELER_USE_DEVICE
 template<>
 inline void copy_steps<MemSpace::device>(
+    DetectorStepOutput*,
+    StepStateData<Ownership::reference, MemSpace::device> const&)
+{
+    CELER_NOT_CONFIGURED("CUDA or HIP");
+}
+
+template<>
+inline void copy_deaths<MemSpace::device>(
     DetectorStepOutput*,
     StepStateData<Ownership::reference, MemSpace::device> const&)
 {

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -151,6 +151,10 @@ struct StepParamsData
     //! Per-state volume instance size if volume_instance_ids selected
     size_type num_volume_levels{0};
 
+    //! Gather final state (pos, dir, energy, time) when a track is killed or
+    //! errored. Used to fire PostUserTrackingAction with correct GPU endpoint.
+    bool track_death{false};
+
     //// METHODS ////
 
     //! Whether the data is assigned
@@ -168,6 +172,7 @@ struct StepParamsData
         detector = other.detector;
         nonzero_energy_deposition = other.nonzero_energy_deposition;
         num_volume_levels = other.num_volume_levels;
+        track_death = other.track_death;
         return *this;
     }
 };
@@ -272,6 +277,18 @@ struct StepStateDataImpl
     StateItems<ParticleId> particle;
     StateItems<Energy> energy_deposition;
 
+    // Track death records: populated for terminal tracks when
+    // StepParamsData::track_death is true. death_track_id is valid (non-null)
+    // when a death occurred in this slot on the current step; invalid
+    // otherwise.
+    StateItems<TrackId> death_track_id;
+    StateItems<PrimaryId> death_primary_id;
+    StateItems<ParticleId> death_particle;
+    StateItems<Real3> death_pos;
+    StateItems<Real3> death_dir;
+    StateItems<Energy> death_energy;
+    StateItems<real_type> death_time;
+
     //// METHODS ////
 
     //! True if constructed and correctly sized
@@ -286,7 +303,7 @@ struct StepStateDataImpl
                && right_sized(primary_id) && right_sized(track_step_count)
                && right_sized(action_id) && right_sized(step_length)
                && right_sized(weight) && right_sized(particle)
-               && right_sized(energy_deposition);
+               && right_sized(energy_deposition) && right_sized(death_track_id);
     }
 
     //! State size
@@ -319,6 +336,13 @@ struct StepStateDataImpl
         weight = other.weight;
         particle = other.particle;
         energy_deposition = other.energy_deposition;
+        death_track_id = other.death_track_id;
+        death_primary_id = other.death_primary_id;
+        death_particle = other.death_particle;
+        death_pos = other.death_pos;
+        death_dir = other.death_dir;
+        death_energy = other.death_energy;
+        death_time = other.death_time;
         return *this;
     }
 };
@@ -355,6 +379,9 @@ struct StepStateData
     //! Thread IDs of active tracks that are in a detector
     StateItems<size_type> valid_id;
 
+    //! Thread IDs of active tracks that died this step (device only)
+    StateItems<size_type> death_valid_id;
+
     // Copy of params max depth for dimensioning volume_instance_ids
     size_type num_volume_levels{0};
 
@@ -387,6 +414,7 @@ struct StepStateData
         data = other.data;
         scratch = other.scratch;
         valid_id = other.valid_id;
+        death_valid_id = other.death_valid_id;
         num_volume_levels = other.num_volume_levels;
         stream_id = other.stream_id;
         return *this;
@@ -471,6 +499,17 @@ inline void resize(StepStateDataImpl<Ownership::value, M>* state,
     SD_RESIZE_IF_SELECTED(action_id);
     SD_RESIZE_IF_SELECTED(particle);
     SD_RESIZE_IF_SELECTED(energy_deposition);
+
+    if (params.track_death)
+    {
+        resize(&state->death_track_id, size);
+        resize(&state->death_primary_id, size);
+        resize(&state->death_particle, size);
+        resize(&state->death_pos, size);
+        resize(&state->death_dir, size);
+        resize(&state->death_energy, size);
+        resize(&state->death_time, size);
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -496,6 +535,10 @@ inline void resize(StepStateData<Ownership::value, M>* state,
         // Allocate extra space on device for gathering step data
         resize(&state->scratch, params, size);
         resize(&state->valid_id, size);
+        if (params.track_death)
+        {
+            resize(&state->death_valid_id, size);
+        }
     }
 }
 

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -95,6 +95,7 @@ struct StepSelection
             true,
             true,
             true,
+            true,
             true};
     }
 
@@ -102,8 +103,8 @@ struct StepSelection
     explicit CELER_FUNCTION operator bool() const
     {
         return points[StepPoint::pre] || points[StepPoint::post] || event_id
-               || parent_id || track_step_count || action_id || step_length
-               || weight || particle || energy_deposition;
+               || parent_id || primary_id || track_step_count || action_id
+               || step_length || weight || particle || energy_deposition;
     }
 
     //! Combine the selection with another
@@ -116,6 +117,7 @@ struct StepSelection
 
         this->event_id |= other.event_id;
         this->parent_id |= other.parent_id;
+        this->primary_id |= other.primary_id;
         this->track_step_count |= other.track_step_count;
         this->action_id |= other.action_id;
         this->step_length |= other.step_length;
@@ -462,6 +464,7 @@ inline void resize(StepStateDataImpl<Ownership::value, M>* state,
 
     SD_RESIZE_IF_SELECTED(event_id);
     SD_RESIZE_IF_SELECTED(parent_id);
+    SD_RESIZE_IF_SELECTED(primary_id);
     SD_RESIZE_IF_SELECTED(track_step_count);
     SD_RESIZE_IF_SELECTED(step_length);
     SD_RESIZE_IF_SELECTED(weight);

--- a/src/celeritas/user/StepInterface.hh
+++ b/src/celeritas/user/StepInterface.hh
@@ -58,6 +58,8 @@ class StepInterface
         MapVolumeDetector detectors;
         //! Only select data with nonzero energy deposition (if detectors)
         bool nonzero_energy_deposition{false};
+        //! Gather terminal track state for PostUserTrackingAction dispatch
+        bool track_death{false};
     };
 
   public:

--- a/src/celeritas/user/detail/StepGatherExecutor.hh
+++ b/src/celeritas/user/detail/StepGatherExecutor.hh
@@ -45,6 +45,8 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
 {
     CELER_EXPECT(params && state);
 
+    auto const slot = track.track_slot_id();
+
     {
         auto const sim = track.sim();
         bool inactive = (sim.status() == TrackStatus::inactive
@@ -53,8 +55,15 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
         if (P == StepPoint::post)
         {
             // Always save track ID to clear output from inactive slots
-            this->state.data.track_id[track.track_slot_id()]
-                = inactive ? TrackId{} : sim.track_id();
+            this->state.data.track_id[slot] = inactive ? TrackId{}
+                                                       : sim.track_id();
+        }
+
+        if (P == StepPoint::pre && !this->state.data.death_track_id.empty())
+        {
+            // Clear death record every step so each track is recorded at
+            // most once (only the step in which it transitions to killed).
+            this->state.data.death_track_id[slot] = {};
         }
 
         if (inactive)
@@ -62,11 +71,33 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
             if (P == StepPoint::pre && !this->params.detector.empty())
             {
                 // Clear detector ID for inactive threads
-                this->state.data.detector[track.track_slot_id()] = {};
+                this->state.data.detector[slot] = {};
             }
 
             // No more data to be written
             return;
+        }
+    }
+
+    // Gather death record for terminal tracks, independently of the detector
+    // filter. Must run before any detector-filter early returns below.
+    if constexpr (P == StepPoint::post)
+    {
+        if (!this->state.data.death_track_id.empty())
+        {
+            auto const sim = track.sim();
+            if (sim.status() == TrackStatus::killed)
+            {
+                auto const geo = track.geometry();
+                auto const par = track.particle();
+                this->state.data.death_track_id[slot] = sim.track_id();
+                this->state.data.death_primary_id[slot] = sim.primary_id();
+                this->state.data.death_particle[slot] = par.particle_id();
+                this->state.data.death_pos[slot] = geo.pos();
+                this->state.data.death_dir[slot] = geo.dir();
+                this->state.data.death_energy[slot] = par.energy();
+                this->state.data.death_time[slot] = sim.time();
+            }
         }
     }
 
@@ -82,11 +113,10 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
             CELER_ASSERT(vol);
 
             // Map volume ID to detector ID
-            this->state.data.detector[track.track_slot_id()]
-                = this->params.detector[vol];
+            this->state.data.detector[slot] = this->params.detector[vol];
         }
 
-        if (!this->state.data.detector[track.track_slot_id()])
+        if (!this->state.data.detector[slot])
         {
             // We're not in a sensitive detector: don't save any further data
             return;
@@ -99,7 +129,7 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
             if (pstep.energy_deposition() == zero_quantity())
             {
                 // Clear detector ID and stop recording
-                this->state.data.detector[track.track_slot_id()] = {};
+                this->state.data.detector[slot] = {};
                 return;
             }
         }

--- a/src/celeritas/user/detail/StepParams.cc
+++ b/src/celeritas/user/detail/StepParams.cc
@@ -44,6 +44,7 @@ StepParams::StepParams(AuxId aux_id,
     CELER_ASSERT(!selection);
     StepInterface::MapVolumeDetector detector_map;
     bool nonzero_energy_deposition{true};
+    bool track_death{false};
 
     // Loop over callbacks to take union of step selections
     HasDetectors has_det = HasDetectors::unknown;
@@ -73,6 +74,9 @@ StepParams::StepParams(AuxId aux_id,
         nonzero_energy_deposition = nonzero_energy_deposition
                                     && filters.nonzero_energy_deposition;
 
+        // Enable track death gathering if any interface requests it
+        track_death = track_death || filters.track_death;
+
         auto this_has_detectors = filters.detectors.empty()
                                       ? HasDetectors::none
                                       : HasDetectors::all;
@@ -101,6 +105,7 @@ StepParams::StepParams(AuxId aux_id,
     mirror_ = ParamsDataStore{[&] {
         HostVal<StepParamsData> host_data;
         host_data.selection = selection;
+        host_data.track_death = track_death;
 
         if (!detector_map.empty())
         {

--- a/src/celeritas/user/detail/StepScratchCopyExecutor.hh
+++ b/src/celeritas/user/detail/StepScratchCopyExecutor.hh
@@ -106,5 +106,50 @@ CELER_FUNCTION void StepScratchCopyExecutor::operator()(ThreadId dst_id)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Compact death records, copying from a full state vector to one with #
+ * deaths.
+ */
+struct DeathScratchCopyExecutor
+{
+    NativeRef<StepStateData> state;
+    size_type num_valid{};
+
+    // Gather death data from dying tracks into scratch
+    inline CELER_FUNCTION void operator()(ThreadId id);
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Gather death state from dying tracks indexed by death_valid_id.
+ */
+CELER_FUNCTION void DeathScratchCopyExecutor::operator()(ThreadId dst_id)
+{
+    CELER_EXPECT(state.size() == state.scratch.size()
+                 && num_valid <= state.size()
+                 && dst_id < state.death_valid_id.size());
+
+    TrackSlotId src_id{fast_get(state.death_valid_id, dst_id)};
+    CELER_ASSERT(src_id < state.size());
+
+#define DS_DEATH_COPY(FIELD)                      \
+    do                                            \
+    {                                             \
+        fast_get(state.scratch.FIELD, dst_id)     \
+            = fast_get(state.data.FIELD, src_id); \
+    } while (0)
+
+    DS_DEATH_COPY(death_track_id);
+    DS_DEATH_COPY(death_primary_id);
+    DS_DEATH_COPY(death_particle);
+    DS_DEATH_COPY(death_pos);
+    DS_DEATH_COPY(death_dir);
+    DS_DEATH_COPY(death_energy);
+    DS_DEATH_COPY(death_time);
+
+#undef DS_DEATH_COPY
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace detail
 }  // namespace celeritas

--- a/test/celeritas/ext/GeantTrackReconstruction.test.cc
+++ b/test/celeritas/ext/GeantTrackReconstruction.test.cc
@@ -388,5 +388,112 @@ TEST_F(GeantTrackReconstructionTest, multi_flush_view)
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Verify view_initial restores handover-time kinematics and primary particle.
+ */
+TEST_F(GeantTrackReconstructionTest, view_initial)
+{
+    GeantTrackReconstruction recon(particles_, step_);
+
+
+    // Create primary with known kinematics
+    auto primary_track = std::make_unique<G4Track>(
+        new G4DynamicParticle(particles_[1], G4ThreeVector(0, 0, 1), 500.0),
+        3.14,
+        G4ThreeVector(10, 20, 30));
+    primary_track->SetTrackID(42);
+    primary_track->SetParentID(0);
+
+    PrimaryId pid = recon.acquire(*primary_track, ParticleId{1});
+
+    // Modify the track to simulate post-transport state
+    G4Track& track = recon.view(ParticleId{1}, pid);
+    track.SetPosition(G4ThreeVector(99, 99, 99));
+    track.SetKineticEnergy(0.0);
+
+    // view_initial should restore original handover state
+    G4Track& initial = recon.view_initial(ParticleId{1}, pid);
+    EXPECT_EQ(42, initial.GetTrackID());
+    EXPECT_EQ(0, initial.GetParentID());
+    EXPECT_DOUBLE_EQ(500.0, initial.GetKineticEnergy());
+    EXPECT_DOUBLE_EQ(3.14, initial.GetGlobalTime());
+    EXPECT_DOUBLE_EQ(10, initial.GetPosition().x());
+    EXPECT_DOUBLE_EQ(20, initial.GetPosition().y());
+    EXPECT_DOUBLE_EQ(30, initial.GetPosition().z());
+    EXPECT_DOUBLE_EQ(0, initial.GetMomentumDirection().x());
+    EXPECT_DOUBLE_EQ(0, initial.GetMomentumDirection().y());
+    EXPECT_DOUBLE_EQ(1, initial.GetMomentumDirection().z());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Verify is_generator_primary distinguishes generator primaries from
+ * re-offloaded secondaries.
+ */
+TEST_F(GeantTrackReconstructionTest, is_generator_primary)
+{
+    GeantTrackReconstruction recon(particles_, step_);
+
+
+    // Generator primary (parent_id == 0)
+    auto gen_track = std::make_unique<G4Track>(
+        new G4DynamicParticle(particles_[0], G4ThreeVector(1, 0, 0)),
+        0.0,
+        G4ThreeVector());
+    gen_track->SetTrackID(1);
+    gen_track->SetParentID(0);
+    PrimaryId gen_id = recon.acquire(*gen_track, ParticleId{0});
+
+    // Re-offloaded secondary (parent_id != 0)
+    auto sec_track = std::make_unique<G4Track>(
+        new G4DynamicParticle(particles_[1], G4ThreeVector(0, 1, 0)),
+        0.0,
+        G4ThreeVector());
+    sec_track->SetTrackID(2);
+    sec_track->SetParentID(1);
+    PrimaryId sec_id = recon.acquire(*sec_track, ParticleId{1});
+
+    EXPECT_TRUE(recon.is_generator_primary(gen_id));
+    EXPECT_FALSE(recon.is_generator_primary(sec_id));
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Verify for_each_primary iterates all acquired primaries with restored state.
+ */
+TEST_F(GeantTrackReconstructionTest, for_each_primary)
+{
+    GeantTrackReconstruction recon(particles_, step_);
+
+
+    // Register 5 primaries cycling through particle types (gamma, e-, e+)
+    int const expected_ids[] = {10, 20, 30, 40, 50};
+    std::vector<std::unique_ptr<G4Track>> src_tracks;
+    for (size_type i = 0; i < 5; ++i)
+    {
+        auto pidx = i % particles_.size();
+        src_tracks.push_back(std::make_unique<G4Track>(
+            new G4DynamicParticle(particles_[pidx], G4ThreeVector()),
+            0.0,
+            G4ThreeVector()));
+        src_tracks.back()->SetTrackID(expected_ids[i]);
+        PrimaryId pid = recon.acquire(
+            *src_tracks.back(), ParticleId{static_cast<size_type>(pidx)});
+        EXPECT_EQ(i, pid.unchecked_get());
+    }
+
+    std::vector<int> visited_ids;
+    recon.for_each_primary([&visited_ids](G4Track& track) {
+        visited_ids.push_back(track.GetTrackID());
+    });
+
+    ASSERT_EQ(5, visited_ids.size());
+    for (size_type i = 0; i < 5; ++i)
+    {
+        EXPECT_EQ(expected_ids[i], visited_ids[i]);
+    }
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/celeritas/ext/GeantTrackReconstruction.test.cc
+++ b/test/celeritas/ext/GeantTrackReconstruction.test.cc
@@ -140,7 +140,7 @@ TEST_F(GeantTrackReconstructionTest, primary_registration)
     primary_track->SetCreatorProcess(mock_process.get());
 
     // Register primary
-    PrimaryId primary_id = recon.acquire(*primary_track);
+    PrimaryId primary_id = recon.acquire(*primary_track, ParticleId{0});
 
     // Verify primary ID
     EXPECT_EQ(0, primary_id.unchecked_get());
@@ -161,7 +161,7 @@ TEST_F(GeantTrackReconstructionTest, primary_registration)
     primary_track2->SetTrackID(456);
     primary_track2->SetParentID(0);
 
-    PrimaryId primary_id2 = recon.acquire(*primary_track2);
+    PrimaryId primary_id2 = recon.acquire(*primary_track2, ParticleId{1});
     EXPECT_EQ(1, primary_id2.unchecked_get());
 }
 
@@ -186,7 +186,7 @@ TEST_F(GeantTrackReconstructionTest, track_restoration)
     auto mock_process = std::make_unique<MockProcess>("TestBremsstrahlung");
     primary_track->SetCreatorProcess(mock_process.get());
 
-    PrimaryId primary_id = recon.acquire(*primary_track);
+    PrimaryId primary_id = recon.acquire(*primary_track, ParticleId{1});
 
     // Restore track for electron (particle ID 1) with primary information
     G4Track& restored_track = recon.view(ParticleId{1}, primary_id);
@@ -254,8 +254,8 @@ TEST_F(GeantTrackReconstructionTest, end_event_cleanup)
     auto mock_process2 = std::make_unique<MockProcess>("TestProcess2");
     primary_track2->SetCreatorProcess(mock_process2.get());
 
-    PrimaryId id1 = recon.acquire(*primary_track1);
-    PrimaryId id2 = recon.acquire(*primary_track2);
+    PrimaryId id1 = recon.acquire(*primary_track1, ParticleId{0});
+    PrimaryId id2 = recon.acquire(*primary_track2, ParticleId{1});
 
     // Verify primaries are registered
     EXPECT_EQ(0, id1.unchecked_get());
@@ -323,7 +323,7 @@ TEST_F(GeantTrackReconstructionTest, reconstruction_data_persistence)
     auto mock_process = std::make_unique<MockProcess>("TestIonization");
     primary_track->SetCreatorProcess(mock_process.get());
 
-    PrimaryId primary_id = recon.acquire(*primary_track);
+    PrimaryId primary_id = recon.acquire(*primary_track, ParticleId{2});
 
     // Test reconstruction data persists across multiple restore calls
     for (int i = 0; i < 3; ++i)
@@ -339,6 +339,55 @@ TEST_F(GeantTrackReconstructionTest, reconstruction_data_persistence)
         ASSERT_NE(nullptr, restored_info);
         EXPECT_EQ(777, restored_info->value());
     }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Verify view() uses flush-local indexing across multiple clear() cycles.
+ *
+ * Simulates two Flush() calls within one event (e.g. auto_flush_ triggered
+ * mid-event). After clear(), start_ advances so that absolute primary IDs
+ * from the second flush index correctly into a freshly-repopulated
+ * g4_track_data_ vector.
+ */
+TEST_F(GeantTrackReconstructionTest, multi_flush_view)
+{
+    GeantTrackReconstruction recon(particles_, step_);
+    recon.init_event();
+
+    // --- Flush 1: acquire one primary (absolute id = 0) ---
+    auto track1 = std::make_unique<G4Track>(
+        new G4DynamicParticle(particles_[0], G4ThreeVector(1, 0, 0)),
+        0.0,
+        G4ThreeVector());
+    track1->SetTrackID(111);
+    auto mock_proc1 = std::make_unique<MockProcess>("proc1");
+    track1->SetCreatorProcess(mock_proc1.get());
+
+    PrimaryId id1 = recon.acquire(*track1, ParticleId{0});
+    EXPECT_EQ(0, id1.unchecked_get());
+
+    // view() must find track1 via id1
+    EXPECT_EQ(111, recon.view(ParticleId{0}, id1).GetTrackID());
+
+    // Simulate end of first flush
+    recon.clear();
+
+    // --- Flush 2: acquire one primary (absolute id = 1) ---
+    auto track2 = std::make_unique<G4Track>(
+        new G4DynamicParticle(particles_[1], G4ThreeVector(0, 1, 0)),
+        0.0,
+        G4ThreeVector());
+    track2->SetTrackID(222);
+    auto mock_proc2 = std::make_unique<MockProcess>("proc2");
+    track2->SetCreatorProcess(mock_proc2.get());
+
+    PrimaryId id2 = recon.acquire(*track2, ParticleId{1});
+    EXPECT_EQ(1, id2.unchecked_get());
+
+    // view() must find track2 via id2, not index out-of-bounds or return
+    // track1's stale data
+    EXPECT_EQ(222, recon.view(ParticleId{1}, id2).GetTrackID());
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantTrackReconstruction.test.cc
+++ b/test/celeritas/ext/GeantTrackReconstruction.test.cc
@@ -346,16 +346,14 @@ TEST_F(GeantTrackReconstructionTest, reconstruction_data_persistence)
  * Verify view() uses flush-local indexing across multiple clear() cycles.
  *
  * Simulates two Flush() calls within one event (e.g. auto_flush_ triggered
- * mid-event). After clear(), start_ advances so that absolute primary IDs
- * from the second flush index correctly into a freshly-repopulated
- * g4_track_data_ vector.
+ * mid-event). After clear(), primary IDs reset to 0 for the next flush so
+ * that they always index directly into the current g4_track_data_ vector.
  */
 TEST_F(GeantTrackReconstructionTest, multi_flush_view)
 {
     GeantTrackReconstruction recon(particles_, step_);
-    recon.init_event();
 
-    // --- Flush 1: acquire one primary (absolute id = 0) ---
+    // --- Flush 1: acquire one primary (flush-local id = 0) ---
     auto track1 = std::make_unique<G4Track>(
         new G4DynamicParticle(particles_[0], G4ThreeVector(1, 0, 0)),
         0.0,
@@ -373,7 +371,7 @@ TEST_F(GeantTrackReconstructionTest, multi_flush_view)
     // Simulate end of first flush
     recon.clear();
 
-    // --- Flush 2: acquire one primary (absolute id = 1) ---
+    // --- Flush 2: acquire one primary (flush-local id = 0 again) ---
     auto track2 = std::make_unique<G4Track>(
         new G4DynamicParticle(particles_[1], G4ThreeVector(0, 1, 0)),
         0.0,
@@ -383,10 +381,9 @@ TEST_F(GeantTrackReconstructionTest, multi_flush_view)
     track2->SetCreatorProcess(mock_proc2.get());
 
     PrimaryId id2 = recon.acquire(*track2, ParticleId{1});
-    EXPECT_EQ(1, id2.unchecked_get());
+    EXPECT_EQ(0, id2.unchecked_get());
 
-    // view() must find track2 via id2, not index out-of-bounds or return
-    // track1's stale data
+    // view() must find track2 via id2
     EXPECT_EQ(222, recon.view(ParticleId{1}, id2).GetTrackID());
 }
 

--- a/test/celeritas/ext/GeantTrackReconstruction.test.cc
+++ b/test/celeritas/ext/GeantTrackReconstruction.test.cc
@@ -395,7 +395,6 @@ TEST_F(GeantTrackReconstructionTest, view_initial)
 {
     GeantTrackReconstruction recon(particles_, step_);
 
-
     // Create primary with known kinematics
     auto primary_track = std::make_unique<G4Track>(
         new G4DynamicParticle(particles_[1], G4ThreeVector(0, 0, 1), 500.0),
@@ -434,7 +433,6 @@ TEST_F(GeantTrackReconstructionTest, is_generator_primary)
 {
     GeantTrackReconstruction recon(particles_, step_);
 
-
     // Generator primary (parent_id == 0)
     auto gen_track = std::make_unique<G4Track>(
         new G4DynamicParticle(particles_[0], G4ThreeVector(1, 0, 0)),
@@ -464,7 +462,6 @@ TEST_F(GeantTrackReconstructionTest, is_generator_primary)
 TEST_F(GeantTrackReconstructionTest, for_each_primary)
 {
     GeantTrackReconstruction recon(particles_, step_);
-
 
     // Register 5 primaries cycling through particle types (gamma, e-, e+)
     int const expected_ids[] = {10, 20, 30, 40, 50};

--- a/test/celeritas/user/DetectorSteps.test.cc
+++ b/test/celeritas/user/DetectorSteps.test.cc
@@ -356,6 +356,48 @@ TEST_F(SmallDetectorStepsTest, TEST_IF_CELER_DEVICE(device))
     EXPECT_EQ(0, post.volume_instance_ids.size());
 }
 
+TEST_F(DetectorStepsTest, death_fields_allocated)
+{
+    // Build params with track_death enabled
+    celeritas::HostVal<StepParamsData> host_data;
+    std::vector<DetectorId> detectors
+        = {DetectorId{}, DetectorId{1}, DetectorId{0}};
+    make_builder(&host_data.detector)
+        .insert_back(detectors.begin(), detectors.end());
+    host_data.selection = this->selection();
+    host_data.track_death = true;
+    host_data.num_volume_levels = 0;
+
+    auto params = ParamsDataStore<StepParamsData>(std::move(host_data));
+
+    HostStates states;
+    resize(&states, params.host_ref(), StreamId{0}, 16);
+
+    // Death fields must be allocated
+    EXPECT_EQ(16, states.data.death_track_id.size());
+    EXPECT_EQ(16, states.data.death_primary_id.size());
+    EXPECT_EQ(16, states.data.death_particle.size());
+    EXPECT_EQ(16, states.data.death_pos.size());
+    EXPECT_EQ(16, states.data.death_dir.size());
+    EXPECT_EQ(16, states.data.death_energy.size());
+    EXPECT_EQ(16, states.data.death_time.size());
+}
+
+TEST_F(DetectorStepsTest, death_fields_not_allocated)
+{
+    // Default params: track_death is false
+    auto states = this->build_states(16);
+
+    // Death fields must NOT be allocated
+    EXPECT_EQ(0, states.data.death_track_id.size());
+    EXPECT_EQ(0, states.data.death_primary_id.size());
+    EXPECT_EQ(0, states.data.death_particle.size());
+    EXPECT_EQ(0, states.data.death_pos.size());
+    EXPECT_EQ(0, states.data.death_dir.size());
+    EXPECT_EQ(0, states.data.death_energy.size());
+    EXPECT_EQ(0, states.data.death_time.size());
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/celeritas/user/DetectorSteps.test.cc
+++ b/test/celeritas/user/DetectorSteps.test.cc
@@ -358,13 +358,17 @@ TEST_F(SmallDetectorStepsTest, TEST_IF_CELER_DEVICE(device))
 
 TEST_F(DetectorStepsTest, death_fields_allocated)
 {
-    // Build params with track_death enabled
+    // Build params with track_death enabled (no volume instances needed)
     celeritas::HostVal<StepParamsData> host_data;
     std::vector<DetectorId> detectors
         = {DetectorId{}, DetectorId{1}, DetectorId{0}};
     make_builder(&host_data.detector)
         .insert_back(detectors.begin(), detectors.end());
     host_data.selection = this->selection();
+    for (auto& sp : host_data.selection.points)
+    {
+        sp.volume_instance_ids = false;
+    }
     host_data.track_death = true;
     host_data.num_volume_levels = 0;
 
@@ -400,13 +404,17 @@ TEST_F(DetectorStepsTest, death_fields_not_allocated)
 
 TEST_F(DetectorStepsTest, copy_deaths_host)
 {
-    // Build params with track_death enabled
+    // Build params with track_death enabled (no volume instances needed)
     celeritas::HostVal<StepParamsData> host_data;
     std::vector<DetectorId> detectors
         = {DetectorId{}, DetectorId{1}, DetectorId{0}};
     make_builder(&host_data.detector)
         .insert_back(detectors.begin(), detectors.end());
     host_data.selection = this->selection();
+    for (auto& sp : host_data.selection.points)
+    {
+        sp.volume_instance_ids = false;
+    }
     host_data.track_death = true;
     host_data.num_volume_levels = 0;
 

--- a/test/celeritas/user/DetectorSteps.test.cc
+++ b/test/celeritas/user/DetectorSteps.test.cc
@@ -398,6 +398,97 @@ TEST_F(DetectorStepsTest, death_fields_not_allocated)
     EXPECT_EQ(0, states.data.death_time.size());
 }
 
+TEST_F(DetectorStepsTest, copy_deaths_host)
+{
+    // Build params with track_death enabled
+    celeritas::HostVal<StepParamsData> host_data;
+    std::vector<DetectorId> detectors
+        = {DetectorId{}, DetectorId{1}, DetectorId{0}};
+    make_builder(&host_data.detector)
+        .insert_back(detectors.begin(), detectors.end());
+    host_data.selection = this->selection();
+    host_data.track_death = true;
+    host_data.num_volume_levels = 0;
+
+    auto params = ParamsDataStore<StepParamsData>(std::move(host_data));
+
+    HostStates states;
+    resize(&states, params.host_ref(), StreamId{0}, 8);
+
+    // Populate death fields: slots 1, 3, 5 have valid deaths
+    auto& d = states.data;
+    for (auto tid : range(TrackSlotId{8}))
+    {
+        d.death_track_id[tid] = TrackId{};
+        d.death_primary_id[tid] = PrimaryId{};
+        d.death_particle[tid] = ParticleId{};
+        d.death_energy[tid] = units::MevEnergy{0};
+        d.death_time[tid] = 0;
+        d.death_pos[tid] = {0, 0, 0};
+        d.death_dir[tid] = {0, 0, 1};
+    }
+
+    d.death_track_id[TrackSlotId{1}] = TrackId{10};
+    d.death_primary_id[TrackSlotId{1}] = PrimaryId{0};
+    d.death_particle[TrackSlotId{1}] = ParticleId{1};
+    d.death_energy[TrackSlotId{1}] = units::MevEnergy{100};
+    d.death_time[TrackSlotId{1}] = 1.5;
+    d.death_pos[TrackSlotId{1}] = {1, 2, 3};
+    d.death_dir[TrackSlotId{1}] = {0, 0, 1};
+
+    d.death_track_id[TrackSlotId{3}] = TrackId{30};
+    d.death_primary_id[TrackSlotId{3}] = PrimaryId{1};
+    d.death_particle[TrackSlotId{3}] = ParticleId{0};
+    d.death_energy[TrackSlotId{3}] = units::MevEnergy{200};
+    d.death_time[TrackSlotId{3}] = 2.5;
+    d.death_pos[TrackSlotId{3}] = {4, 5, 6};
+    d.death_dir[TrackSlotId{3}] = {1, 0, 0};
+
+    d.death_track_id[TrackSlotId{5}] = TrackId{50};
+    d.death_primary_id[TrackSlotId{5}] = PrimaryId{2};
+    d.death_particle[TrackSlotId{5}] = ParticleId{2};
+    d.death_energy[TrackSlotId{5}] = units::MevEnergy{300};
+    d.death_time[TrackSlotId{5}] = 3.5;
+    d.death_pos[TrackSlotId{5}] = {7, 8, 9};
+    d.death_dir[TrackSlotId{5}] = {0, 1, 0};
+
+    // Compact deaths
+    DetectorStepOutput output;
+    copy_deaths(&output, make_ref(states));
+
+    // Verify 3 deaths compacted
+    ASSERT_EQ(3, output.deaths.size());
+
+    EXPECT_EQ(TrackId{10}, output.deaths[0].track_id);
+    EXPECT_EQ(PrimaryId{0}, output.deaths[0].primary_id);
+    EXPECT_EQ(ParticleId{1}, output.deaths[0].particle);
+    EXPECT_DOUBLE_EQ(100, output.deaths[0].final_energy.value());
+    EXPECT_DOUBLE_EQ(1.5, output.deaths[0].final_time);
+    EXPECT_EQ((Real3{1, 2, 3}), output.deaths[0].final_pos);
+
+    EXPECT_EQ(TrackId{30}, output.deaths[1].track_id);
+    EXPECT_EQ(PrimaryId{1}, output.deaths[1].primary_id);
+    EXPECT_EQ(ParticleId{0}, output.deaths[1].particle);
+    EXPECT_DOUBLE_EQ(200, output.deaths[1].final_energy.value());
+
+    EXPECT_EQ(TrackId{50}, output.deaths[2].track_id);
+    EXPECT_EQ(PrimaryId{2}, output.deaths[2].primary_id);
+    EXPECT_EQ(ParticleId{2}, output.deaths[2].particle);
+    EXPECT_DOUBLE_EQ(300, output.deaths[2].final_energy.value());
+}
+
+TEST_F(DetectorStepsTest, copy_deaths_empty)
+{
+    // Without track_death, copy_deaths should clear output
+    auto states = this->build_states(8);
+
+    DetectorStepOutput output;
+    output.deaths.resize(5);  // Pre-populate to verify it gets cleared
+    copy_deaths(&output, make_ref(states));
+
+    EXPECT_TRUE(output.deaths.empty());
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas


### PR DESCRIPTION
 ## Title

Save and restore initial handover state for PreUserTrackingAction dispatch

Depends on: https://github.com/celeritas-project/celeritas/pull/2367
Pre-requisite for: https://github.com/celeritas-project/celeritas/pull/2363


## Description
  - Store initial kinematic state (position, direction, energy, time) and `G4PrimaryParticle` pointer in `AcquiredData`
  - Add `restore_initial()` to prepare a track with handover-time state
  - Add `view_initial()` on `GeantTrackReconstruction` for PreUserTrackingAction dispatch
  - Add `is_generator_primary()` to filter by parent_id == 0
  - Add `for_each_primary()` template iterator

Assisted by: Claude-Opus-4-6 and Claude-Sonnet-4-6