### PR TITLE
Hotfix: nvtx kernel names

### DIFF
--- a/doc/usage/execution/environment.rst
+++ b/doc/usage/execution/environment.rst
@@ -60,7 +60,8 @@ has a default value but can be overridden with any boolean value.
  ORANGE_BIH_STRUCTURE      orange    Include "structure" info in BIH JSON output
  ========================= ========= ==========================================
 
-.. [#pr] See :ref:`profiling`
+.. [#pr] See :ref:`profiling`. This should default to 1 when running through
+   an NVTX-enabled driver such as ``nsys``.
 .. [#lg] See :ref:`logging`
 .. [#mp] CELER_MEMPOOL_RELEASE_THRESHOLD changes the amount of memory used for
    the device asynchronous memory pool.

--- a/src/celeritas/optical/surface/model/DielectricInteractionModel.cc
+++ b/src/celeritas/optical/surface/model/DielectricInteractionModel.cc
@@ -26,7 +26,7 @@ namespace optical
  */
 DielectricInteractionModel::DielectricInteractionModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "interaction-dielectric")
+    : SurfaceModel(id, "dielectric-interaction")
 {
     HostVal<DielectricData> dielectric_data;
     HostVal<UnifiedReflectionData> reflection_data;

--- a/src/celeritas/optical/surface/model/FresnelReflectivityModel.cc
+++ b/src/celeritas/optical/surface/model/FresnelReflectivityModel.cc
@@ -24,7 +24,7 @@ namespace optical
  */
 FresnelReflectivityModel::FresnelReflectivityModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "reflectivity-fresnel")
+    : SurfaceModel(id, "fresnel-reflectivity")
 {
     surfaces_.reserve(layer_map.size());
 

--- a/src/celeritas/optical/surface/model/GaussianRoughnessModel.cc
+++ b/src/celeritas/optical/surface/model/GaussianRoughnessModel.cc
@@ -26,7 +26,7 @@ namespace optical
  */
 GaussianRoughnessModel::GaussianRoughnessModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "roughness-gaussian")
+    : SurfaceModel(id, "gaussian-roughness")
 {
     surfaces_.reserve(layer_map.size());
     std::transform(layer_map.begin(),

--- a/src/celeritas/optical/surface/model/GridReflectivityModel.cc
+++ b/src/celeritas/optical/surface/model/GridReflectivityModel.cc
@@ -29,7 +29,7 @@ namespace optical
  */
 GridReflectivityModel::GridReflectivityModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "reflectivity-grid")
+    : SurfaceModel(id, "grid-reflectivity")
 {
     using GridId = OpaqueId<NonuniformGridRecord>;
 

--- a/src/celeritas/optical/surface/model/OnlyReflectionModel.cc
+++ b/src/celeritas/optical/surface/model/OnlyReflectionModel.cc
@@ -25,7 +25,7 @@ namespace optical
  */
 OnlyReflectionModel::OnlyReflectionModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "interaction-only_reflection")
+    : SurfaceModel(id, "only-reflection-interaction")
 {
     HostVal<OnlyReflectionData> data;
     auto build_modes = CollectionBuilder{&data.modes};

--- a/src/celeritas/optical/surface/model/PolishedRoughnessModel.cc
+++ b/src/celeritas/optical/surface/model/PolishedRoughnessModel.cc
@@ -25,7 +25,7 @@ namespace optical
  */
 PolishedRoughnessModel::PolishedRoughnessModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "roughness-polished")
+    : SurfaceModel(id, "polished-roughness")
 {
     surfaces_.reserve(layer_map.size());
     std::transform(layer_map.begin(),

--- a/src/celeritas/optical/surface/model/SmearRoughnessModel.cc
+++ b/src/celeritas/optical/surface/model/SmearRoughnessModel.cc
@@ -26,7 +26,7 @@ namespace optical
  */
 SmearRoughnessModel::SmearRoughnessModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "roughness-smear")
+    : SurfaceModel(id, "smear-roughness")
 {
     surfaces_.reserve(layer_map.size());
     std::transform(layer_map.begin(),

--- a/src/celeritas/optical/surface/model/TrivialInteractionModel.cc
+++ b/src/celeritas/optical/surface/model/TrivialInteractionModel.cc
@@ -25,7 +25,7 @@ namespace optical
  */
 TrivialInteractionModel::TrivialInteractionModel(
     SurfaceModelId id, std::map<PhysSurfaceId, InputT> const& layer_map)
-    : SurfaceModel(id, "interaction-trivial")
+    : SurfaceModel(id, "trivial-interaction")
 {
     HostVal<TrivialInteractionData> data;
     auto build_modes = CollectionBuilder{&data.modes};

--- a/src/corecel/sys/KernelLauncher.device.hh
+++ b/src/corecel/sys/KernelLauncher.device.hh
@@ -89,7 +89,7 @@ class KernelLauncher
 template<class F>
 KernelLauncher<F>::KernelLauncher(std::string&& name)
     : name_{std::move(name)}
-    , calc_launch_params_{name, &detail::launch_action_impl<F>}
+    , calc_launch_params_{name_, &detail::launch_action_impl<F>}
 {
 }
 

--- a/src/corecel/sys/ScopedProfiling.cc
+++ b/src/corecel/sys/ScopedProfiling.cc
@@ -32,8 +32,13 @@ namespace celeritas
 bool ScopedProfiling::enabled()
 {
     static bool const enabled_ = [] {
-        auto result = celeritas::getenv_flag("CELER_ENABLE_PROFILING",
-                                             CELERITAS_USE_CUDA);
+#if CELERITAS_USE_CUDA
+        constexpr auto get_default_profiling = ScopedProfiling::is_nvtx_enabled;
+#else
+        constexpr auto get_default_profiling = [] { return false; };
+#endif
+        auto result = celeritas::getenv_flag_lazy("CELER_ENABLE_PROFILING",
+                                                  get_default_profiling);
         if (result.value)
         {
             if constexpr (CELERITAS_USE_HIP && !CELERITAS_HAVE_ROCTX)

--- a/src/corecel/sys/ScopedProfiling.cuda.cc
+++ b/src/corecel/sys/ScopedProfiling.cuda.cc
@@ -100,4 +100,13 @@ void ScopedProfiling::deactivate() noexcept
 }
 
 //---------------------------------------------------------------------------//
+/*!
+ * Test whether nvtx is enabled by pushing/popping a domain.
+ */
+bool ScopedProfiling::is_nvtx_enabled()
+{
+    return domain_handle() != nullptr;
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/sys/ScopedProfiling.hh
+++ b/src/corecel/sys/ScopedProfiling.hh
@@ -104,6 +104,8 @@ class ScopedProfiling
 
     void activate(Input const& input) noexcept;
     void deactivate() noexcept;
+
+    static bool is_nvtx_enabled();
 };
 
 //---------------------------------------------------------------------------//
@@ -150,6 +152,12 @@ inline void ScopedProfiling::activate(Input const&) noexcept
 inline void ScopedProfiling::deactivate() noexcept
 {
     CELER_UNREACHABLE;
+}
+#endif
+#if !CELERITAS_USE_CUDA
+inline bool ScopedProfiling::is_nvtx_enabled()
+{
+    return false;
 }
 #endif
 //---------------------------------------------------------------------------//

--- a/test/celeritas/optical/SurfacePhysics.test.cc
+++ b/test/celeritas/optical/SurfacePhysics.test.cc
@@ -350,16 +350,16 @@ TEST_F(SurfacePhysicsTest, init_params)
 
     SurfaceOrderArray<std::vector<std::string_view>> expected_model_names;
     expected_model_names[SurfacePhysicsOrder::roughness] = {
-        "roughness-polished",
-        "roughness-smear",
-        "roughness-gaussian",
+        "polished-roughness",
+        "smear-roughness",
+        "gaussian-roughness",
     };
     expected_model_names[SurfacePhysicsOrder::reflectivity] = {
-        "reflectivity-grid",
-        "reflectivity-fresnel",
+        "grid-reflectivity",
+        "fresnel-reflectivity",
     };
     expected_model_names[SurfacePhysicsOrder::interaction] = {
-        "interaction-dielectric",
+        "dielectric-interaction",
     };
 
     for (auto step : range(SurfacePhysicsOrder::size_))


### PR DESCRIPTION
I was working on two systems at the same time and didn't check that commits that I thought were pushed to #2389 were actually pushed :( Until this gets merged, kernel names will be empty because of an ill-timed `move`.