### PR TITLE
Add LLDB synthetic/summary helper classes for improved debugging

### DIFF
--- a/scripts/dev/celerlldb.py
+++ b/scripts/dev/celerlldb.py
@@ -7,7 +7,7 @@ To use from inside ``${SOURCE}/build``::
    (lldb) command script import ../scripts/dev/celerlldb.py --allow-reload
    (lldb) type synthetic add -x "^celeritas::Span<.+>$" --python-class celerlldb.SpanSynthetic
    (lldb) type synthetic add -x "^celeritas::ItemRange<.+>$" --python-class celerlldb.ItemRangeSynthetic
-   (lldb) type synthetic add -x "^celeritas::OpaqueId<.+>$" --python-class celerlldb.OpaqueIdSynthetic
+   (lldb) type summary add -x "^celeritas::OpaqueId<.+>$" --python-function celerlldb.opaqueid_summary
 
 """
 
@@ -106,43 +106,21 @@ class ItemRangeSynthetic:
         return self.valobj.CreateValueFromExpression(name, f"(unsigned){val_int}")
 
 
-class OpaqueIdSynthetic:
-    def __init__(self, valobj, *args):
-        self.valobj = valobj  # type: SBValue
-        self._value = None
-        self._is_null = True
+def opaqueid_summary(valobj, _internal_dict):
+    value = valobj.GetChildMemberWithName("value_")
+    if not valobj.IsValid() or not value.IsValid():
+        return "null"
 
-    def update(self):
-        if not self.valobj.IsValid():
-            self._value = None
-            self._is_null = True
-            return False
+    raw_value = value.GetValueAsUnsigned(0)
 
-        value = self.valobj.GetChildMemberWithName("value_")
-        null_value = self.valobj.GetChildMemberWithName("null_")
-        if not value.IsValid() or not null_value.IsValid():
-            self._value = None
-            self._is_null = True
-            return False
+    # OpaqueId null sentinel is max value for the unsigned index type.
+    byte_size = value.GetType().GetByteSize()
+    if byte_size <= 0:
+        return str(raw_value)
+    bit_size = 8 * byte_size
+    null_value = (1 << min(bit_size, 64)) - 1
 
-        self._value = value.GetValueAsUnsigned(0)
-        self._is_null = self._value == null_value.GetValueAsUnsigned(0)
-        return False
+    if raw_value == null_value:
+        return "null"
 
-    def has_children(self):
-        return True
-
-    def num_children(self):
-        return 1
-
-    def get_child_index(self, name):
-        if name == "value":
-            return 0
-        return None
-
-    def get_child_at_index(self, index):
-        if index != 0:
-            return None
-        if self._value is None or self._is_null:
-            return self.valobj.CreateValueFromExpression("value", '(const char*)"null"')
-        return self.valobj.CreateValueFromExpression("value", str(self._value))
+    return str(raw_value)

--- a/scripts/dev/celerlldb.py
+++ b/scripts/dev/celerlldb.py
@@ -6,11 +6,16 @@ Add LLDB wrappers for Celeritas types.
 To use from inside ``${SOURCE}/build``::
    (lldb) command script import ../scripts/dev/celerlldb.py --allow-reload
    (lldb) type synthetic add -x "^celeritas::Span<.+>$" --python-class celerlldb.SpanSynthetic
-    (lldb) type synthetic add -x "^celeritas::Array<.+>$" --python-class celerlldb.ArraySynthetic
+   (lldb) type synthetic add -x "^celeritas::Array<.+>$" --python-class celerlldb.ArraySynthetic
    (lldb) type synthetic add -x "^celeritas::ItemRange<.+>$" --python-class celerlldb.ItemRangeSynthetic
    (lldb) type summary add -x "^celeritas::OpaqueId<.+>$" --python-function celerlldb.opaqueid_summary
 
 """
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lldb import SBValue
 
 
 class _ContiguousSyntheticBase:
@@ -77,6 +82,7 @@ class SpanSynthetic(_ContiguousSyntheticBase):
             return False
 
         storage = self.valobj.GetChildMemberWithName("s_")
+        assert storage.IsValid()
         size = storage.GetChildMemberWithName("size")
         assert size.IsValid()
         data = storage.GetChildMemberWithName("data")
@@ -98,14 +104,9 @@ class ArraySynthetic(_ContiguousSyntheticBase):
             return False
 
         data = self.valobj.GetChildMemberWithName("d_")
-        if not data.IsValid():
-            self._set_storage(None, 0, self._value_t)
-            return False
-
+        assert data.IsValid()
         data_ptr = data.AddressOf()
-        if not data_ptr.IsValid():
-            self._set_storage(None, 0, self._value_t)
-            return False
+        assert data_ptr.IsValid()
 
         self._set_storage(data_ptr, data.GetNumChildren(), self._value_t)
         return False
@@ -163,11 +164,11 @@ def opaqueid_summary(valobj, _internal_dict):
     raw_value = value.GetValueAsUnsigned(0)
 
     # OpaqueId null sentinel is max value for the unsigned index type.
-    byte_size = value.GetType().GetByteSize()
-    if byte_size <= 0:
+    size_bytes = value.GetType().GetByteSize()
+    if size_bytes <= 0 or size_bytes > 8:
         return str(raw_value)
-    bit_size = 8 * byte_size
-    null_value = (1 << min(bit_size, 64)) - 1
+    num_bits = 8 * size_bytes
+    null_value = (1 << num_bits) - 1
 
     if raw_value == null_value:
         return "null"

--- a/scripts/dev/celerlldb.py
+++ b/scripts/dev/celerlldb.py
@@ -6,34 +6,29 @@ Add LLDB wrappers for Celeritas types.
 To use from inside ``${SOURCE}/build``::
    (lldb) command script import ../scripts/dev/celerlldb.py --allow-reload
    (lldb) type synthetic add -x "^celeritas::Span<.+>$" --python-class celerlldb.SpanSynthetic
+    (lldb) type synthetic add -x "^celeritas::Array<.+>$" --python-class celerlldb.ArraySynthetic
    (lldb) type synthetic add -x "^celeritas::ItemRange<.+>$" --python-class celerlldb.ItemRangeSynthetic
    (lldb) type summary add -x "^celeritas::OpaqueId<.+>$" --python-function celerlldb.opaqueid_summary
 
 """
 
 
-class SpanSynthetic:
+class _ContiguousSyntheticBase:
     def __init__(self, valobj, *args):
         self.valobj = valobj  # type: SBValue
-
-        valtype = valobj.GetType()
         self._size = 0
-        self._t = valtype.GetTemplateArgumentType(0)
-        self._extent = valtype.GetTemplateArgumentType(1)
-        self.sizeof_value = self._t.GetByteSize()
+        self._t = None
+        self._dataobj = None
+        self._sizeof_value = 0
 
-    def update(self):
-        if not self.valobj.IsValid():
-            self._size = 0
-            return False
-
-        storage = self.valobj.GetChildMemberWithName("s_")
-        size = storage.GetChildMemberWithName("size")
-        assert size.IsValid()
-        self._size = size.GetValueAsUnsigned(0)
-        self._dataobj = storage.GetChildMemberWithName("data")
-        assert self._dataobj.IsValid()
-        return False
+    def _set_storage(self, dataobj, size, value_type):
+        self._dataobj = dataobj
+        self._size = size
+        self._t = value_type
+        if value_type is None or not value_type.IsValid():
+            self._sizeof_value = 0
+        else:
+            self._sizeof_value = value_type.GetByteSize()
 
     def has_children(self):
         return True
@@ -45,7 +40,7 @@ class SpanSynthetic:
         try:
             # See CreateChildAtOffset
             return int(name[1:-1])
-        except TypeError as e:
+        except (TypeError, ValueError) as e:
             print(f"Failed to get child index {name}: {e}")
             return None
 
@@ -58,9 +53,62 @@ class SpanSynthetic:
             print(f"Value is bad")
             # Value is bad?
             return None
+        if self._dataobj is None or not self._dataobj.IsValid():
+            print("Container data is invalid")
+            return None
+        if self._t is None or not self._t.IsValid() or self._sizeof_value <= 0:
+            print("Container value type is invalid")
+            return None
         return self._dataobj.CreateChildAtOffset(
-            "[{:d}]".format(index), index * self.sizeof_value, self._t
+            "[{:d}]".format(index), index * self._sizeof_value, self._t
         )
+
+
+class SpanSynthetic(_ContiguousSyntheticBase):
+    def __init__(self, valobj, *args):
+        super().__init__(valobj, *args)
+
+        valtype = valobj.GetType()
+        self._value_t = valtype.GetTemplateArgumentType(0)
+
+    def update(self):
+        if not self.valobj.IsValid():
+            self._set_storage(None, 0, self._value_t)
+            return False
+
+        storage = self.valobj.GetChildMemberWithName("s_")
+        size = storage.GetChildMemberWithName("size")
+        assert size.IsValid()
+        data = storage.GetChildMemberWithName("data")
+        assert data.IsValid()
+        self._set_storage(data, size.GetValueAsUnsigned(0), self._value_t)
+        return False
+
+
+class ArraySynthetic(_ContiguousSyntheticBase):
+    def __init__(self, valobj, *args):
+        super().__init__(valobj, *args)
+
+        valtype = valobj.GetType()
+        self._value_t = valtype.GetTemplateArgumentType(0)
+
+    def update(self):
+        if not self.valobj.IsValid():
+            self._set_storage(None, 0, self._value_t)
+            return False
+
+        data = self.valobj.GetChildMemberWithName("d_")
+        if not data.IsValid():
+            self._set_storage(None, 0, self._value_t)
+            return False
+
+        data_ptr = data.AddressOf()
+        if not data_ptr.IsValid():
+            self._set_storage(None, 0, self._value_t)
+            return False
+
+        self._set_storage(data_ptr, data.GetNumChildren(), self._value_t)
+        return False
 
 
 class ItemRangeSynthetic:

--- a/scripts/dev/celerlldb.py
+++ b/scripts/dev/celerlldb.py
@@ -43,7 +43,8 @@ class SpanSynthetic:
 
     def get_child_index(self, name):
         try:
-            return int(name.lstrip("[").rstrip("]"))
+            # See CreateChildAtOffset
+            return int(name[1:-1])
         except TypeError as e:
             print(f"Failed to get child index {name}: {e}")
             return None
@@ -88,7 +89,7 @@ class ItemRangeSynthetic:
         return len(self.values_)
 
     def get_child_index(self, name):
-        # Find the index of the child
+        # Find the index of the child in the begin/end list
         for i, (n, _) in enumerate(self.values_):
             if n == name:
                 return i

--- a/scripts/dev/celerlldb.py
+++ b/scripts/dev/celerlldb.py
@@ -7,6 +7,7 @@ To use from inside ``${SOURCE}/build``::
    (lldb) command script import ../scripts/dev/celerlldb.py --allow-reload
    (lldb) type synthetic add -x "^celeritas::Span<.+>$" --python-class celerlldb.SpanSynthetic
    (lldb) type synthetic add -x "^celeritas::ItemRange<.+>$" --python-class celerlldb.ItemRangeSynthetic
+   (lldb) type synthetic add -x "^celeritas::OpaqueId<.+>$" --python-class celerlldb.OpaqueIdSynthetic
 
 """
 
@@ -103,3 +104,45 @@ class ItemRangeSynthetic:
         (name, val) = self.values_[index]
         val_int = val.GetValueAsUnsigned()
         return self.valobj.CreateValueFromExpression(name, f"(unsigned){val_int}")
+
+
+class OpaqueIdSynthetic:
+    def __init__(self, valobj, *args):
+        self.valobj = valobj  # type: SBValue
+        self._value = None
+        self._is_null = True
+
+    def update(self):
+        if not self.valobj.IsValid():
+            self._value = None
+            self._is_null = True
+            return False
+
+        value = self.valobj.GetChildMemberWithName("value_")
+        null_value = self.valobj.GetChildMemberWithName("null_")
+        if not value.IsValid() or not null_value.IsValid():
+            self._value = None
+            self._is_null = True
+            return False
+
+        self._value = value.GetValueAsUnsigned(0)
+        self._is_null = self._value == null_value.GetValueAsUnsigned(0)
+        return False
+
+    def has_children(self):
+        return True
+
+    def num_children(self):
+        return 1
+
+    def get_child_index(self, name):
+        if name == "value":
+            return 0
+        return None
+
+    def get_child_at_index(self, index):
+        if index != 0:
+            return None
+        if self._value is None or self._is_null:
+            return self.valobj.CreateValueFromExpression("value", '(const char*)"null"')
+        return self.valobj.CreateValueFromExpression("value", str(self._value))

--- a/scripts/dev/debug-ctest.py
+++ b/scripts/dev/debug-ctest.py
@@ -31,6 +31,7 @@ from pathlib import Path
 LLDB_COMMANDS = """
 command script import ${workspaceFolder}/scripts/dev/celerlldb.py --allow-reload
 type synthetic add -x "^celeritas::Span<.+>$" --python-class celerlldb.SpanSynthetic
+type synthetic add -x "^celeritas::Array<.+>$" --python-class celerlldb.ArraySynthetic
 type synthetic add -x "^celeritas::ItemRange<.+>$" --python-class celerlldb.ItemRangeSynthetic
 type summary add -x "^celeritas::OpaqueId<.+>$" --python-function celerlldb.opaqueid_summary
 break set --name celeritas::throw_debug_error

--- a/scripts/dev/debug-ctest.py
+++ b/scripts/dev/debug-ctest.py
@@ -32,6 +32,7 @@ LLDB_COMMANDS = """
 command script import ${workspaceFolder}/scripts/dev/celerlldb.py --allow-reload
 type synthetic add -x "^celeritas::Span<.+>$" --python-class celerlldb.SpanSynthetic
 type synthetic add -x "^celeritas::ItemRange<.+>$" --python-class celerlldb.ItemRangeSynthetic
+type synthetic add -x "^celeritas::OpaqueId<.+>$" --python-class celerlldb.OpaqueIdSynthetic
 break set --name celeritas::throw_debug_error
 break set --name celeritas::throw_runtime_error
 """.strip().splitlines()

--- a/scripts/dev/debug-ctest.py
+++ b/scripts/dev/debug-ctest.py
@@ -32,7 +32,7 @@ LLDB_COMMANDS = """
 command script import ${workspaceFolder}/scripts/dev/celerlldb.py --allow-reload
 type synthetic add -x "^celeritas::Span<.+>$" --python-class celerlldb.SpanSynthetic
 type synthetic add -x "^celeritas::ItemRange<.+>$" --python-class celerlldb.ItemRangeSynthetic
-type synthetic add -x "^celeritas::OpaqueId<.+>$" --python-class celerlldb.OpaqueIdSynthetic
+type summary add -x "^celeritas::OpaqueId<.+>$" --python-function celerlldb.opaqueid_summary
 break set --name celeritas::throw_debug_error
 break set --name celeritas::throw_runtime_error
 """.strip().splitlines()


### PR DESCRIPTION
This adds code to help LLDB render Celeritas objects prettily for easier debugging.

Before:
<img width="260" height="306" alt="before" src="https://github.com/user-attachments/assets/09180ec2-eaa4-4db0-936a-2f2aab15f7bf" />
After:
<img width="276" height="307" alt="after" src="https://github.com/user-attachments/assets/1dfd77c3-4e43-4a62-a363-a8c544348709" />
