### PR TITLE
Improve CUDA profiling with default NVTX and ranged kernels

### DIFF
--- a/scripts/cmake-presets/milan1.json
+++ b/scripts/cmake-presets/milan1.json
@@ -1,0 +1,103 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {"major": 3, "minor": 21, "patch": 0},
+  "configurePresets": [
+    {
+      "name": ".base",
+      "hidden": true,
+      "inherits": ["full", ".spack-base"],
+      "binaryDir": "/scratch/$env{USER}/build/celeritas-${presetName}",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS":     {"type": "BOOL", "value": "ON"},
+        "CELERITAS_BUILD_DOCS":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_OpenMP":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_MPI":     {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_PNG":     {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_ROOT":    {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_DD4hep":  {"type": "BOOL", "value": "OFF"},
+        "CELERITAS_USE_LArSoft":  {"type": "BOOL", "value": "OFF"},
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic -Werror -Wno-stringop-overread -fdiagnostics-color",
+        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_COMPILER": "/usr/bin/c++",
+        "CMAKE_CXX_EXTENSIONS": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_INSTALL_PREFIX": "/scratch/$env{USER}/install/celeritas-${presetName}",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": ".orange",
+      "hidden": true,
+      "cacheVariables": {
+        "CELERITAS_USE_VecGeom": {"type": "BOOL", "value": "OFF"},
+        "CMAKE_EXE_LINKER_FLAGS": "-Wl,-z,defs",
+        "CMAKE_SHARED_LINKER_FLAGS": "-Wl,-z,defs"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Build with full optimizations (VecGeom)",
+      "inherits": [".base", ".ndebug"]
+    },
+    {
+      "name": "reldeb",
+      "displayName": "Build with optimizations, but enable host debugging (VecGeom)",
+      "inherits": [".base", ".reldeb"],
+      "cacheVariables": {
+        "CELERITAS_DEVICE_DEBUG":{"type": "BOOL", "value": "OFF"}
+      }
+    },
+    {
+      "name": "dreldeb",
+      "displayName": "Build with optimizations, and enable all debugging (VecGeom)",
+      "inherits": [".base", ".reldeb"],
+      "cacheVariables": {
+        "CELERITAS_DEVICE_DEBUG":{"type": "BOOL", "value": "ON"}
+      }
+    },
+    {
+      "name": "release-orange",
+      "displayName": "Build with full optimizations (ORANGE)",
+      "inherits": [".orange", "release"]
+    },
+    {
+      "name": "reldeb-orange",
+      "displayName": "Build with optimizations, but enable host debugging (ORANGE)",
+      "inherits": [".orange", "reldeb"]
+    },
+    {
+      "name": "debug-orange",
+      "displayName": "Build without optimization, enabling full host debugging (ORANGE)",
+      "inherits": [".orange", ".base", ".debug"],
+      "cacheVariables": {
+        "CELERITAS_DEVICE_DEBUG":{"type": "BOOL", "value": "OFF"}
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": ".base",
+      "configurePreset": ".base",
+      "jobs": 48,
+      "nativeToolOptions": ["-k0"]
+    },
+    {"name": "release", "configurePreset": "release", "inherits": ".base"},
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": ".base"},
+    {"name": "release-orange", "configurePreset": "release-orange", "inherits": ".base"},
+    {"name": "reldeb-orange", "configurePreset": "reldeb-orange", "inherits": ".base"},
+    {"name": "debug-orange", "configurePreset": "debug-orange", "inherits": ".base"}
+  ],
+  "testPresets": [
+    {
+      "name": ".base",
+      "configurePreset": ".base",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": false, "jobs": 8}
+    },
+    {"name": "release", "configurePreset": "release", "inherits": ".base"},
+    {"name": "reldeb", "configurePreset": "reldeb", "inherits": ".base"},
+    {"name": "release-orange", "configurePreset": "release-orange", "inherits": ".base"},
+    {"name": "reldeb-orange", "configurePreset": "reldeb-orange", "inherits": ".base"},
+    {"name": "debug-orange", "configurePreset": "debug-orange", "inherits": ".base"}
+  ]
+}

--- a/scripts/env/milan1.sh
+++ b/scripts/env/milan1.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -ex
+#-------------------------------- -*- sh -*- ---------------------------------#
+# Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#-----------------------------------------------------------------------------#
+
+if ! command -v load_system_env >/dev/null 2>&1; then
+  printf "error: expected load_system_env helper function via build.sh or shell\n" >&2
+  return 1
+fi
+
+# Use same C++ compiler as milan0/2
+export CXX=/usr/bin/c++
+export CC=/usr/bin/cc
+
+# Dispatch common loading to the 'excl' system
+load_system_env excl || return $?

--- a/src/celeritas/global/ActionLauncher.device.hh
+++ b/src/celeritas/global/ActionLauncher.device.hh
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <string>
+#include <string_view>
 #include <type_traits>
 
 #include "corecel/DeviceRuntimeApi.hh"
@@ -52,8 +54,11 @@ class ActionLauncher : public KernelLauncher<F>
     using StepActionT = CoreStepActionInterface;
 
   public:
-    // Create a launcher from a string
-    using KernelLauncher<F>::KernelLauncher;
+    // Create a launcher from a string view
+    explicit ActionLauncher(std::string_view name)
+        : KernelLauncher<F>{std::string{name}}
+    {
+    }
 
     // Create a launcher from an action
     explicit ActionLauncher(StepActionT const& action);
@@ -92,7 +97,7 @@ ActionLauncher<F>::ActionLauncher(StepActionT const& action)
 template<class F>
 ActionLauncher<F>::ActionLauncher(StepActionT const& action,
                                   std::string_view ext)
-    : ActionLauncher{std::string(action.label()) + "-" + std::string(ext)}
+    : KernelLauncher<F>{std::string(action.label()) + "-" + std::string(ext)}
 {
 }
 

--- a/src/celeritas/global/ActionLauncher.hh
+++ b/src/celeritas/global/ActionLauncher.hh
@@ -13,6 +13,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/Types.hh"
 #include "corecel/sys/MultiExceptionHandler.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/ThreadId.hh"
 
 #include "ActionInterface.hh"
@@ -35,6 +36,7 @@ void launch_core(size_type num_threads,
                  celeritas::CoreState<MemSpace::host>& state,
                  F&& execute_thread)
 {
+    ScopedProfiling profile_this_{label};
     MultiExceptionHandler capture_exception;
 #if defined(_OPENMP) && CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
 #    pragma omp parallel for

--- a/src/celeritas/optical/action/ActionLauncher.device.hh
+++ b/src/celeritas/optical/action/ActionLauncher.device.hh
@@ -52,8 +52,11 @@ class ActionLauncher : public KernelLauncher<F>
         R"(Launched action must be a trivially copyable function object)");
 
   public:
-    // Create a launcher from a string
-    using KernelLauncher<F>::KernelLauncher;
+    // Create a launcher from a string view
+    explicit ActionLauncher(std::string_view name)
+        : KernelLauncher<F>{std::string{name}}
+    {
+    }
 
     // Create a launcher from an action
     template<class StepActionT>
@@ -78,7 +81,7 @@ class ActionLauncher : public KernelLauncher<F>
 template<class F>
 template<class StepActionT>
 ActionLauncher<F>::ActionLauncher(StepActionT const& action)
-    : KernelLauncher<F>{action.label()}
+    : ActionLauncher{action.label()}
 {
 }
 

--- a/src/celeritas/optical/action/DetectorAction.cc
+++ b/src/celeritas/optical/action/DetectorAction.cc
@@ -23,8 +23,7 @@ namespace optical
  * Construct with action ID.
  */
 DetectorAction::DetectorAction(ActionId aid, CallbackFunc const& callback)
-    : StaticConcreteAction(
-          aid, "optical-detector", "Score optical detector hits")
+    : StaticConcreteAction(aid, "detector", "Score optical detector hits")
     , callback_(callback)
 {
     CELER_EXPECT(callback);

--- a/src/celeritas/optical/action/DiscreteSelectAction.cc
+++ b/src/celeritas/optical/action/DiscreteSelectAction.cc
@@ -23,9 +23,8 @@ namespace optical
  * Construct with an action ID.
  */
 DiscreteSelectAction::DiscreteSelectAction(ActionId id)
-    : StaticConcreteAction(id,
-                           "optical-discrete-select",
-                           "select a discrete optical interaction")
+    : StaticConcreteAction(
+          id, "discrete-select", "select a discrete optical interaction")
 {
 }
 

--- a/src/celeritas/optical/gen/GeneratorAction.cc
+++ b/src/celeritas/optical/gen/GeneratorAction.cc
@@ -84,7 +84,7 @@ GeneratorAction::GeneratorAction(ActionId id,
     : GeneratorBase(id,
                     aux_id,
                     gen_id,
-                    "optical-generate",
+                    "generate",
                     "generate Cherenkov or scintillation photons from optical "
                     "distribution data")
     , initial_capacity_(capacity)

--- a/src/celeritas/optical/gen/GeneratorAction.cc
+++ b/src/celeritas/optical/gen/GeneratorAction.cc
@@ -14,6 +14,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/ActionRegistry.hh"
 #include "corecel/sys/KernelLauncher.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
 #include "celeritas/optical/CoreParams.hh"
@@ -229,6 +230,8 @@ void GeneratorAction::generate(CoreParams const& params,
 {
     CELER_EXPECT(params.cherenkov() || params.scintillation());
     CELER_EXPECT(state.aux());
+
+    ScopedProfiling profile_this_{"generate"};
 
     auto& aux_state
         = get<GeneratorState<MemSpace::native>>(*state.aux(), this->aux_id());

--- a/src/celeritas/optical/gen/GeneratorAction.cu
+++ b/src/celeritas/optical/gen/GeneratorAction.cu
@@ -36,6 +36,8 @@ void GeneratorAction::generate(CoreParams const& params,
     CELER_EXPECT(params.cherenkov() || params.scintillation());
     CELER_EXPECT(state.aux());
 
+    ScopedProfiling profile_this_{"generate"};
+
     auto& aux_state
         = get<GeneratorState<MemSpace::native>>(*state.aux(), this->aux_id());
     size_type num_gen = min(state.sync_get_counters().num_vacancies,

--- a/src/celeritas/optical/gen/WlsGeneratorAction.cc
+++ b/src/celeritas/optical/gen/WlsGeneratorAction.cc
@@ -61,7 +61,7 @@ WlsGeneratorAction::WlsGeneratorAction(Input&& input)
     : GeneratorBase(input.action_id,
                     input.aux_id,
                     input.gen_id,
-                    "optical-wls-generate",
+                    "wls-generate",
                     "generate photons from a wavelength shifting process")
     , wls_(std::move(input.wls))
     , wls2_(std::move(input.wls2))

--- a/src/celeritas/optical/model/MieModel.cc
+++ b/src/celeritas/optical/model/MieModel.cc
@@ -35,7 +35,7 @@ namespace optical
 MieModel::MieModel(ActionId id,
                    inp::OpticalBulkMie input,
                    SPConstMaterials const& materials)
-    : Model(id, "optical-mie", "interact by optical Mie scattering")
+    : Model(id, "mie", "interact by optical Mie scattering")
     , input_(std::move(input))
 {
     HostVal<MieData> data;

--- a/src/celeritas/optical/model/RayleighModel.cc
+++ b/src/celeritas/optical/model/RayleighModel.cc
@@ -37,7 +37,7 @@ RayleighModel::RayleighModel(ActionId id,
                              inp::OpticalBulkRayleigh input,
                              SPConstMaterials const& materials,
                              SPConstCoreMaterials const& core_materials)
-    : Model(id, "optical-rayleigh", "interact by optical Rayleigh")
+    : Model(id, "rayleigh", "interact by optical Rayleigh")
     , input_(std::move(input))
     , materials_(materials)
     , core_materials_(core_materials)

--- a/src/celeritas/optical/surface/BoundaryAction.cc
+++ b/src/celeritas/optical/surface/BoundaryAction.cc
@@ -29,7 +29,7 @@ struct BoundaryActionTraits;
 template<>
 struct BoundaryActionTraits<detail::InitBoundaryExecutor>
 {
-    constexpr static char const* action_name = "optical-boundary-init";
+    constexpr static char const* action_name = "boundary-init";
     constexpr static char const* action_desc
         = "Initialize optical boundary crossing action";
 };
@@ -37,7 +37,7 @@ struct BoundaryActionTraits<detail::InitBoundaryExecutor>
 template<>
 struct BoundaryActionTraits<detail::PostBoundaryExecutor>
 {
-    constexpr static char const* action_name = "optical-boundary-post";
+    constexpr static char const* action_name = "boundary-post";
     constexpr static char const* action_desc
         = "Finalize optical boundary crossing action";
 };

--- a/src/celeritas/optical/surface/SurfacePhysicsParams.hh
+++ b/src/celeritas/optical/surface/SurfacePhysicsParams.hh
@@ -80,8 +80,6 @@ class SurfacePhysicsParams final
     //!@{
     //! \name Type aliases
     using SPModel = std::shared_ptr<SurfaceModel>;
-    using SurfaceStepModels
-        = EnumArray<SurfacePhysicsOrder, std::vector<SPModel>>;
     //!@}
 
   public:
@@ -120,6 +118,13 @@ class SurfacePhysicsParams final
     }
 
   private:
+    //// TYPES ////
+
+    using SurfaceStepModels
+        = EnumArray<SurfacePhysicsOrder, std::vector<SPModel>>;
+
+    //// DATA ////
+
     // Boundary actions
     std::shared_ptr<InitBoundaryAction> init_boundary_action_;
     std::shared_ptr<SurfaceSteppingAction> surface_stepping_action_;
@@ -129,6 +134,8 @@ class SurfacePhysicsParams final
 
     // Host/device storage
     ParamsDataStore<SurfacePhysicsParamsData> data_;
+
+    //// FUNCTIONS ////
 
     // Build surface data
     void build_surfaces(std::vector<std::vector<OptMatId>> const&,

--- a/src/celeritas/optical/surface/SurfaceSteppingAction.cc
+++ b/src/celeritas/optical/surface/SurfaceSteppingAction.cc
@@ -21,9 +21,8 @@ namespace optical
  * Construct surface stepping action from ID.
  */
 SurfaceSteppingAction::SurfaceSteppingAction(ActionId aid)
-    : ConcreteAction(aid,
-                     "optical-surface-stepping",
-                     "step through optical surface actions")
+    : ConcreteAction(
+          aid, "surface-stepping", "step through optical surface actions")
 {
 }
 

--- a/src/celeritas/optical/surface/SurfaceSteppingAction.cc
+++ b/src/celeritas/optical/surface/SurfaceSteppingAction.cc
@@ -6,6 +6,9 @@
 //---------------------------------------------------------------------------//
 #include "SurfaceSteppingAction.hh"
 
+#include <string_view>
+
+#include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/optical/CoreParams.hh"
 #include "celeritas/optical/CoreState.hh"
 
@@ -21,8 +24,7 @@ namespace optical
  * Construct surface stepping action from ID.
  */
 SurfaceSteppingAction::SurfaceSteppingAction(ActionId aid)
-    : ConcreteAction(
-          aid, "surface-stepping", "step through optical surface actions")
+    : ConcreteAction(aid, "surface-physics", "apply optical surface physics")
 {
 }
 
@@ -58,13 +60,20 @@ template<MemSpace M>
 void SurfaceSteppingAction::step_impl(CoreParams const& params,
                                       CoreState<M>& state) const
 {
+    auto const& physics = *params.surface_physics();
     constexpr size_type num_iterations = 1;
 
     for ([[maybe_unused]] auto iteration : range(num_iterations))
     {
         for (auto substep : range(SurfacePhysicsOrder::size_))
         {
-            for (auto const& model : params.surface_physics()->models(substep))
+            auto const& models = physics.models(substep);
+            if (models.empty())
+                continue;
+
+            ScopedProfiling profile_this_{
+                std::string_view(to_cstring(substep))};
+            for (auto const& model : models)
             {
                 model->step(params, state);
             }

--- a/src/celeritas/random/RngReseed.cc
+++ b/src/celeritas/random/RngReseed.cc
@@ -7,6 +7,7 @@
 #include "RngReseed.hh"
 
 #include "corecel/sys/KernelLauncher.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 
 #include "detail/RngReseedExecutor.hh"
 
@@ -26,6 +27,7 @@ void reseed_rng(HostCRef<RngParamsData> const& params,
                 StreamId,
                 UniqueEventId event_id)
 {
+    ScopedProfiling profile_this_{"rng-reseed"};
     launch_kernel(state.size(),
                   detail::RngReseedExecutor{params, state, event_id});
 }

--- a/src/celeritas/random/RngReseed.cu
+++ b/src/celeritas/random/RngReseed.cu
@@ -8,6 +8,7 @@
 
 #include "corecel/Types.hh"
 #include "corecel/sys/KernelLauncher.device.hh"
+#include "corecel/sys/ThreadId.hh"
 
 #include "detail/RngReseedExecutor.hh"
 

--- a/src/corecel/random/data/CuHipRngData.cc
+++ b/src/corecel/random/data/CuHipRngData.cc
@@ -11,6 +11,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/Ref.hh"
 #include "corecel/sys/Device.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 
 #include "detail/CuHipRngStateInit.hh"
 
@@ -29,6 +30,7 @@ void resize(CuHipRngStateData<Ownership::value, M>* state,
     CELER_EXPECT(stream);
     CELER_EXPECT(size > 0);
     CELER_EXPECT(M == MemSpace::host || celeritas::device());
+    ScopedProfiling profile_this_{"rng-resize"};
 
     // Host-side RNG for creating seeds
     std::mt19937 host_rng(params.seed + stream.get());

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -6,15 +6,13 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <string_view>
-#include <type_traits>
+#include <string>
 
 #include "corecel/DeviceRuntimeApi.hh"
 
-#include "corecel/Assert.hh"
-#include "corecel/Macros.hh"
 #include "corecel/Types.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 
 #include "Device.hh"
 #include "KernelParamCalculator.device.hh"
@@ -62,7 +60,7 @@ class KernelLauncher
 
   public:
     // Create a launcher from a label
-    explicit inline KernelLauncher(std::string_view name);
+    explicit inline KernelLauncher(std::string&& name);
 
     // Launch a kernel for a thread range
     inline void operator()(Range<ThreadId> threads,
@@ -74,7 +72,11 @@ class KernelLauncher
                            StreamId stream_id,
                            F const& execute_thread) const;
 
+    //! Name of this kernel
+    std::string const& name() const { return name_; }
+
   private:
+    std::string name_;
     KernelParamCalculator calc_launch_params_;
 };
 
@@ -85,8 +87,9 @@ class KernelLauncher
  * Create a launcher from a label.
  */
 template<class F>
-KernelLauncher<F>::KernelLauncher(std::string_view name)
-    : calc_launch_params_{name, &detail::launch_action_impl<F>}
+KernelLauncher<F>::KernelLauncher(std::string&& name)
+    : name_{std::move(name)}
+    , calc_launch_params_{name, &detail::launch_action_impl<F>}
 {
 }
 
@@ -101,6 +104,7 @@ void KernelLauncher<F>::operator()(Range<ThreadId> threads,
 {
     if (!threads.empty())
     {
+        ScopedProfiling profile_this_{name_};
         using StreamT = CELER_DEVICE_API_SYMBOL(Stream_t);
         StreamT stream = stream_id
                              ? celeritas::device().stream(stream_id).get()

--- a/src/corecel/sys/ScopedProfiling.cc
+++ b/src/corecel/sys/ScopedProfiling.cc
@@ -25,11 +25,15 @@ namespace celeritas
 //---------------------------------------------------------------------------//
 /*!
  * Whether profiling is enabled.
+ *
+ * This defaults to ON if CUDA is enabled since (as of CUDA 12.0) there is no
+ * measurable performance impact for NVTX hooks. It defaults to OFF otherwise.
  */
 bool ScopedProfiling::enabled()
 {
     static bool const enabled_ = [] {
-        auto result = celeritas::getenv_flag("CELER_ENABLE_PROFILING", false);
+        auto result = celeritas::getenv_flag("CELER_ENABLE_PROFILING",
+                                             CELERITAS_USE_CUDA);
         if (result.value)
         {
             if constexpr (CELERITAS_USE_HIP && !CELERITAS_HAVE_ROCTX)

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -23,8 +23,8 @@ namespace
  */
 nvtxEventAttributes_t make_attributes(ScopedProfiling::Input const& input)
 {
-    nvtxEventAttributes_t attributes = {};  // Initialize all attributes to
-                                            // zero
+    // Initialize all attributes to zero
+    nvtxEventAttributes_t attributes = {};
     attributes.version = NVTX_VERSION;
     attributes.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
     if (input.color)

--- a/src/corecel/sys/detail/KernelLauncherImpl.device.hh
+++ b/src/corecel/sys/detail/KernelLauncherImpl.device.hh
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "corecel/Config.hh"
-#include "corecel/DeviceRuntimeApi.hh"
+#include "corecel/DeviceRuntimeApi.hh"  // IWYU pragma: keep
 
 #include "corecel/Macros.hh"
 #include "corecel/cont/Range.hh"

--- a/test/celeritas/optical/Generator.test.cc
+++ b/test/celeritas/optical/Generator.test.cc
@@ -247,13 +247,13 @@ TEST_F(LArSphereGeneratorTest, offload)
     static std::string const expected_labels[] = {
         "absorption",
         "along-step",
+        "boundary-init",
+        "boundary-post",
+        "discrete-select",
+        "generate",
         "locate-vacancies",
-        "optical-boundary-init",
-        "optical-boundary-post",
-        "optical-discrete-select",
-        "optical-generate",
-        "optical-surface-stepping",
         "pre-step",
+        "surface-physics",
         "tracking-cut",
     };
     EXPECT_VEC_EQ(expected_labels, labels);
@@ -330,8 +330,7 @@ TEST_F(WlsGeneratorTest, primary)
     {
         GeneratorId gen_id(0);
         auto const& gen = result.counters.generators[gen_id.get()];
-        EXPECT_EQ("optical-wls-generate",
-                  run.params()->gen_reg()->at(gen_id)->label());
+        EXPECT_EQ("wls-generate", run.params()->gen_reg()->at(gen_id)->label());
         EXPECT_EQ(0, gen.buffer_size);
         EXPECT_EQ(0, gen.num_pending);
         if (reference_configuration)
@@ -359,17 +358,17 @@ TEST_F(WlsGeneratorTest, primary)
     static std::string const expected_labels[] = {
         "absorption",
         "along-step",
+        "boundary-init",
+        "boundary-post",
+        "discrete-select",
         "locate-vacancies",
-        "optical-boundary-init",
-        "optical-boundary-post",
-        "optical-discrete-select",
-        "optical-rayleigh",
-        "optical-surface-stepping",
-        "optical-wls-generate",
         "pre-step",
         "primary-generate",
+        "rayleigh",
+        "surface-physics",
         "tracking-cut",
         "wls",
+        "wls-generate",
         "wls2",
     };
     EXPECT_VEC_EQ(expected_labels, labels);

--- a/test/celeritas/optical/OpticalCollector.test.cc
+++ b/test/celeritas/optical/OpticalCollector.test.cc
@@ -204,7 +204,7 @@ auto LArSphereOffloadTest::run(size_type num_primaries,
     }
 
     auto const& gen_reg = collector_->gen_reg();
-    auto gen_id = gen_reg.find("optical-generate");
+    auto gen_id = gen_reg.find("generate");
     CELER_ASSERT(gen_id);
 
     // Access the auxiliary data for the generator

--- a/test/celeritas/optical/Physics.test.cc
+++ b/test/celeritas/optical/Physics.test.cc
@@ -195,8 +195,8 @@ TEST_F(OpticalPhysicsTest, physics_params)
     // Check model names
     static std::string_view expected_names[] = {
         "absorption",
-        "optical-mie",
-        "optical-rayleigh",
+        "mie",
+        "rayleigh",
         "wls",
     };
     EXPECT_VEC_EQ(expected_names, model_names);

--- a/test/celeritas/optical/Rayleigh.test.cc
+++ b/test/celeritas/optical/Rayleigh.test.cc
@@ -163,7 +163,7 @@ TEST_F(RayleighInteractorTest, stress_test)
 TEST_F(RayleighModelTest, description)
 {
     EXPECT_EQ(ActionId{0}, model->action_id());
-    EXPECT_EQ("optical-rayleigh", model->label());
+    EXPECT_EQ("rayleigh", model->label());
     EXPECT_EQ("interact by optical Rayleigh", model->description());
 }
 


### PR DESCRIPTION
This wraps the device kernel launches with NVTX ranges to improve debugging/profiling. By checking whether the "domain handle" returned by nvtx is a nullptr, we can also auto-detect whether it's active in the user environment.

Finally, this updates action names for more consistency between optical/em, and to improve debugging in nsight systems:
```diff
       "label": [
-        "optical-discrete-select",
+        "discrete-select",
         "absorption",
-        "optical-rayleigh",
-        "optical-boundary-init",
-        "optical-surface-stepping",
-        "optical-boundary-post",
+        "rayleigh",
+        "boundary-init",
+        "surface-physics",
+        "boundary-post",
         "pre-step",
         "along-step",
         "tracking-cut",
```

<img width="857" height="143" alt="nsight" src="https://github.com/user-attachments/assets/51b02e67-8f8b-4ced-bc7f-962f10683b16" />
