### PR TITLE
Separate optical distribution loading from transport timing

### DIFF
--- a/app/celer-optical/celer-optical.cc
+++ b/app/celer-optical/celer-optical.cc
@@ -79,43 +79,42 @@ void run(std::shared_ptr<OutputRegistry>& output,
     // Set up optical problem
     Stopwatch get_setup_time;
     auto run = Runner(std::move(input));
-    result.time.setup = get_setup_time();
-
-    //! \todo Optical loop warmup
 
     // Get output registry
     output = run.params()->output_reg();
 
     // Transport all tracks to completion
+    std::visit(Overload{
+                   [&run](celeritas::inp::OpticalPrimaryGenerator const&) {
+                       run.insert();
+                   },
+                   [&run](celeritas::inp::OpticalOffloadGenerator const& g) {
+                       CELER_VALIDATE(g.distribution_file,
+                                      << "missing file for loading optical "
+                                         "distribution data");
+                       auto const distributions
+                           = OpticalDistributionReader(*g.distribution_file)();
+                       run.insert(make_span(distributions));
+                   },
+                   [](celeritas::inp::OpticalDirectGenerator const&) {
+                       //! \todo Add support for direct generation from file
+                       CELER_VALIDATE(false,
+                                      << "direct optical photon generation is "
+                                         "not yet supported");
+                   },
+                   [](celeritas::inp::OpticalEmGenerator const&) {
+                       CELER_VALIDATE(false,
+                                      << "optical photon generation from EM "
+                                         "particles is not supported");
+                   },
+               },
+               generator);
+    result.time.setup = get_setup_time();
+
+    //! \todo Optical loop warmup
+
     Stopwatch get_transport_time;
-    Runner::Result run_result = std::visit(
-        Overload{
-            [&run](celeritas::inp::OpticalPrimaryGenerator const&) {
-                return run();
-            },
-            [&run](celeritas::inp::OpticalOffloadGenerator const& g) {
-                CELER_VALIDATE(g.distribution_file,
-                               << "missing file for loading optical "
-                                  "distribution data");
-                auto const distributions
-                    = OpticalDistributionReader(*g.distribution_file)();
-                return run(make_span(distributions));
-            },
-            [](celeritas::inp::OpticalDirectGenerator const&) {
-                //! \todo Add support for direct generation from file
-                CELER_VALIDATE(false,
-                               << "direct optical photon generation is not "
-                                  "yet supported");
-                return Runner::Result{};
-            },
-            [](celeritas::inp::OpticalEmGenerator const&) {
-                CELER_VALIDATE(false,
-                               << "optical photon generation from EM "
-                                  "particles is not supported");
-                return Runner::Result{};
-            },
-        },
-        generator);
+    auto run_result = run();
     result.time.total = get_transport_time();
     result.time.actions = std::move(run_result.action_times);
     result.time.steps = std::move(run_result.step_times);

--- a/src/celeritas/optical/Runner.cc
+++ b/src/celeritas/optical/Runner.cc
@@ -74,9 +74,9 @@ Runner::Runner(Input&& osi)
 
 //---------------------------------------------------------------------------//
 /*!
- * Transport tracks generated with a primary generator.
+ * Set the number of pending tracks for a primary generator.
  */
-auto Runner::operator()() -> Result
+void Runner::insert()
 {
     auto generate
         = std::dynamic_pointer_cast<optical::PrimaryGeneratorAction const>(
@@ -86,15 +86,13 @@ auto Runner::operator()() -> Result
 
     // Set the number of pending tracks
     generate->insert(*state_);
-
-    return this->run();
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Transport tracks generated directly from track initializers.
+ * Insert track initializers.
  */
-auto Runner::operator()(SpanConstTrackInit data) -> Result
+void Runner::insert(SpanConstTrackInit data)
 {
     auto generate
         = std::dynamic_pointer_cast<optical::DirectGeneratorAction const>(
@@ -104,15 +102,13 @@ auto Runner::operator()(SpanConstTrackInit data) -> Result
 
     // Insert track initializers
     generate->insert(*state_, data);
-
-    return this->run();
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Transport tracks generated through scintillation or Cherenkov.
+ * Insert distributions for generating through scintillation or Cherenkov.
  */
-auto Runner::operator()(SpanConstGenDist data) -> Result
+void Runner::insert(SpanConstGenDist data)
 {
     auto generate = std::dynamic_pointer_cast<optical::GeneratorAction const>(
         loaded_.problem.generator);
@@ -132,15 +128,13 @@ auto Runner::operator()(SpanConstGenDist data) -> Result
         counters.num_pending += d.num_photons;
     }
     state_->sync_put_counters(counters);
-
-    return this->run();
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Generate optical photons and transport to completion.
  */
-auto Runner::run() const -> Result
+auto Runner::operator()() const -> Result
 {
     ScopedProfiling profile_this{"run"};
     (*loaded_.problem.transporter)(*state_);

--- a/src/celeritas/optical/Runner.hh
+++ b/src/celeritas/optical/Runner.hh
@@ -57,14 +57,17 @@ class Runner
     // Construct with optical problem input definition
     explicit Runner(Input&&);
 
-    // Transport tracks generated with a primary generator
-    Result operator()();
+    // Set the number of pending tracks for a primary generator
+    void insert();
 
-    // Transport tracks generated directly from track initializers
-    Result operator()(SpanConstTrackInit);
+    // Insert track initializers
+    void insert(SpanConstTrackInit);
 
-    // Transport tracks generated through scintillation or Cherenkov
-    Result operator()(SpanConstGenDist);
+    // Insert distributions for generating through scintillation or Cherenkov
+    void insert(SpanConstGenDist);
+
+    // Generate optical photons and transport to completion
+    Result operator()() const;
 
     //! Access the shared params
     SPConstParams const& params() const
@@ -81,10 +84,6 @@ class Runner
   private:
     setup::OpticalStandaloneLoaded loaded_;
     std::shared_ptr<CoreStateBase> state_;
-
-    //// HELPER FUNCTIONS ////
-
-    Result run() const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/larceler/LarStandaloneRunner.cc
+++ b/src/larceler/LarStandaloneRunner.cc
@@ -217,7 +217,8 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
     }
 
     // Execute
-    auto result = (*runner_)(make_span(std::as_const(gdd)));
+    runner->insert(make_span(std::as_const(gdd)));
+    auto result = (*runner_)();
 
     CELER_ASSERT(result.counters.generators.size() == 1);
     auto const& gen = result.counters.generators.front();

--- a/src/larceler/LarStandaloneRunner.cc
+++ b/src/larceler/LarStandaloneRunner.cc
@@ -217,7 +217,7 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
     }
 
     // Execute
-    runner->insert(make_span(std::as_const(gdd)));
+    runner_->insert(make_span(std::as_const(gdd)));
     auto result = (*runner_)();
 
     CELER_ASSERT(result.counters.generators.size() == 1);

--- a/test/celeritas/optical/Detector.test.cc
+++ b/test/celeritas/optical/Detector.test.cc
@@ -190,7 +190,9 @@ TEST_F(DetectorTest, simple)
     osi_.problem.generator = celeritas::inp::OpticalDirectGenerator{};
 
     // Construct the runner and transport optical primaries
-    optical::Runner(std::move(osi_))(make_span(std::as_const(inits)));
+    optical::Runner run(std::move(osi_));
+    run.insert(make_span(std::as_const(inits)));
+    run();
 
     // Check results
 
@@ -299,7 +301,9 @@ TEST_F(DetectorTest, stress)
     }();
 
     // Construct the runner and transport optical primaries
-    optical::Runner(std::move(osi_))();
+    optical::Runner run(std::move(osi_));
+    run.insert();
+    run();
 
     // Check results
 
@@ -336,7 +340,9 @@ TEST_F(DetectorTest, efficiency)
     }();
 
     // Construct the runner and transport optical primaries
-    optical::Runner(std::move(osi_))();
+    optical::Runner run(std::move(osi_));
+    run.insert();
+    run();
 
     // Check results
     if constexpr (reference_configuration)

--- a/test/celeritas/optical/Generator.test.cc
+++ b/test/celeritas/optical/Generator.test.cc
@@ -152,7 +152,9 @@ TEST_F(LArSphereGeneratorTest, primary)
     osi_.problem.capacity.tracks = 16384;
 
     // Construct the runner and transport optical primaries
-    auto result = optical::Runner(std::move(osi_))();
+    optical::Runner run(std::move(osi_));
+    run.insert();
+    auto result = run();
 
     if (reference_configuration)
     {
@@ -185,7 +187,9 @@ TEST_F(LArSphereGeneratorTest, direct)
                                   ImplVolumeId{0}});
 
     // Construct the runner and transport optical primaries
-    auto result = optical::Runner(std::move(osi_))(make_span(inits));
+    optical::Runner run(std::move(osi_));
+    run.insert(make_span(inits));
+    auto result = run();
 
     if (reference_configuration
         && CELERITAS_CORE_GEO != CELERITAS_CORE_GEO_GEANT4)
@@ -221,7 +225,9 @@ TEST_F(LArSphereGeneratorTest, offload)
         = this->make_distributions(osi_.problem.capacity.generators);
 
     // Construct the runner and transport optical primaries
-    auto result = optical::Runner(std::move(osi_))(make_span(host_data));
+    optical::Runner run(std::move(osi_));
+    run.insert(make_span(host_data));
+    auto result = run();
 
     EXPECT_EQ(1, result.counters.flushes);
     ASSERT_EQ(1, result.counters.generators.size());
@@ -286,7 +292,9 @@ TEST_F(DuneGeneratorTest, offload)
     CELER_ASSERT(gdd);
 
     // Construct the runner and transport the single distribution
-    auto result = optical::Runner(std::move(osi_))({&gdd, 1});
+    optical::Runner run(std::move(osi_));
+    run.insert({&gdd, 1});
+    auto result = run();
 
     EXPECT_EQ(1, result.counters.flushes);
     ASSERT_EQ(1, result.counters.generators.size());
@@ -317,6 +325,7 @@ TEST_F(WlsGeneratorTest, primary)
 
     // Construct the runner and transport optical primaries
     optical::Runner run(std::move(osi_));
+    run.insert();
     auto result = run();
 
     if (reference_configuration)

--- a/test/larceler/LarStandaloneRunner.test.cc
+++ b/test/larceler/LarStandaloneRunner.test.cc
@@ -138,13 +138,13 @@ TEST_F(DuneCryoTest, two_sim_edeps)
     auto raw_result = run({sed, sed2});
     auto result = RunResult::from_btr(raw_result);
     RunResult ref;
-    ref.num_hits = {255, 250, 16, 6};
+    ref.num_hits = {273, 269, 15, 4};
     EXPECT_REF_EQ(ref, result);
     // auto hits = raw_result.at(3).TrackIDsAndEnergies(10.0, 20.0); // [ns]
 
     // Run again (simulating second event)
     result = RunResult::from_btr(run({sed2, sed}));
-    ref.num_hits = {252, 273, 13, 6};
+    ref.num_hits = {233, 264, 16, 5};
     EXPECT_REF_EQ(ref, result);
 }
 


### PR DESCRIPTION
This separates the optical generator insertion from the generation and transport in the runner and counts the time to read the distributions from JSON as setup rather than transport in the optical app.