### PR TITLE
Improve traversal in BIHEnclosingVolFinder

### DIFF
--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -105,7 +105,7 @@ BIHBuilder::operator()(VecBBox&& bboxes,
     {
         // Construct the tree recursively
         VecNodes nodes;
-        this->construct_tree(indices, &nodes, BIHNodeId{}, 0, depth);
+        this->construct_tree(indices, &nodes, 0, depth);
         auto [inner_nodes, leaf_nodes] = this->arrange_nodes(std::move(nodes));
 
         tree.inner_nodes
@@ -143,14 +143,12 @@ BIHBuilder::operator()(VecBBox&& bboxes,
  * \param[in] indices        The indices of the bboxes that will be partitioned
  *                           or placed on a leaf node in this function call
  * \param[in, out] nodes     All nodes constructed so far, to be added to
- * \param[in] parent         The parent node
  * \param[in] current_depth  The recursion depth of this function call
  * \param[in] depth          The maximum recursion depth encountered during the
  *                           full construction process
  */
 void BIHBuilder::construct_tree(VecIndices const& indices,
                                 VecNodes* nodes,
-                                BIHNodeId parent,
                                 size_type current_depth,
                                 size_type& depth)
 {
@@ -166,7 +164,6 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
     // once per call to construct_tree.
     auto make_leaf = [&]() {
         BIHLeafNode node;
-        node.parent = parent;
         node.vol_ids
             = local_volume_ids_.insert_back(indices.begin(), indices.end());
         CELER_EXPECT(node);
@@ -190,7 +187,6 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
     {
         // Create inner node
         BIHInnerNode node;
-        node.parent = parent;
         node.axis = p.axis;
 
         // Populate left/right bounding planes
@@ -206,11 +202,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
         for (auto side : range(Side::size_))
         {
             node.edges[side].child = BIHNodeId(nodes->size());
-            this->construct_tree(p.indices[side],
-                                 nodes,
-                                 BIHNodeId(current_index),
-                                 current_depth,
-                                 depth);
+            this->construct_tree(p.indices[side], nodes, current_depth, depth);
         }
 
         CELER_EXPECT(node);
@@ -267,7 +259,7 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
         }
     }
 
-    // Remap IDs. "parent" will only be undefined for the root node.
+    // Remap IDs
     auto remapped_id = [&new_indices](BIHNodeId old) {
         CELER_EXPECT(old < new_indices.size());
         return id_cast<BIHNodeId>(new_indices[old.unchecked_get()]);
@@ -278,18 +270,6 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
         for (auto& edge : inner_node.edges)
         {
             edge.child = remapped_id(edge.child);
-        }
-        if (inner_node.parent)
-        {
-            inner_node.parent = remapped_id(inner_node.parent);
-        }
-    }
-
-    for (auto& leaf_node : leaf_nodes)
-    {
-        if (leaf_node.parent)
-        {
-            leaf_node.parent = remapped_id(leaf_node.parent);
         }
     }
 

--- a/src/orange/detail/BIHBuilder.hh
+++ b/src/orange/detail/BIHBuilder.hh
@@ -97,7 +97,6 @@ class BIHBuilder
     // Recursively construct BIH nodes for a vector of bbox indices
     void construct_tree(VecIndices const& indices,
                         VecNodes* nodes,
-                        BIHNodeId parent,
                         size_type current_depth,
                         size_type& depth);
 

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -53,7 +53,6 @@ struct BIHInnerNode
         size_
     };
 
-    BIHNodeId parent;  //!< Parent node ID
     Axis axis;  //!< Axis that the partition is performed on
     EnumArray<Side, Edge> edges;  //!< Left/right edges
 
@@ -69,7 +68,6 @@ struct BIHInnerNode
  */
 struct BIHLeafNode
 {
-    BIHNodeId parent;  //!< Parent node ID
     ItemRange<LocalVolumeId> vol_ids;
 
     explicit CELER_FUNCTION operator bool() const { return !vol_ids.empty(); }

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "BIHView.hh"
+#include "../inp/Bih.hh"
 
 namespace celeritas
 {
@@ -50,16 +51,6 @@ class BIHEnclosingVolFinder
 
     //// HELPER FUNCTIONS ////
 
-    // Get the ID of the next node in the traversal sequence
-    inline CELER_FUNCTION BIHNodeId next_node(BIHNodeId current_id,
-                                              BIHNodeId previous_id,
-                                              Real3 const& pos) const;
-
-    // Determine if traversal shall proceed down a given edge
-    inline CELER_FUNCTION bool visit_edge(BIHInnerNode const& node,
-                                          BIHInnerNode::Side side,
-                                          Real3 const& pos) const;
-
     // Determine if any leaf node volumes contain the point
     template<class F>
     inline CELER_FUNCTION LocalVolumeId visit_leaf(BIHLeafNode const& leaf_node,
@@ -96,110 +87,58 @@ template<class F>
 CELER_FUNCTION LocalVolumeId
 BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside) const
 {
-    BIHNodeId previous_node;
-    BIHNodeId current_node{0};
-    LocalVolumeId id;
+    using Side = BIHInnerNode::Side;
 
-    // Depth-first search
-    do
+    BIHNodeId stack[inp::BIHBuilder::max_depth_limit - 1];
+    int stack_ptr = 0;
+    BIHNodeId current_node{0};
+
+    while (current_node)
     {
         if (!view_.is_inner(current_node))
         {
-            id = this->visit_leaf(
+            auto id = this->visit_leaf(
                 view_.leaf_node(current_node), pos, is_inside);
 
             if (id)
             {
                 return id;
             }
+
+            current_node = stack_ptr > 0 ? stack[--stack_ptr] : BIHNodeId{};
+            continue;
         }
 
-        previous_node = exchange(
-            current_node, this->next_node(current_node, previous_node, pos));
+        auto const& node = view_.inner_node(current_node);
+        int ax = to_int(node.axis);
 
-    } while (current_node);
+        bool in_left = pos[ax] <= node.edges[Side::left].bounding_plane_pos;
+        bool in_right = pos[ax] >= node.edges[Side::right].bounding_plane_pos;
+
+        if (in_left && in_right)
+        {
+            stack[stack_ptr++] = node.edges[Side::right].child;
+            current_node = node.edges[Side::left].child;
+        }
+        else if (in_left)
+        {
+            current_node = node.edges[Side::left].child;
+        }
+        else if (in_right)
+        {
+            current_node = node.edges[Side::right].child;
+        }
+        else
+        {
+            current_node = stack_ptr > 0 ? stack[--stack_ptr] : BIHNodeId{};
+        }
+    }
 
     return this->visit_inf_vols(is_inside);
 }
 
 //---------------------------------------------------------------------------//
 // HELPER FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- *  Get the ID of the next node in the traversal sequence.
- */
-CELER_FUNCTION
-BIHNodeId BIHEnclosingVolFinder::next_node(BIHNodeId current_id,
-                                           BIHNodeId previous_id,
-                                           Real3 const& pos) const
-{
-    using Side = BIHInnerNode::Side;
-
-    BIHNodeId next_id;
-
-    if (view_.is_inner(current_id))
-    {
-        auto const& current_node = view_.inner_node(current_id);
-        if (previous_id == current_node.parent)
-        {
-            // Visiting this inner node for the first time; go down either left
-            // or right edge
-            if (this->visit_edge(current_node, Side::left, pos))
-            {
-                next_id = current_node.edges[Side::left].child;
-            }
-            else
-            {
-                next_id = current_node.edges[Side::right].child;
-            }
-        }
-        else if (previous_id == current_node.edges[Side::left].child)
-        {
-            // Visiting this inner node for the second time; go down right edge
-            // or return to parent
-            if (this->visit_edge(current_node, Side::right, pos))
-            {
-                next_id = current_node.edges[Side::right].child;
-            }
-            else
-            {
-                next_id = current_node.parent;
-            }
-        }
-        else
-        {
-            // Visiting this inner node for the third time; return to parent
-            CELER_EXPECT(previous_id == current_node.edges[Side::right].child);
-            next_id = current_node.parent;
-        }
-    }
-    else
-    {
-        // Leaf node; return to parent
-        CELER_EXPECT(previous_id == view_.leaf_node(current_id).parent);
-        next_id = previous_id;
-    }
-
-    return next_id;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Determine if traversal shall proceed down a given edge.
- */
-CELER_FUNCTION
-bool BIHEnclosingVolFinder::visit_edge(BIHInnerNode const& node,
-                                       BIHInnerNode::Side side,
-                                       Real3 const& pos) const
-{
-    CELER_EXPECT(side < BIHInnerNode::Side::size_);
-
-    auto bp_pos = node.edges[side].bounding_plane_pos;
-    auto p = pos[to_int(node.axis)];
-
-    return (side == BIHInnerNode::Side::left) ? (p < bp_pos) : (bp_pos < p);
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Determine if any leaf node volumes contain the point.

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -81,11 +81,11 @@ BIHEnclosingVolFinder::BIHEnclosingVolFinder(BIHTreeRecord const& tree,
 
 //---------------------------------------------------------------------------//
 /*!
- * Find a volume that satisfies is_inside.
+ * Find a volume that satisfies is_inside_vol.
  */
 template<class F>
 CELER_FUNCTION LocalVolumeId
-BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside) const
+BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
 {
     using Side = BIHInnerNode::Side;
 
@@ -98,7 +98,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside) const
         if (!view_.is_inner(current_node))
         {
             auto id = this->visit_leaf(
-                view_.leaf_node(current_node), pos, is_inside);
+                view_.leaf_node(current_node), pos, is_inside_vol);
 
             if (id)
             {
@@ -110,10 +110,9 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside) const
         }
 
         auto const& node = view_.inner_node(current_node);
-        int ax = to_int(node.axis);
 
-        bool in_left = pos[ax] <= node.edges[Side::left].bounding_plane_pos;
-        bool in_right = pos[ax] >= node.edges[Side::right].bounding_plane_pos;
+        bool in_left = is_inside(node.edges[Side::left].bbox, pos);
+        bool in_right = is_inside(node.edges[Side::right].bbox, pos);
 
         if (in_left && in_right)
         {
@@ -134,7 +133,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside) const
         }
     }
 
-    return this->visit_inf_vols(is_inside);
+    return this->visit_inf_vols(is_inside_vol);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -89,8 +89,9 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
 {
     using Side = BIHInnerNode::Side;
 
-    BIHNodeId stack[inp::BIHBuilder::max_depth_limit - 1];
-    int stack_ptr = 0;
+    constexpr auto stack_size = inp::BIHBuilder::max_depth_limit - 1;
+    BIHNodeId stack[stack_size];
+    BIHNodeId::index_type stack_ptr = 0;
     BIHNodeId current_node{0};
 
     while (current_node)
@@ -105,6 +106,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
                 return id;
             }
 
+            CELER_ASSERT(stack_ptr < stack_size);
             current_node = stack_ptr > 0 ? stack[--stack_ptr] : BIHNodeId{};
             continue;
         }
@@ -116,6 +118,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
 
         if (in_left && in_right)
         {
+            CELER_ASSERT(stack_ptr < stack_size);
             stack[stack_ptr++] = node.edges[Side::right].child;
             current_node = node.edges[Side::left].child;
         }
@@ -129,6 +132,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
         }
         else
         {
+            CELER_ASSERT(stack_ptr < stack_size);
             current_node = stack_ptr > 0 ? stack[--stack_ptr] : BIHNodeId{};
         }
     }

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -129,7 +129,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
     // Stack of deferred nodes
     constexpr auto stack_size = inp::BIHBuilder::max_depth_limit - 1;
     BIHNodeId stack[stack_size];
-    size_type stack_ptr = 0;
+    BIHNodeId::index_type stack_ptr = 0;
 
     while (current_node)
     {

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -111,7 +111,6 @@ TEST_F(BIHBuilderTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[0]];
         auto& edges = node.edges;
 
-        ASSERT_FALSE(node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(2.8f, edges[Side::left].bounding_plane_pos);
@@ -134,7 +133,6 @@ TEST_F(BIHBuilderTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[1]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{0}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(1.6f, edges[Side::left].bounding_plane_pos);
@@ -157,7 +155,6 @@ TEST_F(BIHBuilderTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[2]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{0}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(5.f, edges[Side::left].bounding_plane_pos);
@@ -178,7 +175,6 @@ TEST_F(BIHBuilderTest, basic)
     // N3, L0
     {
         auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -186,7 +182,6 @@ TEST_F(BIHBuilderTest, basic)
     // N3, L1
     {
         auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -194,7 +189,6 @@ TEST_F(BIHBuilderTest, basic)
     // N5, L2
     {
         auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(2, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{4}, storage_.local_volume_ids[node.vol_ids[0]]);
         EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[1]]);
@@ -203,7 +197,6 @@ TEST_F(BIHBuilderTest, basic)
     // N6, L3
     {
         auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{3}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -311,7 +304,6 @@ TEST_F(GridTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[0]];
         auto& edges = node.edges;
 
-        ASSERT_FALSE(node.parent);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
@@ -334,7 +326,6 @@ TEST_F(GridTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[1]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{0}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -357,7 +348,6 @@ TEST_F(GridTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[2]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -380,7 +370,6 @@ TEST_F(GridTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[3]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
@@ -403,7 +392,6 @@ TEST_F(GridTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[4]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{3}, node.parent);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -426,7 +414,6 @@ TEST_F(GridTest, basic)
         auto node = storage_.inner_nodes[inner_nodes[5]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{3}, node.parent);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -447,7 +434,6 @@ TEST_F(GridTest, basic)
     // N11, L0
     {
         auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -455,7 +441,6 @@ TEST_F(GridTest, basic)
     // N12, L1
     {
         auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -463,7 +448,6 @@ TEST_F(GridTest, basic)
     // N13, L2
     {
         auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        ASSERT_EQ(BIHNodeId{4}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -471,7 +455,6 @@ TEST_F(GridTest, basic)
     // N14, L3
     {
         auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        ASSERT_EQ(BIHNodeId{4}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{6}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -479,7 +462,6 @@ TEST_F(GridTest, basic)
     // N15, L4
     {
         auto node = storage_.leaf_nodes[leaf_nodes[4]];
-        ASSERT_EQ(BIHNodeId{5}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{9}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -487,7 +469,6 @@ TEST_F(GridTest, basic)
     // N16, L5
     {
         auto node = storage_.leaf_nodes[leaf_nodes[5]];
-        ASSERT_EQ(BIHNodeId{5}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{10},
                   storage_.local_volume_ids[node.vol_ids[0]]);
@@ -544,7 +525,6 @@ TEST_F(GridTest, max_leaf_size)
         auto node = storage_.inner_nodes[inner_nodes[0]];
         auto& edges = node.edges;
 
-        ASSERT_FALSE(node.parent);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
@@ -567,7 +547,6 @@ TEST_F(GridTest, max_leaf_size)
         auto node = storage_.inner_nodes[inner_nodes[1]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{0}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -590,7 +569,6 @@ TEST_F(GridTest, max_leaf_size)
         auto node = storage_.inner_nodes[inner_nodes[2]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{0}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -611,7 +589,6 @@ TEST_F(GridTest, max_leaf_size)
     // N3, L0
     {
         auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(2, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
         EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[1]]);
@@ -620,7 +597,6 @@ TEST_F(GridTest, max_leaf_size)
     // N4, L1
     {
         auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(4, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[0]]);
         EXPECT_EQ(LocalVolumeId{6}, storage_.local_volume_ids[node.vol_ids[1]]);
@@ -632,7 +608,6 @@ TEST_F(GridTest, max_leaf_size)
     // N5, L2
     {
         auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(2, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{3}, storage_.local_volume_ids[node.vol_ids[0]]);
         EXPECT_EQ(LocalVolumeId{4}, storage_.local_volume_ids[node.vol_ids[1]]);
@@ -641,7 +616,6 @@ TEST_F(GridTest, max_leaf_size)
     // N6, L3
     {
         auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(4, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{7}, storage_.local_volume_ids[node.vol_ids[0]]);
         EXPECT_EQ(LocalVolumeId{8}, storage_.local_volume_ids[node.vol_ids[1]]);
@@ -707,7 +681,6 @@ TEST_F(GridTest, depth_limit)
         auto node = storage_.inner_nodes[inner_nodes[0]];
         auto& edges = node.edges;
 
-        ASSERT_FALSE(node.parent);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
@@ -730,7 +703,6 @@ TEST_F(GridTest, depth_limit)
         auto node = storage_.inner_nodes[inner_nodes[1]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{0}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -753,7 +725,6 @@ TEST_F(GridTest, depth_limit)
         auto node = storage_.inner_nodes[inner_nodes[2]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_EQ(Axis{1}, node.axis);
         EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
@@ -776,7 +747,6 @@ TEST_F(GridTest, depth_limit)
         auto node = storage_.inner_nodes[inner_nodes[3]];
         auto& edges = node.edges;
 
-        ASSERT_EQ(BIHNodeId{1}, node.parent);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_EQ(Axis{0}, node.axis);
         EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
@@ -797,7 +767,6 @@ TEST_F(GridTest, depth_limit)
     // N7, L0
     {
         auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -805,7 +774,6 @@ TEST_F(GridTest, depth_limit)
     // N8, L1
     {
         auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        ASSERT_EQ(BIHNodeId{2}, node.parent);
         EXPECT_EQ(1, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
     }
@@ -813,7 +781,6 @@ TEST_F(GridTest, depth_limit)
     // N9, L2
     {
         auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        ASSERT_EQ(BIHNodeId{3}, node.parent);
         EXPECT_EQ(2, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[0]]);
         EXPECT_EQ(LocalVolumeId{6}, storage_.local_volume_ids[node.vol_ids[1]]);
@@ -822,7 +789,6 @@ TEST_F(GridTest, depth_limit)
     // N10, L3
     {
         auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        ASSERT_EQ(BIHNodeId{3}, node.parent);
         EXPECT_EQ(2, node.vol_ids.size());
         EXPECT_EQ(LocalVolumeId{9}, storage_.local_volume_ids[node.vol_ids[0]]);
         EXPECT_EQ(LocalVolumeId{10},
@@ -854,7 +820,6 @@ TEST_F(BIHBuilderTest, single_finite_volume)
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
     auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
-    ASSERT_EQ(BIHNodeId{}, node.parent);
     EXPECT_EQ(1, node.vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0}, storage_.local_volume_ids[node.vol_ids[0]]);
 
@@ -879,7 +844,6 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
     auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
-    ASSERT_EQ(BIHNodeId{}, node.parent);
     EXPECT_EQ(2, node.vol_ids.size());
     EXPECT_EQ(LocalVolumeId{0}, storage_.local_volume_ids[node.vol_ids[0]]);
     EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[1]]);


### PR DESCRIPTION
This MR updates the `BIHEnclosingVolFinder` to use stack-based traversal, as was previously done with `BIHIntersectingVolFinder`. It was found that checking the partitions first before checking bounding boxes did not result in a performance enhancement (Case 55). Additionally, Case 53, which changed  `BIHNodeId` to index on `short unsigned int`, and changed max tree depth to 15 (so that all node indices are less than 2^16 -1), did not make a significant difference. I chose to stick with Case 52 for this MR, not Case 53, because I think it's possible that other geometries will see more benefit from the deeper tree, whereas the benefit of having the stack take up less memory are fully realized in Case 53, and appear to be insignificant.

Note that between Case 44 and 51, the changes from #2375 were merged in. Also note the change in which Hudson GPU is used.

<img width="1075" height="175" alt="Screenshot 2026-05-01 at 5 09 10 PM" src="https://github.com/user-attachments/assets/1cc0e499-7a58-4fd9-9df3-17ef6293ea58" />

