### PR TITLE
Fix missing copies of primary ID, post-step ID

### DIFF
--- a/scripts/cmake-presets/executor.json
+++ b/scripts/cmake-presets/executor.json
@@ -83,10 +83,11 @@
     },
     {
       "name": "base",
-      "displayName": "Goldfinger default options",
+      "displayName": "Executor default options",
       "inherits": [".ccache", ".spackbase", ".debug", "default"],
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
+        "CELERITAS_USE_ROOT":    {"type": "BOOL",   "value": "ON"},
         "CELERITAS_BUILD_DOCS": {"type": "BOOL", "value": "ON"},
         "CELERITAS_PYTHONPATH": "/Users/seth/Code/py-breathe:/Users/seth/Code/py-sphinxcontrib-bibtex/src",
         "CELERITAS_PYTHONWARNINGS": "ignore:::urllib3,ignore:::breathe.project,ignore::UserWarning:pybtex.plugin",

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -186,7 +186,7 @@ LocalTransporter::LocalTransporter(SetupOptions const& options,
         hit_processor_ = hit_manager->make_local_processor(stream_id);
         track_reconstruction_ = hit_processor_->track_reconstruction();
     }
-    else
+    if (!track_reconstruction_)
     {
         using VecConstPD = GeantTrackReconstruction::VecParticle;
         auto const& offload = params.OffloadParticles();

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -258,23 +258,6 @@ void LocalTransporter::Push(G4Track& g4track)
 
     ScopedProfiling profile_this{"push"};
 
-    GeantTrackView gtv{g4track};
-
-    if (!is_inside(bbox_,
-                   static_array_cast<real_type>(native_value_from(gtv.pos()))))
-    {
-        // Primary may have been created by a particle generator outside the
-        // geometry
-        CELER_LOG_LOCAL(error)
-            << "Discarding track outside world bounds: " << gtv.energy()
-            << " from " << gtv.particle().name() << " at " << gtv.pos()
-            << " along " << gtv.dir();
-
-        buffer_accum_.lost_energy += gtv.energy().value();
-        ++buffer_accum_.lost_primaries;
-        return;
-    }
-
     // Always check the event ID when pushing the first EM track, since the
     // GeantTrackReconstruction needs to be initialized before we "acquire" the
     // track
@@ -298,6 +281,22 @@ void LocalTransporter::Push(G4Track& g4track)
         }
     }
     CELER_ASSERT(event_id_ >= 0);
+
+    GeantTrackView gtv{g4track};
+    if (!is_inside(bbox_,
+                   static_array_cast<real_type>(native_value_from(gtv.pos()))))
+    {
+        // Primary may have been created outside the GPU geometry extent (which
+        // may not match the generator's extent *or* the CPU geant4 extent)
+        CELER_LOG_LOCAL(error)
+            << "Discarding track outside world bounds: " << gtv.energy()
+            << " from " << gtv.particle().name() << " at " << gtv.pos()
+            << " along " << gtv.dir();
+
+        buffer_accum_.lost_energy += gtv.energy().value();
+        ++buffer_accum_.lost_primaries;
+        return;
+    }
 
     Primary track;
 

--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -74,6 +74,7 @@ GeantSd::GeantSd(ParticleParams const& par,
     CELER_EXPECT(num_streams > 0);
 
     // Convert setup options to step data
+    selection_.primary_id = setup.track;
     selection_.particle = setup.track;
     selection_.weight = setup.track;
     selection_.energy_deposition = setup.energy_deposition;

--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -75,7 +75,7 @@ GeantSd::GeantSd(ParticleParams const& par,
 
     // Convert setup options to step data
     selection_.primary_id = setup.track;
-    selection_.particle = setup.track;
+    selection_.particle_id = setup.track;
     selection_.weight = setup.track;
     selection_.energy_deposition = setup.energy_deposition;
     selection_.step_length = setup.step_length;
@@ -100,7 +100,7 @@ GeantSd::GeantSd(ParticleParams const& par,
     if (setup.track)
     {
         this->setup_particles(par);
-        CELER_ASSERT(selection_.primary_id && selection_.particle
+        CELER_ASSERT(selection_.primary_id && selection_.particle_id
                      && selection_.weight);
     }
 
@@ -233,7 +233,7 @@ void GeantSd::setup_volumes(inp::GeantSd const& setup)
 //---------------------------------------------------------------------------//
 void GeantSd::setup_particles(ParticleParams const& par)
 {
-    CELER_EXPECT(selection_.particle);
+    CELER_EXPECT(selection_.particle_id);
 
     auto& g4particles = *G4ParticleTable::GetParticleTable();
 

--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -100,6 +100,8 @@ GeantSd::GeantSd(ParticleParams const& par,
     if (setup.track)
     {
         this->setup_particles(par);
+        CELER_ASSERT(selection_.primary_id && selection_.particle
+                     && selection_.weight);
     }
 
     CELER_ENSURE(setup.track == !this->particles_.empty());

--- a/src/celeritas/ext/GeantTrackReconstruction.cc
+++ b/src/celeritas/ext/GeantTrackReconstruction.cc
@@ -95,6 +95,7 @@ GeantTrackReconstruction::GeantTrackReconstruction(VecParticle const& particles,
                                                    SPStep step)
     : step_(std::move(step))
 {
+    CELER_EXPECT(!particles.empty());
     CELER_EXPECT(step_);
 
     // Create track for each particle type

--- a/src/celeritas/ext/GeantTrackReconstruction.hh
+++ b/src/celeritas/ext/GeantTrackReconstruction.hh
@@ -27,6 +27,14 @@ namespace celeritas
  * This class handles the bookkeeping of Geant4 track information needed
  * to reconstruct tracks during hit processing. It maintains mappings between
  * Celeritas PrimaryID and Geant4 track data.
+ *
+ * \par Usage
+ * - \c init_event
+ * - \c acquire (multiple times)
+ * - \c view (may be interleaved with acquire)
+ * - \c clear (once all active tracks are used up)
+ * - then it can be initialized with a new event, or new primaries can be
+ *   added to the current event.
  */
 class GeantTrackReconstruction
 {

--- a/src/celeritas/ext/detail/HitProcessor.cc
+++ b/src/celeritas/ext/detail/HitProcessor.cc
@@ -37,6 +37,13 @@
 #include "../GeantStepPointView.hh"
 #include "../GeantStepView.hh"
 
+#define HP_ASSIGN_TRANSFORMED(SELECTION, VIEW, VAR, DATA, TRANSFORM, IDX) \
+    if (SELECTION.VAR)                                                    \
+    {                                                                     \
+        CELER_ASSERT(IDX < DATA.VAR.size());                              \
+        VIEW.VAR(TRANSFORM(DATA.VAR[IDX]));                               \
+    }
+
 namespace celeritas
 {
 namespace detail
@@ -94,9 +101,9 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
                            StepSelection const& selection,
                            StepPointBool const& locate_touchable)
     : detector_volumes_(std::move(detector_volumes))
-    , step_post_status_{
-          selection.points[StepPoint::pre].volume_instance_ids
-          && selection.points[StepPoint::post].volume_instance_ids}
+    , ss_{selection}
+    , step_post_status_{ss_.points[StepPoint::pre].volume_instance_ids
+                        && ss_.points[StepPoint::post].volume_instance_ids}
 {
     CELER_EXPECT(detector_volumes_ && !detector_volumes_->empty());
 
@@ -113,12 +120,14 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         track_reconstruction_
             = std::make_shared<GeantTrackReconstruction>(particles, step_);
     }
+    CELER_ASSERT(ss_.particle == static_cast<bool>(track_reconstruction_)
+                 && ss_.primary_id == ss_.particle);
 
     GeantStepView step_view{*step_};
 
     for (auto sp : range(StepPoint::size_))
     {
-        if (!selection.points[sp])
+        if (!ss_.points[sp])
         {
             step_view.delete_step_point(sp);
             CELER_ASSERT(!locate_touchable[sp]);
@@ -135,7 +144,7 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
                 step_points_[sp]->SetTouchableHandle(touch_handle_[sp]);
                 if (!update_touchable_)
                 {
-                    CELER_EXPECT(selection.points[sp].volume_instance_ids);
+                    CELER_EXPECT(ss_.points[sp].volume_instance_ids);
                     // FIXME: pass geant geo into this constructor
                     auto ggeo = ::celeritas::global_geant_geo().lock();
                     CELER_ASSERT(ggeo);
@@ -145,10 +154,6 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
             }
         }
     }
-
-    // Set invalid values for unsupported SD attributes
-    step_->SetNonIonizingEnergyDeposit(
-        -std::numeric_limits<double>::infinity());
 
     // Convert logical volumes (global) to sensitive detectors (thread local)
     detectors_.resize(detector_volumes_->size());
@@ -221,16 +226,14 @@ void HitProcessor::operator()(DetectorStepOutput const& out, size_type i) const
     CELER_EXPECT(i < out.size());
 
     GeantStepView step_view{*step_};
-    if (!out.energy_deposition.empty())
-    {
-        step_view.energy_deposition(
-            GeantStepView::Energy{out.energy_deposition[i].value()});
-    }
-    if (!out.step_length.empty())
-    {
-        step_view.step_length(
-            native_value_to<GeantStepView::Length>(out.step_length[i]));
-    }
+
+#define HP_ASSIGN_STEP(VAR, TRANSFORM) \
+    HP_ASSIGN_TRANSFORMED(ss_, step_view, VAR, out, TRANSFORM, i)
+
+    HP_ASSIGN_STEP(energy_deposition, GeantStepView::Energy);
+    HP_ASSIGN_STEP(step_length, native_value_to<GeantStepView::Length>);
+
+#undef HP_ASSIGN_STEP
 
     for (auto sp : range(StepPoint::size_))
     {
@@ -255,33 +258,21 @@ void HitProcessor::operator()(DetectorStepOutput const& out, size_type i) const
             }
         }
 
-        auto const& celer_sp = out.points[sp];
         GeantStepPointView sp_view{*g4sp};
 
-        if (!celer_sp.time.empty())
-        {
-            sp_view.time(
-                native_value_to<GeantStepPointView::Time>(celer_sp.time[i]));
-        }
-        if (!celer_sp.pos.empty())
-        {
-            sp_view.pos(
-                native_value_to<GeantStepPointView::Length>(celer_sp.pos[i]));
-        }
-        if (!celer_sp.energy.empty())
-        {
-            sp_view.energy(
-                GeantStepPointView::Energy{celer_sp.energy[i].value()});
-        }
-        if (!celer_sp.dir.empty())
-        {
-            sp_view.dir(static_array_cast<double>(celer_sp.dir[i]));
-        }
-        if (!out.weight.empty())
-        {
-            // Celeritas weight does not currently change across a step
-            sp_view.weight(out.weight[i]);
-        }
+#define HP_ASSIGN_SP(VAR, TRANSFORM) \
+    HP_ASSIGN_TRANSFORMED(           \
+        ss_.points[sp], sp_view, VAR, out.points[sp], TRANSFORM, i)
+
+        HP_ASSIGN_SP(time, native_value_to<GeantStepPointView::Time>);
+        HP_ASSIGN_SP(pos, native_value_to<GeantStepPointView::Length>);
+        HP_ASSIGN_SP(energy, GeantStepPointView::Energy);
+        HP_ASSIGN_SP(dir, static_array_cast<double>);
+#undef HP_ASSIGN_SP
+
+        // Celeritas weight does not currently change across a step
+        HP_ASSIGN_TRANSFORMED(
+            ss_, sp_view, weight, out, static_cast<G4double>, i);
 
         // Copy attributes from logical volume
         if (sp == StepPoint::pre)

--- a/src/celeritas/ext/detail/HitProcessor.cc
+++ b/src/celeritas/ext/detail/HitProcessor.cc
@@ -120,8 +120,8 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
         track_reconstruction_
             = std::make_shared<GeantTrackReconstruction>(particles, step_);
     }
-    CELER_ASSERT(ss_.particle == static_cast<bool>(track_reconstruction_)
-                 && ss_.primary_id == ss_.particle);
+    CELER_ASSERT(ss_.particle_id == static_cast<bool>(track_reconstruction_)
+                 && ss_.primary_id == ss_.particle_id);
 
     GeantStepView step_view{*step_};
 
@@ -222,7 +222,7 @@ void HitProcessor::operator()(DetectorStepOutput const& out) const
  */
 void HitProcessor::operator()(DetectorStepOutput const& out, size_type i) const
 {
-    CELER_EXPECT(!out.detector.empty());
+    CELER_EXPECT(!out.detector_id.empty());
     CELER_EXPECT(i < out.size());
 
     GeantStepView step_view{*step_};
@@ -277,7 +277,8 @@ void HitProcessor::operator()(DetectorStepOutput const& out, size_type i) const
         // Copy attributes from logical volume
         if (sp == StepPoint::pre)
         {
-            G4LogicalVolume const* lv = this->detector_volume(out.detector[i]);
+            G4LogicalVolume const* lv
+                = this->detector_volume(out.detector_id[i]);
             CELER_ASSERT(lv);
             // Use lv already known from the in-volume detector
             sp_view.update_from_volume(*lv);
@@ -291,15 +292,15 @@ void HitProcessor::operator()(DetectorStepOutput const& out, size_type i) const
 
     // Reconstruct tracks and IDs if particles were provided
     CELER_ASSERT(static_cast<bool>(track_reconstruction_)
-                 == !out.particle.empty());
+                 == !out.particle_id.empty());
     if (track_reconstruction_)
     {
-        CELER_ASSERT(i < out.particle.size());
+        CELER_ASSERT(i < out.particle_id.size());
         CELER_ASSERT(i < out.primary_id.size());
         // Get track corresponding to the particle type, and reload primary
         // data if possible
-        G4Track& g4track
-            = track_reconstruction_->view(out.particle[i], out.primary_id[i]);
+        G4Track& g4track = track_reconstruction_->view(out.particle_id[i],
+                                                       out.primary_id[i]);
         CELER_ASSERT(&g4track == step_->GetTrack());
         // Copy step information to the corresponding track
         GeantStepView{*step_}.update_track();
@@ -314,7 +315,7 @@ void HitProcessor::operator()(DetectorStepOutput const& out, size_type i) const
     }
 
     // Hit sensitive detector
-    this->detector(out.detector[i])->Hit(step_.get());
+    this->detector(out.detector_id[i])->Hit(step_.get());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/ext/detail/HitProcessor.cc
+++ b/src/celeritas/ext/detail/HitProcessor.cc
@@ -107,8 +107,12 @@ HitProcessor::HitProcessor(SPConstVecLV detector_volumes,
 
     step_ = GeantTrackReconstruction::make_g4step();
     CELER_ASSERT(step_);
-    track_reconstruction_
-        = std::make_shared<GeantTrackReconstruction>(particles, step_);
+    if (!particles.empty())
+    {
+        // Reconstruct track
+        track_reconstruction_
+            = std::make_shared<GeantTrackReconstruction>(particles, step_);
+    }
 
     GeantStepView step_view{*step_};
 
@@ -294,14 +298,17 @@ void HitProcessor::operator()(DetectorStepOutput const& out, size_type i) const
         }
     }
 
-    if (!out.particle.empty())
+    // Reconstruct tracks and IDs if particles were provided
+    CELER_ASSERT(static_cast<bool>(track_reconstruction_)
+                 == !out.particle.empty());
+    if (track_reconstruction_)
     {
+        CELER_ASSERT(i < out.particle.size());
+        CELER_ASSERT(i < out.primary_id.size());
         // Get track corresponding to the particle type, and reload primary
         // data if possible
-        G4Track& g4track = out.primary_id.empty()
-                               ? track_reconstruction_->view(out.particle[i])
-                               : track_reconstruction_->view(
-                                     out.particle[i], out.primary_id[i]);
+        G4Track& g4track
+            = track_reconstruction_->view(out.particle[i], out.primary_id[i]);
         CELER_ASSERT(&g4track == step_->GetTrack());
         // Copy step information to the corresponding track
         GeantStepView{*step_}.update_track();

--- a/src/celeritas/ext/detail/HitProcessor.hh
+++ b/src/celeritas/ext/detail/HitProcessor.hh
@@ -116,6 +116,7 @@ class HitProcessor
   private:
     //! Detector volumes for navigation updating
     SPConstVecLV detector_volumes_;
+    StepSelection ss_;
     //! Map detector IDs to sensitive detectors
     std::vector<G4VSensitiveDetector*> detectors_;
     //! Temporary CPU hit information

--- a/src/celeritas/ext/detail/NaviTouchableUpdater.cc
+++ b/src/celeritas/ext/detail/NaviTouchableUpdater.cc
@@ -66,12 +66,12 @@ bool NaviTouchableUpdater::operator()(DetectorStepOutput const& out,
     CELER_EXPECT(i < out.size());
     CELER_EXPECT(!out.points[StepPoint::pre].pos.empty());
     CELER_EXPECT(!out.points[StepPoint::pre].dir.empty());
-    CELER_EXPECT(!out.detector.empty());
+    CELER_EXPECT(!out.detector_id.empty());
     CELER_EXPECT(detector_volumes_
-                 && out.detector[i] < detector_volumes_->size());
+                 && out.detector_id[i] < detector_volumes_->size());
 
     G4LogicalVolume const* lv
-        = (*detector_volumes_)[out.detector[i].unchecked_get()];
+        = (*detector_volumes_)[out.detector_id[i].unchecked_get()];
 
     auto const& point = out.points[step_point];
     return (*this)(point.pos[i], point.dir[i], lv, touchable);

--- a/src/celeritas/global/DebugIO.json.cc
+++ b/src/celeritas/global/DebugIO.json.cc
@@ -160,6 +160,7 @@ void to_json_impl(nlohmann::json& j,
     {
         DIO_ASSIGN(track_id, passthrough);
         DIO_ASSIGN(parent_id, passthrough);
+        DIO_ASSIGN(primary_id, passthrough);
         DIO_ASSIGN(event_id, passthrough);
         DIO_ASSIGN(num_steps, passthrough);
         DIO_ASSIGN(event_id, passthrough);

--- a/src/celeritas/global/KernelContextException.cc
+++ b/src/celeritas/global/KernelContextException.cc
@@ -99,6 +99,7 @@ void KernelContextException::output(JsonPimpl* json) const
     if (track_)
     {
         KCE_INSERT_IF_VALID(parent);
+        KCE_INSERT_IF_VALID(primary);
         j["num_steps"] = num_steps_;
         KCE_INSERT_IF_VALID(particle);
         j["energy"] = energy_;
@@ -128,6 +129,7 @@ void KernelContextException::initialize(CoreTrackView const& core)
         event_ = sim.event_id();
         track_ = sim.track_id();
         parent_ = sim.parent_id();
+        primary_ = sim.primary_id();
         num_steps_ = sim.num_steps();
         {
             auto const&& par = core.particle();

--- a/src/celeritas/global/KernelContextException.hh
+++ b/src/celeritas/global/KernelContextException.hh
@@ -100,6 +100,7 @@ class KernelContextException : public RichContextException
     EventId event_;
     TrackId track_;
     TrackId parent_;
+    PrimaryId primary_;
     size_type num_steps_;
     ParticleId particle_;
     Energy energy_;

--- a/src/celeritas/track/ExtendFromPrimariesAction.hh
+++ b/src/celeritas/track/ExtendFromPrimariesAction.hh
@@ -104,7 +104,7 @@ class ExtendFromPrimariesAction final : public CoreStepActionInterface,
 template<MemSpace M>
 struct PrimaryStateData : public AuxStateInterface
 {
-    // "Resizable" storage
+    // "Resizable" storage (TODO: pinned-memory buffer when using device)
     Collection<Primary, Ownership::value, M> storage;
     size_type count{0};
 

--- a/src/celeritas/track/detail/ProcessSecondariesExecutor.hh
+++ b/src/celeritas/track/detail/ProcessSecondariesExecutor.hh
@@ -16,6 +16,7 @@
 #include "celeritas/global/CoreTrackView.hh"
 #include "celeritas/phys/ParticleData.hh"
 #include "celeritas/phys/Secondary.hh"
+#include "celeritas/track/Utils.hh"
 
 #include "../CoreStateCounters.hh"
 

--- a/src/celeritas/user/DetectorSteps.cc
+++ b/src/celeritas/user/DetectorSteps.cc
@@ -125,7 +125,8 @@ void copy_steps<MemSpace::host>(
 
     // Resize and copy if the fields are present
 #define DS_ASSIGN(FIELD) \
-    assign_field(&(output->FIELD), state.data.FIELD, state.data.detector, size)
+    assign_field(        \
+        &(output->FIELD), state.data.FIELD, state.data.detector_id, size)
 
     DS_ASSIGN(detector_id);
     DS_ASSIGN(track_id);
@@ -149,6 +150,7 @@ void copy_steps<MemSpace::host>(
     DS_ASSIGN(event_id);
     DS_ASSIGN(parent_id);
     DS_ASSIGN(primary_id);
+    DS_ASSIGN(post_step_action_id);
     DS_ASSIGN(track_step_count);
     DS_ASSIGN(step_length);
     DS_ASSIGN(weight);

--- a/src/celeritas/user/DetectorSteps.cc
+++ b/src/celeritas/user/DetectorSteps.cc
@@ -121,13 +121,13 @@ void copy_steps<MemSpace::host>(
     ScopedProfiling profile_this{"copy-steps"};
 
     // Get the number of threads that are active and in a detector
-    size_type size = count_num_valid(state.data.detector);
+    size_type size = count_num_valid(state.data.detector_id);
 
     // Resize and copy if the fields are present
 #define DS_ASSIGN(FIELD) \
     assign_field(&(output->FIELD), state.data.FIELD, state.data.detector, size)
 
-    DS_ASSIGN(detector);
+    DS_ASSIGN(detector_id);
     DS_ASSIGN(track_id);
 
     for (auto sp : range(StepPoint::size_))
@@ -140,7 +140,7 @@ void copy_steps<MemSpace::host>(
         {
             assign_field(&(output->points[sp].volume_instance_ids),
                          state.data.points[sp].volume_instance_ids,
-                         state.data.detector,
+                         state.data.detector_id,
                          size,
                          state.num_volume_levels);
         }
@@ -152,14 +152,14 @@ void copy_steps<MemSpace::host>(
     DS_ASSIGN(track_step_count);
     DS_ASSIGN(step_length);
     DS_ASSIGN(weight);
-    DS_ASSIGN(particle);
+    DS_ASSIGN(particle_id);
     DS_ASSIGN(energy_deposition);
 
     output->num_volume_levels = state.num_volume_levels;
 
 #undef DS_ASSIGN
 
-    CELER_ENSURE(output->detector.size() == size);
+    CELER_ENSURE(output->detector_id.size() == size);
     CELER_ENSURE(output->track_id.size() == size);
 }
 

--- a/src/celeritas/user/DetectorSteps.cu
+++ b/src/celeritas/user/DetectorSteps.cu
@@ -55,12 +55,13 @@ size_type count_num_valid(
 {
     // Store the thread IDs of active tracks that are in a detector
     auto start = device_pointer_cast(state.valid_id.data());
-    auto end = thrust::copy_if(thrust_execute_on(state.stream_id),
-                               thrust::make_counting_iterator(0_sz),
-                               thrust::make_counting_iterator(state.size()),
-                               device_pointer_cast(state.data.detector.data()),
-                               start,
-                               HasDetector{});
+    auto end
+        = thrust::copy_if(thrust_execute_on(state.stream_id),
+                          thrust::make_counting_iterator(0_sz),
+                          thrust::make_counting_iterator(state.size()),
+                          device_pointer_cast(state.data.detector_id.data()),
+                          start,
+                          HasDetector{});
     return end - start;
 }
 
@@ -137,7 +138,7 @@ void copy_steps<MemSpace::device>(
     copy_field(          \
         &(output->FIELD), state.scratch.FIELD, num_valid, state.stream_id)
 
-    DS_ASSIGN(detector);
+    DS_ASSIGN(detector_id);
     DS_ASSIGN(track_id);
 
     for (auto sp : range(StepPoint::size_))
@@ -157,10 +158,11 @@ void copy_steps<MemSpace::device>(
     DS_ASSIGN(event_id);
     DS_ASSIGN(parent_id);
     DS_ASSIGN(primary_id);
+    DS_ASSIGN(post_step_action_id);
     DS_ASSIGN(track_step_count);
     DS_ASSIGN(step_length);
     DS_ASSIGN(weight);
-    DS_ASSIGN(particle);
+    DS_ASSIGN(particle_id);
     DS_ASSIGN(energy_deposition);
 
     output->num_volume_levels = state.num_volume_levels;
@@ -171,7 +173,7 @@ void copy_steps<MemSpace::device>(
     CELER_DEVICE_API_CALL(
         StreamSynchronize(celeritas::device().stream(state.stream_id).get()));
 
-    CELER_ENSURE(output->detector.size() == num_valid);
+    CELER_ENSURE(output->detector_id.size() == num_valid);
     CELER_ENSURE(output->track_id.size() == num_valid);
 }
 

--- a/src/celeritas/user/DetectorSteps.hh
+++ b/src/celeritas/user/DetectorSteps.hh
@@ -73,18 +73,21 @@ struct DetectorStepOutput
     // Pre- and post-step data
     EnumArray<StepPoint, DetectorStepPointOutput> points;
 
-    // Detector ID and track ID are always set
-    PinnedVec<DetectorId> detector;
+    // Track and detector IDs are always set
     PinnedVec<TrackId> track_id;
+    PinnedVec<DetectorId> detector_id;
 
-    // Additional optional data
+    // Additional optional data (sim)
     PinnedVec<EventId> event_id;
     PinnedVec<TrackId> parent_id;
     PinnedVec<PrimaryId> primary_id;
+    PinnedVec<ActionId> post_step_action_id;
     PinnedVec<size_type> track_step_count;
     PinnedVec<real_type> step_length;
     PinnedVec<real_type> weight;
-    PinnedVec<ParticleId> particle;
+
+    // Additional optional data (physics)
+    PinnedVec<ParticleId> particle_id;
     PinnedVec<Energy> energy_deposition;
 
     // 2D size for volume instances
@@ -93,9 +96,9 @@ struct DetectorStepOutput
     //// METHODS ////
 
     //! Number of elements in the detector output.
-    size_type size() const { return detector.size(); }
+    size_type size() const { return detector_id.size(); }
     //! Whether the size is nonzero
-    explicit operator bool() const { return !detector.empty(); }
+    explicit operator bool() const { return !detector_id.empty(); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/user/RootStepWriter.cc
+++ b/src/celeritas/user/RootStepWriter.cc
@@ -163,18 +163,18 @@ void RootStepWriter::process_steps(HostStepState state)
         tstep_.track_id = state.steps.data.track_id[tid].unchecked_get();
 
         RSW_STORE(event_id, .get());
+        if (selection_.particle_id)
+        {
+            copy_if_selected(
+                particles_->id_to_pdg(state.steps.data.particle_id[tid]).get(),
+                tstep_.particle);
+        }
         RSW_STORE(parent_id, .unchecked_get());
-        RSW_STORE(action_id, .get());
+        RSW_STORE(primary_id, .unchecked_get());
+        RSW_STORE(post_step_action_id, .get());
         RSW_STORE(energy_deposition, .value());
         RSW_STORE(step_length, /* no getter */);
         RSW_STORE(track_step_count, /* no getter */);
-        if (selection_.particle)
-        {
-            copy_if_selected(
-                particles_->id_to_pdg(state.steps.data.particle[tid]).get(),
-                tstep_.particle);
-        }
-
         for (auto const sp : range(StepPoint::size_))
         {
             RSW_STORE(points[sp].volume_id, .unchecked_get());
@@ -221,7 +221,7 @@ void RootStepWriter::make_tree()
     RSW_CREATE_BRANCH(event_id, "event_id");
     RSW_CREATE_BRANCH(parent_id, "parent_id");
     RSW_CREATE_BRANCH(track_step_count, "track_step_count");
-    RSW_CREATE_BRANCH(action_id, "action_id");
+    RSW_CREATE_BRANCH(post_step_id, "post_step_id");
     RSW_CREATE_BRANCH(step_length, "step_length");
     RSW_CREATE_BRANCH(particle, "particle");
     RSW_CREATE_BRANCH(energy_deposition, "energy_deposition");
@@ -251,9 +251,9 @@ RootStepWriter::WriteFilter make_write_filter(SimpleRootFilterInput const& inp)
     }
 
     return [inp](RootStepWriter::TStepData const& step) {
-        if (inp.action_id != SimpleRootFilterInput::unspecified)
+        if (inp.post_step_action_id != SimpleRootFilterInput::unspecified)
         {
-            return step.action_id == inp.action_id;
+            return step.post_step_action_id == inp.post_step_action_id;
         }
         return (srf_match(step.event_id, inp.event_id)
                 && srf_match(step.track_id, inp.track_id)

--- a/src/celeritas/user/RootStepWriter.cc
+++ b/src/celeritas/user/RootStepWriter.cc
@@ -163,18 +163,18 @@ void RootStepWriter::process_steps(HostStepState state)
         tstep_.track_id = state.steps.data.track_id[tid].unchecked_get();
 
         RSW_STORE(event_id, .get());
+        RSW_STORE(parent_id, .unchecked_get());
+        RSW_STORE(primary_id, .unchecked_get());
+        RSW_STORE(post_step_action_id, .get());
+        RSW_STORE(track_step_count, /* no getter */);
+        RSW_STORE(step_length, /* no getter */);
+        RSW_STORE(energy_deposition, .value());
         if (selection_.particle_id)
         {
             copy_if_selected(
                 particles_->id_to_pdg(state.steps.data.particle_id[tid]).get(),
                 tstep_.particle);
         }
-        RSW_STORE(parent_id, .unchecked_get());
-        RSW_STORE(primary_id, .unchecked_get());
-        RSW_STORE(post_step_action_id, .get());
-        RSW_STORE(energy_deposition, .value());
-        RSW_STORE(step_length, /* no getter */);
-        RSW_STORE(track_step_count, /* no getter */);
         for (auto const sp : range(StepPoint::size_))
         {
             RSW_STORE(points[sp].volume_id, .unchecked_get());
@@ -220,11 +220,15 @@ void RootStepWriter::make_tree()
     tstep_tree_->Branch("track_id", &tstep_.track_id);  // Always on
     RSW_CREATE_BRANCH(event_id, "event_id");
     RSW_CREATE_BRANCH(parent_id, "parent_id");
+    RSW_CREATE_BRANCH(primary_id, "primary_id");
+    RSW_CREATE_BRANCH(post_step_action_id, "post_step_action_id");
     RSW_CREATE_BRANCH(track_step_count, "track_step_count");
-    RSW_CREATE_BRANCH(post_step_id, "post_step_id");
     RSW_CREATE_BRANCH(step_length, "step_length");
-    RSW_CREATE_BRANCH(particle, "particle");
     RSW_CREATE_BRANCH(energy_deposition, "energy_deposition");
+    if (this->selection_.particle_id)
+    {
+        this->tstep_tree_->Branch("particle", &tstep_.particle);
+    }
     // Pre-step
     RSW_CREATE_BRANCH(points[StepPoint::pre].volume_id, "pre_volume_id");
     RSW_CREATE_BRANCH(points[StepPoint::pre].dir, "pre_dir");

--- a/src/celeritas/user/RootStepWriter.hh
+++ b/src/celeritas/user/RootStepWriter.hh
@@ -56,11 +56,11 @@ class RootStepWriter final : public StepInterface
     struct TStepData
     {
         size_type event_id = unspecified;
+        int particle = 0;  //!< PDG number
         size_type track_id = unspecified;
         size_type parent_id = unspecified;
-        size_type action_id = unspecified;
+        size_type post_step_action_id = unspecified;
         size_type track_step_count = unspecified;
-        int particle = 0;  //!< PDG number
         real_type energy_deposition = 0;  //!< [MeV]
         real_type step_length = 0;  //!< [len]
         EnumArray<StepPoint, TStepPoint> points;

--- a/src/celeritas/user/RootStepWriter.hh
+++ b/src/celeritas/user/RootStepWriter.hh
@@ -56,13 +56,14 @@ class RootStepWriter final : public StepInterface
     struct TStepData
     {
         size_type event_id = unspecified;
-        int particle = 0;  //!< PDG number
         size_type track_id = unspecified;
         size_type parent_id = unspecified;
+        size_type primary_id = unspecified;
         size_type post_step_action_id = unspecified;
         size_type track_step_count = unspecified;
-        real_type energy_deposition = 0;  //!< [MeV]
         real_type step_length = 0;  //!< [len]
+        real_type energy_deposition = 0;  //!< [MeV]
+        int particle = 0;  //!< PDG number
         EnumArray<StepPoint, TStepPoint> points;
     };
 

--- a/src/celeritas/user/RootStepWriterIO.json.cc
+++ b/src/celeritas/user/RootStepWriterIO.json.cc
@@ -22,7 +22,7 @@ void from_json(nlohmann::json const& j, SimpleRootFilterInput& options)
     SRFI_LOAD_OPTION(track_id);
     SRFI_LOAD_OPTION(event_id);
     SRFI_LOAD_OPTION(parent_id);
-    SRFI_LOAD_OPTION(action_id);
+    SRFI_LOAD_OPTION(post_step_action_id);
 #undef SRFI_LOAD_OPTION
 }
 
@@ -38,7 +38,7 @@ void to_json(nlohmann::json& j, SimpleRootFilterInput const& options)
     CELER_JSON_SAVE(j, options, track_id);
     SRFI_SAVE_OPTION(event_id);
     SRFI_SAVE_OPTION(parent_id);
-    SRFI_SAVE_OPTION(action_id);
+    SRFI_SAVE_OPTION(post_step_action_id);
 #undef SRFI_SAVE_OPTION
 }
 

--- a/src/celeritas/user/RootStepWriterInput.hh
+++ b/src/celeritas/user/RootStepWriterInput.hh
@@ -25,13 +25,14 @@ struct SimpleRootFilterInput
     std::vector<size_type> track_id;
     size_type event_id = unspecified;
     size_type parent_id = unspecified;
-    size_type action_id = unspecified;
+    size_type post_step_action_id = unspecified;
 
     //! True if any filtering is being applied
     explicit operator bool() const
     {
         return !track_id.empty() || event_id != unspecified
-               || parent_id != unspecified || action_id != unspecified;
+               || parent_id != unspecified
+               || post_step_action_id != unspecified;
     }
 };
 

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -462,6 +462,7 @@ inline void resize(StepStateDataImpl<Ownership::value, M>* state,
 
     SD_RESIZE_IF_SELECTED(event_id);
     SD_RESIZE_IF_SELECTED(parent_id);
+    SD_RESIZE_IF_SELECTED(primary_id);
     SD_RESIZE_IF_SELECTED(track_step_count);
     SD_RESIZE_IF_SELECTED(step_length);
     SD_RESIZE_IF_SELECTED(weight);

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -94,6 +94,7 @@ struct StepSelection
             true,
             true,
             true,
+            true,
             true};
     }
 

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -65,8 +65,6 @@ struct StepPointSelection
  * Which track properties to gather at every step.
  *
  * These should correspond to the data items in StepStateDataImpl.
- *
- * TODO: particle -> particle_id for consistency
  */
 struct StepSelection
 {
@@ -75,11 +73,12 @@ struct StepSelection
     bool event_id{false};
     bool parent_id{false};
     bool primary_id{false};
+    bool post_step_action_id{false};
     bool track_step_count{false};
-    bool action_id{false};
     bool step_length{false};
     bool weight{false};
-    bool particle{false};
+
+    bool particle_id{false};
     bool energy_deposition{false};
 
     //! Create StepSelection with all options set to true
@@ -102,8 +101,8 @@ struct StepSelection
     explicit CELER_FUNCTION operator bool() const
     {
         return points[StepPoint::pre] || points[StepPoint::post] || event_id
-               || parent_id || track_step_count || action_id || step_length
-               || weight || particle || energy_deposition;
+               || parent_id || track_step_count || post_step_action_id
+               || step_length || weight || particle_id || energy_deposition;
     }
 
     //! Combine the selection with another
@@ -117,10 +116,10 @@ struct StepSelection
         this->event_id |= other.event_id;
         this->parent_id |= other.parent_id;
         this->track_step_count |= other.track_step_count;
-        this->action_id |= other.action_id;
+        this->post_step_action_id |= other.post_step_action_id;
         this->step_length |= other.step_length;
         this->weight |= other.weight;
-        this->particle |= other.particle;
+        this->particle_id |= other.particle_id;
         this->energy_deposition |= other.energy_deposition;
         return *this;
     }
@@ -255,19 +254,19 @@ struct StepStateDataImpl
     StateItems<TrackId> track_id;
 
     //! Detector ID is non-empty if params.detector is nonempty
-    StateItems<DetectorId> detector;
+    StateItems<DetectorId> detector_id;
 
     // Sim
     StateItems<EventId> event_id;
     StateItems<TrackId> parent_id;
     StateItems<PrimaryId> primary_id;
-    StateItems<ActionId> action_id;
+    StateItems<ActionId> post_step_action_id;
     StateItems<size_type> track_step_count;
     StateItems<real_type> step_length;
     StateItems<real_type> weight;
 
     // Physics
-    StateItems<ParticleId> particle;
+    StateItems<ParticleId> particle_id;
     StateItems<Energy> energy_deposition;
 
     //// METHODS ////
@@ -279,11 +278,11 @@ struct StepStateDataImpl
             return (t.size() == this->size()) || t.empty();
         };
 
-        return !track_id.empty() && right_sized(detector)
+        return !track_id.empty() && right_sized(detector_id)
                && right_sized(event_id) && right_sized(parent_id)
                && right_sized(primary_id) && right_sized(track_step_count)
-               && right_sized(action_id) && right_sized(step_length)
-               && right_sized(weight) && right_sized(particle)
+               && right_sized(post_step_action_id) && right_sized(step_length)
+               && right_sized(weight) && right_sized(particle_id)
                && right_sized(energy_deposition);
     }
 
@@ -309,13 +308,13 @@ struct StepStateDataImpl
         track_id = other.track_id;
         parent_id = other.parent_id;
         primary_id = other.primary_id;
-        detector = other.detector;
+        detector_id = other.detector_id;
         event_id = other.event_id;
         track_step_count = other.track_step_count;
-        action_id = other.action_id;
+        post_step_action_id = other.post_step_action_id;
         step_length = other.step_length;
         weight = other.weight;
-        particle = other.particle;
+        particle_id = other.particle_id;
         energy_deposition = other.energy_deposition;
         return *this;
     }
@@ -457,7 +456,7 @@ inline void resize(StepStateDataImpl<Ownership::value, M>* state,
     resize(&state->track_id, size);
     if (!params.detector.empty())
     {
-        resize(&state->detector, size);
+        resize(&state->detector_id, size);
     }
 
     SD_RESIZE_IF_SELECTED(event_id);
@@ -466,8 +465,8 @@ inline void resize(StepStateDataImpl<Ownership::value, M>* state,
     SD_RESIZE_IF_SELECTED(track_step_count);
     SD_RESIZE_IF_SELECTED(step_length);
     SD_RESIZE_IF_SELECTED(weight);
-    SD_RESIZE_IF_SELECTED(action_id);
-    SD_RESIZE_IF_SELECTED(particle);
+    SD_RESIZE_IF_SELECTED(post_step_action_id);
+    SD_RESIZE_IF_SELECTED(particle_id);
     SD_RESIZE_IF_SELECTED(energy_deposition);
 }
 

--- a/src/celeritas/user/StepData.hh
+++ b/src/celeritas/user/StepData.hh
@@ -101,8 +101,9 @@ struct StepSelection
     explicit CELER_FUNCTION operator bool() const
     {
         return points[StepPoint::pre] || points[StepPoint::post] || event_id
-               || parent_id || track_step_count || post_step_action_id
-               || step_length || weight || particle_id || energy_deposition;
+               || parent_id || primary_id || post_step_action_id
+               || track_step_count || step_length || weight || particle_id
+               || energy_deposition;
     }
 
     //! Combine the selection with another
@@ -115,8 +116,9 @@ struct StepSelection
 
         this->event_id |= other.event_id;
         this->parent_id |= other.parent_id;
-        this->track_step_count |= other.track_step_count;
+        this->primary_id |= other.primary_id;
         this->post_step_action_id |= other.post_step_action_id;
+        this->track_step_count |= other.track_step_count;
         this->step_length |= other.step_length;
         this->weight |= other.weight;
         this->particle_id |= other.particle_id;
@@ -230,7 +232,7 @@ struct StepPointStateData
  * - If the flag is disabled (no step interfaces require the data), then the
  *   corresponding member data will be empty.
  * - The track ID will be set to "false" if the track is inactive.
- * - If sensitive detector are specified, the \c detector field is set based
+ * - If sensitive detector are specified, the \c detector_id field is set based
  *   on the pre-step geometric volume. Data members will have \b unspecified
  *   values if the detector ID is "false" (i.e. no information is being
  *   collected). The detector ID for inactive threads is always "false".
@@ -280,8 +282,8 @@ struct StepStateDataImpl
 
         return !track_id.empty() && right_sized(detector_id)
                && right_sized(event_id) && right_sized(parent_id)
-               && right_sized(primary_id) && right_sized(track_step_count)
-               && right_sized(post_step_action_id) && right_sized(step_length)
+               && right_sized(primary_id) && right_sized(post_step_action_id)
+               && right_sized(track_step_count) && right_sized(step_length)
                && right_sized(weight) && right_sized(particle_id)
                && right_sized(energy_deposition);
     }
@@ -306,12 +308,12 @@ struct StepStateDataImpl
         }
 
         track_id = other.track_id;
-        parent_id = other.parent_id;
-        primary_id = other.primary_id;
         detector_id = other.detector_id;
         event_id = other.event_id;
-        track_step_count = other.track_step_count;
+        parent_id = other.parent_id;
+        primary_id = other.primary_id;
         post_step_action_id = other.post_step_action_id;
+        track_step_count = other.track_step_count;
         step_length = other.step_length;
         weight = other.weight;
         particle_id = other.particle_id;
@@ -462,10 +464,10 @@ inline void resize(StepStateDataImpl<Ownership::value, M>* state,
     SD_RESIZE_IF_SELECTED(event_id);
     SD_RESIZE_IF_SELECTED(parent_id);
     SD_RESIZE_IF_SELECTED(primary_id);
+    SD_RESIZE_IF_SELECTED(post_step_action_id);
     SD_RESIZE_IF_SELECTED(track_step_count);
     SD_RESIZE_IF_SELECTED(step_length);
     SD_RESIZE_IF_SELECTED(weight);
-    SD_RESIZE_IF_SELECTED(post_step_action_id);
     SD_RESIZE_IF_SELECTED(particle_id);
     SD_RESIZE_IF_SELECTED(energy_deposition);
 }

--- a/src/celeritas/user/detail/SimpleCaloExecutor.hh
+++ b/src/celeritas/user/detail/SimpleCaloExecutor.hh
@@ -46,10 +46,10 @@ struct SimpleCaloExecutor
  */
 CELER_FUNCTION void SimpleCaloExecutor::operator()(TrackSlotId tid)
 {
-    CELER_EXPECT(tid < step.data.detector.size());
+    CELER_EXPECT(tid < step.data.detector_id.size());
     CELER_EXPECT(!step.data.energy_deposition.empty());
 
-    DetectorId det = step.data.detector[tid];
+    DetectorId det = step.data.detector_id[tid];
     if (!det)
     {
         // No energy deposition or inactive track

--- a/src/celeritas/user/detail/StepGatherExecutor.hh
+++ b/src/celeritas/user/detail/StepGatherExecutor.hh
@@ -133,9 +133,8 @@ StepGatherExecutor<P>::fill(celeritas::CoreTrackView const& track)
             SGL_SET_IF_SELECTED(event_id, sim.event_id());
             SGL_SET_IF_SELECTED(parent_id, sim.parent_id());
             SGL_SET_IF_SELECTED(primary_id, sim.primary_id());
-            SGL_SET_IF_SELECTED(track_step_count, sim.num_steps());
-
             SGL_SET_IF_SELECTED(post_step_action_id, sim.post_step_action());
+            SGL_SET_IF_SELECTED(track_step_count, sim.num_steps());
             SGL_SET_IF_SELECTED(step_length, sim.step_length());
             SGL_SET_IF_SELECTED(weight, sim.weight());
         }

--- a/src/celeritas/user/detail/StepGatherExecutor.hh
+++ b/src/celeritas/user/detail/StepGatherExecutor.hh
@@ -9,7 +9,6 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
-#include "celeritas/global/CoreTrackData.hh"
 #include "celeritas/global/CoreTrackView.hh"
 #include "celeritas/user/StepData.hh"
 
@@ -62,7 +61,7 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
             if (P == StepPoint::pre && !this->params.detector.empty())
             {
                 // Clear detector ID for inactive threads
-                this->state.data.detector[track.track_slot_id()] = {};
+                this->state.data.detector_id[track.track_slot_id()] = {};
             }
 
             // No more data to be written
@@ -82,11 +81,11 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
             CELER_ASSERT(vol);
 
             // Map volume ID to detector ID
-            this->state.data.detector[track.track_slot_id()]
+            this->state.data.detector_id[track.track_slot_id()]
                 = this->params.detector[vol];
         }
 
-        if (!this->state.data.detector[track.track_slot_id()])
+        if (!this->state.data.detector_id[track.track_slot_id()])
         {
             // We're not in a sensitive detector: don't save any further data
             return;
@@ -99,7 +98,7 @@ StepGatherExecutor<P>::operator()(celeritas::CoreTrackView const& track)
             if (pstep.energy_deposition() == zero_quantity())
             {
                 // Clear detector ID and stop recording
-                this->state.data.detector[track.track_slot_id()] = {};
+                this->state.data.detector_id[track.track_slot_id()] = {};
                 return;
             }
         }
@@ -136,7 +135,7 @@ StepGatherExecutor<P>::fill(celeritas::CoreTrackView const& track)
             SGL_SET_IF_SELECTED(primary_id, sim.primary_id());
             SGL_SET_IF_SELECTED(track_step_count, sim.num_steps());
 
-            SGL_SET_IF_SELECTED(action_id, sim.post_step_action());
+            SGL_SET_IF_SELECTED(post_step_action_id, sim.post_step_action());
             SGL_SET_IF_SELECTED(step_length, sim.step_length());
             SGL_SET_IF_SELECTED(weight, sim.weight());
         }
@@ -195,7 +194,7 @@ StepGatherExecutor<P>::fill(celeritas::CoreTrackView const& track)
         {
             auto const pstep = track.physics_step();
             SGL_SET_IF_SELECTED(energy_deposition, pstep.energy_deposition());
-            SGL_SET_IF_SELECTED(particle, par.particle_id());
+            SGL_SET_IF_SELECTED(particle_id, par.particle_id());
         }
         SGL_SET_IF_SELECTED(points[P].energy, par.energy());
     }

--- a/src/celeritas/user/detail/StepScratchCopyExecutor.hh
+++ b/src/celeritas/user/detail/StepScratchCopyExecutor.hh
@@ -97,6 +97,8 @@ CELER_FUNCTION void StepScratchCopyExecutor::operator()(ThreadId dst_id)
 
     DS_COPY_IF_SELECTED(event_id);
     DS_COPY_IF_SELECTED(parent_id);
+    DS_COPY_IF_SELECTED(primary_id);
+    DS_COPY_IF_SELECTED(post_step_action_id);
     DS_COPY_IF_SELECTED(track_step_count);
     DS_COPY_IF_SELECTED(step_length);
     DS_COPY_IF_SELECTED(weight);

--- a/src/celeritas/user/detail/StepScratchCopyExecutor.hh
+++ b/src/celeritas/user/detail/StepScratchCopyExecutor.hh
@@ -67,7 +67,7 @@ CELER_FUNCTION void StepScratchCopyExecutor::operator()(ThreadId dst_id)
         }                                             \
     } while (0)
 
-    DS_COPY_IF_SELECTED(detector);
+    DS_COPY_IF_SELECTED(detector_id);
     DS_COPY_IF_SELECTED(track_id);
 
     for (auto sp : range(StepPoint::size_))
@@ -100,7 +100,7 @@ CELER_FUNCTION void StepScratchCopyExecutor::operator()(ThreadId dst_id)
     DS_COPY_IF_SELECTED(track_step_count);
     DS_COPY_IF_SELECTED(step_length);
     DS_COPY_IF_SELECTED(weight);
-    DS_COPY_IF_SELECTED(particle);
+    DS_COPY_IF_SELECTED(particle_id);
     DS_COPY_IF_SELECTED(energy_deposition);
 #undef DS_COPY_IF_SELECTED
 }

--- a/test/accel/CMakeLists.txt
+++ b/test/accel/CMakeLists.txt
@@ -174,7 +174,7 @@ celeritas_add_integration_tests(
   TrackingManagerIntegration WaterSphere run_small_flush
   OFFLOAD cpu
   RMTYPE serial mt
-  ${_no_vgsurf} # VG Surface geometry is broken (no hits)
+  ${_no_vgsurf} # VG Surface geometry is broken (no hits) and will be deleted soon (v0.7)
 )
 
 #-----------------------------------------------------------------------------#

--- a/test/accel/CMakeLists.txt
+++ b/test/accel/CMakeLists.txt
@@ -11,6 +11,10 @@ if(NOT CELERITAS_USE_covfie)
   set(_needs_covfie DISABLE)
 endif()
 
+if(CELERITAS_VecGeom_SURFACE)
+  set(_no_vgsurf DISABLE)
+endif()
+
 include(CeleritasG4Tests)
 
 #-----------------------------------------------------------------------------#
@@ -170,6 +174,7 @@ celeritas_add_integration_tests(
   TrackingManagerIntegration WaterSphere run_small_flush
   OFFLOAD cpu
   RMTYPE serial mt
+  ${_no_vgsurf} # VG Surface geometry is broken (no hits)
 )
 
 #-----------------------------------------------------------------------------#

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -717,7 +717,7 @@ SetupOptions OpNoviceIntegrationMixin::make_setup_options()
 // WaterSphere
 //---------------------------------------------------------------------------//
 /*!
- * Create physics list with
+ * Create physics list with loose EM physics.
  */
 auto WaterSphereIntegrationMixin::make_physics_input() const -> PhysicsInput
 {

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -924,7 +924,40 @@ TEST_F(TestEm3, run)
 class WaterSphere : public WaterSphereIntegrationMixin, public TMITestBase
 {
   public:
-    void process_hit(G4Step const*) override { /* null-op */ }
+    void process_hit(G4Step const* s) override
+    {
+        auto* t = s->GetTrack();
+        CELER_ASSERT(t);
+        int const track_id = t->GetTrackID();
+        int const parent_id = t->GetParentID();
+
+        EXPECT_GE(track_id, 0);
+        EXPECT_GE(parent_id, 0);
+
+        auto atomic_max = [](std::atomic<int>& dst, int value) {
+            int current = dst.load(std::memory_order_relaxed);
+            while (current < value
+                   && !dst.compare_exchange_weak(current,
+                                                 value,
+                                                 std::memory_order_relaxed,
+                                                 std::memory_order_relaxed))
+            {
+            }
+        };
+
+        atomic_max(max_track_id_, track_id);
+        atomic_max(max_parent_id_, parent_id);
+    }
+
+    //! Get and reset track, parent IDs
+    std::pair<int, int> exchange_max_ids()
+    {
+        return {max_track_id_.exchange(0), max_parent_id_.exchange(0)};
+    }
+
+  protected:
+    std::atomic<int> max_track_id_{0};
+    std::atomic<int> max_parent_id_{0};
 };
 
 /*!
@@ -960,6 +993,10 @@ TEST_F(WaterSphere, run_small_flush)
         EXPECT_TRUE(it != messages.end())
             << "Expected message not found in logs:\n"
             << scoped_log_;
+
+        auto&& [max_track, max_parent] = this->exchange_max_ids();
+        EXPECT_GE(max_parent, 0);
+        EXPECT_GT(max_track, max_parent);
     }
 
     if (this->HasFatalFailure())
@@ -972,6 +1009,9 @@ TEST_F(WaterSphere, run_small_flush)
     }
 
     rm.BeamOn(4);
+    auto&& [max_track, max_parent] = this->exchange_max_ids();
+    EXPECT_GE(max_parent, 0);
+    EXPECT_GT(max_track, max_parent);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -947,17 +947,22 @@ class WaterSphere : public WaterSphereIntegrationMixin, public TMITestBase
 
         atomic_max(max_track_id_, track_id);
         atomic_max(max_parent_id_, parent_id);
+        ++num_hits_;
     }
 
     //! Get and reset track, parent IDs
     std::pair<int, int> exchange_max_ids()
     {
-        return {max_track_id_.exchange(0), max_parent_id_.exchange(0)};
+        return {max_track_id_.exchange(-1), max_parent_id_.exchange(-1)};
     }
 
+    //! Exchange hit counter
+    int exchange_hit_count() { return num_hits_.exchange(0); }
+
   protected:
-    std::atomic<int> max_track_id_{0};
-    std::atomic<int> max_parent_id_{0};
+    std::atomic<int> max_track_id_{-1};
+    std::atomic<int> max_parent_id_{-1};
+    std::atomic<int> num_hits_{0};
 };
 
 /*!
@@ -994,6 +999,8 @@ TEST_F(WaterSphere, run_small_flush)
             << "Expected message not found in logs:\n"
             << scoped_log_;
 
+        auto num_hits = this->exchange_hit_count();
+        EXPECT_GT(num_hits, 0);
         auto&& [max_track, max_parent] = this->exchange_max_ids();
         EXPECT_GE(max_parent, 0);
         EXPECT_GT(max_track, max_parent);
@@ -1009,9 +1016,13 @@ TEST_F(WaterSphere, run_small_flush)
     }
 
     rm.BeamOn(4);
-    auto&& [max_track, max_parent] = this->exchange_max_ids();
-    EXPECT_GE(max_parent, 0);
-    EXPECT_GT(max_track, max_parent);
+    {
+        auto num_hits = this->exchange_hit_count();
+        EXPECT_GT(num_hits, 0);
+        auto&& [max_track, max_parent] = this->exchange_max_ids();
+        EXPECT_GE(max_parent, 0);
+        EXPECT_GT(max_track, max_parent);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/GeantTrackReconstruction.test.cc
+++ b/test/celeritas/ext/GeantTrackReconstruction.test.cc
@@ -135,20 +135,10 @@ int GtrTest::test_cur_event{0};
 
 //---------------------------------------------------------------------------//
 
-TEST_F(GtrTest, construction)
+TEST_F(GtrTest, TEST_IF_CELERITAS_DEBUG(empty_construction))
 {
     // Create an empty processor first to test basic construction
-    GeantTrackReconstruction recon({}, step_);
-
-    // One empty event
-    GtrTest::test_cur_event = 1;
-    recon.init_event();
-    recon.clear();
-
-    // Another
-    GtrTest::test_cur_event = 2;
-    recon.init_event();
-    recon.clear();
+    EXPECT_THROW(GeantTrackReconstruction({}, step_), DebugError);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/celeritas/ext/SimpleSensitiveDetector.cc
+++ b/test/celeritas/ext/SimpleSensitiveDetector.cc
@@ -46,15 +46,30 @@ void SimpleHitsResult::print_expected() const
          << ";\n"
             "EXPECT_VEC_EQ(expected_particle, result.particle);\n"
 
+            "static double const expected_weight[] = "
+         << repr(this->weight)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_weight, result.weight);\n"
+
             "static double const expected_pre_energy[] = "
          << repr(this->pre_energy)
          << ";\n"
             "EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);\n"
 
+            "static double const expected_pre_time[] = "
+         << repr(this->pre_time)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_pre_time, result.pre_time);\n"
+
             "static double const expected_pre_pos[] = "
          << repr(this->pre_pos)
          << ";\n"
             "EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);\n"
+
+            "static double const expected_pre_dir[] = "
+         << repr(this->pre_dir)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_pre_dir, result.pre_dir);\n"
 
             "static char const* const expected_pre_physvol[] = "
          << repr(this->pre_physvol)
@@ -65,6 +80,21 @@ void SimpleHitsResult::print_expected() const
          << repr(this->post_time)
          << ";\n"
             "EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);\n"
+
+            "static double const expected_post_energy[] = "
+         << repr(this->post_energy)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_post_energy, result.post_energy);\n"
+
+            "static double const expected_post_pos[] = "
+         << repr(this->post_pos)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_post_pos, result.post_pos);\n"
+
+            "static double const expected_post_dir[] = "
+         << repr(this->post_dir)
+         << ";\n"
+            "EXPECT_VEC_SOFT_EQ(expected_post_dir, result.post_dir);\n"
 
             "static char const* const expected_post_physvol[] = "
          << repr(this->post_physvol)
@@ -109,14 +139,20 @@ bool SimpleSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         hits_.particle.push_back(pv.name());
         double weight = track->GetWeight();
         CELER_ASSERT(weight > 0);
+        hits_.weight.push_back(weight);
         edep *= weight;
     }
     hits_.energy_deposition.push_back(edep);
     hits_.pre_energy.push_back(pre_step->GetKineticEnergy() / CLHEP::MeV);
+    hits_.pre_time.push_back(pre_step->GetGlobalTime() / CLHEP::ns);
 
     for (int i : range(3))
     {
         hits_.pre_pos.push_back(pre_step->GetPosition()[i] / CLHEP::cm);
+    }
+    for (int i : range(3))
+    {
+        hits_.pre_dir.push_back(pre_step->GetMomentumDirection()[i]);
     }
 
     if (auto* touchable = pre_step->GetTouchable())
@@ -129,6 +165,15 @@ bool SimpleSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
 
     if (auto* post_step = step->GetPostStepPoint())
     {
+        hits_.post_energy.push_back(post_step->GetKineticEnergy() / CLHEP::MeV);
+        for (int i : range(3))
+        {
+            hits_.post_pos.push_back(post_step->GetPosition()[i] / CLHEP::cm);
+        }
+        for (int i : range(3))
+        {
+            hits_.post_dir.push_back(post_step->GetMomentumDirection()[i]);
+        }
         if (auto* touchable = post_step->GetTouchable())
         {
             auto* vol = touchable->GetVolume();

--- a/test/celeritas/ext/SimpleSensitiveDetector.cc
+++ b/test/celeritas/ext/SimpleSensitiveDetector.cc
@@ -51,6 +51,16 @@ void SimpleHitsResult::print_expected() const
          << ";\n"
             "EXPECT_VEC_SOFT_EQ(expected_weight, result.weight);\n"
 
+            "static int const expected_track_id[] = "
+         << repr(this->track_id)
+         << ";\n"
+            "EXPECT_VEC_EQ(expected_track_id, result.track_id);\n"
+
+            "static int const expected_parent_id[] = "
+         << repr(this->parent_id)
+         << ";\n"
+            "EXPECT_VEC_EQ(expected_parent_id, result.parent_id);\n"
+
             "static double const expected_pre_energy[] = "
          << repr(this->pre_energy)
          << ";\n"
@@ -140,6 +150,8 @@ bool SimpleSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*)
         double weight = track->GetWeight();
         CELER_ASSERT(weight > 0);
         hits_.weight.push_back(weight);
+        hits_.track_id.push_back(track->GetTrackID());
+        hits_.parent_id.push_back(track->GetParentID());
         edep *= weight;
     }
     hits_.energy_deposition.push_back(edep);

--- a/test/celeritas/ext/SimpleSensitiveDetector.hh
+++ b/test/celeritas/ext/SimpleSensitiveDetector.hh
@@ -20,10 +20,16 @@ struct SimpleHitsResult
     std::vector<double> energy_deposition;  // [MeV]
     std::vector<double> step_length;  // [cm]
     std::vector<std::string> particle;
+    std::vector<double> weight;
     std::vector<double> pre_energy;  // [MeV]
+    std::vector<double> pre_time;  // [ns]
     std::vector<double> pre_pos;  // [cm]
+    std::vector<double> pre_dir;
     std::vector<std::string> pre_physvol;
     std::vector<double> post_time;  // [ns]
+    std::vector<double> post_energy;  // [MeV]
+    std::vector<double> post_pos;  // [cm]
+    std::vector<double> post_dir;
     std::vector<std::string> post_physvol;
     std::vector<std::string> post_status;
 

--- a/test/celeritas/ext/SimpleSensitiveDetector.hh
+++ b/test/celeritas/ext/SimpleSensitiveDetector.hh
@@ -21,6 +21,8 @@ struct SimpleHitsResult
     std::vector<double> step_length;  // [cm]
     std::vector<std::string> particle;
     std::vector<double> weight;
+    std::vector<int> track_id;
+    std::vector<int> parent_id;
     std::vector<double> pre_energy;  // [MeV]
     std::vector<double> pre_time;  // [ns]
     std::vector<double> pre_pos;  // [cm]

--- a/test/celeritas/ext/detail/HitProcessor.test.cc
+++ b/test/celeritas/ext/detail/HitProcessor.test.cc
@@ -92,7 +92,7 @@ void SimpleCmsTest::SetUp()
     selection_.points[StepPoint::post].pos = true;
     selection_.points[StepPoint::post].dir = true;
     selection_.points[StepPoint::post].energy = true;
-    selection_.particle = true;
+    selection_.particle_id = true;
 }
 
 auto SimpleCmsTest::detector_volumes() const -> SetStr
@@ -124,7 +124,7 @@ auto SimpleCmsTest::make_detector_volumes() -> SPConstVecLV
 auto SimpleCmsTest::make_particles() -> VecParticle
 {
     VecParticle result;
-    if (!selection_.particle)
+    if (!selection_.particle_id)
     {
         return result;
     }
@@ -164,7 +164,7 @@ auto SimpleCmsTest::get_hits(std::string const& name) const
 DetectorStepOutput SimpleCmsTest::make_dso() const
 {
     DetectorStepOutput dso;
-    dso.detector = {
+    dso.detector_id = {
         DetectorId{2},  // si_tracker
         DetectorId{0},  // em_calorimeter
         DetectorId{1},  // had_calorimeter
@@ -265,9 +265,9 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
             MevEnergy{2.7},
         };
     }
-    if (selection_.particle)
+    if (selection_.particle_id)
     {
-        dso.particle = {
+        dso.particle_id = {
             ParticleId{2},
             ParticleId{1},
             ParticleId{0},
@@ -396,7 +396,7 @@ TEST_F(SimpleCmsTest, no_touchable)
 //---------------------------------------------------------------------------//
 TEST_F(SimpleCmsTest, touchable_midvol)
 {
-    selection_.particle = false;
+    selection_.particle_id = false;
     locate_touchable_ = {true, false};
     HitProcessor process_hits = this->make_hit_processor();
     auto dso_hits = this->make_dso();
@@ -476,11 +476,11 @@ TEST_F(SimpleCmsTest, touchable_edgecase)
 TEST_F(SimpleCmsTest, touchable_exiting)
 {
     locate_touchable_ = {true, true};
-    selection_.particle = false;
+    selection_.particle_id = false;
 
     HitProcessor process_hits = this->make_hit_processor();
     DetectorStepOutput dso;
-    dso.detector = {DetectorId{3}, DetectorId{2}};
+    dso.detector_id = {DetectorId{3}, DetectorId{2}};
     dso.energy_deposition = {MevEnergy{1.0}, MevEnergy{10.0}};
     dso.step_length = {
         from_cm(300),

--- a/test/celeritas/ext/detail/HitProcessor.test.cc
+++ b/test/celeritas/ext/detail/HitProcessor.test.cc
@@ -6,7 +6,10 @@
 //---------------------------------------------------------------------------//
 #include "celeritas/ext/detail/HitProcessor.hh"
 
+#include <G4DynamicParticle.hh>
 #include <G4ParticleTable.hh>
+#include <G4ThreeVector.hh>
+#include <G4Track.hh>
 
 #include "geocel/UnitUtils.hh"
 #include "geocel/VolumeParams.hh"
@@ -53,10 +56,27 @@ class SimpleCmsTest : public ::celeritas::test::SensDetTestBase,
 
     SimpleHitsResult const& get_hits(std::string const& name) const;
 
+    // Event ID mock for GeantTrackReconstruction (used in CELERITAS_DEBUG)
+    static int test_cur_event;
+    static int get_test_current_event_id() { return test_cur_event; }
+
+    static void SetUpTestCase()
+    {
+        GeantTrackReconstruction::get_current_event_id
+            = get_test_current_event_id;
+    }
+
+    static void TearDownTestCase()
+    {
+        GeantTrackReconstruction::get_current_event_id = nullptr;
+    }
+
   protected:
     StepSelection selection_;
     HitProcessor::StepPointBool locate_touchable_{{false, false}};
 };
+
+int SimpleCmsTest::test_cur_event{0};
 
 //---------------------------------------------------------------------------//
 void SimpleCmsTest::SetUp()
@@ -503,6 +523,72 @@ TEST_F(SimpleCmsTest, touchable_exiting)
         EXPECT_VEC_EQ(expected_post_physvol, result.post_physvol);
         static char const* const expected_post_status[] = {"world"};
         EXPECT_VEC_EQ(expected_post_status, result.post_status);
+    }
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(SimpleCmsTest, with_primary_id)
+{
+    selection_.primary_id = true;
+    HitProcessor process_hits = this->make_hit_processor();
+    auto& recon = *process_hits.track_reconstruction();
+
+    // Initialize a mock event so debug builds don't fail the event-ID check
+    SimpleCmsTest::test_cur_event = 1;
+    recon.init_event();
+
+    // Acquire two primaries: PrimaryId{0} -> track 10, PrimaryId{1} -> track
+    // 20
+    auto* gamma_def = G4ParticleTable::GetParticleTable()->FindParticle(
+        pdg::gamma().get());
+    ASSERT_NE(nullptr, gamma_def);
+
+    auto primary0 = std::make_unique<G4Track>(
+        new G4DynamicParticle(gamma_def, G4ThreeVector(1, 0, 0)),
+        0.0,
+        G4ThreeVector());
+    primary0->SetTrackID(10);
+    primary0->SetParentID(0);
+    auto pid0 = recon.acquire(*primary0);
+    EXPECT_EQ(0, pid0.unchecked_get());
+
+    auto primary1 = std::make_unique<G4Track>(
+        new G4DynamicParticle(gamma_def, G4ThreeVector(0, 1, 0)),
+        0.0,
+        G4ThreeVector());
+    primary1->SetTrackID(20);
+    primary1->SetParentID(5);
+    auto pid1 = recon.acquire(*primary1);
+    EXPECT_EQ(1, pid1.unchecked_get());
+
+    // Run a single batch of hits (dso.primary_id = {PrimaryId{0}, {1}, {1}})
+    auto dso = this->make_dso();
+    process_hits(dso);
+    recon.clear();
+
+    {
+        // si_tracker -> PrimaryId{0} -> track_id=10, parent_id=0
+        auto& result = this->get_hits("si_tracker");
+        static int const expected_track_id[] = {10};
+        EXPECT_VEC_EQ(expected_track_id, result.track_id);
+        static int const expected_parent_id[] = {0};
+        EXPECT_VEC_EQ(expected_parent_id, result.parent_id);
+    }
+    {
+        // em_calorimeter -> PrimaryId{1} -> track_id=20, parent_id=5
+        auto& result = this->get_hits("em_calorimeter");
+        static int const expected_track_id[] = {20};
+        EXPECT_VEC_EQ(expected_track_id, result.track_id);
+        static int const expected_parent_id[] = {5};
+        EXPECT_VEC_EQ(expected_parent_id, result.parent_id);
+    }
+    {
+        // had_calorimeter -> PrimaryId{1} -> track_id=20, parent_id=5
+        auto& result = this->get_hits("had_calorimeter");
+        static int const expected_track_id[] = {20};
+        EXPECT_VEC_EQ(expected_track_id, result.track_id);
+        static int const expected_parent_id[] = {5};
+        EXPECT_VEC_EQ(expected_parent_id, result.parent_id);
     }
 }
 

--- a/test/celeritas/ext/detail/HitProcessor.test.cc
+++ b/test/celeritas/ext/detail/HitProcessor.test.cc
@@ -64,9 +64,14 @@ void SimpleCmsTest::SetUp()
     // Create default step selection (see GeantSd)
     selection_.energy_deposition = true;
     selection_.step_length = true;
+    selection_.points[StepPoint::pre].time = true;
     selection_.points[StepPoint::pre].energy = true;
     selection_.points[StepPoint::pre].pos = true;
+    selection_.points[StepPoint::pre].dir = true;
     selection_.points[StepPoint::post].time = true;
+    selection_.points[StepPoint::post].pos = true;
+    selection_.points[StepPoint::post].dir = true;
+    selection_.points[StepPoint::post].energy = true;
     selection_.particle = true;
 }
 
@@ -188,6 +193,16 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
             3e-8 * second,
         };
     }
+    if (selection_.points[StepPoint::pre].time)
+    {
+        using celeritas::units::second;
+
+        dso.points[StepPoint::pre].time = {
+            0.5e-9 * second,
+            1.5e-10 * second,
+            2.5e-8 * second,
+        };
+    }
     if (selection_.points[StepPoint::pre].pos)
     {
         // note: points must correspond to detector volumes!
@@ -203,6 +218,31 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
             {1, 0, 0},
             {0, 1, 0},
             {0, 0, -1},
+        };
+    }
+    if (selection_.points[StepPoint::post].pos)
+    {
+        // note: points must correspond to detector volumes!
+        dso.points[StepPoint::post].pos = {
+            from_cm(Real3{105, 0, 0}),
+            from_cm(Real3{0, 155, 10}),
+            from_cm(Real3{0, 205, -20}),
+        };
+    }
+    if (selection_.points[StepPoint::post].dir)
+    {
+        dso.points[StepPoint::post].dir = {
+            {1, 0, 0},
+            {0, 1, 0},
+            {0, 0, -1},
+        };
+    }
+    if (selection_.points[StepPoint::post].energy)
+    {
+        dso.points[StepPoint::post].energy = {
+            MevEnergy{0.9},
+            MevEnergy{1.8},
+            MevEnergy{2.7},
         };
     }
     if (selection_.particle)
@@ -258,12 +298,24 @@ TEST_F(SimpleCmsTest, no_touchable)
                            result.energy_deposition);
         static real_type const expected_step_length[] = {0.1, 1.0};
         EXPECT_VEC_SOFT_EQ(expected_step_length, result.step_length);
+        static real_type const expected_weight[] = {1.0, 1.0};
+        EXPECT_VEC_SOFT_EQ(expected_weight, result.weight);
         static real_type const expected_pre_energy[] = {0, 0};
         EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);
+        static real_type const expected_pre_time[] = {0.5, 0.5};
+        EXPECT_VEC_SOFT_EQ(expected_pre_time, result.pre_time);
         static real_type const expected_pre_pos[] = {100, 0, 0, 100, 0, 0};
         EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);
+        static real_type const expected_pre_dir[] = {1, 0, 0, 1, 0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_pre_dir, result.pre_dir);
         static real_type const expected_post_time[] = {1, 1};
         EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);
+        static real_type const expected_post_energy[] = {0.9, 0.9};
+        EXPECT_VEC_SOFT_EQ(expected_post_energy, result.post_energy);
+        static real_type const expected_post_pos[] = {105, 0, 0, 105, 0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_post_pos, result.post_pos);
+        static real_type const expected_post_dir[] = {1, 0, 0, 1, 0, 0};
+        EXPECT_VEC_SOFT_EQ(expected_post_dir, result.post_dir);
     }
     {
         auto& result = this->get_hits("em_calorimeter");
@@ -273,12 +325,24 @@ TEST_F(SimpleCmsTest, no_touchable)
                            result.energy_deposition);
         static char const* const expected_particle[] = {"e-", "e-"};
         EXPECT_VEC_EQ(expected_particle, result.particle);
+        static real_type const expected_weight[] = {0.5, 0.5};
+        EXPECT_VEC_SOFT_EQ(expected_weight, result.weight);
         static real_type const expected_pre_energy[] = {0, 0};
         EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);
+        static real_type const expected_pre_time[] = {0.15, 0.15};
+        EXPECT_VEC_SOFT_EQ(expected_pre_time, result.pre_time);
         static real_type const expected_pre_pos[] = {0, 150, 10, 0, 150, 10};
         EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);
+        static real_type const expected_pre_dir[] = {0, 1, 0, 0, 1, 0};
+        EXPECT_VEC_SOFT_EQ(expected_pre_dir, result.pre_dir);
         static real_type const expected_post_time[] = {0.2, 0.2};
         EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);
+        static real_type const expected_post_energy[] = {1.8, 1.8};
+        EXPECT_VEC_SOFT_EQ(expected_post_energy, result.post_energy);
+        static real_type const expected_post_pos[] = {0, 155, 10, 0, 155, 10};
+        EXPECT_VEC_SOFT_EQ(expected_post_pos, result.post_pos);
+        static real_type const expected_post_dir[] = {0, 1, 0, 0, 1, 0};
+        EXPECT_VEC_SOFT_EQ(expected_post_dir, result.post_dir);
     }
     {
         auto& result = this->get_hits("had_calorimeter");
@@ -288,12 +352,24 @@ TEST_F(SimpleCmsTest, no_touchable)
                            result.energy_deposition);
         static char const* const expected_particle[] = {"gamma", "gamma"};
         EXPECT_VEC_EQ(expected_particle, result.particle);
+        static real_type const expected_weight[] = {0.8, 0.8};
+        EXPECT_VEC_SOFT_EQ(expected_weight, result.weight);
         static real_type const expected_pre_energy[] = {0, 0};
         EXPECT_VEC_SOFT_EQ(expected_pre_energy, result.pre_energy);
+        static real_type const expected_pre_time[] = {25, 25};
+        EXPECT_VEC_SOFT_EQ(expected_pre_time, result.pre_time);
         static real_type const expected_pre_pos[] = {0, 200, -20, 0, 200, -20};
         EXPECT_VEC_SOFT_EQ(expected_pre_pos, result.pre_pos);
+        static real_type const expected_pre_dir[] = {0, 0, -1, 0, 0, -1};
+        EXPECT_VEC_SOFT_EQ(expected_pre_dir, result.pre_dir);
         static real_type const expected_post_time[] = {30, 30};
         EXPECT_VEC_SOFT_EQ(expected_post_time, result.post_time);
+        static real_type const expected_post_energy[] = {2.7, 2.7};
+        EXPECT_VEC_SOFT_EQ(expected_post_energy, result.post_energy);
+        static real_type const expected_post_pos[] = {0, 205, -20, 0, 205, -20};
+        EXPECT_VEC_SOFT_EQ(expected_post_pos, result.post_pos);
+        static real_type const expected_post_dir[] = {0, 0, -1, 0, 0, -1};
+        EXPECT_VEC_SOFT_EQ(expected_post_dir, result.post_dir);
     }
 }
 

--- a/test/celeritas/ext/detail/HitProcessor.test.cc
+++ b/test/celeritas/ext/detail/HitProcessor.test.cc
@@ -11,6 +11,7 @@
 #include "geocel/UnitUtils.hh"
 #include "geocel/VolumeParams.hh"
 #include "celeritas/SimpleCmsTestBase.hh"
+#include "celeritas/Types.hh"
 #include "celeritas/ext/GeantTrackReconstruction.hh"
 #include "celeritas/geo/CoreGeoParams.hh"
 #include "celeritas/phys/PDGNumber.hh"
@@ -153,6 +154,14 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
         0.5_r,  // em_calorimeter
         0.8_r,  // had_calorimeter
     };
+    if (selection_.primary_id)
+    {
+        dso.primary_id = {
+            PrimaryId{0},
+            PrimaryId{1},
+            PrimaryId{1},
+        };
+    }
     if (selection_.energy_deposition)
     {
         dso.energy_deposition = {

--- a/test/celeritas/ext/detail/HitProcessor.test.cc
+++ b/test/celeritas/ext/detail/HitProcessor.test.cc
@@ -84,6 +84,7 @@ void SimpleCmsTest::SetUp()
     // Create default step selection (see GeantSd)
     selection_.energy_deposition = true;
     selection_.step_length = true;
+    selection_.weight = true;
     selection_.points[StepPoint::pre].time = true;
     selection_.points[StepPoint::pre].energy = true;
     selection_.points[StepPoint::pre].pos = true;
@@ -93,6 +94,7 @@ void SimpleCmsTest::SetUp()
     selection_.points[StepPoint::post].dir = true;
     selection_.points[StepPoint::post].energy = true;
     selection_.particle_id = true;
+    selection_.primary_id = true;
 }
 
 auto SimpleCmsTest::detector_volumes() const -> SetStr
@@ -265,6 +267,14 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
             MevEnergy{2.7},
         };
     }
+    if (selection_.points[StepPoint::pre].energy)
+    {
+        dso.points[StepPoint::pre].energy = {
+            MevEnergy{0.0},
+            MevEnergy{0.0},
+            MevEnergy{0.0},
+        };
+    }
     if (selection_.particle_id)
     {
         dso.particle_id = {
@@ -293,6 +303,35 @@ DetectorStepOutput SimpleCmsTest::make_dso() const
 TEST_F(SimpleCmsTest, no_touchable)
 {
     HitProcessor process_hits = this->make_hit_processor();
+    auto& recon = *process_hits.track_reconstruction();
+
+    // Initialize a mock event and primaries for reconstruction.
+    SimpleCmsTest::test_cur_event = 1;
+    recon.init_event();
+    auto* gamma_def = G4ParticleTable::GetParticleTable()->FindParticle(
+        pdg::gamma().get());
+    ASSERT_NE(nullptr, gamma_def);
+    {
+        auto primary0 = std::make_unique<G4Track>(
+            new G4DynamicParticle(gamma_def, G4ThreeVector(1, 0, 0)),
+            0.0,
+            G4ThreeVector());
+        primary0->SetTrackID(10);
+        primary0->SetParentID(0);
+        auto const pid0 = recon.acquire(*primary0);
+        EXPECT_EQ(0, pid0.unchecked_get());
+    }
+    {
+        auto primary1 = std::make_unique<G4Track>(
+            new G4DynamicParticle(gamma_def, G4ThreeVector(0, 1, 0)),
+            0.0,
+            G4ThreeVector());
+        primary1->SetTrackID(20);
+        primary1->SetParentID(5);
+        auto const pid1 = recon.acquire(*primary1);
+        EXPECT_EQ(1, pid1.unchecked_get());
+    }
+
     auto dso_hits = this->make_dso();
     process_hits(dso_hits);
 
@@ -309,6 +348,7 @@ TEST_F(SimpleCmsTest, no_touchable)
     };
 
     process_hits(dso_hits);
+    recon.clear();
 
     {
         auto& result = this->get_hits("si_tracker");
@@ -397,6 +437,7 @@ TEST_F(SimpleCmsTest, no_touchable)
 TEST_F(SimpleCmsTest, touchable_midvol)
 {
     selection_.particle_id = false;
+    selection_.primary_id = false;
     locate_touchable_ = {true, false};
     HitProcessor process_hits = this->make_hit_processor();
     auto dso_hits = this->make_dso();
@@ -426,8 +467,11 @@ TEST_F(SimpleCmsTest, touchable_midvol)
 //---------------------------------------------------------------------------//
 TEST_F(SimpleCmsTest, touchable_edgecase)
 {
+    selection_.particle_id = false;
+    selection_.primary_id = false;
     locate_touchable_ = {true, false};
     HitProcessor process_hits = this->make_hit_processor();
+
     auto dso_hits = this->make_dso();
     auto& pos = dso_hits.points[StepPoint::pre].pos;
     auto& dir = dso_hits.points[StepPoint::pre].dir;
@@ -477,10 +521,16 @@ TEST_F(SimpleCmsTest, touchable_exiting)
 {
     locate_touchable_ = {true, true};
     selection_.particle_id = false;
+    selection_.primary_id = false;
+    selection_.points[StepPoint::pre].time = false;
+    selection_.points[StepPoint::post].time = false;
+    selection_.points[StepPoint::pre].energy = false;
+    selection_.points[StepPoint::post].energy = false;
 
     HitProcessor process_hits = this->make_hit_processor();
     DetectorStepOutput dso;
     dso.detector_id = {DetectorId{3}, DetectorId{2}};
+    dso.weight = {1.0, 1.0};
     dso.energy_deposition = {MevEnergy{1.0}, MevEnergy{10.0}};
     dso.step_length = {
         from_cm(300),

--- a/test/celeritas/global/KernelContextException.test.cc
+++ b/test/celeritas/global/KernelContextException.test.cc
@@ -70,6 +70,7 @@ class KernelContextExceptionTest : public SimpleTestBase, public StepperTestBase
         for (auto i : range(count))
         {
             result[i].event_id = EventId{i / (count / 2)};
+            result[i].primary_id = PrimaryId{i % 2};
         }
         return result;
     }
@@ -130,7 +131,7 @@ TEST_F(KernelContextExceptionTest, typical)
         if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
         {
             EXPECT_EQ(
-                R"(track slot {15} in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":null,"post_step_action":"geo-boundary","status":"alive","step_length":[5.0,"cm"],"time":[1.67e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
+                R"(track slot {15} in kernel 'test-kernel': {"geo":{"dir":[0.0,0.0,1.0],"is_on_boundary":true,"is_outside":false,"pos":[[0.0,1.0,5.0],"cm"],"volume_id":"world"},"mat":"hard vacuum","particle":{"energy":[10.0,"MeV"],"particle_id":"gamma"},"sim":{"along_step_action":"along-step-neutral","event_id":1,"num_steps":1,"parent_id":null,"post_step_action":"geo-boundary","primary_id":1,"status":"alive","step_length":[5.0,"cm"],"time":[1.67e-10,"s"],"track_id":3},"thread_id":15,"track_slot_id":15})",
                 simplified_str)
                 << repr(simplified_str);
         }
@@ -154,7 +155,7 @@ TEST_F(KernelContextExceptionTest, typical)
             && CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE)
         {
             std::stringstream ss;
-            ss << R"json({"dir":[0.0,0.0,1.0],"energy":[10.0,"MeV"],"event":1,"label":"test-kernel","num_steps":1,"particle":0,"pos":[0.0,1.0,5.0],"surface":11,"thread":)json"
+            ss << R"json({"dir":[0.0,0.0,1.0],"energy":[10.0,"MeV"],"event":1,"label":"test-kernel","num_steps":1,"particle":0,"pos":[0.0,1.0,5.0],"primary":1,"surface":11,"thread":)json"
                << e.thread().unchecked_get()
                << R"json(,"track":3,"track_slot":15,"volume":2})json";
             EXPECT_JSON_EQ(ss.str(), get_json_str(e));

--- a/test/celeritas/global/Stepper.test.cc
+++ b/test/celeritas/global/Stepper.test.cc
@@ -193,7 +193,7 @@ TEST_F(SimpleComptonTest, fail_initialize)
         {
             std::vector<std::string> expected_log_messages = {
                 "Track 31 started outside the geometry",
-                R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
+                R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[1001.,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","primary_id":null,"status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":15},"thread_id":31,"track_slot_id":31}: depositing 100 MeV)",
             };
             if (CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM)
             {
@@ -311,8 +311,8 @@ TEST_F(SimpleComptonTest, kill_active)
     EXPECT_EQ(0, counters.alive);
     static char const* const expected_log_messages[] = {
         "Killing 2 active tracks",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","primary_id":null,"status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":0},"thread_id":6,"track_slot_id":6}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":false,"pos":[[-5.0,0.0,0.0],"cm"],"volume_id":"inner"},"mat":"Al","particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","primary_id":null,"status":"errored","step_length":[17.0,"cm"],"time":[0.25,"s"],"track_id":1},"thread_id":7,"track_slot_id":7}: lost 100 MeV)",
     };
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS && CELERITAS_USE_GEANT4)
     {
@@ -417,7 +417,7 @@ TEST_F(BadGeometryTest, no_volume_host)
 
     static char const* const expected_log_messages[] = {
         R"(Failed to initialize geometry state: could not find associated volume in universe 0 at local position {-5, 0, 0})",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[-5.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","primary_id":null,"status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
         && CELERITAS_REAL_TYPE == CELERITAS_REAL_TYPE_DOUBLE)
@@ -435,7 +435,7 @@ TEST_F(BadGeometryTest, no_material_host)
 
     static char const* const expected_log_messages[] = {
         "Track 0 started in an unknown material",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":false,"pos":[[5.0,0.0,0.0],"cm"],"volume_id":"[missing material]@world"},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","primary_id":null,"status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: lost 100 MeV)",
     };
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)
@@ -451,7 +451,7 @@ TEST_F(BadGeometryTest, no_new_volume_host)
 
     static char const* const expected_log_messages[] = {
         R"(track failed to cross local surface 2 in universe 0 at local position {-6, 0, 0} along local direction {1, 0, 0})",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.001000,"cm"],"time":[3.336e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":true,"is_outside":true,"pos":[[-6.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":1,"parent_id":null,"post_step_action":"tracking-cut","primary_id":null,"status":"errored","step_length":[0.001000,"cm"],"time":[3.336e-14,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS
@@ -470,7 +470,7 @@ TEST_F(BadGeometryTest, start_outside_host)
 
     static char const* const expected_log_messages[] = {
         "Track 0 started outside the geometry",
-        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
+        R"(Killing track {"geo":{"dir":[1.0,0.0,0.0],"is_on_boundary":false,"is_outside":true,"pos":[[20.0,0.0,0.0],"cm"]},"mat":null,"particle":{"energy":[100.0,"MeV"],"particle_id":"gamma"},"sim":{"event_id":0,"num_steps":0,"parent_id":null,"post_step_action":"tracking-cut","primary_id":null,"status":"errored","step_length":[0.0,"cm"],"time":[0.0,"s"],"track_id":0},"thread_id":0,"track_slot_id":0}: depositing 100 MeV)",
     };
 
     if (CELERITAS_UNITS == CELERITAS_UNITS_CGS)

--- a/test/celeritas/user/DetectorSteps.test.cc
+++ b/test/celeritas/user/DetectorSteps.test.cc
@@ -82,10 +82,10 @@ class DetectorStepsTest : public ::celeritas::test::Test
         }
         result.event_id = true;
         result.track_step_count = true;
-        result.action_id = true;
+        result.post_step_action_id = true;
         result.step_length = true;
         result.weight = true;
-        result.particle = true;
+        result.particle_id = true;
         result.energy_deposition = true;
         return result;
     }
@@ -142,20 +142,20 @@ class DetectorStepsTest : public ::celeritas::test::Test
             DetectorId det{tid.get() % 4};
             if (!step.track_id[tid] || det == DetectorId{3})
                 det = {};
-            step.detector[tid] = det;
+            step.detector_id[tid] = det;
 
             if (!step.event_id.empty())
                 step.event_id[tid] = EventId(i++);
             if (!step.track_step_count.empty())
                 step.track_step_count[tid] = i++;
-            if (!step.action_id.empty())
-                step.action_id[tid] = ActionId(i++);
+            if (!step.post_step_action_id.empty())
+                step.post_step_action_id[tid] = ActionId(i++);
             if (!step.step_length.empty())
                 step.step_length[tid] = i++;
             if (!step.weight.empty())
                 step.weight[tid] = 0.9;
-            if (!step.particle.empty())
-                step.particle[tid] = ParticleId(i++);
+            if (!step.particle_id.empty())
+                step.particle_id[tid] = ParticleId(i++);
             if (!step.energy_deposition.empty())
                 step.energy_deposition[tid] = units::MevEnergy(i++);
         }
@@ -192,7 +192,7 @@ TEST_F(DetectorStepsTest, host)
 
     static int const expected_detector[]
         = {1, 2, 0, 2, 0, 1, 0, 1, 2, 0, 1, 2, 1, 2, 0, 2, 0, 1};
-    EXPECT_VEC_EQ(expected_detector, extract_ids(output.detector));
+    EXPECT_VEC_EQ(expected_detector, extract_ids(output.detector_id));
 
     std::size_t num_tracks = 18;
     EXPECT_EQ(num_tracks, output.track_id.size());
@@ -200,7 +200,7 @@ TEST_F(DetectorStepsTest, host)
     EXPECT_EQ(num_tracks, output.track_step_count.size());
     EXPECT_EQ(num_tracks, output.step_length.size());
     EXPECT_EQ(num_tracks, output.weight.size());
-    EXPECT_EQ(num_tracks, output.particle.size());
+    EXPECT_EQ(num_tracks, output.particle_id.size());
     EXPECT_EQ(num_tracks, output.energy_deposition.size());
 
     auto const& pre = output.points[StepPoint::pre];
@@ -258,7 +258,7 @@ TEST_F(DetectorStepsTest, TEST_IF_CELER_DEVICE(device))
     EXPECT_VEC_EQ(host_output.track_step_count, output.track_step_count);
     EXPECT_VEC_EQ(host_output.step_length, output.step_length);
     EXPECT_VEC_EQ(host_output.weight, output.weight);
-    EXPECT_VEC_EQ(host_output.particle, output.particle);
+    EXPECT_VEC_EQ(host_output.particle_id, output.particle_id);
     EXPECT_VEC_EQ(host_output.energy_deposition, output.energy_deposition);
 
     auto const& host_pre = host_output.points[StepPoint::pre];
@@ -288,7 +288,7 @@ TEST_F(SmallDetectorStepsTest, host)
 
     static int const expected_detector[]
         = {1, 2, 0, 2, 0, 1, 0, 1, 2, 0, 1, 2, 1, 2, 0, 2, 0, 1};
-    EXPECT_VEC_EQ(expected_detector, extract_ids(output.detector));
+    EXPECT_VEC_EQ(expected_detector, extract_ids(output.detector_id));
 
     std::size_t num_tracks = 18;
     EXPECT_EQ(num_tracks, output.track_id.size());
@@ -296,7 +296,7 @@ TEST_F(SmallDetectorStepsTest, host)
     EXPECT_EQ(0, output.track_step_count.size());
     EXPECT_EQ(0, output.step_length.size());
     EXPECT_EQ(0, output.weight.size());
-    EXPECT_EQ(0, output.particle.size());
+    EXPECT_EQ(0, output.particle_id.size());
     EXPECT_EQ(num_tracks, output.energy_deposition.size());
 
     auto const& pre = output.points[StepPoint::pre];
@@ -338,7 +338,7 @@ TEST_F(SmallDetectorStepsTest, TEST_IF_CELER_DEVICE(device))
     EXPECT_EQ(0, output.track_step_count.size());
     EXPECT_EQ(0, output.step_length.size());
     EXPECT_EQ(0, output.weight.size());
-    EXPECT_EQ(0, output.particle.size());
+    EXPECT_EQ(0, output.particle_id.size());
     EXPECT_EQ(num_tracks, output.energy_deposition.size());
 
     auto const& pre = output.points[StepPoint::pre];

--- a/test/celeritas/user/ExampleInstanceCalo.cc
+++ b/test/celeritas/user/ExampleInstanceCalo.cc
@@ -130,8 +130,8 @@ void ExampleInstanceCalo::process_steps(DeviceStepState state)
  */
 void ExampleInstanceCalo::process_steps(DetectorStepOutput const& out)
 {
-    CELER_EXPECT(!out.detector.empty());
-    CELER_EXPECT(out.energy_deposition.size() == out.detector.size());
+    CELER_EXPECT(!out.detector_id.empty());
+    CELER_EXPECT(out.energy_deposition.size() == out.detector_id.size());
     auto const& vi_ids = out.points[StepPoint::pre].volume_instance_ids;
     auto const vi_depth = out.num_volume_levels;
     CELER_EXPECT(vi_ids.size() == out.size() * vi_depth);
@@ -145,8 +145,8 @@ void ExampleInstanceCalo::process_steps(DetectorStepOutput const& out)
     for (auto hit : range(out.size()))
     {
         std::ostringstream os;
-        CELER_ASSERT(out.detector[hit] < det_labels_.size());
-        os << det_labels_[out.detector[hit].get()].name;
+        CELER_ASSERT(out.detector_id[hit] < det_labels_.size());
+        os << det_labels_[out.detector_id[hit].get()].name;
         for (auto id_index : range(vi_depth))
         {
             VolumeInstanceId vi_id = vi_ids[hit * vi_depth + id_index];

--- a/test/geocel/data/water-sphere.gdml
+++ b/test/geocel/data/water-sphere.gdml
@@ -47,9 +47,9 @@
      <D value="1.0"/>
      <composite n="2" ref="Hydrogen"/>
      <composite n="1" ref="Oxygen"/>
-      <property name="RINDEX" ref="RINDEX"/>
-      <property name="GROUPVEL" ref="GROUPVEL"/>
-      <property name="ABSLENGTH" ref="ABSLENGTH"/>
+     <property name="RINDEX" ref="RINDEX"/>
+     <property name="GROUPVEL" ref="GROUPVEL"/>
+     <property name="ABSLENGTH" ref="ABSLENGTH"/>
     </material>
     <material name="FakePlastic" state="solid">
      <D value="4.0"/>

--- a/test/geocel/data/water-sphere.gdml
+++ b/test/geocel/data/water-sphere.gdml
@@ -25,12 +25,6 @@
       <D unit="g/cm3" value="1e-25"/>
       <fraction n="1" ref="H"/>
     </material>
-    <isotope N="1" Z="1" name="H1">
-      <atom unit="g/mole" value="1.00782503081372"/>
-    </isotope>
-    <isotope N="2" Z="1" name="H2">
-      <atom unit="g/mole" value="2.01410199966617"/>
-    </isotope>
     <element name="Hydrogen">
       <fraction n="0.999885" ref="H1"/>
       <fraction n="0.000115" ref="H2"/>
@@ -64,14 +58,14 @@
   </materials>
 
   <solids>
-    <orb lunit="cm" name="sphere" r="100"/>
+    <sphere lunit="cm" name="interiorsph" rmax="100" startphi="0" deltaphi="360" deltatheta="180" aunit="deg"/>
     <sphere lunit="cm" name="shell" rmin="100.0" rmax="110.0" startphi="0" deltaphi="360" deltatheta="180" aunit="deg"/>
-    <box lunit="cm" name="world" x="500" y="500" z="500"/>
+    <box lunit="cm" name="worldbox" x="500" y="500" z="500"/>
   </solids>
 
   <structure>
-    <volume name="sphere">
-      <solidref ref="sphere"/>
+    <volume name="interior">
+      <solidref ref="interiorsph"/>
       <materialref ref="Water"/>
     </volume>
     <volume name="detshell">
@@ -80,13 +74,13 @@
       <auxiliary auxtype="SensDet" auxvalue="detshell"/>
     </volume>
     <volume name="world">
-      <solidref ref="world"/>
+      <solidref ref="worldbox"/>
       <materialref ref="vacuum"/>
       <physvol>
         <volumeref ref="detshell"/>
       </physvol>
       <physvol>
-        <volumeref ref="sphere"/>
+        <volumeref ref="interior"/>
       </physvol>
     </volume>
   </structure>


### PR DESCRIPTION
Follow-on to #2310

This fixes inconsistencies in ordering and assignment of the several classes between the "core data" and the tallied hit result.
- Primary ID wasn't being copied in some places
- Track reconstruction (including track provenance) now takes place anytime the 'track' GeantSd selection is requested
- Rename `detector`,`particle` -> `{}_id` for consistency
- Rename action_id -> post_step_action_id in root step writer
- Fixed StepSelection::all()
- Added test for track and parent IDs making it through the track reconstruction 
- Added additional hit processor tests
- Add primary ID to debug output