### PR TITLE
Allow G4 geo to keep persistent volume params

### DIFF
--- a/app/celer-geo/Runner.cc
+++ b/app/celer-geo/Runner.cc
@@ -14,6 +14,7 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/Stopwatch.hh"
 #include "geocel/GeantGeoParams.hh"
+#include "geocel/VolumeParams.hh"
 #include "geocel/rasterize/RaytraceImager.hh"
 #include "orange/OrangeParams.hh"
 #if CELERITAS_USE_VECGEOM
@@ -51,7 +52,7 @@ Runner::Runner(ModelSetup const& input)
         // Retain the Geant4 world for possible reuse across geometries
         CELER_EXPECT(celeritas::global_geant_geo().expired());
         this->load_geometry<Geometry::geant4>();
-        CELER_EXPECT(!celeritas::global_geant_geo().expired());
+        CELER_ASSERT(!celeritas::global_geant_geo().expired());
     }
     else
     {
@@ -92,11 +93,12 @@ auto Runner::trace(TraceSetup const& setup) -> SPImage
     SPImage image = this->make_traced_image(setup.memspace, *imager);
     return image;
 }
+
 //---------------------------------------------------------------------------//
 /*!
  * Get volume names from an already loaded geometry.
  */
-std::vector<std::string> Runner::get_volumes(Geometry g) const&
+std::vector<std::string> Runner::get_impl_volumes(Geometry g) const&
 {
     CELER_EXPECT(geo_cache_[g]);
 

--- a/app/celer-geo/Runner.hh
+++ b/app/celer-geo/Runner.hh
@@ -58,12 +58,14 @@ class Runner
     //! Access timers
     MapTimers const& timers() const { return timers_; }
 
-    //! Access volumes
-    std::vector<std::string> get_volumes(Geometry) const&;
+    //! Access impl volume names
+    std::vector<std::string> get_impl_volumes(Geometry) const&;
 
     //! Load a geometry
     template<Geometry G>
     std::shared_ptr<GeoParams_t<G> const> load_geometry();
+
+    //! Access loaded volume params
 
   private:
     //// TYPES ////

--- a/app/celer-geo/Runner.hh
+++ b/app/celer-geo/Runner.hh
@@ -65,8 +65,6 @@ class Runner
     template<Geometry G>
     std::shared_ptr<GeoParams_t<G> const> load_geometry();
 
-    //! Access loaded volume params
-
   private:
     //// TYPES ////
 

--- a/app/celer-geo/celer-geo.cc
+++ b/app/celer-geo/celer-geo.cc
@@ -12,7 +12,7 @@
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
 
-#include "corecel/Config.hh"
+#include "corecel/Config.hh"  // IWYU pragma: keep
 #include "corecel/Version.hh"
 
 #include "corecel/Assert.hh"
@@ -25,13 +25,15 @@
 #include "corecel/io/Repr.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Device.hh"
-#include "corecel/sys/DeviceIO.json.hh"
+#include "corecel/sys/DeviceIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/Environment.hh"
-#include "corecel/sys/EnvironmentIO.json.hh"
+#include "corecel/sys/EnvironmentIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/KernelRegistry.hh"
-#include "corecel/sys/KernelRegistryIO.json.hh"
+#include "corecel/sys/KernelRegistryIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/ScopedMpiInit.hh"
 #include "corecel/sys/ScopedSignalHandler.hh"
+#include "geocel/GeantGeoParams.hh"
+#include "geocel/VolumeParamsIO.json.hh"  // IWYU pragma: keep
 #include "geocel/rasterize/Image.hh"
 #include "geocel/rasterize/ImageIO.json.hh"
 #include "orange/OrangeParamsOutput.hh"
@@ -178,7 +180,7 @@ void run_trace(Runner& runner,
     if (trace_setup.volumes)
     {
         // Get geometry names
-        out["volumes"] = runner.get_volumes(trace_setup.geometry);
+        out["volumes"] = runner.get_impl_volumes(trace_setup.geometry);
     }
 
     put_json_line(out);
@@ -227,6 +229,14 @@ void cmd_orange_stats(Runner* runner, nlohmann::json const&)
         OrangeParamsOutput{runner->load_geometry<Geometry::orange>()});
 }
 
+void cmd_volumes(Runner* runner, nlohmann::json const&)
+{
+    CELER_EXPECT(runner);
+    auto geo = celeritas::global_geant_geo().lock();
+    CELER_VALIDATE(geo, << "no geant4 geometry is loaded");
+    put_json_line(*geo->volume_params());
+}
+
 CmdFuncPtr
 get_cmd_funcptr(nlohmann::json const& input, std::string_view cmd_str)
 {
@@ -247,6 +257,7 @@ get_cmd_funcptr(nlohmann::json const& input, std::string_view cmd_str)
         {"config", &cmd_config},
         {"trace", &cmd_trace},
         {"orange_stats", &cmd_orange_stats},
+        {"volumes", &cmd_volumes},
     };
 
     auto func_iter = cmd_to_func.find(cmd_str);

--- a/app/celer-geo/celer-geo.cc
+++ b/app/celer-geo/celer-geo.cc
@@ -234,7 +234,7 @@ void cmd_volumes(Runner* runner, nlohmann::json const&)
     CELER_EXPECT(runner);
     auto geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geo, << "no geant4 geometry is loaded");
-    put_json_line(*geo->volume_params());
+    put_json_line(*geo->volumes());
 }
 
 CmdFuncPtr

--- a/app/celer-geo/test-harness.py
+++ b/app/celer-geo/test-harness.py
@@ -206,6 +206,7 @@ def run_main_test(config: Config, run_celer_geo: CelerGeoDriver) -> int:
     commands = [
         {"geometry_file": str(config.model_path)},
         {"_cmd": "orange_stats"},
+        {"_cmd": "volumes"},
         {
             "_cmd": "trace",
             "image": IMAGES[config.model_path.stem],

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -196,7 +196,7 @@ void GeantSimpleCalo::output(JsonPimpl* j) const
             ggp = GeantGeoParams::from_tracking_manager();
         }
         CELER_ASSERT(ggp);
-        vols = ggp->volume_params();
+        vols = ggp->volumes();
 
         std::vector<int> ids(volumes_.size());
         std::vector<Label> labels(volumes_.size());

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -8,8 +8,6 @@
 
 #include <nlohmann/json.hpp>
 
-#include "corecel/Config.hh"
-
 #include "corecel/cont/Range.hh"
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/io/LabelIO.json.hh"

--- a/src/accel/GeantSimpleCalo.cc
+++ b/src/accel/GeantSimpleCalo.cc
@@ -190,7 +190,7 @@ void GeantSimpleCalo::output(JsonPimpl* j) const
     // Save detector volumes
     {
         auto ggp = celeritas::global_geant_geo().lock();
-        auto vols = celeritas::global_volumes().lock();
+        std::shared_ptr<VolumeParams const> vols;
         if (!ggp)
         {
             // This can happen if using this class without Celeritas offloading
@@ -198,6 +198,7 @@ void GeantSimpleCalo::output(JsonPimpl* j) const
             ggp = GeantGeoParams::from_tracking_manager();
         }
         CELER_ASSERT(ggp);
+        vols = ggp->volume_params();
 
         std::vector<int> ids(volumes_.size());
         std::vector<Label> labels(volumes_.size());

--- a/src/accel/detail/IntegrationSingleton.cc
+++ b/src/accel/detail/IntegrationSingleton.cc
@@ -44,7 +44,7 @@ validate_and_return_offloaded(std::optional<SetupOptions::VecG4PD> const& user)
         return SharedParams::default_offload_particles();
     }
 
-    auto const supported = SharedParams::supported_offload_particles();
+    auto const& supported = SharedParams::supported_offload_particles();
     auto find = [&supported](G4ParticleDefinition* user) -> bool {
         return std::any_of(
             supported.begin(),

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -934,9 +934,11 @@ std::vector<ImportVolume> import_volumes()
     auto geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geo, << "global Geant4 geometry is not loaded");
 
-    VolumeParams volume_params{geo->make_model_input().volumes};
+    auto volume_params = geo->volume_params();
+    CELER_VALIDATE(volume_params,
+                   << "canonical volume metadata is unavailable");
 
-    auto const& volumes = volume_params.volume_labels();
+    auto const& volumes = volume_params->volume_labels();
     std::vector<ImportVolume> result(volumes.size());
     size_type count{0};
 
@@ -959,7 +961,7 @@ std::vector<ImportVolume> import_volumes()
         {
             volume.phys_material_id = cuts->GetIndex();
         }
-        volume.name = to_string(volume_params.volume_labels().at(vol_id));
+        volume.name = to_string(volume_params->volume_labels().at(vol_id));
         volume.solid_name = g4lv->GetSolid()->GetName();
 
         ++count;

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -933,16 +933,13 @@ std::vector<ImportVolume> import_volumes()
 {
     auto geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geo, << "global Geant4 geometry is not loaded");
+    CELER_ASSERT(geo->volumes());
 
-    auto volume_params = geo->volumes();
-    CELER_VALIDATE(volume_params,
-                   << "canonical volume metadata is unavailable");
-
-    auto const& volumes = volume_params->volume_labels();
-    std::vector<ImportVolume> result(volumes.size());
+    auto const& volume_labels = geo->volumes()->volume_labels();
+    std::vector<ImportVolume> result(volume_labels.size());
     size_type count{0};
 
-    for (auto vol_id : range(VolumeId{volumes.size()}))
+    for (auto vol_id : range(VolumeId{volume_labels.size()}))
     {
         auto* g4lv = geo->id_to_geant(vol_id);
         if (!g4lv)
@@ -961,7 +958,7 @@ std::vector<ImportVolume> import_volumes()
         {
             volume.phys_material_id = cuts->GetIndex();
         }
-        volume.name = to_string(volume_params->volume_labels().at(vol_id));
+        volume.name = to_string(volume_labels.at(vol_id));
         volume.solid_name = g4lv->GetSolid()->GetName();
 
         ++count;

--- a/src/celeritas/ext/GeantImporter.cc
+++ b/src/celeritas/ext/GeantImporter.cc
@@ -934,7 +934,7 @@ std::vector<ImportVolume> import_volumes()
     auto geo = celeritas::global_geant_geo().lock();
     CELER_VALIDATE(geo, << "global Geant4 geometry is not loaded");
 
-    auto volume_params = geo->volume_params();
+    auto volume_params = geo->volumes();
     CELER_VALIDATE(volume_params,
                    << "canonical volume metadata is unavailable");
 

--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -179,7 +179,7 @@ void GeantSd::setup_volumes(inp::GeantSd const& setup)
 
     // Helper for inserting volumes
     auto geant_geo = celeritas::global_geant_geo().lock();
-    auto const* volume_params = geant_geo ? geant_geo->volume_params().get()
+    auto const* volume_params = geant_geo ? geant_geo->volumes().get()
                                           : nullptr;
     SensDetInserter::MapIdLv found_id_lv;
     SensDetInserter::VecLV missing_lv;

--- a/src/celeritas/ext/GeantSd.cc
+++ b/src/celeritas/ext/GeantSd.cc
@@ -16,6 +16,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/Join.hh"
+#include "geocel/GeantGeoParams.hh"
 #include "geocel/GeantGeoUtils.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/inp/Scoring.hh"
@@ -177,10 +178,13 @@ void GeantSd::setup_volumes(inp::GeantSd const& setup)
     auto force_volumes = make_set_lv(setup.force_volumes);
 
     // Helper for inserting volumes
-    // FIXME: geant geo and volume params are implicitly used by this
+    auto geant_geo = celeritas::global_geant_geo().lock();
+    auto const* volume_params = geant_geo ? geant_geo->volume_params().get()
+                                          : nullptr;
     SensDetInserter::MapIdLv found_id_lv;
     SensDetInserter::VecLV missing_lv;
-    SensDetInserter insert_volume(skip_volumes, &found_id_lv, &missing_lv);
+    SensDetInserter insert_volume(
+        skip_volumes, volume_params, geant_geo.get(), &found_id_lv, &missing_lv);
 
     // Loop over all logical volumes and map detectors to Volume IDs
     for (G4LogicalVolume const* lv : *G4LogicalVolumeStore::GetInstance())

--- a/src/celeritas/ext/detail/SensDetInserter.cc
+++ b/src/celeritas/ext/detail/SensDetInserter.cc
@@ -24,9 +24,14 @@ namespace detail
  * Construct with references to the inserted data.
  */
 SensDetInserter::SensDetInserter(SetLV const& skip_volumes,
+                                 VolumeParams const* volumes,
+                                 GeantGeoParams const* geant_geo,
                                  MapIdLv* found,
                                  VecLV* missing)
-    : skip_volumes_{skip_volumes}, found_{found}, missing_{missing}
+    : to_vol_id_{volumes, geant_geo}
+    , skip_volumes_{skip_volumes}
+    , found_{found}
+    , missing_{missing}
 {
     CELER_EXPECT(found_);
     CELER_EXPECT(missing_);

--- a/src/celeritas/ext/detail/SensDetInserter.hh
+++ b/src/celeritas/ext/detail/SensDetInserter.hh
@@ -20,6 +20,7 @@ class G4VSensitiveDetector;
 namespace celeritas
 {
 class GeantGeoParams;
+class VolumeParams;
 
 namespace detail
 {
@@ -41,7 +42,11 @@ class SensDetInserter
 
   public:
     // Construct from interfaces, loading geant geo
-    SensDetInserter(SetLV const& skip_volumes, MapIdLv* found, VecLV* missing);
+    SensDetInserter(SetLV const& skip_volumes,
+                    VolumeParams const* volumes,
+                    GeantGeoParams const* geant_geo,
+                    MapIdLv* found,
+                    VecLV* missing);
 
     // Save a sensitive detector
     void operator()(G4LogicalVolume const* lv, G4VSensitiveDetector const* sd);

--- a/src/celeritas/field/UniformFieldParams.cc
+++ b/src/celeritas/field/UniformFieldParams.cc
@@ -40,7 +40,7 @@ make_volume_ids(CoreGeoParams const& geo, inp::UniformField const& inp)
     using SetVolume = std::unordered_set<VolumeId>;
 
     auto geant_geo = celeritas::global_geant_geo().lock();
-    auto const* volumes = geo.volume_params().get();
+    auto const* volumes = geo.volumes().get();
 
     VolumeIdBuilder to_vol_id(volumes, geant_geo.get());
     SetVolume result;

--- a/src/celeritas/field/UniformFieldParams.cc
+++ b/src/celeritas/field/UniformFieldParams.cc
@@ -18,8 +18,10 @@
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/ArrayQuantity.hh"
 #include "corecel/math/ArrayUtils.hh"
+#include "geocel/GeantGeoParams.hh"
 #include "geocel/VolumeCollectionBuilder.hh"
 #include "geocel/VolumeIdBuilder.hh"
+#include "geocel/VolumeParams.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/Units.hh"
 #include "celeritas/geo/CoreGeoParams.hh"
@@ -32,11 +34,15 @@ namespace celeritas
 namespace
 {
 //---------------------------------------------------------------------------//
-std::unordered_set<VolumeId> make_volume_ids(inp::UniformField const& inp)
+std::unordered_set<VolumeId>
+make_volume_ids(CoreGeoParams const& geo, inp::UniformField const& inp)
 {
     using SetVolume = std::unordered_set<VolumeId>;
 
-    VolumeIdBuilder to_vol_id;
+    auto geant_geo = celeritas::global_geant_geo().lock();
+    auto const* volumes = geo.volume_params().get();
+
+    VolumeIdBuilder to_vol_id(volumes, geant_geo.get());
     SetVolume result;
 
     std::visit(Overload{
@@ -90,7 +96,7 @@ UniformFieldParams::UniformFieldParams(CoreGeoParams const& geo,
 
     // If logical volumes are specified, flag whether or not the field should
     // be present in each volume
-    auto volumes = make_volume_ids(inp);
+    auto volumes = make_volume_ids(geo, inp);
     if (!volumes.empty())
     {
         // Convert from canonical to implementation volumes

--- a/src/celeritas/setup/Model.cc
+++ b/src/celeritas/setup/Model.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "Model.hh"
 
+#include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/io/StringUtils.hh"
 #include "corecel/sys/Environment.hh"
@@ -88,6 +89,32 @@ auto build_geometry(inp::Model const& m)
 {
     return std::visit(GeoBuilder{}, m.geometry);
 }
+
+std::shared_ptr<VolumeParams> build_volumes(inp::Model const& m)
+{
+    return std::visit(
+        Overload{[](inp::Volumes const& v) {
+                     return std::make_shared<VolumeParams>(v);
+                 },
+                 [](std::shared_ptr<VolumeParams const> const& v) {
+                     if (v)
+                     {
+                         return std::const_pointer_cast<VolumeParams>(v);
+                     }
+                     return std::make_shared<VolumeParams>();
+                 }},
+        m.volumes);
+}
+
+bool has_volume_data(inp::Model const& m)
+{
+    return std::visit(
+        Overload{[](inp::Volumes const& v) { return static_cast<bool>(v); },
+                 [](std::shared_ptr<VolumeParams const> const& v) {
+                     return static_cast<bool>(v);
+                 }},
+        m.volumes);
+}
 }  // namespace
 
 //---------------------------------------------------------------------------//
@@ -104,12 +131,11 @@ ModelLoaded model(inp::Model const& m)
     result.geometry = build_geometry(m);
 
     // Construct volume params if it was added to the input
-    if (!m.volumes)
+    if (!has_volume_data(m))
     {
         CELER_LOG(debug) << "Volume structure data is unavailable";
     }
-    result.volume = std::make_shared<VolumeParams>(m.volumes);
-    celeritas::global_volumes(result.volume);
+    result.volume = build_volumes(m);
 
     // Construct surfaces
     if (!m.surfaces)
@@ -119,7 +145,7 @@ ModelLoaded model(inp::Model const& m)
     result.surface
         = std::make_shared<SurfaceParams>(m.surfaces, *result.volume);
 
-    if (m.volumes)
+    if (has_volume_data(m))
     {
         result.detector
             = std::make_shared<DetectorParams>(m.detectors, *result.volume);

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -741,7 +741,7 @@ ProblemLoaded problem(inp::Problem const& p, ImportData const& imported)
     if (p.scoring.simple_calo)
     {
         auto simple_calo = std::make_shared<SimpleCalo>(
-            p.scoring.simple_calo->volumes, num_streams);
+            p.scoring.simple_calo->volumes, num_streams, *core_params->volume());
 
         // Add to step interfaces
         step_interfaces.push_back(simple_calo);

--- a/src/celeritas/user/SimpleCalo.cc
+++ b/src/celeritas/user/SimpleCalo.cc
@@ -20,6 +20,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/math/Algorithms.hh"
 #include "geocel/VolumeIdBuilder.hh"
+#include "geocel/VolumeParams.hh"
 
 #include "detail/SimpleCaloImpl.hh"
 
@@ -33,7 +34,8 @@ namespace celeritas
  */
 SimpleCalo::SimpleCalo(std::string output_label,
                        VecLabel labels,
-                       size_type num_streams)
+                       size_type num_streams,
+                       VolumeParams const& volumes)
     : output_label_{std::move(output_label)}, volume_labels_{std::move(labels)}
 {
     CELER_EXPECT(!output_label_.empty());
@@ -41,9 +43,8 @@ SimpleCalo::SimpleCalo(std::string output_label,
     CELER_EXPECT(num_streams > 0);
 
     // Map labels to volume IDs
-    // FIXME: pass volumes and/or geant geo into the constructor
     volume_ids_.resize(volume_labels_.size());
-    VolumeIdBuilder label_to_vol_id;
+    VolumeIdBuilder label_to_vol_id(&volumes, nullptr);
     for (auto i : range(volume_labels_.size()))
     {
         volume_ids_[i] = label_to_vol_id(volume_labels_[i]);

--- a/src/celeritas/user/SimpleCalo.hh
+++ b/src/celeritas/user/SimpleCalo.hh
@@ -20,6 +20,8 @@
 
 namespace celeritas
 {
+class VolumeParams;
+
 //---------------------------------------------------------------------------//
 /*!
  * Accumulate energy deposition in volumes.
@@ -42,11 +44,16 @@ class SimpleCalo final : public StepInterface, public OutputInterface
 
   public:
     // Construct with all requirements
-    SimpleCalo(std::string output_label, VecLabel labels, size_type max_streams);
+    SimpleCalo(std::string output_label,
+               VecLabel labels,
+               size_type max_streams,
+               VolumeParams const& volumes);
 
     //! Construct with default label
-    SimpleCalo(VecLabel labels, size_type max_streams)
-        : SimpleCalo{"simple_calo", std::move(labels), max_streams}
+    SimpleCalo(VecLabel labels,
+               size_type max_streams,
+               VolumeParams const& volumes)
+        : SimpleCalo{"simple_calo", std::move(labels), max_streams, volumes}
     {
     }
 

--- a/src/celeritas/user/StepCollector.cc
+++ b/src/celeritas/user/StepCollector.cc
@@ -31,6 +31,7 @@ std::shared_ptr<StepCollector>
 StepCollector::make_and_insert(CoreParams const& core, VecInterface callbacks)
 {
     return std::make_shared<StepCollector>(core.geometry(),
+                                           core.volume(),
                                            std::move(callbacks),
                                            core.aux_reg().get(),
                                            core.action_reg().get());
@@ -41,6 +42,7 @@ StepCollector::make_and_insert(CoreParams const& core, VecInterface callbacks)
  * Construct with options and register pre and/or post-step actions.
  */
 StepCollector::StepCollector(SPConstCoreGeo geo,
+                             SPConstVolume volume,
                              VecInterface&& callbacks,
                              AuxParamsRegistry* aux_registry,
                              ActionRegistry* action_registry)
@@ -48,11 +50,12 @@ StepCollector::StepCollector(SPConstCoreGeo geo,
     CELER_EXPECT(!callbacks.empty());
     CELER_EXPECT(std::all_of(callbacks.begin(), callbacks.end(), Identity{}));
     CELER_EXPECT(geo);
+    CELER_EXPECT(volume);
     CELER_EXPECT(aux_registry);
     CELER_EXPECT(action_registry);
 
     params_ = std::make_shared<detail::StepParams>(
-        aux_registry->next_id(), *geo, callbacks);
+        aux_registry->next_id(), *geo, *volume, callbacks);
     aux_registry->insert(params_);
 
     if (this->selection().points[StepPoint::pre] || params_->has_detectors())

--- a/src/celeritas/user/StepCollector.hh
+++ b/src/celeritas/user/StepCollector.hh
@@ -20,6 +20,7 @@ namespace celeritas
 class ActionRegistry;
 class AuxParamsRegistry;
 class CoreParams;
+class VolumeParams;
 
 namespace detail
 {
@@ -52,6 +53,7 @@ class StepCollector
     //! \name Type aliases
     using SPStepInterface = std::shared_ptr<StepInterface>;
     using SPConstCoreGeo = std::shared_ptr<CoreGeoParams const>;
+    using SPConstVolume = std::shared_ptr<VolumeParams const>;
     using VecInterface = std::vector<SPStepInterface>;
     //!@}
 
@@ -62,6 +64,7 @@ class StepCollector
 
     // Construct with options and register pre/post-step actions
     StepCollector(SPConstCoreGeo geo,
+                  SPConstVolume volume,
                   VecInterface&& callbacks,
                   AuxParamsRegistry* aux_registry,
                   ActionRegistry* action_registry);

--- a/src/celeritas/user/detail/StepParams.cc
+++ b/src/celeritas/user/detail/StepParams.cc
@@ -23,6 +23,7 @@ namespace detail
  */
 StepParams::StepParams(AuxId aux_id,
                        CoreGeoParams const& geo,
+                       VolumeParams const& volume_params,
                        VecInterface const& callbacks)
     : aux_id_{aux_id}
 {
@@ -35,11 +36,7 @@ StepParams::StepParams(AuxId aux_id,
         all
     };
 
-    // FIXME: pass these into the constructor rather than using globals
-    auto const& volume_params = celeritas::global_volumes().lock();
-    CELER_ASSERT(volume_params);
-
-    auto const& volumes = volume_params->volume_labels();
+    auto const& volumes = volume_params.volume_labels();
     StepSelection selection;
     CELER_ASSERT(!selection);
     StepInterface::MapVolumeDetector detector_map;
@@ -115,7 +112,7 @@ StepParams::StepParams(AuxId aux_id,
         {
             // TODO: replace with volume params, so we can use touchable
             // representation
-            host_data.num_volume_levels = volume_params->num_volume_levels();
+            host_data.num_volume_levels = volume_params.num_volume_levels();
             CELER_VALIDATE(host_data.num_volume_levels > 0,
                            << "geometry type does not support volume "
                               "instance IDs: max depth is "

--- a/src/celeritas/user/detail/StepParams.hh
+++ b/src/celeritas/user/detail/StepParams.hh
@@ -18,6 +18,7 @@ namespace celeritas
 {
 class AuxStateVec;
 class StepInterface;
+class VolumeParams;
 
 namespace detail
 {
@@ -41,6 +42,7 @@ class StepParams : public AuxParams<StepParamsData, StepStateData>
     // Construct from data IDs and interfaces
     StepParams(AuxId aux_id,
                CoreGeoParams const& geo,
+               VolumeParams const& volume,
                VecInterface const& interfaces);
 
     //!@{

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -42,6 +42,7 @@
 #include "GeoOpticalIdMap.hh"
 #include "ScopedGeantExceptionHandler.hh"
 #include "ScopedGeantLogger.hh"
+#include "VolumeParams.hh"
 #include "g4/Convert.hh"  // IWYU pragma: associated
 #include "g4/GeantGeoData.hh"  // IWYU pragma: associated
 #include "g4/detail/GeantGeoNavCollection.hh"
@@ -789,7 +790,18 @@ GeantGeoParams::GeantGeoParams(G4VPhysicalVolume const* world, Ownership owns)
 
     this->build_metadata();
 
+    // Construct canonical volume metadata once and reuse it downstream.
+    {
+        inp::Volumes volumes;
+        volumes.volumes = make_inp_volumes(*this);
+        volumes.volume_instances = make_inp_volume_instances(*this);
+        volumes.world = this->geant_to_id(*(this->world()->GetLogicalVolume()));
+        volume_params_
+            = std::make_shared<VolumeParams const>(std::move(volumes));
+    }
+
     CELER_ENSURE(impl_volumes_);
+    CELER_ENSURE(volume_params_);
     CELER_ENSURE(data_);
 }
 
@@ -828,16 +840,7 @@ inp::Model GeantGeoParams::make_model_input() const
     inp::Model result;
 
     result.geometry = this->world();
-    result.volumes = [this] {
-        inp::Volumes result;
-
-        // Get volumes from Geant4 geometry
-        result.volumes = make_inp_volumes(*this);
-        result.volume_instances = make_inp_volume_instances(*this);
-        result.world = this->geant_to_id(*(this->world()->GetLogicalVolume()));
-
-        return result;
-    }();
+    result.volumes = volume_params_;
     result.surfaces = [this] {
         inp::Surfaces result;
         result.surfaces = make_inp_surfaces(*this);

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -117,6 +117,12 @@ class GeantGeoParams final : public GeoParamsInterface,
     // Get (logical) volume metadata
     inline ImplVolumeMap const& impl_volumes() const final;
 
+    // Get canonical volume metadata
+    SPConstVolumeParams const& volume_params() const final
+    {
+        return volume_params_;
+    }
+
     // Get the Geant4 physical volume corresponding to a volume instance ID
     inline G4VPhysicalVolume const* id_to_geant(VolumeInstanceId vol_id) const;
 
@@ -191,6 +197,7 @@ class GeantGeoParams final : public GeoParamsInterface,
 
     // Host metadata/access
     ImplVolumeMap impl_volumes_;
+    SPConstVolumeParams volume_params_;
     detail::GeantVolumeInstanceMapper vi_mapper_;
     std::shared_ptr<GeoOpticalIdMap> geo_to_opt_;
     std::vector<G4LogicalSurface const*> surfaces_;

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -117,7 +117,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     // Get (logical) volume metadata
     inline ImplVolumeMap const& impl_volumes() const final;
 
-    // Get canonical volume metadata
+    //! Get canonical volume metadata
     SPConstVolumeParams const& volumes() const final { return volume_params_; }
 
     // Get the Geant4 physical volume corresponding to a volume instance ID

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -118,10 +118,7 @@ class GeantGeoParams final : public GeoParamsInterface,
     inline ImplVolumeMap const& impl_volumes() const final;
 
     // Get canonical volume metadata
-    SPConstVolumeParams const& volume_params() const final
-    {
-        return volume_params_;
-    }
+    SPConstVolumeParams const& volumes() const final { return volume_params_; }
 
     // Get the Geant4 physical volume corresponding to a volume instance ID
     inline G4VPhysicalVolume const* id_to_geant(VolumeInstanceId vol_id) const;

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <memory>
+
 #include "corecel/Macros.hh"
 #include "corecel/cont/LabelIdMultiMap.hh"  // IWYU pragma: export
 #include "corecel/cont/Span.hh"  // IWYU pragma: export
@@ -19,6 +21,8 @@ class G4VPhysicalVolume;
 
 namespace celeritas
 {
+class VolumeParams;
+
 namespace inp
 {
 struct Model;
@@ -38,6 +42,7 @@ class GeoParamsInterface
     //! \name Type aliases
     using SpanConstVolumeId = Span<ImplVolumeId const>;
     using ImplVolumeMap = LabelIdMultiMap<ImplVolumeId>;
+    using SPConstVolumeParams = std::shared_ptr<VolumeParams const>;
     //!@}
 
   public:
@@ -56,6 +61,9 @@ class GeoParamsInterface
 
     //! Get volume metadata
     virtual ImplVolumeMap const& impl_volumes() const = 0;
+
+    //! Get canonical volume metadata if available
+    virtual SPConstVolumeParams const& volume_params() const = 0;
 
     //! Get the canonical volume IDs corresponding to an implementation volume
     virtual VolumeId volume_id(ImplVolumeId) const = 0;

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -32,8 +32,8 @@ struct Model;
  * Interface class for accessing host geometry metadata.
  *
  * This class is implemented by \c OrangeParams to allow navigation with the
- * ORANGE geometry implementation, \c VecgeomParams for using VecGeom, and \c
- * GeantGeoParams for testing with the Geant4-provided navigator.
+ * ORANGE geometry implementation, \c VecgeomParams for using VecGeom, and
+ * \c GeantGeoParams for testing with the Geant4-provided navigator.
  */
 class GeoParamsInterface
 {
@@ -62,7 +62,7 @@ class GeoParamsInterface
     //! Get volume metadata
     virtual ImplVolumeMap const& impl_volumes() const = 0;
 
-    //! Get canonical volume metadata if available
+    //! Get structural volume metadata if available
     virtual SPConstVolumeParams const& volumes() const = 0;
 
     //! Get the canonical volume IDs corresponding to an implementation volume

--- a/src/geocel/GeoParamsInterface.hh
+++ b/src/geocel/GeoParamsInterface.hh
@@ -63,7 +63,7 @@ class GeoParamsInterface
     virtual ImplVolumeMap const& impl_volumes() const = 0;
 
     //! Get canonical volume metadata if available
-    virtual SPConstVolumeParams const& volume_params() const = 0;
+    virtual SPConstVolumeParams const& volumes() const = 0;
 
     //! Get the canonical volume IDs corresponding to an implementation volume
     virtual VolumeId volume_id(ImplVolumeId) const = 0;

--- a/src/geocel/VolumeIdBuilder.cc
+++ b/src/geocel/VolumeIdBuilder.cc
@@ -18,16 +18,6 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct from global geometry.
- */
-VolumeIdBuilder::VolumeIdBuilder()
-    : VolumeIdBuilder{global_volumes().lock().get(),
-                      global_geant_geo().lock().get()}
-{
-}
-
-//---------------------------------------------------------------------------//
-/*!
  * Map from a string using VolumeParams.
  */
 VolumeId VolumeIdBuilder::operator()(std::string const& s) const

--- a/src/geocel/VolumeIdBuilder.hh
+++ b/src/geocel/VolumeIdBuilder.hh
@@ -38,9 +38,6 @@ class VolumeIdBuilder
     //!@}
 
   public:
-    // Construct using "global" values (NOT PREFERRED)
-    VolumeIdBuilder();
-
     // Construct using geant4 params and/or volume params
     inline VolumeIdBuilder(VolumeParams const*, GeantGeoParams const*);
 

--- a/src/geocel/VolumeParams.cc
+++ b/src/geocel/VolumeParams.cc
@@ -171,47 +171,7 @@ calc_unique_instance_offsets(HostVal<VolumeParamsData> const& params,
     return offsets;
 }
 
-//---------------------------------------------------------------------------//
-//! Volumes corresponding to global tracking model
-std::weak_ptr<VolumeParams const> g_volumes_;
-
-//---------------------------------------------------------------------------//
 }  // namespace
-
-//---------------------------------------------------------------------------//
-/*!
- * Set global geometry instance.
- *
- * This allows many parts of the codebase to independently access Geant4
- * metadata. It should be called during initialization of any Celeritas front
- * end that integrates with Geant4. We can't use shared pointers here because
- * of global initialization order issues (the low-level Geant4 objects may be
- * cleared before a static celeritas::VolumeParams is destroyed).
- *
- * \note This should be done only during setup on the main thread.
- */
-void global_volumes(std::shared_ptr<VolumeParams const> const& gv)
-{
-    CELER_LOG(debug) << (!gv                    ? "Clearing"
-                         : g_volumes_.expired() ? "Setting"
-                                                : "Updating")
-                     << " celeritas::volumes";
-    g_volumes_ = gv;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Access the global canonical volume metadata.
- *
- * This can be used by geometry-related helper functions throughout
- * the code base.
- *
- * \return Weak pointer to the global VolumeParams wrapper, which may be null.
- */
-std::weak_ptr<VolumeParams const> const& global_volumes()
-{
-    return g_volumes_;
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/geocel/VolumeParams.hh
+++ b/src/geocel/VolumeParams.hh
@@ -150,16 +150,6 @@ class VolumeParams final : public ParamsDataInterface<VolumeParamsData>
     ParamsDataStore<VolumeParamsData> data_;
 };
 
-//---------------------------------------------------------------------------//
-// HACKY GLOBAL VARIABLES DURING REFACTORING
-//---------------------------------------------------------------------------//
-// Set non-owning reference to global canonical volumes
-void global_volumes(std::shared_ptr<VolumeParams const> const&);
-
-// Global canonical volumes: may be nullptr
-std::weak_ptr<VolumeParams const> const& global_volumes();
-
-//---------------------------------------------------------------------------//
 // FREE FUNCTIONS
 //---------------------------------------------------------------------------//
 // Write volume hierarchy to a stream (defined in IO.json.cc)

--- a/src/geocel/inp/Model.hh
+++ b/src/geocel/inp/Model.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -19,6 +20,8 @@ class G4VPhysicalVolume;
 
 namespace celeritas
 {
+class VolumeParams;
+
 namespace inp
 {
 //---------------------------------------------------------------------------//
@@ -182,7 +185,7 @@ struct Model
     std::variant<std::string, G4VPhysicalVolume const*> geometry;
 
     // TODO: Materials
-    Volumes volumes;
+    std::variant<Volumes, std::shared_ptr<VolumeParams const>> volumes;
     Surfaces surfaces;
     Detectors detectors;
     Regions regions;

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -528,7 +528,7 @@ VecgeomParams::VecgeomParams(vecgeom::GeoManager const& geo,
         // Construct Impl vol/inst maps
         if (geant_geo_)
         {
-            volume_params_ = geant_geo_->volumes();
+            volumes_ = geant_geo_->volumes();
 
             // Built with Geant4: use G4VG-provided mapping
             for (auto iv_id : range(ImplVolumeId{host_data.volumes.size()}))
@@ -656,9 +656,9 @@ inp::Model VecgeomParams::make_model_input() const
         << R"(VecGeom standalone model input is not fully implemented)";
 
     inp::Model result;
-    if (volume_params_)
+    if (volumes_)
     {
-        result.volumes = volume_params_;
+        result.volumes = volumes_;
         return result;
     }
 

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -255,21 +255,22 @@ get_placed_volume(vecgeom::GeoManager const& geo, VgVolumeInstanceId ivi_id)
 struct StreamablePointer
 {
     void const* ptr{nullptr};
+
+    [[maybe_unused]]
+    friend std::ostream& operator<<(std::ostream& os, StreamablePointer sp)
+    {
+        if (sp.ptr)
+        {
+            os << sp.ptr;
+        }
+        else
+        {
+            os << "nullptr";
+        }
+
+        return os;
+    }
 };
-
-std::ostream& operator<<(std::ostream& os, StreamablePointer sp)
-{
-    if (sp.ptr)
-    {
-        os << sp.ptr;
-    }
-    else
-    {
-        os << "nullptr";
-    }
-
-    return os;
-}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -528,7 +528,7 @@ VecgeomParams::VecgeomParams(vecgeom::GeoManager const& geo,
         // Construct Impl vol/inst maps
         if (geant_geo_)
         {
-            volume_params_ = geant_geo_->volume_params();
+            volume_params_ = geant_geo_->volumes();
 
             // Built with Geant4: use G4VG-provided mapping
             for (auto iv_id : range(ImplVolumeId{host_data.volumes.size()}))

--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -527,6 +527,8 @@ VecgeomParams::VecgeomParams(vecgeom::GeoManager const& geo,
         // Construct Impl vol/inst maps
         if (geant_geo_)
         {
+            volume_params_ = geant_geo_->volume_params();
+
             // Built with Geant4: use G4VG-provided mapping
             for (auto iv_id : range(ImplVolumeId{host_data.volumes.size()}))
             {
@@ -653,7 +655,13 @@ inp::Model VecgeomParams::make_model_input() const
         << R"(VecGeom standalone model input is not fully implemented)";
 
     inp::Model result;
-    inp::Volumes& v = result.volumes;
+    if (volume_params_)
+    {
+        result.volumes = volume_params_;
+        return result;
+    }
+
+    inp::Volumes& v = std::get<inp::Volumes>(result.volumes);
     v.volumes.resize(impl_volumes_.size());
     v.volume_instances.resize(impl_vol_instances_.size());
 
@@ -688,8 +696,7 @@ inp::Model VecgeomParams::make_model_input() const
             = id_cast<VolumeId>(placed_vol.GetLogicalVolume()->id());
     }
 
-    result.volumes.world
-        = id_cast<VolumeId>(geo.GetWorld()->GetLogicalVolume()->id());
+    v.world = id_cast<VolumeId>(geo.GetWorld()->GetLogicalVolume()->id());
     return result;
 }
 

--- a/src/geocel/vg/VecgeomParams.hh
+++ b/src/geocel/vg/VecgeomParams.hh
@@ -123,10 +123,7 @@ class VecgeomParams final : public GeoParamsInterface,
     inline ImplVolumeMap const& impl_volumes() const final;
 
     // Get canonical volume metadata
-    SPConstVolumeParams const& volume_params() const final
-    {
-        return volume_params_;
-    }
+    SPConstVolumeParams const& volumes() const final { return volume_params_; }
 
     // Get volume metadata for VG placed volumes
     inline ImplVolInstanceMap const& impl_volume_instances() const;

--- a/src/geocel/vg/VecgeomParams.hh
+++ b/src/geocel/vg/VecgeomParams.hh
@@ -122,6 +122,12 @@ class VecgeomParams final : public GeoParamsInterface,
     // Get volume metadata for VG logical volumes
     inline ImplVolumeMap const& impl_volumes() const final;
 
+    // Get canonical volume metadata
+    SPConstVolumeParams const& volume_params() const final
+    {
+        return volume_params_;
+    }
+
     // Get volume metadata for VG placed volumes
     inline ImplVolInstanceMap const& impl_volume_instances() const;
 
@@ -148,6 +154,7 @@ class VecgeomParams final : public GeoParamsInterface,
 
     // Geant4 model used to construct
     std::shared_ptr<GeantGeoParams const> geant_geo_;
+    SPConstVolumeParams volume_params_;
 
     // Host metadata/access
     LabelIdMultiMap<ImplVolumeId> impl_volumes_;

--- a/src/geocel/vg/VecgeomParams.hh
+++ b/src/geocel/vg/VecgeomParams.hh
@@ -122,8 +122,8 @@ class VecgeomParams final : public GeoParamsInterface,
     // Get volume metadata for VG logical volumes
     inline ImplVolumeMap const& impl_volumes() const final;
 
-    // Get canonical volume metadata
-    SPConstVolumeParams const& volumes() const final { return volume_params_; }
+    // Get structural volume metadata
+    SPConstVolumeParams const& volumes() const final { return volumes_; }
 
     // Get volume metadata for VG placed volumes
     inline ImplVolInstanceMap const& impl_volume_instances() const;
@@ -151,7 +151,7 @@ class VecgeomParams final : public GeoParamsInterface,
 
     // Geant4 model used to construct
     std::shared_ptr<GeantGeoParams const> geant_geo_;
-    SPConstVolumeParams volume_params_;
+    SPConstVolumeParams volumes_;
 
     // Host metadata/access
     LabelIdMultiMap<ImplVolumeId> impl_volumes_;

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -182,13 +182,22 @@ std::shared_ptr<OrangeParams>
 OrangeParams::from_geant(std::shared_ptr<GeantGeoParams const> const& geo)
 {
     CELER_EXPECT(geo);
-    SPConstVolumes volumes = celeritas::global_volumes().lock();
+    SPConstVolumes volumes = geo->volume_params();
     if (!volumes)
     {
-        CELER_LOG(debug) << "Constructing global volumes from GeantGeoParams";
-        volumes
-            = std::make_shared<VolumeParams>(geo->make_model_input().volumes);
-        celeritas::global_volumes(volumes);
+        CELER_LOG(debug) << "Constructing canonical volumes from "
+                            "GeantGeoParams";
+        auto model_input = geo->make_model_input();
+        auto const& model_volumes = model_input.volumes;
+        if (auto const* sp = std::get_if<SPConstVolumes>(&model_volumes))
+        {
+            volumes = *sp;
+        }
+        else
+        {
+            volumes = std::make_shared<VolumeParams>(
+                std::get<inp::Volumes>(model_volumes));
+        }
     }
     return OrangeParams::from_geant(geo, std::move(volumes));
 }
@@ -348,7 +357,7 @@ inp::Model OrangeParams::make_model_input() const
     CELER_LOG(info) << R"(Generating fake model input for unit tests)";
 
     inp::Model result;
-    inp::Volumes& v = result.volumes;
+    inp::Volumes& v = std::get<inp::Volumes>(result.volumes);
     v.volumes.resize(impl_vol_labels_.size());
     v.volume_instances.resize(v.volumes.size());
 

--- a/src/orange/OrangeParams.cc
+++ b/src/orange/OrangeParams.cc
@@ -182,7 +182,7 @@ std::shared_ptr<OrangeParams>
 OrangeParams::from_geant(std::shared_ptr<GeantGeoParams const> const& geo)
 {
     CELER_EXPECT(geo);
-    SPConstVolumes volumes = geo->volume_params();
+    SPConstVolumes volumes = geo->volumes();
     if (!volumes)
     {
         CELER_LOG(debug) << "Constructing canonical volumes from "

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -104,7 +104,7 @@ class OrangeParams final : public GeoParamsInterface,
     // Get volume metadata
     inline ImplVolumeMap const& impl_volumes() const final;
 
-    // Get canonical volume metadata
+    // Get structural volume metadata
     SPConstVolumeParams const& volumes() const final { return volumes_; }
 
     // Get the canonical volume IDs corresponding to an implementation volume

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -105,7 +105,7 @@ class OrangeParams final : public GeoParamsInterface,
     inline ImplVolumeMap const& impl_volumes() const final;
 
     // Get canonical volume metadata
-    SPConstVolumeParams const& volume_params() const final { return volumes_; }
+    SPConstVolumeParams const& volumes() const final { return volumes_; }
 
     // Get the canonical volume IDs corresponding to an implementation volume
     inline VolumeId volume_id(ImplVolumeId) const final;

--- a/src/orange/OrangeParams.hh
+++ b/src/orange/OrangeParams.hh
@@ -104,6 +104,9 @@ class OrangeParams final : public GeoParamsInterface,
     // Get volume metadata
     inline ImplVolumeMap const& impl_volumes() const final;
 
+    // Get canonical volume metadata
+    SPConstVolumeParams const& volume_params() const final { return volumes_; }
+
     // Get the canonical volume IDs corresponding to an implementation volume
     inline VolumeId volume_id(ImplVolumeId) const final;
 

--- a/src/orange/OrangeTypesIO.json.cc
+++ b/src/orange/OrangeTypesIO.json.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "OrangeTypesIO.json.hh"
 
+#include "corecel/io/Logger.hh"
 #include "corecel/io/StringEnumMapper.hh"
 #include "orange/OrangeTypes.hh"
 
@@ -18,6 +19,13 @@ namespace celeritas
 template<class T>
 void from_json(nlohmann::json const& j, Tolerance<T>& value)
 {
+    if (j == nullptr)
+    {
+        CELER_LOG(warning) << "Given default null tolerance";
+        value = {};
+        return;
+    }
+
     j.at("rel").get_to(value.rel);
     CELER_VALIDATE(value.rel > 0 && value.rel < 1,
                    << "tolerance " << value.rel
@@ -38,7 +46,11 @@ template void from_json(nlohmann::json const&, Tolerance<real_type>&);
 template<class T>
 void to_json(nlohmann::json& j, Tolerance<T> const& value)
 {
-    CELER_EXPECT(value);
+    if (!value)
+    {
+        j = nullptr;
+        return;
+    }
 
     j = {
         {"rel", value.rel},

--- a/test/celeritas/GlobalTestBase.cc
+++ b/test/celeritas/GlobalTestBase.cc
@@ -13,6 +13,7 @@
 
 #include "corecel/Config.hh"
 
+#include "corecel/cont/VariantUtils.hh"
 #include "corecel/data/AuxParamsRegistry.hh"
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/io/Logger.hh"
@@ -65,8 +66,6 @@ GlobalTestBase::~GlobalTestBase()
             std::cerr << "Failed to write diagnostics: " << e.what();
         }
     }
-    // Reset global volumes that we set
-    celeritas::global_volumes(nullptr);
 }
 
 //---------------------------------------------------------------------------//
@@ -147,8 +146,14 @@ auto GlobalTestBase::build_geometry() -> SPConstCoreGeo
     }
 
     auto mi = model_geo->make_model_input();
-    volume_ = make_shared<VolumeParams>(std::move(mi.volumes));
-    celeritas::global_volumes(volume_);
+    volume_ = std::visit(
+        Overload{[](inp::Volumes const& v) {
+                     return make_shared<VolumeParams const>(v);
+                 },
+                 [](std::shared_ptr<VolumeParams const> const& v) {
+                     return v ? v : make_shared<VolumeParams const>();
+                 }},
+        mi.volumes);
     surface_ = make_shared<SurfaceParams>(std::move(mi.surfaces), *volume_);
     detector_ = make_shared<DetectorParams>(std::move(mi.detectors), *volume_);
     return core_geo;

--- a/test/celeritas/user/CaloTestBase.cc
+++ b/test/celeritas/user/CaloTestBase.cc
@@ -36,7 +36,8 @@ void CaloTestBase::SetUp()
     this->geometry();
 
     size_type const num_streams = 1;
-    calo_ = std::make_shared<SimpleCalo>(std::move(labels), num_streams);
+    calo_ = std::make_shared<SimpleCalo>(
+        std::move(labels), num_streams, *this->volume());
 
     StepCollector::VecInterface interfaces = {calo_};
 

--- a/test/celeritas/user/ExampleInstanceCalo.cc
+++ b/test/celeritas/user/ExampleInstanceCalo.cc
@@ -48,16 +48,17 @@ void ExampleInstanceCalo::Result::print_expected() const
 /*!
  * Construct with detector labels.
  */
-ExampleInstanceCalo::ExampleInstanceCalo(VecLabel vol_labels)
-    : det_labels_{std::move(vol_labels)}
+ExampleInstanceCalo::ExampleInstanceCalo(
+    VecLabel vol_labels, std::shared_ptr<VolumeParams const> volumes)
+    : det_labels_{std::move(vol_labels)}, volumes_{std::move(volumes)}
 {
-    CELER_VALIDATE(!celeritas::global_volumes().expired(),
+    CELER_VALIDATE(volumes_,
                    << "geometry volumes were not constructed before "
                       "instantiating ExampleInstanceCalo");
 
     // Map labels to volume IDs
     volume_ids_.resize(det_labels_.size());
-    VolumeIdBuilder label_to_vol_id;
+    VolumeIdBuilder label_to_vol_id(volumes_.get(), nullptr);
     for (auto i : range(det_labels_.size()))
     {
         volume_ids_[i] = label_to_vol_id(det_labels_[i]);
@@ -138,9 +139,7 @@ void ExampleInstanceCalo::process_steps(DetectorStepOutput const& out)
 
     CELER_LOG_LOCAL(debug) << "Processing " << out.size() << " hits";
 
-    auto volumes = celeritas::global_volumes().lock();
-    CELER_ASSERT(volumes);
-    auto const& vi_labels = volumes->volume_instance_labels();
+    auto const& vi_labels = volumes_->volume_instance_labels();
 
     for (auto hit : range(out.size()))
     {

--- a/test/celeritas/user/ExampleInstanceCalo.hh
+++ b/test/celeritas/user/ExampleInstanceCalo.hh
@@ -16,6 +16,8 @@
 
 namespace celeritas
 {
+class VolumeParams;
+
 namespace test
 {
 //---------------------------------------------------------------------------//
@@ -42,7 +44,8 @@ class ExampleInstanceCalo final : public StepInterface
 
   public:
     // Construct with labels
-    explicit ExampleInstanceCalo(VecLabel vol_labels);
+    explicit ExampleInstanceCalo(VecLabel vol_labels,
+                                 std::shared_ptr<VolumeParams const> volumes);
 
     // Selection of data required for this interface
     Filters filters() const final;
@@ -64,6 +67,7 @@ class ExampleInstanceCalo final : public StepInterface
 
   private:
     VecLabel det_labels_;
+    std::shared_ptr<VolumeParams const> volumes_;
     std::vector<VolumeId> volume_ids_;
 
     std::map<std::string, real_type> edep_;

--- a/test/celeritas/user/StepCollector.test.cc
+++ b/test/celeritas/user/StepCollector.test.cc
@@ -155,7 +155,8 @@ class TestMultiEm3InstanceCaloTest : public TestEm3CollectorTestBase
         // Construct geometry before instantiating calo
         this->geometry();
         ExampleInstanceCalo::VecLabel labels = {"lar", "calorimeter", "world"};
-        calo_ = std::make_shared<ExampleInstanceCalo>(std::move(labels));
+        calo_ = std::make_shared<ExampleInstanceCalo>(std::move(labels),
+                                                      this->volume());
         collector_ = StepCollector::make_and_insert(*this->core(), {calo_});
     }
 
@@ -180,12 +181,14 @@ class TestMultiEm3InstanceCaloTest : public TestEm3CollectorTestBase
 TEST_F(KnSimpleLoopTestBase, mixing_types)
 {
     this->geometry();
-    auto calo = std::make_shared<SimpleCalo>(std::vector<Label>{"inner"}, 1);
+    auto calo = std::make_shared<SimpleCalo>(
+        std::vector<Label>{"inner"}, 1, *this->volume());
     auto mctruth = std::make_shared<ExampleMctruth>();
 
     StepCollector::VecInterface interfaces = {calo, mctruth};
 
     EXPECT_THROW((StepCollector{this->geometry(),
+                                this->volume(),
                                 std::move(interfaces),
                                 this->aux_reg().get(),
                                 this->action_reg().get()}),

--- a/test/geocel/GenericGeoResults.cc
+++ b/test/geocel/GenericGeoResults.cc
@@ -256,50 +256,6 @@ GenericGeoModelInp GenericGeoModelInp::from_model_input(inp::Model const& in)
 {
     GenericGeoModelInp result;
 
-    // Extract volume data
-    if (auto* vols = std::get_if<inp::Volumes>(&in.volumes))
-    {
-        result.volume.labels.reserve(vols->volumes.size());
-        result.volume.materials.reserve(vols->volumes.size());
-        result.volume.daughters.reserve(vols->volumes.size());
-
-        for (auto i : range(vols->volumes.size()))
-        {
-            auto const& vol = vols->volumes[i];
-            result.volume.labels.push_back(to_string(vol.label));
-            result.volume.materials.push_back(id_to_int(vol.material));
-
-            std::vector<int> daughters;
-            daughters.reserve(vol.children.size());
-            for (auto child_id : vol.children)
-            {
-                daughters.push_back(id_to_int(child_id));
-            }
-            result.volume.daughters.push_back(std::move(daughters));
-        }
-
-        // Extract volume instance data
-        result.volume_instance.labels.reserve(vols->volume_instances.size());
-        result.volume_instance.volumes.reserve(vols->volume_instances.size());
-
-        for (auto i : range(vols->volume_instances.size()))
-        {
-            auto const& vol_inst = vols->volume_instances[i];
-            result.volume_instance.labels.push_back(to_string(vol_inst.label));
-            result.volume_instance.volumes.push_back(
-                id_to_int(vol_inst.volume));
-        }
-
-        if (vols->world < result.volume.labels.size())
-        {
-            result.world = result.volume.labels[vols->world.get()];
-        }
-        else
-        {
-            result.world = "<invalid>";
-        }
-    }
-
     // Extract surface data
     result.surface.labels.reserve(in.surfaces.surfaces.size());
     result.surface.volumes.reserve(in.surfaces.surfaces.size());
@@ -357,11 +313,7 @@ void GenericGeoModelInp::print_expected() const
     using std::cout;
     auto const& ref = *this;
     cout << "/*** ADD THE FOLLOWING UNIT TEST CODE ***/\n"
-            "GenericGeoModelInp ref;\n"
-         << CELER_REF_ATTR(volume.labels) << CELER_REF_ATTR(volume.materials)
-         << CELER_REF_ATTR(volume.daughters)
-         << CELER_REF_ATTR(volume_instance.labels)
-         << CELER_REF_ATTR(volume_instance.volumes) << CELER_REF_ATTR(world);
+            "GenericGeoModelInp ref;\n";
 
     if (!surface.labels.empty())
     {
@@ -397,12 +349,6 @@ void GenericGeoModelInp::print_expected() const
     else                                                           \
         CELER_DISCARD(int)
 
-    IRE_COMPARE(volume.labels);
-    IRE_COMPARE(volume.materials);
-    IRE_COMPARE(volume.daughters);
-    IRE_COMPARE(volume_instance.labels);
-    IRE_COMPARE(volume_instance.volumes);
-    IRE_COMPARE(world);
     IRE_COMPARE(surface.labels);
     IRE_COMPARE(surface.volumes);
     IRE_COMPARE(region.labels);

--- a/test/geocel/GenericGeoResults.cc
+++ b/test/geocel/GenericGeoResults.cc
@@ -17,7 +17,6 @@
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "corecel/math/SoftEqual.hh"
-#include "geocel/VolumeParams.hh"
 #include "geocel/inp/Model.hh"
 
 #include "GenericGeoTestInterface.hh"
@@ -257,103 +256,49 @@ GenericGeoModelInp GenericGeoModelInp::from_model_input(inp::Model const& in)
 {
     GenericGeoModelInp result;
 
-    std::visit(
-        Overload{
-            [&result](inp::Volumes const& volumes) {
-                // Extract volume data
-                result.volume.labels.reserve(volumes.volumes.size());
-                result.volume.materials.reserve(volumes.volumes.size());
-                result.volume.daughters.reserve(volumes.volumes.size());
+    // Extract volume data
+    if (auto* vols = std::get_if<inp::Volumes>(&in.volumes))
+    {
+        result.volume.labels.reserve(vols->volumes.size());
+        result.volume.materials.reserve(vols->volumes.size());
+        result.volume.daughters.reserve(vols->volumes.size());
 
-                for (auto i : range(volumes.volumes.size()))
-                {
-                    auto const& vol = volumes.volumes[i];
-                    result.volume.labels.push_back(to_string(vol.label));
-                    result.volume.materials.push_back(id_to_int(vol.material));
+        for (auto i : range(vols->volumes.size()))
+        {
+            auto const& vol = vols->volumes[i];
+            result.volume.labels.push_back(to_string(vol.label));
+            result.volume.materials.push_back(id_to_int(vol.material));
 
-                    std::vector<int> daughters;
-                    daughters.reserve(vol.children.size());
-                    for (auto child_id : vol.children)
-                    {
-                        daughters.push_back(id_to_int(child_id));
-                    }
-                    result.volume.daughters.push_back(std::move(daughters));
-                }
+            std::vector<int> daughters;
+            daughters.reserve(vol.children.size());
+            for (auto child_id : vol.children)
+            {
+                daughters.push_back(id_to_int(child_id));
+            }
+            result.volume.daughters.push_back(std::move(daughters));
+        }
 
-                // Extract volume instance data
-                result.volume_instance.labels.reserve(
-                    volumes.volume_instances.size());
-                result.volume_instance.volumes.reserve(
-                    volumes.volume_instances.size());
+        // Extract volume instance data
+        result.volume_instance.labels.reserve(vols->volume_instances.size());
+        result.volume_instance.volumes.reserve(vols->volume_instances.size());
 
-                for (auto i : range(volumes.volume_instances.size()))
-                {
-                    auto const& vol_inst = volumes.volume_instances[i];
-                    result.volume_instance.labels.push_back(
-                        to_string(vol_inst.label));
-                    result.volume_instance.volumes.push_back(
-                        id_to_int(vol_inst.volume));
-                }
+        for (auto i : range(vols->volume_instances.size()))
+        {
+            auto const& vol_inst = vols->volume_instances[i];
+            result.volume_instance.labels.push_back(to_string(vol_inst.label));
+            result.volume_instance.volumes.push_back(
+                id_to_int(vol_inst.volume));
+        }
 
-                if (volumes.world < result.volume.labels.size())
-                {
-                    result.world = result.volume.labels[volumes.world.get()];
-                }
-                else
-                {
-                    result.world = "<invalid>";
-                }
-            },
-            [&result](std::shared_ptr<VolumeParams const> const& volumes) {
-                CELER_ASSERT(volumes);
-
-                auto const num_volumes = volumes->num_volumes();
-                result.volume.labels.reserve(num_volumes);
-                result.volume.materials.reserve(num_volumes);
-                result.volume.daughters.reserve(num_volumes);
-
-                auto const& vol_labels = volumes->volume_labels();
-                for (auto i : range(num_volumes))
-                {
-                    VolumeId vid{i};
-                    result.volume.labels.push_back(
-                        to_string(vol_labels.at(vid)));
-                    result.volume.materials.push_back(
-                        id_to_int(volumes->material(vid)));
-
-                    std::vector<int> daughters;
-                    for (auto child_id : volumes->children(vid))
-                    {
-                        daughters.push_back(id_to_int(child_id));
-                    }
-                    result.volume.daughters.push_back(std::move(daughters));
-                }
-
-                auto const num_instances = volumes->num_volume_instances();
-                result.volume_instance.labels.reserve(num_instances);
-                result.volume_instance.volumes.reserve(num_instances);
-
-                auto const& vi_labels = volumes->volume_instance_labels();
-                for (auto i : range(num_instances))
-                {
-                    VolumeInstanceId vid{i};
-                    result.volume_instance.labels.push_back(
-                        to_string(vi_labels.at(vid)));
-                    result.volume_instance.volumes.push_back(
-                        id_to_int(volumes->volume(vid)));
-                }
-
-                if (auto world = volumes->world();
-                    world < result.volume.labels.size())
-                {
-                    result.world = result.volume.labels[world.get()];
-                }
-                else
-                {
-                    result.world = "<invalid>";
-                }
-            }},
-        in.volumes);
+        if (vols->world < result.volume.labels.size())
+        {
+            result.world = result.volume.labels[vols->world.get()];
+        }
+        else
+        {
+            result.world = "<invalid>";
+        }
+    }
 
     // Extract surface data
     result.surface.labels.reserve(in.surfaces.surfaces.size());

--- a/test/geocel/GenericGeoResults.cc
+++ b/test/geocel/GenericGeoResults.cc
@@ -17,6 +17,7 @@
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
 #include "corecel/math/SoftEqual.hh"
+#include "geocel/VolumeParams.hh"
 #include "geocel/inp/Model.hh"
 
 #include "GenericGeoTestInterface.hh"
@@ -256,45 +257,103 @@ GenericGeoModelInp GenericGeoModelInp::from_model_input(inp::Model const& in)
 {
     GenericGeoModelInp result;
 
-    // Extract volume data
-    result.volume.labels.reserve(in.volumes.volumes.size());
-    result.volume.materials.reserve(in.volumes.volumes.size());
-    result.volume.daughters.reserve(in.volumes.volumes.size());
+    std::visit(
+        Overload{
+            [&result](inp::Volumes const& volumes) {
+                // Extract volume data
+                result.volume.labels.reserve(volumes.volumes.size());
+                result.volume.materials.reserve(volumes.volumes.size());
+                result.volume.daughters.reserve(volumes.volumes.size());
 
-    for (auto i : range(in.volumes.volumes.size()))
-    {
-        auto const& vol = in.volumes.volumes[i];
-        result.volume.labels.push_back(to_string(vol.label));
-        result.volume.materials.push_back(id_to_int(vol.material));
+                for (auto i : range(volumes.volumes.size()))
+                {
+                    auto const& vol = volumes.volumes[i];
+                    result.volume.labels.push_back(to_string(vol.label));
+                    result.volume.materials.push_back(id_to_int(vol.material));
 
-        std::vector<int> daughters;
-        daughters.reserve(vol.children.size());
-        for (auto child_id : vol.children)
-        {
-            daughters.push_back(id_to_int(child_id));
-        }
-        result.volume.daughters.push_back(std::move(daughters));
-    }
+                    std::vector<int> daughters;
+                    daughters.reserve(vol.children.size());
+                    for (auto child_id : vol.children)
+                    {
+                        daughters.push_back(id_to_int(child_id));
+                    }
+                    result.volume.daughters.push_back(std::move(daughters));
+                }
 
-    // Extract volume instance data
-    result.volume_instance.labels.reserve(in.volumes.volume_instances.size());
-    result.volume_instance.volumes.reserve(in.volumes.volume_instances.size());
+                // Extract volume instance data
+                result.volume_instance.labels.reserve(
+                    volumes.volume_instances.size());
+                result.volume_instance.volumes.reserve(
+                    volumes.volume_instances.size());
 
-    for (auto i : range(in.volumes.volume_instances.size()))
-    {
-        auto const& vol_inst = in.volumes.volume_instances[i];
-        result.volume_instance.labels.push_back(to_string(vol_inst.label));
-        result.volume_instance.volumes.push_back(id_to_int(vol_inst.volume));
-    }
+                for (auto i : range(volumes.volume_instances.size()))
+                {
+                    auto const& vol_inst = volumes.volume_instances[i];
+                    result.volume_instance.labels.push_back(
+                        to_string(vol_inst.label));
+                    result.volume_instance.volumes.push_back(
+                        id_to_int(vol_inst.volume));
+                }
 
-    if (in.volumes.world < result.volume.labels.size())
-    {
-        result.world = result.volume.labels[in.volumes.world.get()];
-    }
-    else
-    {
-        result.world = "<invalid>";
-    }
+                if (volumes.world < result.volume.labels.size())
+                {
+                    result.world = result.volume.labels[volumes.world.get()];
+                }
+                else
+                {
+                    result.world = "<invalid>";
+                }
+            },
+            [&result](std::shared_ptr<VolumeParams const> const& volumes) {
+                CELER_ASSERT(volumes);
+
+                auto const num_volumes = volumes->num_volumes();
+                result.volume.labels.reserve(num_volumes);
+                result.volume.materials.reserve(num_volumes);
+                result.volume.daughters.reserve(num_volumes);
+
+                auto const& vol_labels = volumes->volume_labels();
+                for (auto i : range(num_volumes))
+                {
+                    VolumeId vid{i};
+                    result.volume.labels.push_back(
+                        to_string(vol_labels.at(vid)));
+                    result.volume.materials.push_back(
+                        id_to_int(volumes->material(vid)));
+
+                    std::vector<int> daughters;
+                    for (auto child_id : volumes->children(vid))
+                    {
+                        daughters.push_back(id_to_int(child_id));
+                    }
+                    result.volume.daughters.push_back(std::move(daughters));
+                }
+
+                auto const num_instances = volumes->num_volume_instances();
+                result.volume_instance.labels.reserve(num_instances);
+                result.volume_instance.volumes.reserve(num_instances);
+
+                auto const& vi_labels = volumes->volume_instance_labels();
+                for (auto i : range(num_instances))
+                {
+                    VolumeInstanceId vid{i};
+                    result.volume_instance.labels.push_back(
+                        to_string(vi_labels.at(vid)));
+                    result.volume_instance.volumes.push_back(
+                        id_to_int(volumes->volume(vid)));
+                }
+
+                if (auto world = volumes->world();
+                    world < result.volume.labels.size())
+                {
+                    result.world = result.volume.labels[world.get()];
+                }
+                else
+                {
+                    result.world = "<invalid>";
+                }
+            }},
+        in.volumes);
 
     // Extract surface data
     result.surface.labels.reserve(in.surfaces.surfaces.size());

--- a/test/geocel/GenericGeoResults.hh
+++ b/test/geocel/GenericGeoResults.hh
@@ -139,19 +139,6 @@ struct GenericGeoModelInp
     struct
     {
         std::vector<std::string> labels;
-        std::vector<int> materials;
-        std::vector<std::vector<int>> daughters;
-    } volume;
-    struct
-    {
-        std::vector<std::string> labels;
-        std::vector<int> volumes;
-    } volume_instance;
-    std::string world;
-
-    struct
-    {
-        std::vector<std::string> labels;
         std::vector<std::string> volumes;
     } surface;
 

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "corecel/Types.hh"
+#include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArrayUtils.hh"
@@ -345,11 +346,19 @@ auto GenericGeoTestInterface::get_test_volumes() const -> SPConstVolumes const&
         // Built without using Geant4 model
         static PersistentSP<VolumeParams const> pv{
             "GenericGeoTestBase volumes"};
-        pv.lazy_update(std::string{this->gdml_basename()},
-                       [g = this->geometry_interface()]() {
-                           return std::make_shared<VolumeParams const>(
-                               g->make_model_input().volumes);
-                       });
+        pv.lazy_update(
+            std::string{this->gdml_basename()},
+            [g = this->geometry_interface()]() {
+                auto model_input = g->make_model_input();
+                return std::visit(
+                    Overload{[](inp::Volumes const& v) {
+                                 return std::make_shared<VolumeParams const>(v);
+                             },
+                             [](std::shared_ptr<VolumeParams const> const& v) {
+                                 return v;
+                             }},
+                    model_input.volumes);
+            });
         volumes_ = pv.value();
     }
     CELER_ENSURE(volumes_);

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #include "GenericGeoTestInterface.hh"
 
+#include <memory>
+#include <variant>
 #include <gtest/gtest.h>
 
 #include "corecel/Types.hh"
@@ -346,6 +348,7 @@ auto GenericGeoTestInterface::get_test_volumes() const -> SPConstVolumes const&
         // Built without using Geant4 model
         static PersistentSP<VolumeParams const> pv{
             "GenericGeoTestBase volumes"};
+
         pv.lazy_update(
             std::string{this->gdml_basename()},
             [g = this->geometry_interface()]() {

--- a/test/geocel/GenericGeoTestInterface.cc
+++ b/test/geocel/GenericGeoTestInterface.cc
@@ -57,7 +57,7 @@ struct StreamableActionException
     CheckedGeoTrackView const& geo;
     std::exception const& e;
 
-    friend std::ostream&
+    [[maybe_unused]] friend std::ostream&
     operator<<(std::ostream& os, StreamableActionException const& sae)
     {
         os << "Caught exception during '" << sae.action

--- a/test/geocel/LazyGeantGeoManager.cc
+++ b/test/geocel/LazyGeantGeoManager.cc
@@ -84,7 +84,7 @@ auto LazyGeantGeoManager::lazy_geo() const -> SPConstGeoI
             // secondary geometry and reloads from the same Geant4 geo
             pgeant_geo.lazy_update(basename, [&]() {
                 auto result = this->build_geant_geo(filename);
-                persistent_volumes().set(basename, result->volume_params());
+                persistent_volumes().set(basename, result->volumes());
                 return result;
             });
 

--- a/test/geocel/LazyGeantGeoManager.cc
+++ b/test/geocel/LazyGeantGeoManager.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "LazyGeantGeoManager.hh"
 
+#include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/StringUtils.hh"
 #include "geocel/GeantGeoParams.hh"
 #include "geocel/VolumeParams.hh"
@@ -95,7 +96,12 @@ auto LazyGeantGeoManager::lazy_geo() const -> SPConstGeoI
         {
             // Fallback: geometry may be able to build without Geant4
             new_geo = this->build_geo_from_gdml(filename);
-            auto volumes = std::make_shared<VolumeParams const>(
+            auto volumes = std::visit(
+                Overload{
+                    [](inp::Volumes&& v) {
+                        return std::make_shared<VolumeParams const>(v);
+                    },
+                    [](std::shared_ptr<VolumeParams const>&& v) { return v; }},
                 new_geo->make_model_input().volumes);
             persistent_volumes().set(basename, std::move(volumes));
         }

--- a/test/geocel/LazyGeantGeoManager.cc
+++ b/test/geocel/LazyGeantGeoManager.cc
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "LazyGeantGeoManager.hh"
 
-#include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/StringUtils.hh"
 #include "geocel/GeantGeoParams.hh"
 #include "geocel/VolumeParams.hh"
@@ -85,16 +84,7 @@ auto LazyGeantGeoManager::lazy_geo() const -> SPConstGeoI
             // secondary geometry and reloads from the same Geant4 geo
             pgeant_geo.lazy_update(basename, [&]() {
                 auto result = this->build_geant_geo(filename);
-                auto model_input = result->make_model_input();
-                auto volumes = std::visit(
-                    Overload{[](inp::Volumes const& v) {
-                                 return std::make_shared<VolumeParams const>(v);
-                             },
-                             [](std::shared_ptr<VolumeParams const> const& v) {
-                                 return v;
-                             }},
-                    model_input.volumes);
-                persistent_volumes().set(basename, std::move(volumes));
+                persistent_volumes().set(basename, result->volume_params());
                 return result;
             });
 
@@ -105,15 +95,8 @@ auto LazyGeantGeoManager::lazy_geo() const -> SPConstGeoI
         {
             // Fallback: geometry may be able to build without Geant4
             new_geo = this->build_geo_from_gdml(filename);
-            auto model_input = new_geo->make_model_input();
-            auto volumes = std::visit(
-                Overload{[](inp::Volumes const& v) {
-                             return std::make_shared<VolumeParams const>(v);
-                         },
-                         [](std::shared_ptr<VolumeParams const> const& v) {
-                             return v;
-                         }},
-                model_input.volumes);
+            auto volumes = std::make_shared<VolumeParams const>(
+                new_geo->make_model_input().volumes);
             persistent_volumes().set(basename, std::move(volumes));
         }
 

--- a/test/geocel/LazyGeantGeoManager.cc
+++ b/test/geocel/LazyGeantGeoManager.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "LazyGeantGeoManager.hh"
 
+#include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/StringUtils.hh"
 #include "geocel/GeantGeoParams.hh"
 #include "geocel/VolumeParams.hh"
@@ -84,8 +85,15 @@ auto LazyGeantGeoManager::lazy_geo() const -> SPConstGeoI
             // secondary geometry and reloads from the same Geant4 geo
             pgeant_geo.lazy_update(basename, [&]() {
                 auto result = this->build_geant_geo(filename);
-                auto volumes = std::make_shared<VolumeParams const>(
-                    result->make_model_input().volumes);
+                auto model_input = result->make_model_input();
+                auto volumes = std::visit(
+                    Overload{[](inp::Volumes const& v) {
+                                 return std::make_shared<VolumeParams const>(v);
+                             },
+                             [](std::shared_ptr<VolumeParams const> const& v) {
+                                 return v;
+                             }},
+                    model_input.volumes);
                 persistent_volumes().set(basename, std::move(volumes));
                 return result;
             });
@@ -97,8 +105,15 @@ auto LazyGeantGeoManager::lazy_geo() const -> SPConstGeoI
         {
             // Fallback: geometry may be able to build without Geant4
             new_geo = this->build_geo_from_gdml(filename);
-            auto volumes = std::make_shared<VolumeParams const>(
-                new_geo->make_model_input().volumes);
+            auto model_input = new_geo->make_model_input();
+            auto volumes = std::visit(
+                Overload{[](inp::Volumes const& v) {
+                             return std::make_shared<VolumeParams const>(v);
+                         },
+                         [](std::shared_ptr<VolumeParams const> const& v) {
+                             return v;
+                         }},
+                model_input.volumes);
             persistent_volumes().set(basename, std::move(volumes));
         }
 

--- a/test/geocel/g4/GeantGeo.test.cc
+++ b/test/geocel/g4/GeantGeo.test.cc
@@ -130,41 +130,20 @@ class GeantGeoTest : public GeantGeoTestBase
 using AtlasHgtdTest
     = GenericGeoParameterizedTest<GeantGeoTest, AtlasHgtdGeoTest>;
 
-TEST_F(AtlasHgtdTest, model)
+TEST_F(AtlasHgtdTest, volumes)
 {
-    auto result = this->summarize_model();
-    GenericGeoModelInp ref;
-    ref.volume.labels = {"SPlate", "HGTD", "ITK", "Atlas"};
-    ref.volume.materials = {0, 1, 1, 1};
-    ref.volume.daughters = {{}, {3, 4, 5, 6, 7, 8, 9, 10}, {2}, {1}};
-    ref.volume_instance.labels = {
-        "Atlas_PV",
-        "ITK",
-        "HGTD",
-        "SPlate_4@0",
-        "SPlate_5@0",
-        "SPlate_6@0",
-        "SPlate_7@0",
-        "SPlate_4@1",
-        "SPlate_5@1",
-        "SPlate_6@1",
-        "SPlate_7@1",
-    };
-    ref.volume_instance.volumes = {
-        3,
-        2,
-        1,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    };
-    ref.world = "Atlas";
-    EXPECT_REF_EQ(ref, result);
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+        R"json({
+"children": [ [], [ 3, 4, 5, 6, 7, 8, 9, 10 ], [ 2 ], [ 1 ] ], "instance_to_volume": [ 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
+"volume_instances": [ "Atlas_PV", "ITK", "HGTD", "SPlate_4@0", "SPlate_5@0", "SPlate_6@0", "SPlate_7@0", "SPlate_4@1", "SPlate_5@1", "SPlate_6@1", "SPlate_7@1" ],
+"volumes": [ "SPlate", "HGTD", "ITK", "Atlas" ],
+"world": 3
+})json"
+
+        ,
+        stream_to_string(*volumes));
 }
 
 TEST_F(AtlasHgtdTest, trace)
@@ -185,85 +164,21 @@ TEST_F(AtlasHgtdTest, detailed_track)
 //---------------------------------------------------------------------------//
 using CmseTest = GenericGeoParameterizedTest<GeantGeoTest, CmseGeoTest>;
 
-TEST_F(CmseTest, model)
+TEST_F(CmseTest, volumes)
 {
-    auto result = this->summarize_model();
-    GenericGeoModelInp ref;
-    ref.volume.labels = {
-        "CMStoZDC", "ZDCtoFP420", "Tracker", "CALO",    "MUON",
-        "BEAM",     "BEAM1",      "BEAM2",   "BEAM3",   "TrackerPixelNose",
-        "VCAL",     "TotemT1",    "TotemT2", "CastorF", "CastorB",
-        "OQUA",     "BSC2",       "ZDC",     "CMSE",    "OCMS",
-    };
-    ref.volume.materials = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    };
-    ref.volume.daughters = {
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {
-            2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
-            18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
-        },
-        {1},
-    };
-    ref.volume_instance.labels = {
-        "OCMS_PV",
-        "CMSE",
-        "CMStoZDC@0",
-        "CMStoZDC@1",
-        "ZDCtoFP420@0",
-        "ZDCtoFP420@1",
-        "Tracker",
-        "CALO",
-        "MUON",
-        "BEAM@0",
-        "BEAM@1",
-        "BEAM1@0",
-        "BEAM1@1",
-        "BEAM2@0",
-        "BEAM2@1",
-        "BEAM3@0",
-        "BEAM3@1",
-        "TrackerPixelNose@0",
-        "TrackerPixelNose@1",
-        "VCAL@0",
-        "VCAL@1",
-        "TotemT1@0",
-        "TotemT1@1",
-        "TotemT2@0",
-        "TotemT2@1",
-        "CastorF",
-        "CastorB",
-        "OQUA@0",
-        "OQUA@1",
-        "BSC2@0",
-        "BSC2@1",
-        "ZDC@0",
-        "ZDC@1",
-    };
-    ref.volume_instance.volumes = {
-        19, 18, 0,  0,  1,  1,  2,  3,  4,  5,  5,  6,  6,  7,  7,  8,  8,
-        9,  9,  10, 10, 11, 11, 12, 12, 13, 14, 15, 15, 16, 16, 17, 17,
-    };
-    ref.world = "OCMS";
-    EXPECT_REF_EQ(ref, result);
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+        R"json({
+"children": [ [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32 ], [ 1 ] ],
+"instance_to_volume": [ 19, 18, 0, 0, 1, 1, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 14, 15, 15, 16, 16, 17, 17 ],
+"volume_instances": [ "OCMS_PV", "CMSE", "CMStoZDC@0", "CMStoZDC@1", "ZDCtoFP420@0", "ZDCtoFP420@1", "Tracker", "CALO", "MUON", "BEAM@0", "BEAM@1", "BEAM1@0", "BEAM1@1", "BEAM2@0", "BEAM2@1", "BEAM3@0", "BEAM3@1", "TrackerPixelNose@0", "TrackerPixelNose@1", "VCAL@0", "VCAL@1", "TotemT1@0", "TotemT1@1", "TotemT2@0", "TotemT2@1", "CastorF", "CastorB", "OQUA@0", "OQUA@1", "BSC2@0", "BSC2@1", "ZDC@0", "ZDC@1" ],
+"volumes": [ "CMStoZDC", "ZDCtoFP420", "Tracker", "CALO", "MUON", "BEAM", "BEAM1", "BEAM2", "BEAM3", "TrackerPixelNose", "VCAL", "TotemT1", "TotemT2", "CastorF", "CastorB", "OQUA", "BSC2", "ZDC", "CMSE", "OCMS" ],
+"world": 19
+})json"
+
+        ,
+        stream_to_string(*volumes));
 }
 
 TEST_F(CmseTest, trace)
@@ -295,32 +210,26 @@ TEST_F(CmsEeBackDeeTest, accessors)
     this->impl().test_accessors();
 }
 
+TEST_F(CmsEeBackDeeTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [ 2, 3 ], [ 1, 4 ], [ 5, 6 ], [], [] ],
+"instance_to_volume": [ 3, 2, 0, 1, 4, 5, 6 ],
+"volume_instances": [ "EEBackDee_PV", "EEBackQuad@0", "EEBackPlate@0", "EESRing@0", "EEBackQuad@1", "EEBackPlate@1", "EESRing@1" ],
+"volumes": [ "EEBackPlate", "EESRing", "EEBackQuad", "EEBackDee", "EEBackQuad_refl", "EEBackPlate_refl", "EESRing_refl" ],
+"world": 3
+})json",
+        stream_to_string(*volumes));
+}
+
 TEST_F(CmsEeBackDeeTest, model)
 {
     auto result = this->summarize_model();
     GenericGeoModelInp ref;
-    ref.volume.labels = {
-        "EEBackPlate",
-        "EESRing",
-        "EEBackQuad",
-        "EEBackDee",
-        "EEBackQuad_refl",
-        "EEBackPlate_refl",
-        "EESRing_refl",
-    };
-    ref.volume.materials = {0, 0, 1, 1, 1, 0, 0};
-    ref.volume.daughters = {{}, {}, {2, 3}, {1, 4}, {5, 6}, {}, {}};
-    ref.volume_instance.labels = {
-        "EEBackDee_PV",
-        "EEBackQuad@0",
-        "EEBackPlate@0",
-        "EESRing@0",
-        "EEBackQuad@1",
-        "EEBackPlate@1",
-        "EESRing@1",
-    };
-    ref.volume_instance.volumes = {3, 2, 0, 1, 4, 5, 6};
-    ref.world = "EEBackDee";
     ref.detector.labels = {"ee_back_plate", "ee_s_ring"};
     ref.detector.volumes = {{0, 5}, {1, 6}};
     EXPECT_REF_EQ(ref, result);
@@ -335,34 +244,27 @@ TEST_F(CmsEeBackDeeTest, trace)
 using DuneCryostatTest
     = GenericGeoParameterizedTest<GeantGeoTest, DuneCryostatGeoTest>;
 
+TEST_F(DuneCryostatTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+        R"json({
+"children": [ [], [], [], [], [], [], [ 2, 3, 4, 5, 6, 7 ], [ 1 ] ],
+"instance_to_volume": [ 7, 6, 0, 1, 2, 3, 4, 5 ],
+"volume_instances": [ "volDetEnclosure_PV", "volCryostat_PV", "volGaseousArgon_PV", "volArapuca_0-0_PV", "volOpDetSensitive_0-0-0_PV", "volOpDetSensitive_0-0-1_PV", "volOpDetSensitive_0-0-2_PV", "volOpDetSensitive_0-0-3_PV" ],
+"volumes": [ "volGaseousArgon", "volArapuca_0-0", "volOpDetSensitive_0-0-0", "volOpDetSensitive_0-0-1", "volOpDetSensitive_0-0-2", "volOpDetSensitive_0-0-3", "volCryostat", "volDetEnclosure" ],
+"world": 7
+})json"
+
+        ,
+        stream_to_string(*volumes));
+}
+
 TEST_F(DuneCryostatTest, model)
 {
     auto result = this->summarize_model();
     GenericGeoModelInp ref;
-    ref.volume.labels = {
-        "volGaseousArgon",
-        "volArapuca_0-0",
-        "volOpDetSensitive_0-0-0",
-        "volOpDetSensitive_0-0-1",
-        "volOpDetSensitive_0-0-2",
-        "volOpDetSensitive_0-0-3",
-        "volCryostat",
-        "volDetEnclosure",
-    };
-    ref.volume.materials = {0, 1, 2, 2, 2, 2, 3, 4};
-    ref.volume.daughters = {{}, {}, {}, {}, {}, {}, {2, 3, 4, 5, 6, 7}, {1}};
-    ref.volume_instance.labels = {
-        "volDetEnclosure_PV",
-        "volCryostat_PV",
-        "volGaseousArgon_PV",
-        "volArapuca_0-0_PV",
-        "volOpDetSensitive_0-0-0_PV",
-        "volOpDetSensitive_0-0-1_PV",
-        "volOpDetSensitive_0-0-2_PV",
-        "volOpDetSensitive_0-0-3_PV",
-    };
-    ref.volume_instance.volumes = {7, 6, 0, 1, 2, 3, 4, 5};
-    ref.world = "volDetEnclosure";
     ref.surface.labels = {
         "volOpDetSensitive_0-0-0_Surface",
         "volOpDetSensitive_0-0-1_Surface",
@@ -389,40 +291,26 @@ TEST_F(FourLevelsTest, accessors)
     this->impl().test_accessors();
 }
 
+TEST_F(FourLevelsTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [ 3 ], [ 2 ], [ 1, 4, 5, 6, 7, 8, 9, 10 ] ],
+"instance_to_volume": [ 3, 2, 1, 0, 2, 2, 2, 2, 2, 2, 2 ],
+"volume_instances": [ "World_PV", "env1", "Shape1", "Shape2", "env2", "env3", "env4", "env5", "env6", "env7", "env8" ],
+"volumes": [ "Shape2", "Shape1", "Envelope", "World" ],
+"world": 3
+})json",
+        stream_to_string(*volumes));
+}
+
 TEST_F(FourLevelsTest, model)
 {
     auto result = this->summarize_model();
     GenericGeoModelInp ref;
-    ref.volume.labels = {"Shape2", "Shape1", "Envelope", "World"};
-    ref.volume.materials = {0, 1, 2, 3};
-    ref.volume.daughters = {{}, {3}, {2}, {1, 4, 5, 6, 7, 8, 9, 10}};
-    ref.volume_instance.labels = {
-        "World_PV",
-        "env1",
-        "Shape1",
-        "Shape2",
-        "env2",
-        "env3",
-        "env4",
-        "env5",
-        "env6",
-        "env7",
-        "env8",
-    };
-    ref.volume_instance.volumes = {
-        3,
-        2,
-        1,
-        0,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-        2,
-    };
-    ref.world = "World";
     ref.region.labels = {"envelope_region"};
     ref.region.volumes = {{0, 1, 2}};
     EXPECT_REF_EQ(ref, result);
@@ -486,24 +374,27 @@ TEST_F(FourLevelsTest, trace)
 using LarSphereTest
     = GenericGeoParameterizedTest<GeantGeoTest, LarSphereGeoTest>;
 
+TEST_F(LarSphereTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [], [ 2, 3 ], [ 1, 4 ] ],
+"instance_to_volume": [ 4, 3, 1, 2, 0 ],
+"volume_instances": [ "world_PV", "detshell_PV", "detshell_top_PV", "detshell_bot_PV", "sphere_PV" ],
+"volumes": [ "sphere", "detshell_top", "detshell_bot", "detshell", "world" ],
+"world": 4
+})json",
+        stream_to_string(*volumes));
+}
+
 TEST_F(LarSphereTest, model)
 {
     auto result = this->summarize_model();
 
     GenericGeoModelInp ref;
-    ref.volume.labels
-        = {"sphere", "detshell_top", "detshell_bot", "detshell", "world"};
-    ref.volume.materials = {1, 1, 1, 0, 0};
-    ref.volume.daughters = {{}, {}, {}, {2, 3}, {1, 4}};
-    ref.volume_instance.labels = {
-        "world_PV",
-        "detshell_PV",
-        "detshell_top_PV",
-        "detshell_bot_PV",
-        "sphere_PV",
-    };
-    ref.volume_instance.volumes = {4, 3, 1, 2, 0};
-    ref.world = "world";
     ref.detector.labels = {"detshell"};
     ref.detector.volumes = {{1, 2}};
     EXPECT_REF_EQ(ref, result);
@@ -523,44 +414,26 @@ TEST_F(LarSphereTest, volume_stack)
 using MultiLevelTest
     = GenericGeoParameterizedTest<GeantGeoTest, MultiLevelGeoTest>;
 
+TEST_F(MultiLevelTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [ 2, 3, 4 ], [ 1, 5, 6, 7, 8 ], [ 9, 10, 11 ], [], [] ],
+"instance_to_volume": [ 3, 2, 0, 0, 1, 0, 2, 2, 4, 5, 5, 6 ],
+"volume_instances": [ "world_PV", "topbox1", "boxsph1@0", "boxsph2@0", "boxtri@0", "topsph1", "topbox2", "topbox3", "topbox4", "boxsph1@1", "boxsph2@1", "boxtri@1" ],
+"volumes": [ "sph", "tri", "box", "world", "box_refl", "sph_refl", "tri_refl" ],
+"world": 3
+})json",
+        stream_to_string(*volumes));
+}
+
 TEST_F(MultiLevelTest, model)
 {
     auto result = this->summarize_model();
     GenericGeoModelInp ref;
-    ref.volume.labels
-        = {"sph", "tri", "box", "world", "box_refl", "sph_refl", "tri_refl"};
-    ref.volume.materials = {0, 0, 1, 0, 1, 0, 0};
-    ref.volume.daughters
-        = {{}, {}, {2, 3, 4}, {1, 5, 6, 7, 8}, {9, 10, 11}, {}, {}};
-    ref.volume_instance.labels = {
-        "world_PV",
-        "topbox1",
-        "boxsph1@0",
-        "boxsph2@0",
-        "boxtri@0",
-        "topsph1",
-        "topbox2",
-        "topbox3",
-        "topbox4",
-        "boxsph1@1",
-        "boxsph2@1",
-        "boxtri@1",
-    };
-    ref.volume_instance.volumes = {
-        3,
-        2,
-        0,
-        0,
-        1,
-        0,
-        2,
-        2,
-        4,
-        5,
-        5,
-        6,
-    };
-    ref.world = "world";
     ref.detector.labels = {"sph_sd"};
     ref.detector.volumes = {{0, 5}};
     ref.region.labels = {"sph_region", "tri_region", "box_region"};
@@ -602,23 +475,26 @@ TEST_F(MultiLevelTest, volume_stack)
 using OpticalSurfacesTest
     = GenericGeoParameterizedTest<GeantGeoTest, OpticalSurfacesGeoTest>;
 
+TEST_F(OpticalSurfacesTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [], [], [ 1, 2, 3, 4, 5 ] ],
+"instance_to_volume": [ 4, 0, 1, 3, 2, 3 ],
+"volume_instances": [ "world_PV", "lar_pv", "death_pv", "tube2_below_pv", "tube1_mid_pv", "tube2_above_pv" ],
+"volumes": [ "lar_sphere", "death", "tube1_mid", "tube2", "world" ],
+"world": 4
+})json",
+        stream_to_string(*volumes));
+}
+
 TEST_F(OpticalSurfacesTest, model)
 {
     auto result = this->summarize_model();
     GenericGeoModelInp ref;
-    ref.volume.labels = {"lar_sphere", "death", "tube1_mid", "tube2", "world"};
-    ref.volume.materials = {1, 2, 2, 2, 3};
-    ref.volume.daughters = {{}, {}, {}, {}, {1, 2, 3, 4, 5}};
-    ref.volume_instance.labels = {
-        "world_PV",
-        "lar_pv",
-        "death_pv",
-        "tube2_below_pv",
-        "tube1_mid_pv",
-        "tube2_above_pv",
-    };
-    ref.volume_instance.volumes = {4, 0, 1, 3, 2, 3};
-    ref.world = "world";
     ref.surface.labels = {
         "sphere_skin",
         "tube2_skin",
@@ -666,124 +542,20 @@ TEST_F(PincellTest, imager)
 using PolyhedraTest
     = GenericGeoParameterizedTest<GeantGeoTest, PolyhedraGeoTest>;
 
-TEST_F(PolyhedraTest, model)
+TEST_F(PolyhedraTest, volumes)
 {
-    auto result = this->summarize_model();
-    GenericGeoModelInp ref;
-    ref.volume.labels = {
-        "tri",
-        "tri_third",
-        "tri_half",
-        "tri_full",
-        "quad",
-        "quad_third",
-        "quad_half",
-        "quad_full",
-        "penta",
-        "penta_third",
-        "penta_half",
-        "penta_full",
-        "hex",
-        "hex_third",
-        "hex_half",
-        "hex_full",
-        "world",
-    };
-    ref.volume.materials = {
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        0,
-    };
-    ref.volume.daughters = {
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-        },
-    };
-    ref.volume_instance.labels = {
-        "world_PV",
-        "tri0_pv",
-        "tri30_pv",
-        "tri60_pv",
-        "tri90_pv",
-        "quad0_pv",
-        "quad30_pv",
-        "quad60_pv",
-        "quad90_pv",
-        "penta0_pv",
-        "penta30_pv",
-        "penta60_pv",
-        "penta90_pv",
-        "hex0_pv",
-        "hex30_pv",
-        "hex60_pv",
-        "hex90_pv",
-    };
-    ref.volume_instance.volumes = {
-        16,
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-    };
-    ref.world = "world";
-    EXPECT_REF_EQ(ref, result);
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ] ],
+"instance_to_volume": [ 16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ],
+"volume_instances": [ "world_PV", "tri0_pv", "tri30_pv", "tri60_pv", "tri90_pv", "quad0_pv", "quad30_pv", "quad60_pv", "quad90_pv", "penta0_pv", "penta30_pv", "penta60_pv", "penta90_pv", "hex0_pv", "hex30_pv", "hex60_pv", "hex90_pv" ],
+"volumes": [ "tri", "tri_third", "tri_half", "tri_full", "quad", "quad_third", "quad_half", "quad_full", "penta", "penta_third", "penta_half", "penta_full", "hex", "hex_third", "hex_half", "hex_full", "world" ],
+"world": 16
+})json",
+        stream_to_string(*volumes));
 }
 
 TEST_F(PolyhedraTest, trace)
@@ -805,19 +577,20 @@ class ReplicaTest
     }
 };
 
-TEST_F(ReplicaTest, model)
+TEST_F(ReplicaTest, volumes)
 {
-    auto result = this->summarize_model();
-    // clang-format off
-    GenericGeoModelInp ref;
-    ref.volume.labels = {"magnetic", "hodoscope1", "wirePlane1", "chamber1", "firstArm", "hodoscope2", "wirePlane2", "chamber2", "cell", "EMcalorimeter", "HadCalScinti", "HadCalLayer", "HadCalCell", "HadCalColumn", "HadCalorimeter", "secondArm", "world",};
-    ref.volume.materials = {0, 1, 2, 2, 0, 1, 2, 2, 3, 3, 1, 4, 4, 4, 4, 0, 0,};
-    ref.volume.daughters = {{}, {}, {}, {19}, {3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23,}, {}, {}, {51}, {}, {57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,}, {}, {170}, {150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169,}, {148, 149}, {138, 139, 140, 141, 142, 143, 144, 145, 146, 147,}, {25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52, 53, 54, 55, 56, 137,}, {1, 2, 24},};
-    ref.volume_instance.labels = {"world_PV", "magnetic", "firstArm", "hodoscope1@0", "hodoscope1@1", "hodoscope1@2", "hodoscope1@3", "hodoscope1@4", "hodoscope1@5", "hodoscope1@6", "hodoscope1@7", "hodoscope1@8", "hodoscope1@9", "hodoscope1@10", "hodoscope1@11", "hodoscope1@12", "hodoscope1@13", "hodoscope1@14", "chamber1@0", "wirePlane1", "chamber1@1", "chamber1@2", "chamber1@3", "chamber1@4", "fSecondArmPhys", "hodoscope2@0", "hodoscope2@1", "hodoscope2@2", "hodoscope2@3", "hodoscope2@4", "hodoscope2@5", "hodoscope2@6", "hodoscope2@7", "hodoscope2@8", "hodoscope2@9", "hodoscope2@10", "hodoscope2@11", "hodoscope2@12", "hodoscope2@13", "hodoscope2@14", "hodoscope2@15", "hodoscope2@16", "hodoscope2@17", "hodoscope2@18", "hodoscope2@19", "hodoscope2@20", "hodoscope2@21", "hodoscope2@22", "hodoscope2@23", "hodoscope2@24", "chamber2@0", "wirePlane2", "chamber2@1", "chamber2@2", "chamber2@3", "chamber2@4", "EMcalorimeter", "cell_param@0", "cell_param@1", "cell_param@2", "cell_param@3", "cell_param@4", "cell_param@5", "cell_param@6", "cell_param@7", "cell_param@8", "cell_param@9", "cell_param@10", "cell_param@11", "cell_param@12", "cell_param@13", "cell_param@14", "cell_param@15", "cell_param@16", "cell_param@17", "cell_param@18", "cell_param@19", "cell_param@20", "cell_param@21", "cell_param@22", "cell_param@23", "cell_param@24", "cell_param@25", "cell_param@26", "cell_param@27", "cell_param@28", "cell_param@29", "cell_param@30", "cell_param@31", "cell_param@32", "cell_param@33", "cell_param@34", "cell_param@35", "cell_param@36", "cell_param@37", "cell_param@38", "cell_param@39", "cell_param@40", "cell_param@41", "cell_param@42", "cell_param@43", "cell_param@44", "cell_param@45", "cell_param@46", "cell_param@47", "cell_param@48", "cell_param@49", "cell_param@50", "cell_param@51", "cell_param@52", "cell_param@53", "cell_param@54", "cell_param@55", "cell_param@56", "cell_param@57", "cell_param@58", "cell_param@59", "cell_param@60", "cell_param@61", "cell_param@62", "cell_param@63", "cell_param@64", "cell_param@65", "cell_param@66", "cell_param@67", "cell_param@68", "cell_param@69", "cell_param@70", "cell_param@71", "cell_param@72", "cell_param@73", "cell_param@74", "cell_param@75", "cell_param@76", "cell_param@77", "cell_param@78", "cell_param@79", "HadCalorimeter", "HadCalColumn_PV@0", "HadCalColumn_PV@1", "HadCalColumn_PV@2", "HadCalColumn_PV@3", "HadCalColumn_PV@4", "HadCalColumn_PV@5", "HadCalColumn_PV@6", "HadCalColumn_PV@7", "HadCalColumn_PV@8", "HadCalColumn_PV@9", "HadCalCell_PV@0", "HadCalCell_PV@1", "HadCalLayer_PV@0", "HadCalLayer_PV@1", "HadCalLayer_PV@2", "HadCalLayer_PV@3", "HadCalLayer_PV@4", "HadCalLayer_PV@5", "HadCalLayer_PV@6", "HadCalLayer_PV@7", "HadCalLayer_PV@8", "HadCalLayer_PV@9", "HadCalLayer_PV@10", "HadCalLayer_PV@11", "HadCalLayer_PV@12", "HadCalLayer_PV@13", "HadCalLayer_PV@14", "HadCalLayer_PV@15", "HadCalLayer_PV@16", "HadCalLayer_PV@17", "HadCalLayer_PV@18", "HadCalLayer_PV@19", "HadCalScinti",};
-    ref.volume_instance.volumes = {16, 0, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 2, 3, 3, 3, 3, 15, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 7, 6, 7, 7, 7, 7, 9, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 12, 12, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10,};
-    ref.world = "world";
-    EXPECT_REF_EQ(ref, result);
-    // clang-format on
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [], [ 19 ], [ 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23 ], [], [], [ 51 ], [], [ 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136 ], [], [ 170 ], [ 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169 ], [ 148, 149 ], [ 138, 139, 140, 141, 142, 143, 144, 145, 146, 147 ], [ 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 52, 53, 54, 55, 56, 137 ], [ 1, 2, 24 ] ],
+"instance_to_volume": [ 16, 0, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 2, 3, 3, 3, 3, 15, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 7, 6, 7, 7, 7, 7, 9, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 14, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 12, 12, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10 ],
+"volume_instances": [ "world_PV", "magnetic", "firstArm", "hodoscope1@0", "hodoscope1@1", "hodoscope1@2", "hodoscope1@3", "hodoscope1@4", "hodoscope1@5", "hodoscope1@6", "hodoscope1@7", "hodoscope1@8", "hodoscope1@9", "hodoscope1@10", "hodoscope1@11", "hodoscope1@12", "hodoscope1@13", "hodoscope1@14", "chamber1@0", "wirePlane1", "chamber1@1", "chamber1@2", "chamber1@3", "chamber1@4", "fSecondArmPhys", "hodoscope2@0", "hodoscope2@1", "hodoscope2@2", "hodoscope2@3", "hodoscope2@4", "hodoscope2@5", "hodoscope2@6", "hodoscope2@7", "hodoscope2@8", "hodoscope2@9", "hodoscope2@10", "hodoscope2@11", "hodoscope2@12", "hodoscope2@13", "hodoscope2@14", "hodoscope2@15", "hodoscope2@16", "hodoscope2@17", "hodoscope2@18", "hodoscope2@19", "hodoscope2@20", "hodoscope2@21", "hodoscope2@22", "hodoscope2@23", "hodoscope2@24", "chamber2@0", "wirePlane2", "chamber2@1", "chamber2@2", "chamber2@3", "chamber2@4", "EMcalorimeter", "cell_param@0", "cell_param@1", "cell_param@2", "cell_param@3", "cell_param@4", "cell_param@5", "cell_param@6", "cell_param@7", "cell_param@8", "cell_param@9", "cell_param@10", "cell_param@11", "cell_param@12", "cell_param@13", "cell_param@14", "cell_param@15", "cell_param@16", "cell_param@17", "cell_param@18", "cell_param@19", "cell_param@20", "cell_param@21", "cell_param@22", "cell_param@23", "cell_param@24", "cell_param@25", "cell_param@26", "cell_param@27", "cell_param@28", "cell_param@29", "cell_param@30", "cell_param@31", "cell_param@32", "cell_param@33", "cell_param@34", "cell_param@35", "cell_param@36", "cell_param@37", "cell_param@38", "cell_param@39", "cell_param@40", "cell_param@41", "cell_param@42", "cell_param@43", "cell_param@44", "cell_param@45", "cell_param@46", "cell_param@47", "cell_param@48", "cell_param@49", "cell_param@50", "cell_param@51", "cell_param@52", "cell_param@53", "cell_param@54", "cell_param@55", "cell_param@56", "cell_param@57", "cell_param@58", "cell_param@59", "cell_param@60", "cell_param@61", "cell_param@62", "cell_param@63", "cell_param@64", "cell_param@65", "cell_param@66", "cell_param@67", "cell_param@68", "cell_param@69", "cell_param@70", "cell_param@71", "cell_param@72", "cell_param@73", "cell_param@74", "cell_param@75", "cell_param@76", "cell_param@77", "cell_param@78", "cell_param@79", "HadCalorimeter", "HadCalColumn_PV@0", "HadCalColumn_PV@1", "HadCalColumn_PV@2", "HadCalColumn_PV@3", "HadCalColumn_PV@4", "HadCalColumn_PV@5", "HadCalColumn_PV@6", "HadCalColumn_PV@7", "HadCalColumn_PV@8", "HadCalColumn_PV@9", "HadCalCell_PV@0", "HadCalCell_PV@1", "HadCalLayer_PV@0", "HadCalLayer_PV@1", "HadCalLayer_PV@2", "HadCalLayer_PV@3", "HadCalLayer_PV@4", "HadCalLayer_PV@5", "HadCalLayer_PV@6", "HadCalLayer_PV@7", "HadCalLayer_PV@8", "HadCalLayer_PV@9", "HadCalLayer_PV@10", "HadCalLayer_PV@11", "HadCalLayer_PV@12", "HadCalLayer_PV@13", "HadCalLayer_PV@14", "HadCalLayer_PV@15", "HadCalLayer_PV@16", "HadCalLayer_PV@17", "HadCalLayer_PV@18", "HadCalLayer_PV@19", "HadCalScinti" ],
+"volumes": [ "magnetic", "hodoscope1", "wirePlane1", "chamber1", "firstArm", "hodoscope2", "wirePlane2", "chamber2", "cell", "EMcalorimeter", "HadCalScinti", "HadCalLayer", "HadCalCell", "HadCalColumn", "HadCalorimeter", "secondArm", "world" ],
+"world": 16
+})json",
+        stream_to_string(*volumes));
 }
 
 TEST_F(ReplicaTest, trace)
@@ -835,28 +608,26 @@ TEST_F(ReplicaTest, volume_stack)
 using SimpleCmsTest
     = GenericGeoParameterizedTest<GeantGeoTest, SimpleCmsGeoTest>;
 
+TEST_F(SimpleCmsTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [], [], [], [], [ 1, 2, 3, 4, 5, 6 ] ],
+"instance_to_volume": [ 6, 0, 1, 2, 3, 4, 5 ],
+"volume_instances": [ "world_PV", "vacuum_tube_pv", "si_tracker_pv", "em_calorimeter_pv", "had_calorimeter_pv", "sc_solenoid_pv", "iron_muon_chambers_pv" ],
+"volumes": [ "vacuum_tube", "si_tracker", "em_calorimeter", "had_calorimeter", "sc_solenoid", "fe_muon_chambers", "world" ],
+"world": 6
+})json",
+        stream_to_string(*volumes));
+}
+
 TEST_F(SimpleCmsTest, model)
 {
     auto result = this->summarize_model();
     GenericGeoModelInp ref;
-    ref.volume.labels = {"vacuum_tube",
-                         "si_tracker",
-                         "em_calorimeter",
-                         "had_calorimeter",
-                         "sc_solenoid",
-                         "fe_muon_chambers",
-                         "world"};
-    ref.volume.materials = {0, 1, 2, 3, 4, 5, 0};
-    ref.volume.daughters = {{}, {}, {}, {}, {}, {}, {1, 2, 3, 4, 5, 6}};
-    ref.volume_instance.labels = {"world_PV",
-                                  "vacuum_tube_pv",
-                                  "si_tracker_pv",
-                                  "em_calorimeter_pv",
-                                  "had_calorimeter_pv",
-                                  "sc_solenoid_pv",
-                                  "iron_muon_chambers_pv"};
-    ref.volume_instance.volumes = {6, 0, 1, 2, 3, 4, 5};
-    ref.world = "world";
     ref.detector.labels = {"si_tracker_sd", "em_calorimeter_sd"};
     ref.detector.volumes = {{1}, {2}};
     EXPECT_REF_EQ(ref, result);
@@ -880,7 +651,22 @@ class SolidsTest
 {
 };
 
-//---------------------------------------------------------------------------//
+TEST_F(SolidsTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+
+        R"json({
+"children": [ [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 ], [] ],
+"instance_to_volume": [ 24, 0, 1, 2, 3, 4, 5, 6, 7, 25, 9, 10, 11, 16, 12, 18, 17, 15, 22, 21, 14, 19, 20, 13, 23 ],
+"volume_instances": [ "World_PV", "box500_PV", "cone1_PV", "para1_PV", "sphere1_PV", "parabol1_PV", "trap1_PV", "trd1_PV", "reflNormal", "reflected@0", "reflected@1", "tube100_PV", "boolean1_PV", "orb1_PV", "polycone1_PV", "hype1_PV", "polyhedr1_PV", "tetrah1_PV", "arb8a_PV", "arb8b_PV", "ellipsoid1_PV", "elltube1_PV", "ellcone1_PV", "genPocone1_PV", "xtru1_PV" ],
+"volumes": [ "box500", "cone1", "para1", "sphere1", "parabol1", "trap1", "trd1", "trd2", "", "trd3_also", "tube100", "boolean1", "polycone1", "genPocone1", "ellipsoid1", "tetrah1", "orb1", "polyhedr1", "hype1", "elltube1", "ellcone1", "arb8b", "arb8a", "xtru1", "World", "trd3_refl" ],
+"world": 24
+})json",
+        stream_to_string(*volumes));
+}
+
 TEST_F(SolidsTest, output)
 {
     GeoParamsOutput out(this->geometry());
@@ -896,21 +682,16 @@ TEST_F(SolidsTest, output)
             actual);
     }
 }
-//---------------------------------------------------------------------------//
 
 TEST_F(SolidsTest, accessors)
 {
     TestImpl(this).test_accessors();
 }
 
-//---------------------------------------------------------------------------//
-
 TEST_F(SolidsTest, trace)
 {
     TestImpl(this).test_trace();
 }
-
-//---------------------------------------------------------------------------//
 
 TEST_F(SolidsTest, reflected_vol)
 {
@@ -942,18 +723,21 @@ TEST_F(SolidsTest, DISABLED_imager)
 using TilecalPlugTest
     = GenericGeoParameterizedTest<GeantGeoTest, TilecalPlugGeoTest>;
 
-TEST_F(TilecalPlugTest, model)
+TEST_F(TilecalPlugTest, volumes)
 {
-    auto result = this->summarize_model();
-    GenericGeoModelInp ref;
-    ref.volume.labels = {"Tile_Absorber", "Tile_Plug1Module", "Tile_ITCModule"};
-    ref.volume.materials = {0, 1, 1};
-    ref.volume.daughters = {{}, {2}, {1}};
-    ref.volume_instance.labels
-        = {"Tile_ITCModule_PV", "Tile_Plug1Module", "Tile_Absorber"};
-    ref.volume_instance.volumes = {2, 1, 0};
-    ref.world = "Tile_ITCModule";
-    EXPECT_REF_EQ(ref, result);
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+        R"json({
+"children": [ [], [ 2 ], [ 1 ] ],
+"instance_to_volume": [ 2, 1, 0 ],
+"volume_instances": [ "Tile_ITCModule_PV", "Tile_Plug1Module", "Tile_Absorber" ],
+"volumes": [ "Tile_Absorber", "Tile_Plug1Module", "Tile_ITCModule" ],
+"world": 2
+})json"
+
+        ,
+        stream_to_string(*volumes));
 }
 
 TEST_F(TilecalPlugTest, trace)
@@ -965,23 +749,26 @@ TEST_F(TilecalPlugTest, trace)
 using TransformedBoxTest
     = GenericGeoParameterizedTest<GeantGeoTest, TransformedBoxGeoTest>;
 
+TEST_F(TransformedBoxTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+        R"json({
+"children": [ [], [], [ 3 ], [ 1, 2, 4 ] ],
+"instance_to_volume": [ 3, 0, 2, 1, 0 ],
+"volume_instances": [ "world_PV", "transrot", "default", "rot", "trans" ],
+"volumes": [ "simple", "tiny", "enclosing", "world" ],
+"world": 3
+})json"
+
+        ,
+        stream_to_string(*volumes));
+}
+
 TEST_F(TransformedBoxTest, accessors)
 {
     this->impl().test_accessors();
-}
-
-TEST_F(TransformedBoxTest, model)
-{
-    auto result = this->summarize_model();
-    GenericGeoModelInp ref;
-    ref.volume.labels = {"simple", "tiny", "enclosing", "world"};
-    ref.volume.materials = {0, 0, 0, 0};
-    ref.volume.daughters = {{}, {}, {3}, {1, 2, 4}};
-    ref.volume_instance.labels
-        = {"world_PV", "transrot", "default", "rot", "trans"};
-    ref.volume_instance.volumes = {3, 0, 2, 1, 0};
-    ref.world = "world";
-    EXPECT_REF_EQ(ref, result);
 }
 
 TEST_F(TransformedBoxTest, trace)
@@ -996,6 +783,23 @@ class TwoBoxesTest
 {
 };
 
+TEST_F(TwoBoxesTest, volumes)
+{
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+        R"json({
+"children": [ [], [ 1 ] ],
+"instance_to_volume": [ 1, 0 ],
+"volume_instances": [ "world_PV", "inner_PV" ],
+"volumes": [ "inner", "world" ],
+"world": 1
+})json"
+
+        ,
+        stream_to_string(*volumes));
+}
+
 TEST_F(TwoBoxesTest, accessors)
 {
     this->impl().test_accessors();
@@ -1004,19 +808,6 @@ TEST_F(TwoBoxesTest, accessors)
 TEST_F(TwoBoxesTest, detailed_tracking)
 {
     this->impl().test_detailed_tracking();
-}
-
-TEST_F(TwoBoxesTest, model)
-{
-    auto result = this->summarize_model();
-    GenericGeoModelInp ref;
-    ref.volume.labels = {"inner", "world"};
-    ref.volume.materials = {-1, -1};
-    ref.volume.daughters = {{}, {1}};
-    ref.volume_instance.labels = {"world_PV", "inner_PV"};
-    ref.volume_instance.volumes = {1, 0};
-    ref.world = "world";
-    EXPECT_REF_EQ(ref, result);
 }
 
 TEST_F(TwoBoxesTest, reentrant)
@@ -1042,61 +833,20 @@ TEST_F(TwoBoxesTest, trace)
 //---------------------------------------------------------------------------//
 using ZnenvTest = GenericGeoParameterizedTest<GeantGeoTest, ZnenvGeoTest>;
 
-TEST_F(ZnenvTest, model)
+TEST_F(ZnenvTest, volumes)
 {
-    auto result = this->summarize_model();
-    GenericGeoModelInp ref;
-    ref.volume.labels = {
-        "ZNF1",
-        "ZNG1",
-        "ZNF2",
-        "ZNG2",
-        "ZNF3",
-        "ZNG3",
-        "ZNF4",
-        "ZNG4",
-        "ZNST",
-        "ZNSL",
-        "ZN1",
-        "ZNTX",
-        "ZNEU",
-        "ZNENV",
-        "World",
-    };
-    ref.volume.materials = {0, 1, 0, 1, 0, 1, 0, 1, 2, 2, 2, 2, 2, 3, 3};
-    ref.volume.daughters = {
-        {},
-        {30},
-        {},
-        {32},
-        {},
-        {34},
-        {},
-        {36},
-        {29, 31, 33, 35},
-        {18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28},
-        {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17},
-        {5, 6},
-        {3, 4},
-        {2},
-        {1},
-    };
-    ref.volume_instance.labels = {
-        "World_PV",  "WorldBoxPV", "ZNEU_1",     "ZNTX_PV@0",  "ZNTX_PV@1",
-        "ZN1_PV@0",  "ZN1_PV@1",   "ZNSL_PV@0",  "ZNSL_PV@1",  "ZNSL_PV@2",
-        "ZNSL_PV@3", "ZNSL_PV@4",  "ZNSL_PV@5",  "ZNSL_PV@6",  "ZNSL_PV@7",
-        "ZNSL_PV@8", "ZNSL_PV@9",  "ZNSL_PV@10", "ZNST_PV@0",  "ZNST_PV@1",
-        "ZNST_PV@2", "ZNST_PV@3",  "ZNST_PV@4",  "ZNST_PV@5",  "ZNST_PV@6",
-        "ZNST_PV@7", "ZNST_PV@8",  "ZNST_PV@9",  "ZNST_PV@10", "ZNG1_1",
-        "ZNF1_1",    "ZNG2_1",     "ZNF2_1",     "ZNG3_1",     "ZNF3_1",
-        "ZNG4_1",    "ZNF4_1",
-    };
-    ref.volume_instance.volumes = {
-        14, 13, 12, 11, 11, 10, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 8,
-        8,  8,  8,  8,  8,  8,  8,  8, 8, 8, 1, 0, 3, 2, 5, 4, 7, 6,
-    };
-    ref.world = "World";
-    EXPECT_REF_EQ(ref, result);
+    auto volumes = this->geometry()->volumes();
+    ASSERT_TRUE(volumes);
+    EXPECT_JSON_EQ(
+        R"json({
+"children": [ [], [ 30 ], [], [ 32 ], [], [ 34 ], [], [ 36 ], [ 29, 31, 33, 35 ], [ 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28 ], [ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ], [ 5, 6 ], [ 3, 4 ], [ 2 ], [ 1 ] ], "instance_to_volume": [ 14, 13, 12, 11, 11, 10, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 1, 0, 3, 2, 5, 4, 7, 6 ],
+"volume_instances": [ "World_PV", "WorldBoxPV", "ZNEU_1", "ZNTX_PV@0", "ZNTX_PV@1", "ZN1_PV@0", "ZN1_PV@1", "ZNSL_PV@0", "ZNSL_PV@1", "ZNSL_PV@2", "ZNSL_PV@3", "ZNSL_PV@4", "ZNSL_PV@5", "ZNSL_PV@6", "ZNSL_PV@7", "ZNSL_PV@8", "ZNSL_PV@9", "ZNSL_PV@10", "ZNST_PV@0", "ZNST_PV@1", "ZNST_PV@2", "ZNST_PV@3", "ZNST_PV@4", "ZNST_PV@5", "ZNST_PV@6", "ZNST_PV@7", "ZNST_PV@8", "ZNST_PV@9", "ZNST_PV@10", "ZNG1_1", "ZNF1_1", "ZNG2_1", "ZNF2_1", "ZNG3_1", "ZNF3_1", "ZNG4_1", "ZNF4_1" ],
+"volumes": [ "ZNF1", "ZNG1", "ZNF2", "ZNG2", "ZNF3", "ZNG3", "ZNF4", "ZNG4", "ZNST", "ZNSL", "ZN1", "ZNTX", "ZNEU", "ZNENV", "World" ],
+"world": 14
+})json"
+
+        ,
+        stream_to_string(*volumes));
 }
 
 TEST_F(ZnenvTest, trace)


### PR DESCRIPTION
This removes one of the 'temporary hacks' for sharing volume metadata across the code and adds a method to export the volume metadata from celer-geo for debugging.