### PR TITLE
Define BIH node view to make data layout changes easier to test

### DIFF
--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -40,9 +40,6 @@ inline constexpr UnivLevelId orange_global_univ_level{0};
 //! Logic notation used for boolean expressions
 inline constexpr auto orange_tracking_logic{LogicNotation::infix};
 
-//! The maximum depth of the BIH tree (single leaf node is 1)
-inline constexpr size_type max_bih_depth = 18;
-
 //---------------------------------------------------------------------------//
 // PARAMS
 //---------------------------------------------------------------------------//
@@ -345,46 +342,6 @@ struct UniverseIndexerData
 
 //---------------------------------------------------------------------------//
 /*!
- * Persistent data used by all BIH trees.
- *
- * \todo move to detail/BihTreeData
- */
-template<Ownership W, MemSpace M>
-struct BIHTreeData
-{
-    template<class T>
-    using Items = Collection<T, W, M>;
-
-    // Low-level storage
-    Items<FastBBox> bboxes;
-    Items<LocalVolumeId> local_volume_ids;
-    Items<detail::BIHInternalNode> internal_nodes;
-    Items<detail::BIHLeafNode> leaf_nodes;
-
-    //! True if assigned
-    explicit CELER_FUNCTION operator bool() const
-    {
-        // Note that internal_nodes may be empty for single-node trees
-        return !bboxes.empty() && !local_volume_ids.empty()
-               && !leaf_nodes.empty();
-    }
-
-    //! Assign from another set of data
-    template<Ownership W2, MemSpace M2>
-    BIHTreeData& operator=(BIHTreeData<W2, M2> const& other)
-    {
-        bboxes = other.bboxes;
-        local_volume_ids = other.local_volume_ids;
-        internal_nodes = other.internal_nodes;
-        leaf_nodes = other.leaf_nodes;
-
-        CELER_ENSURE(static_cast<bool>(*this) == static_cast<bool>(other));
-        return *this;
-    }
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * Persistent data used by ORANGE implementation.
  *
  * Most data will be accessed through the individual units, which reference
@@ -424,7 +381,7 @@ struct OrangeParamsData
     ImplVolumeItems<VolumeInstanceId> volume_instance_ids;
 
     // BIH tree storage
-    BIHTreeData<W, M> bih_tree_data;
+    detail::BIHTreeData<W, M> bih_tree_data;
 
     // Low-level storage
     Items<LocalSurfaceId> local_surface_ids;

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -390,7 +390,6 @@ struct OrangeParamsData
     Items<vol_level_uint> vl_uints;
     Items<logic_int> logic_ints;
     Items<real_type> reals;
-    Items<FastReal3> fast_real3s;
     Items<SurfaceType> surface_types;
     Items<ConnectivityRecord> connectivity_records;
     Items<LocalVolumeRecord> volume_records;

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -358,13 +358,13 @@ struct BIHTreeData
     // Low-level storage
     Items<FastBBox> bboxes;
     Items<LocalVolumeId> local_volume_ids;
-    Items<detail::BIHInnerNode> inner_nodes;
+    Items<detail::BIHInternalNode> internal_nodes;
     Items<detail::BIHLeafNode> leaf_nodes;
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
     {
-        // Note that inner_nodes may be empty for single-node trees
+        // Note that internal_nodes may be empty for single-node trees
         return !bboxes.empty() && !local_volume_ids.empty()
                && !leaf_nodes.empty();
     }
@@ -375,7 +375,7 @@ struct BIHTreeData
     {
         bboxes = other.bboxes;
         local_volume_ids = other.local_volume_ids;
-        inner_nodes = other.inner_nodes;
+        internal_nodes = other.internal_nodes;
         leaf_nodes = other.leaf_nodes;
 
         CELER_ENSURE(static_cast<bool>(*this) == static_cast<bool>(other));

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -39,9 +39,9 @@ nlohmann::json make_bih_structure_json(detail::BIHTreeRecord const& tree,
     detail::BIHView view{tree, storage};
 
     // Handle internal nodes
-    for (auto i : range(tree.internal_nodes.size()))
+    for (auto i : range(BIHNodeId{view.num_internal_nodes()}))
     {
-        auto const& inner = view.inner_node(BIHNodeId{i});
+        auto const& inner = view.inner_node(i);
         using Side = detail::BIHInternalNode::Side;
 
         out.push_back(json::array(
@@ -54,14 +54,13 @@ nlohmann::json make_bih_structure_json(detail::BIHTreeRecord const& tree,
     }
 
     // Handle leaf nodes
-    size_type offset = tree.internal_nodes.size();
-    for (auto i : range(tree.leaf_nodes.size()))
+    for (auto i : range(BIHNodeId{view.num_internal_nodes()},
+                        BIHNodeId{view.num_nodes()}))
     {
         auto vols = json::array();
-        for (auto id :
-             remove_ldg_wrapper(view.leaf_vol_ids(BIHNodeId{offset + i})))
+        for (LocalVolumeId id : remove_ldg_wrapper(view.leaf_vol_ids(i)))
         {
-            vols.push_back(id.unchecked_get());
+            vols.push_back(*id);
         }
         out.push_back(json::array({"l", std::move(vols)}));
     }

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -42,15 +42,15 @@ nlohmann::json make_bih_structure_json(detail::BIHTreeRecord const& tree,
     for (auto i : range(tree.inner_nodes.size()))
     {
         auto const& inner = view.inner_node(BIHNodeId{i});
-        auto const& left = inner.edges[detail::BIHInnerNode::Side::left];
-        auto const& right = inner.edges[detail::BIHInnerNode::Side::right];
+        using Side = detail::BIHInnerNode::Side;
 
-        out.push_back(json::array({"i",
-                                   std::string(1, to_char(inner.axis)),
-                                   json::array({left.child.unchecked_get(),
-                                                right.child.unchecked_get()}),
-                                   json::array({left.bounding_plane_pos,
-                                                right.bounding_plane_pos})}));
+        out.push_back(json::array(
+            {"i",
+             std::string(1, to_char(inner.axis())),
+             json::array({inner.child(Side::left).unchecked_get(),
+                          inner.child(Side::right).unchecked_get()}),
+             json::array({inner.bounding_plane_pos(Side::left),
+                          inner.bounding_plane_pos(Side::right)})}));
     }
 
     // Handle leaf nodes

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -29,8 +29,9 @@ namespace
 /*!
  * Create JSON representation of the structure of a BIH tree.
  */
-nlohmann::json make_bih_structure_json(detail::BIHTreeRecord const& tree,
-                                       NativeCRef<BIHTreeData> const& storage)
+nlohmann::json
+make_bih_structure_json(detail::BIHTreeRecord const& tree,
+                        NativeCRef<detail::BIHTreeData> const& storage)
 {
     using json = nlohmann::json;
 
@@ -200,7 +201,7 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
  * Print a BIH structure to a JSON string for debugging.
  */
 std::string dump_bih_structure(detail::BIHTreeRecord const& tree,
-                               NativeCRef<BIHTreeData> const& data)
+                               NativeCRef<detail::BIHTreeData> const& data)
 {
     return make_bih_structure_json(tree, data).dump();
 }

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -57,9 +57,9 @@ nlohmann::json make_bih_structure_json(detail::BIHTreeRecord const& tree,
     size_type offset = tree.inner_nodes.size();
     for (auto i : range(tree.leaf_nodes.size()))
     {
-        auto const& leaf = view.leaf_node(BIHNodeId{offset + i});
         auto vols = json::array();
-        for (auto id : remove_ldg_wrapper(view.leaf_vol_ids(leaf)))
+        for (auto id :
+             remove_ldg_wrapper(view.leaf_vol_ids(BIHNodeId{offset + i})))
         {
             vols.push_back(id.unchecked_get());
         }

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -38,11 +38,11 @@ nlohmann::json make_bih_structure_json(detail::BIHTreeRecord const& tree,
 
     detail::BIHView view{tree, storage};
 
-    // Handle inner nodes
-    for (auto i : range(tree.inner_nodes.size()))
+    // Handle internal nodes
+    for (auto i : range(tree.internal_nodes.size()))
     {
         auto const& inner = view.inner_node(BIHNodeId{i});
-        using Side = detail::BIHInnerNode::Side;
+        using Side = detail::BIHInternalNode::Side;
 
         out.push_back(json::array(
             {"i",
@@ -54,7 +54,7 @@ nlohmann::json make_bih_structure_json(detail::BIHTreeRecord const& tree,
     }
 
     // Handle leaf nodes
-    size_type offset = tree.inner_nodes.size();
+    size_type offset = tree.internal_nodes.size();
     for (auto i : range(tree.leaf_nodes.size()))
     {
         auto vols = json::array();
@@ -141,7 +141,7 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
     obj["sizes"]["bih"] = [&bihdata = data.bih_tree_data] {
         return json::object({
             OPO_SIZE_PAIR(bihdata, bboxes),
-            OPO_SIZE_PAIR(bihdata, inner_nodes),
+            OPO_SIZE_PAIR(bihdata, internal_nodes),
             OPO_SIZE_PAIR(bihdata, leaf_nodes),
             OPO_SIZE_PAIR(bihdata, local_volume_ids),
         });

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -121,7 +121,6 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
     obj["sizes"] = {
         OPO_SIZE_PAIR(data, connectivity_records),
         OPO_SIZE_PAIR(data, daughters),
-        OPO_SIZE_PAIR(data, fast_real3s),
         OPO_SIZE_PAIR(data, local_surface_ids),
         OPO_SIZE_PAIR(data, local_volume_ids),
         OPO_SIZE_PAIR(data, logic_ints),

--- a/src/orange/OrangeParamsOutput.hh
+++ b/src/orange/OrangeParamsOutput.hh
@@ -14,12 +14,12 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 class OrangeParams;
-template<Ownership W, MemSpace M>
-struct BIHTreeData;
 namespace detail
 {
+template<Ownership W, MemSpace M>
+struct BIHTreeData;
 struct BIHTreeRecord;
-}
+}  // namespace detail
 
 //---------------------------------------------------------------------------//
 /*!
@@ -58,7 +58,7 @@ class OrangeParamsOutput final : public OutputInterface
 //---------------------------------------------------------------------------//
 // Print a BIH structure to a JSON string for debugging
 std::string dump_bih_structure(detail::BIHTreeRecord const& tree,
-                               NativeCRef<BIHTreeData> const& data);
+                               NativeCRef<detail::BIHTreeData> const& data);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -36,7 +36,7 @@ namespace detail
 BIHBuilder::BIHBuilder(Storage* storage, Input inp)
     : bboxes_{&storage->bboxes}
     , local_volume_ids_{&storage->local_volume_ids}
-    , inner_nodes_{&storage->inner_nodes}
+    , internal_nodes_{&storage->internal_nodes}
     , leaf_nodes_{&storage->leaf_nodes}
     , inp_{inp}
 {
@@ -126,10 +126,11 @@ BIHBuilder::operator()(VecBBox&& bboxes,
         // Construct the tree recursively
         VecNodes nodes;
         this->construct_tree(indices, &nodes, 0, depth);
-        auto [inner_nodes, leaf_nodes] = this->arrange_nodes(std::move(nodes));
+        auto [internal_nodes, leaf_nodes]
+            = this->arrange_nodes(std::move(nodes));
 
-        tree.inner_nodes
-            = inner_nodes_.insert_back(inner_nodes.begin(), inner_nodes.end());
+        tree.internal_nodes = internal_nodes_.insert_back(
+            internal_nodes.begin(), internal_nodes.end());
 
         tree.leaf_nodes
             = leaf_nodes_.insert_back(leaf_nodes.begin(), leaf_nodes.end());
@@ -174,7 +175,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
 {
     CELER_EXPECT(current_depth < inp_.depth_limit);
 
-    using Side = BIHInnerNode::Side;
+    using Side = BIHInternalNode::Side;
 
     ++current_depth;
     auto current_index = nodes->size();
@@ -206,8 +207,8 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
 
     if (auto p = partition(indices))
     {
-        // Create inner node
-        BIHInnerNode node;
+        // Create internal node
+        BIHInternalNode node;
         node.axis = p.axis;
 
         // Recursively construct the left and right branches
@@ -233,7 +234,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
 
 //---------------------------------------------------------------------------//
 /*!
- * Separate inner nodes from leaf nodes and renumber accordingly.
+ * Separate internal nodes from leaf nodes and renumber accordingly.
  *
  * \param[in] nodes  The interspersed inner and leaf nodes
  *
@@ -241,7 +242,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
  */
 BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
 {
-    VecInnerNodes inner_nodes;
+    VecInnerNodes internal_nodes;
     VecLeafNodes leaf_nodes;
 
     std::vector<bool> is_leaf;
@@ -250,23 +251,24 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
     is_leaf.reserve(nodes.size());
     new_indices.reserve(nodes.size());
 
-    auto insert_node = Overload{[&](BIHInnerNode const& node) {
-                                    new_indices.push_back(inner_nodes.size());
-                                    inner_nodes.push_back(node);
-                                    is_leaf.push_back(false);
-                                },
-                                [&](BIHLeafNode const& node) {
-                                    new_indices.push_back(leaf_nodes.size());
-                                    leaf_nodes.push_back(node);
-                                    is_leaf.push_back(true);
-                                }};
+    auto insert_node
+        = Overload{[&](BIHInternalNode const& node) {
+                       new_indices.push_back(internal_nodes.size());
+                       internal_nodes.push_back(node);
+                       is_leaf.push_back(false);
+                   },
+                   [&](BIHLeafNode const& node) {
+                       new_indices.push_back(leaf_nodes.size());
+                       leaf_nodes.push_back(node);
+                       is_leaf.push_back(true);
+                   }};
     for (auto const& node : nodes)
     {
         std::visit(insert_node, node);
     }
 
     // Transform "leaf ID" to "node ID"
-    auto offset = inner_nodes.size();
+    auto offset = internal_nodes.size();
     for (auto i : range(nodes.size()))
     {
         if (is_leaf[i])
@@ -281,7 +283,7 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
         return id_cast<BIHNodeId>(new_indices[old.unchecked_get()]);
     };
 
-    for (auto& inner_node : inner_nodes)
+    for (auto& inner_node : internal_nodes)
     {
         for (auto& edge : inner_node.edges)
         {
@@ -289,7 +291,7 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
         }
     }
 
-    return {std::move(inner_nodes), std::move(leaf_nodes)};
+    return {std::move(internal_nodes), std::move(leaf_nodes)};
 }
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/orange/detail/BIHBuilder.cc
+++ b/src/orange/detail/BIHBuilder.cc
@@ -13,9 +13,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/VariantUtils.hh"
 #include "corecel/data/Collection.hh"
-#include "corecel/math/Algorithms.hh"
-#include "geocel/BoundingBox.hh"
-#include "orange/OrangeData.hh"
+#include "orange/detail/BIHData.hh"
 
 #include "BIHPartitioner.hh"
 #include "../BoundingBoxUtils.hh"

--- a/src/orange/detail/BIHBuilder.hh
+++ b/src/orange/detail/BIHBuilder.hh
@@ -18,7 +18,6 @@
 #include "orange/OrangeTypes.hh"
 #include "orange/detail/BIHData.hh"
 
-#include "../OrangeData.hh"
 #include "../inp/Bih.hh"
 
 namespace celeritas

--- a/src/orange/detail/BIHBuilder.hh
+++ b/src/orange/detail/BIHBuilder.hh
@@ -77,8 +77,8 @@ class BIHBuilder
 
     using Real3 = Array<fast_real_type, 3>;
     using VecIndices = std::vector<LocalVolumeId>;
-    using VecNodes = std::vector<std::variant<BIHInnerNode, BIHLeafNode>>;
-    using VecInnerNodes = std::vector<BIHInnerNode>;
+    using VecNodes = std::vector<std::variant<BIHInternalNode, BIHLeafNode>>;
+    using VecInnerNodes = std::vector<BIHInternalNode>;
     using VecLeafNodes = std::vector<BIHLeafNode>;
     using ArrangedNodes = std::pair<VecInnerNodes, VecLeafNodes>;
 
@@ -93,7 +93,7 @@ class BIHBuilder
 
     CollectionBuilder<FastBBox> bboxes_;
     CollectionBuilder<LocalVolumeId> local_volume_ids_;
-    CollectionBuilder<BIHInnerNode> inner_nodes_;
+    CollectionBuilder<BIHInternalNode> internal_nodes_;
     CollectionBuilder<BIHLeafNode> leaf_nodes_;
 
     Input inp_;

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -10,7 +10,6 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/EnumArray.hh"
 #include "corecel/data/Collection.hh"
-#include "corecel/grid/GridTypes.hh"
 #include "geocel/BoundingBox.hh"  // IWYU pragma: keep
 
 #include "../OrangeTypes.hh"

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -19,6 +19,10 @@ namespace celeritas
 {
 namespace detail
 {
+//---------------------------------------------------------------------------//!
+// The maximum depth of the BIH tree (single leaf node is 1)
+inline constexpr size_type max_bih_depth = 18;
+
 //---------------------------------------------------------------------------//
 /*!
  * Data for a single internal node in a Bounding Interval Hierarchy.
@@ -127,6 +131,46 @@ struct BIHTreeRecord
             // b) only infinite volumes.
             return !bboxes.empty() && leaf_nodes.size() == 1;
         }
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Persistent data used by all BIH trees.
+ *
+ * \todo move to detail/BihTreeData
+ */
+template<Ownership W, MemSpace M>
+struct BIHTreeData
+{
+    template<class T>
+    using Items = Collection<T, W, M>;
+
+    // Low-level storage
+    Items<FastBBox> bboxes;
+    Items<LocalVolumeId> local_volume_ids;
+    Items<detail::BIHInternalNode> internal_nodes;
+    Items<detail::BIHLeafNode> leaf_nodes;
+
+    //! True if assigned
+    explicit CELER_FUNCTION operator bool() const
+    {
+        // Note that internal_nodes may be empty for single-node trees
+        return !bboxes.empty() && !local_volume_ids.empty()
+               && !leaf_nodes.empty();
+    }
+
+    //! Assign from another set of data
+    template<Ownership W2, MemSpace M2>
+    BIHTreeData& operator=(BIHTreeData<W2, M2> const& other)
+    {
+        bboxes = other.bboxes;
+        local_volume_ids = other.local_volume_ids;
+        internal_nodes = other.internal_nodes;
+        leaf_nodes = other.leaf_nodes;
+
+        CELER_ENSURE(static_cast<bool>(*this) == static_cast<bool>(other));
+        return *this;
     }
 };
 

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -21,7 +21,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Data for a single inner node in a Bounding Interval Hierarchy.
+ * Data for a single internal node in a Bounding Interval Hierarchy.
  *
  * As a convention, a node's LEFT edge corresponds to the half space that is
  * less than the partition value. In other words, the LEFT bounding plane
@@ -31,7 +31,7 @@ namespace detail
  * the LEFT bounding plane position could be either left or right of the RIGHT
  * bounding plane position.
  */
-struct BIHInnerNode
+struct BIHInternalNode
 {
     struct Edge
     {
@@ -98,8 +98,8 @@ struct BIHTreeRecord
     //! All bounding boxes managed by the BIH
     ItemMap<LocalVolumeId, FastBBoxId> bboxes;
 
-    //! Inner nodes, the first being the root
-    ItemRange<BIHInnerNode> inner_nodes;
+    //! Internal (branch) nodes, the first being the root
+    ItemRange<BIHInternalNode> internal_nodes;
 
     //! Leaf nodes
     ItemRange<BIHLeafNode> leaf_nodes;
@@ -114,7 +114,7 @@ struct BIHTreeRecord
 
     explicit CELER_FUNCTION operator bool() const
     {
-        if (!inner_nodes.empty())
+        if (!internal_nodes.empty())
         {
             return !bboxes.empty() && !leaf_nodes.empty();
         }

--- a/src/orange/detail/BIHData.hh
+++ b/src/orange/detail/BIHData.hh
@@ -137,8 +137,6 @@ struct BIHTreeRecord
 //---------------------------------------------------------------------------//
 /*!
  * Persistent data used by all BIH trees.
- *
- * \todo move to detail/BihTreeData
  */
 template<Ownership W, MemSpace M>
 struct BIHTreeData

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -111,13 +111,13 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
         }
         else
         {
-            auto const& edges = view_.inner_node(stack.top()).edges;
+            auto const& node = view_.inner_node(stack.top());
             stack.pop();
             for (auto s : {Side::right, Side::left})
             {
-                if (is_inside(edges[s].bbox, pos))
+                if (is_inside(node.bbox(s), pos))
                 {
-                    stack.push(edges[s].child);
+                    stack.push(node.child(s));
                 }
             }
         }

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -89,7 +89,7 @@ template<class F>
 CELER_FUNCTION LocalVolumeId
 BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
 {
-    using Side = BIHInnerNode::Side;
+    using Side = BIHInternalNode::Side;
 
     // Stack of deferred nodes
     using StackT = IdStack<BIHNodeId, max_bih_depth - 1>;
@@ -99,7 +99,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
 
     while (!stack.empty())
     {
-        if (!view_.is_inner(stack.top()))
+        if (!view_.is_internal(stack.top()))
         {
             auto id = this->visit_leaf(stack.top(), pos, is_inside_vol);
             stack.pop();

--- a/src/orange/detail/BIHEnclosingVolFinder.hh
+++ b/src/orange/detail/BIHEnclosingVolFinder.hh
@@ -55,7 +55,7 @@ class BIHEnclosingVolFinder
 
     // Determine if any leaf node volumes contain the point
     template<class F>
-    inline CELER_FUNCTION LocalVolumeId visit_leaf(BIHLeafNode const& leaf_node,
+    inline CELER_FUNCTION LocalVolumeId visit_leaf(BIHNodeId leaf_id,
                                                    Real3 const& pos,
                                                    F&& is_inside) const;
 
@@ -101,8 +101,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
     {
         if (!view_.is_inner(stack.top()))
         {
-            auto id = this->visit_leaf(
-                view_.leaf_node(stack.top()), pos, is_inside_vol);
+            auto id = this->visit_leaf(stack.top(), pos, is_inside_vol);
             stack.pop();
 
             if (id)
@@ -135,9 +134,9 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
  */
 template<class F>
 CELER_FUNCTION LocalVolumeId BIHEnclosingVolFinder::visit_leaf(
-    BIHLeafNode const& leaf_node, Real3 const& pos, F&& is_inside) const
+    BIHNodeId leaf_id, Real3 const& pos, F&& is_inside) const
 {
-    for (auto id : view_.leaf_vol_ids(leaf_node))
+    for (auto id : view_.leaf_vol_ids(leaf_id))
     {
         if (this->visit_bbox(id, pos) && is_inside(id))
         {

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -122,7 +122,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
                                      real_type max_search_dist) const
     -> Intersection
 {
-    using Side = BIHInnerNode::Side;
+    using Side = BIHInternalNode::Side;
 
     Intersection intersection{OnLocalSurface{}, max_search_dist};
 
@@ -135,7 +135,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
 
     while (!stack.empty())
     {
-        if (!view_.is_inner(stack.top()))
+        if (!view_.is_internal(stack.top()))
         {
             intersection
                 = this->visit_leaf(stack.top(), ray, intersection, visit_vol);

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -78,7 +78,7 @@ class BIHIntersectingVolFinder
     // Calculate the current min intersection, which may/may not be on this
     // leaf
     template<class F>
-    inline CELER_FUNCTION Intersection visit_leaf(BIHLeafNode const& leaf_node,
+    inline CELER_FUNCTION Intersection visit_leaf(BIHNodeId leaf_node_id,
                                                   Ray ray,
                                                   Intersection intersection,
                                                   F&& visit_vol) const;
@@ -137,8 +137,8 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
     {
         if (!view_.is_inner(stack.top()))
         {
-            intersection = this->visit_leaf(
-                view_.leaf_node(stack.top()), ray, intersection, visit_vol);
+            intersection
+                = this->visit_leaf(stack.top(), ray, intersection, visit_vol);
             stack.pop();
             continue;
         }
@@ -206,12 +206,12 @@ bool BIHIntersectingVolFinder::visit_bbox(FastBBox const& bbox,
  */
 template<class F>
 CELER_FUNCTION auto
-BIHIntersectingVolFinder::visit_leaf(BIHLeafNode const& leaf_node,
+BIHIntersectingVolFinder::visit_leaf(BIHNodeId leaf_node_id,
                                      BIHIntersectingVolFinder::Ray ray,
                                      Intersection min_intersection,
                                      F&& visit_vol) const -> Intersection
 {
-    for (auto id : view_.leaf_vol_ids(leaf_node))
+    for (auto id : view_.leaf_vol_ids(leaf_node_id))
     {
         auto const& bbox = view_.bbox(id);
 

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -143,7 +143,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
             continue;
         }
 
-        auto const& node = view_.inner_node(stack.top());
+        auto node = view_.inner_node(stack.top());
         stack.pop();
         int ax = to_int(node.axis());
 

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -147,41 +147,42 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
         stack.pop();
         int ax = to_int(node.axis());
 
-        // Guess the better edge to traverse first
-        Side first_side = Side::left;
-        Side second_side = Side::right;
+        // Guess the better edge to traverse first: unrolled with loads for
+        // GPU performance
+        fast_real_type left_pos = node.bounding_plane_pos(Side::left);
+        FastBBox first_bbox = node.bbox(Side::left);
+        BIHNodeId first_child = node.child(Side::left);
+        fast_real_type right_pos = node.bounding_plane_pos(Side::right);
+        FastBBox second_bbox = node.bbox(Side::right);
+        BIHNodeId second_child = node.child(Side::right);
 
-        bool skip_first
-            = (ray.dir[ax] >= 0)
-              && (ray.pos[ax] > node.bounding_plane_pos(Side::left));
-        bool skip_second
-            = (ray.dir[ax] <= 0)
-              && (ray.pos[ax] < node.bounding_plane_pos(Side::right));
+        bool skip_first = (ray.dir[ax] >= 0) && (ray.pos[ax] > left_pos);
+        bool skip_second = (ray.dir[ax] <= 0) && (ray.pos[ax] < right_pos);
 
-        if (ray.pos[ax] > node.bounding_plane_pos(Side::right))
+        if (ray.pos[ax] > right_pos)
         {
-            trivial_swap(first_side, second_side);
+            trivial_swap(first_bbox, second_bbox);
+            trivial_swap(first_child, second_child);
             trivial_swap(skip_first, skip_second);
         }
 
         // Determine if the first and second edges are hits, short circuiting
         // with skip_* before testing bounding boxes
-        bool hit_first = !skip_first
-                         && this->visit_bbox(
-                             node.bbox(first_side), ray, intersection.distance);
-        bool hit_second = !skip_second
-                          && this->visit_bbox(node.bbox(second_side),
-                                              ray,
-                                              intersection.distance);
+        bool hit_first
+            = !skip_first
+              && this->visit_bbox(first_bbox, ray, intersection.distance);
+        bool hit_second
+            = !skip_second
+              && this->visit_bbox(second_bbox, ray, intersection.distance);
 
         // Choose the next node on the basis of which edges are hits
         if (hit_second)
         {
-            stack.push(node.child(second_side));
+            stack.push(second_child);
         }
         if (hit_first)
         {
-            stack.push(node.child(first_side));
+            stack.push(first_child);
         }
     }
 

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -143,7 +143,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
             continue;
         }
 
-        auto node = view_.inner_node(stack.top());
+        auto const& node = view_.inner_node(stack.top());
         stack.pop();
         int ax = to_int(node.axis());
 

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -145,42 +145,43 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
 
         auto const& node = view_.inner_node(stack.top());
         stack.pop();
-        int ax = to_int(node.axis);
+        int ax = to_int(node.axis());
 
         // Guess the better edge to traverse first
-        auto first_edge = node.edges[Side::left];
-        auto second_edge = node.edges[Side::right];
+        Side first_side = Side::left;
+        Side second_side = Side::right;
 
         bool skip_first
             = (ray.dir[ax] >= 0)
-              && (ray.pos[ax] > node.edges[Side::left].bounding_plane_pos);
+              && (ray.pos[ax] > node.bounding_plane_pos(Side::left));
         bool skip_second
             = (ray.dir[ax] <= 0)
-              && (ray.pos[ax] < node.edges[Side::right].bounding_plane_pos);
+              && (ray.pos[ax] < node.bounding_plane_pos(Side::right));
 
-        if (ray.pos[ax] > node.edges[Side::right].bounding_plane_pos)
+        if (ray.pos[ax] > node.bounding_plane_pos(Side::right))
         {
-            trivial_swap(first_edge, second_edge);
+            trivial_swap(first_side, second_side);
             trivial_swap(skip_first, skip_second);
         }
 
         // Determine if the first and second edges are hits, short circuiting
         // with skip_* before testing bounding boxes
-        bool hit_first
-            = !skip_first
-              && this->visit_bbox(first_edge.bbox, ray, intersection.distance);
+        bool hit_first = !skip_first
+                         && this->visit_bbox(
+                             node.bbox(first_side), ray, intersection.distance);
         bool hit_second = !skip_second
-                          && this->visit_bbox(
-                              second_edge.bbox, ray, intersection.distance);
+                          && this->visit_bbox(node.bbox(second_side),
+                                              ray,
+                                              intersection.distance);
 
         // Choose the next node on the basis of which edges are hits
         if (hit_second)
         {
-            stack.push(second_edge.child);
+            stack.push(node.child(second_side));
         }
         if (hit_first)
         {
-            stack.push(first_edge.child);
+            stack.push(node.child(first_side));
         }
     }
 

--- a/src/orange/detail/BIHIntersectingVolFinder.hh
+++ b/src/orange/detail/BIHIntersectingVolFinder.hh
@@ -12,7 +12,6 @@
 
 #include "BIHView.hh"
 #include "../BoundingBoxUtils.hh"
-#include "../OrangeData.hh"
 #include "../univ/detail/Types.hh"
 
 namespace celeritas

--- a/src/orange/detail/BIHPartitioner.hh
+++ b/src/orange/detail/BIHPartitioner.hh
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "corecel/cont/EnumArray.hh"
-#include "corecel/grid/GridTypes.hh"
 #include "geocel/BoundingBox.hh"  // IWYU pragma: keep
 
 #include "BIHData.hh"

--- a/src/orange/detail/BIHPartitioner.hh
+++ b/src/orange/detail/BIHPartitioner.hh
@@ -38,7 +38,7 @@ class BIHPartitioner
     using VecBBox = std::vector<FastBBox>;
     using VecReal3 = std::vector<Real3>;
     using VecIndices = std::vector<LocalVolumeId>;
-    using Side = BIHInnerNode::Side;
+    using Side = BIHInternalNode::Side;
 
     //! Output struct specifying the indices and bboxes of the left and right
     //! sides of the partition

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -43,7 +43,7 @@ class BIHInternalNodeView
     inline CELER_FUNCTION fast_real_type bounding_plane_pos(Side side) const;
 
   private:
-    BIHInternalNode node_;
+    BIHInternalNode const& node_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "orange/OrangeTypes.hh"
+
 #include "../OrangeData.hh"
 
 namespace celeritas
@@ -37,15 +39,11 @@ class BIHView
     // Get an inner node for a given BIHNodeId
     inline CELER_FUNCTION BIHInnerNode const& inner_node(BIHNodeId id) const;
 
-    // Get a leaf node for a given BIHNodeId
-    inline CELER_FUNCTION BIHLeafNode const& leaf_node(BIHNodeId id) const;
-
     // Get the bbox for a given vol_id.
     inline CELER_FUNCTION FastBBox const& bbox(LocalVolumeId vol_id) const;
 
     // Get the vol_ids on a given leaf node
-    inline CELER_FUNCTION SpanLocalVol
-    leaf_vol_ids(BIHLeafNode const& leaf) const;
+    inline CELER_FUNCTION SpanLocalVol leaf_vol_ids(BIHNodeId) const;
 
     // Get the inf_vol_ids
     inline CELER_FUNCTION SpanLocalVol inf_vol_ids() const;
@@ -92,18 +90,6 @@ BIHInnerNode const& BIHView::inner_node(BIHNodeId id) const
 
 //---------------------------------------------------------------------------//
 /*!
- *  Get a leaf node for a given BIHNodeId.
- */
-CELER_FUNCTION
-BIHLeafNode const& BIHView::leaf_node(BIHNodeId id) const
-{
-    CELER_EXPECT(!this->is_inner(id));
-    return storage_.leaf_nodes[tree_.leaf_nodes[id.unchecked_get()
-                                                - tree_.inner_nodes.size()]];
-}
-
-//---------------------------------------------------------------------------//
-/*!
  *  Get the bbox for a given vol_id.
  */
 CELER_FUNCTION FastBBox const& BIHView::bbox(LocalVolumeId vol_id) const
@@ -116,10 +102,13 @@ CELER_FUNCTION FastBBox const& BIHView::bbox(LocalVolumeId vol_id) const
 /*!
  *  Get the vol_ids on a given leaf node.
  */
-CELER_FUNCTION auto BIHView::leaf_vol_ids(BIHLeafNode const& leaf) const
-    -> SpanLocalVol
+CELER_FUNCTION auto BIHView::leaf_vol_ids(BIHNodeId id) const -> SpanLocalVol
 {
-    return storage_.local_volume_ids[leaf.vol_ids];
+    CELER_EXPECT(!this->is_inner(id));
+    ItemId<BIHLeafNode> leaf_id
+        = tree_.leaf_nodes[id.unchecked_get() - tree_.inner_nodes.size()];
+    auto const& leaf_node = storage_.leaf_nodes[leaf_id];
+    return storage_.local_volume_ids[leaf_node.vol_ids];
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -8,7 +8,7 @@
 
 #include "orange/OrangeTypes.hh"
 
-#include "../OrangeData.hh"
+#include "BIHData.hh"
 
 namespace celeritas
 {

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -223,10 +223,12 @@ CELER_FUNCTION FastBBox const& BIHView::bbox(LocalVolumeId vol_id) const
  */
 CELER_FUNCTION auto BIHView::leaf_vol_ids(BIHNodeId id) const -> SpanLocalVol
 {
-    CELER_EXPECT(!this->is_internal(id));
+    CELER_EXPECT(id >= BIHNodeId{this->num_internal_nodes()}
+                 && id < this->num_nodes());
     ItemId<BIHLeafNode> leaf_id
-        = tree_.leaf_nodes[id.unchecked_get() - tree_.internal_nodes.size()];
-    auto const& leaf_node = storage_.leaf_nodes[leaf_id];
+        = tree_.leaf_nodes[*id - this->num_internal_nodes()];
+    CELER_ASSERT(leaf_id < storage_.leaf_nodes.size());
+    auto&& leaf_node = storage_.leaf_nodes[leaf_id];
     return storage_.local_volume_ids[leaf_node.vol_ids];
 }
 

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -155,7 +155,7 @@ CELER_FUNCTION
 BIHView::BIHView(BIHTreeRecord const& tree, BIHView::Storage const& storage)
     : tree_(tree), storage_(storage)
 {
-    CELER_EXPECT(tree);
+    CELER_EXPECT(tree_);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -16,18 +16,19 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Access data for a BIH inner node.
+ * Access data for a BIH internal node.
  */
 class BIHInternalNodeView
 {
   public:
     //!@{
     //! \name Type aliases
-    using Side = BIHInnerNode::Side;
+    using Side = BIHInternalNode::Side;
     //!@}
 
-    // Construct from inner node data
-    inline CELER_FUNCTION explicit BIHInternalNodeView(BIHInnerNode const& node);
+    // Construct from internal node data
+    inline CELER_FUNCTION explicit BIHInternalNodeView(
+        BIHInternalNode const& node);
 
     // Get partition axis
     inline CELER_FUNCTION Axis axis() const;
@@ -42,7 +43,7 @@ class BIHInternalNodeView
     inline CELER_FUNCTION fast_real_type bounding_plane_pos(Side side) const;
 
   private:
-    BIHInnerNode const& node_;
+    BIHInternalNode const& node_;
 };
 
 //---------------------------------------------------------------------------//
@@ -65,9 +66,9 @@ class BIHView
     BIHView(BIHTreeRecord const& tree, Storage const& storage);
 
     // Determine if a node is inner, i.e., not a leaf
-    inline CELER_FUNCTION bool is_inner(BIHNodeId id) const;
+    inline CELER_FUNCTION bool is_internal(BIHNodeId id) const;
 
-    // Get an inner node for a given BIHNodeId
+    // Get an internal node for a given BIHNodeId
     inline CELER_FUNCTION BIHInternalNodeView inner_node(BIHNodeId id) const;
 
     // Get the bbox for a given vol_id.
@@ -89,10 +90,10 @@ class BIHView
 // INLINE DEFINITIONS
 //---------------------------------------------------------------------------//
 /*!
- * Construct from an inner node.
+ * Construct from an internal node.
  */
 CELER_FUNCTION
-BIHInternalNodeView::BIHInternalNodeView(BIHInnerNode const& node)
+BIHInternalNodeView::BIHInternalNodeView(BIHInternalNode const& node)
     : node_(node)
 {
     CELER_EXPECT(node_);
@@ -153,21 +154,21 @@ BIHView::BIHView(BIHTreeRecord const& tree, BIHView::Storage const& storage)
  *  Determine if a node is inner, i.e., not a leaf.
  */
 CELER_FUNCTION
-bool BIHView::is_inner(BIHNodeId id) const
+bool BIHView::is_internal(BIHNodeId id) const
 {
-    return id.unchecked_get() < tree_.inner_nodes.size();
+    return id.unchecked_get() < tree_.internal_nodes.size();
 }
 
 //---------------------------------------------------------------------------//
 /*!
- *  Get an inner node for a given BIHNodeId.
+ *  Get an internal node for a given BIHNodeId.
  */
 CELER_FUNCTION
 BIHInternalNodeView BIHView::inner_node(BIHNodeId id) const
 {
-    CELER_EXPECT(this->is_inner(id));
+    CELER_EXPECT(this->is_internal(id));
     return BIHInternalNodeView{
-        storage_.inner_nodes[tree_.inner_nodes[id.unchecked_get()]]};
+        storage_.internal_nodes[tree_.internal_nodes[id.unchecked_get()]]};
 }
 
 //---------------------------------------------------------------------------//
@@ -186,9 +187,9 @@ CELER_FUNCTION FastBBox const& BIHView::bbox(LocalVolumeId vol_id) const
  */
 CELER_FUNCTION auto BIHView::leaf_vol_ids(BIHNodeId id) const -> SpanLocalVol
 {
-    CELER_EXPECT(!this->is_inner(id));
+    CELER_EXPECT(!this->is_internal(id));
     ItemId<BIHLeafNode> leaf_id
-        = tree_.leaf_nodes[id.unchecked_get() - tree_.inner_nodes.size()];
+        = tree_.leaf_nodes[id.unchecked_get() - tree_.internal_nodes.size()];
     auto const& leaf_node = storage_.leaf_nodes[leaf_id];
     return storage_.local_volume_ids[leaf_node.vol_ids];
 }

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -71,6 +71,15 @@ class BIHView
     // Get an internal node for a given BIHNodeId
     inline CELER_FUNCTION BIHInternalNodeView inner_node(BIHNodeId id) const;
 
+    // Get number of internal nodes
+    inline CELER_FUNCTION size_type num_internal_nodes() const;
+
+    // Get number of leaf nodes
+    inline CELER_FUNCTION size_type num_leaf_nodes() const;
+
+    // Get total number of nodes
+    inline CELER_FUNCTION size_type num_nodes() const;
+
     // Get the bbox for a given vol_id.
     inline CELER_FUNCTION FastBBox const& bbox(LocalVolumeId vol_id) const;
 
@@ -169,6 +178,33 @@ BIHInternalNodeView BIHView::inner_node(BIHNodeId id) const
     CELER_EXPECT(this->is_internal(id));
     return BIHInternalNodeView{
         storage_.internal_nodes[tree_.internal_nodes[id.unchecked_get()]]};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Get number of internal nodes.
+ */
+CELER_FUNCTION auto BIHView::num_internal_nodes() const -> size_type
+{
+    return tree_.internal_nodes.size();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Get number of leaf nodes.
+ */
+CELER_FUNCTION auto BIHView::num_leaf_nodes() const -> size_type
+{
+    return tree_.leaf_nodes.size();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ *  Get total number of nodes.
+ */
+CELER_FUNCTION auto BIHView::num_nodes() const -> size_type
+{
+    return tree_.internal_nodes.size() + tree_.leaf_nodes.size();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -43,7 +43,7 @@ class BIHInternalNodeView
     inline CELER_FUNCTION fast_real_type bounding_plane_pos(Side side) const;
 
   private:
-    BIHInternalNode const& node_;
+    BIHInternalNode node_;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/detail/BIHView.hh
+++ b/src/orange/detail/BIHView.hh
@@ -16,6 +16,37 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Access data for a BIH inner node.
+ */
+class BIHInternalNodeView
+{
+  public:
+    //!@{
+    //! \name Type aliases
+    using Side = BIHInnerNode::Side;
+    //!@}
+
+    // Construct from inner node data
+    inline CELER_FUNCTION explicit BIHInternalNodeView(BIHInnerNode const& node);
+
+    // Get partition axis
+    inline CELER_FUNCTION Axis axis() const;
+
+    // Get child node for a side
+    inline CELER_FUNCTION BIHNodeId child(Side side) const;
+
+    // Get edge bounding box for a side
+    inline CELER_FUNCTION FastBBox const& bbox(Side side) const;
+
+    // Get edge bounding plane position for a side
+    inline CELER_FUNCTION fast_real_type bounding_plane_pos(Side side) const;
+
+  private:
+    BIHInnerNode const& node_;
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Traverse BIH tree using a depth-first search.
  *
  * \todo move to top-level orange directory out of detail namespace
@@ -37,7 +68,7 @@ class BIHView
     inline CELER_FUNCTION bool is_inner(BIHNodeId id) const;
 
     // Get an inner node for a given BIHNodeId
-    inline CELER_FUNCTION BIHInnerNode const& inner_node(BIHNodeId id) const;
+    inline CELER_FUNCTION BIHInternalNodeView inner_node(BIHNodeId id) const;
 
     // Get the bbox for a given vol_id.
     inline CELER_FUNCTION FastBBox const& bbox(LocalVolumeId vol_id) const;
@@ -56,6 +87,56 @@ class BIHView
 
 //---------------------------------------------------------------------------//
 // INLINE DEFINITIONS
+//---------------------------------------------------------------------------//
+/*!
+ * Construct from an inner node.
+ */
+CELER_FUNCTION
+BIHInternalNodeView::BIHInternalNodeView(BIHInnerNode const& node)
+    : node_(node)
+{
+    CELER_EXPECT(node_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get partition axis.
+ */
+CELER_FUNCTION Axis BIHInternalNodeView::axis() const
+{
+    return node_.axis;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get child node for a side.
+ */
+CELER_FUNCTION BIHNodeId
+BIHInternalNodeView::child(BIHInternalNodeView::Side side) const
+{
+    return node_.edges[side].child;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get edge bounding box for a side.
+ */
+CELER_FUNCTION FastBBox const&
+BIHInternalNodeView::bbox(BIHInternalNodeView::Side side) const
+{
+    return node_.edges[side].bbox;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get edge bounding plane position for a side.
+ */
+CELER_FUNCTION fast_real_type
+BIHInternalNodeView::bounding_plane_pos(BIHInternalNodeView::Side side) const
+{
+    return node_.edges[side].bounding_plane_pos;
+}
+
 //---------------------------------------------------------------------------//
 /*!
  * Construct from vector of bounding boxes and storage.
@@ -82,10 +163,11 @@ bool BIHView::is_inner(BIHNodeId id) const
  *  Get an inner node for a given BIHNodeId.
  */
 CELER_FUNCTION
-BIHInnerNode const& BIHView::inner_node(BIHNodeId id) const
+BIHInternalNodeView BIHView::inner_node(BIHNodeId id) const
 {
     CELER_EXPECT(this->is_inner(id));
-    return storage_.inner_nodes[tree_.inner_nodes[id.unchecked_get()]];
+    return BIHInternalNodeView{
+        storage_.inner_nodes[tree_.inner_nodes[id.unchecked_get()]]};
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -199,7 +199,7 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"inner_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"fast_real3s":0,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"fast_real3s":0,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -713,7 +713,7 @@ TEST_F(HexArrayTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"inner_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"fast_real3s":0,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"fast_real3s":0,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -775,7 +775,7 @@ TEST_F(InputBuilderTest, globalspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"inner_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"fast_real3s":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"fast_real3s":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -841,7 +841,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"inner_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"fast_real3s":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"fast_real3s":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -965,7 +965,7 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"inner_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"fast_real3s":0,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"fast_real3s":0,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -974,7 +974,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"inner_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"fast_real3s":0,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"fast_real3s":0,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
         to_string(out));
 }
 

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -199,7 +199,7 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"fast_real3s":0,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -713,7 +713,7 @@ TEST_F(HexArrayTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"fast_real3s":0,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -775,7 +775,7 @@ TEST_F(InputBuilderTest, globalspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"fast_real3s":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -841,7 +841,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"fast_real3s":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -965,7 +965,7 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"fast_real3s":0,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -974,7 +974,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"fast_real3s":0,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
         to_string(out));
 }
 

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -17,27 +17,26 @@
 
 #include "celeritas_test.hh"
 
+using celeritas::test::id_to_int;
+
 namespace celeritas
 {
 namespace detail
 {
 namespace test
 {
-using celeritas::test::id_to_int;
-using VecInt = std::vector<int>;
-
 //---------------------------------------------------------------------------//
 class BIHBuilderTest : public ::celeritas::test::Test
 {
   public:
     using VecFastReal = std::vector<fast_real_type>;
     using VecFastBbox = BIHBuilder::VecBBox;
+    using VecInt = std::vector<int>;
 
   protected:
     static constexpr auto inff
         = std::numeric_limits<fast_real_type>::infinity();
 
-    BIHBuilder::SetLocalVolId implicit_vol_ids_;
     BIHTreeData<Ownership::value, MemSpace::host> storage_;
 };
 
@@ -93,21 +92,13 @@ TEST_F(BIHBuilderTest, basic)
     };
 
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
-
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
-    EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
-
-    // Test bounding box storage
-    auto bbox1 = storage_.bboxes[bih_tree.bboxes[LocalVolumeId{2}]];
-    EXPECT_VEC_SOFT_EQ(Real3({1.2f, 0, 0}), bbox1.lower());
-    EXPECT_VEC_SOFT_EQ(Real3({2.8f, 1, 100}), bbox1.upper());
+    auto bih_tree = build(std::move(bboxes), {});
 
     // Test nodes
     BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(3, view.num_internal_nodes());
     ASSERT_EQ(4, view.num_leaf_nodes());
+    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
@@ -264,15 +255,13 @@ class GridTest : public BIHBuilderTest
 TEST_F(GridTest, basic)
 {
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
-    EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+    auto bih_tree = build(std::move(bboxes), {});
 
     // Test nodes
     BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(11, view.num_internal_nodes());
     ASSERT_EQ(12, view.num_leaf_nodes());
+    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
@@ -442,15 +431,13 @@ TEST_F(GridTest, basic)
 TEST_F(GridTest, max_leaf_size)
 {
     BIHBuilder build(&storage_, BIHBuilder::Input{4});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
-    EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+    auto bih_tree = build(std::move(bboxes), {});
 
     // Test nodes
     BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(3, view.num_internal_nodes());
     ASSERT_EQ(4, view.num_leaf_nodes());
+    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
@@ -562,15 +549,13 @@ TEST_F(GridTest, max_leaf_size)
 TEST_F(GridTest, depth_limit)
 {
     BIHBuilder build(&storage_, BIHBuilder::Input{1, 4});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
-    EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+    auto bih_tree = build(std::move(bboxes), {});
 
     // Test nodes
     BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(7, view.num_internal_nodes());
     ASSERT_EQ(8, view.num_leaf_nodes());
+    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
@@ -679,7 +664,7 @@ TEST_F(BIHBuilderTest, single_finite_volume)
     VecFastBbox bboxes = {{{0, 0, 0}, {1, 1, 1}}};
 
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
+    auto bih_tree = build(std::move(bboxes), {});
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
     BIHView view{bih_tree, make_const_ref(storage_)};
@@ -702,7 +687,7 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
     };
 
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
+    auto bih_tree = build(std::move(bboxes), {});
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
     BIHView view{bih_tree, make_const_ref(storage_)};
@@ -722,15 +707,12 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
     VecFastBbox bboxes = {FastBBox::from_infinite()};
 
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
+    auto bih_tree = build(std::move(bboxes), {});
 
     BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
-    ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
-
-    EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
+    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     auto const& md = bih_tree.metadata;
     EXPECT_EQ(0, md.num_finite_bboxes);
@@ -746,17 +728,12 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
     };
 
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
+    auto bih_tree = build(std::move(bboxes), {});
 
     BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
-    ASSERT_EQ(2, bih_tree.inf_vol_ids.size());
-
-    EXPECT_EQ(LocalVolumeId{0},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
-    EXPECT_EQ(LocalVolumeId{1},
-              storage_.local_volume_ids[bih_tree.inf_vol_ids[1]]);
+    EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.inf_vol_ids()));
 
     auto const& md = bih_tree.metadata;
     EXPECT_EQ(0, md.num_finite_bboxes);
@@ -776,7 +753,7 @@ TEST_F(BIHBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))
     };
 
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    EXPECT_THROW(build(std::move(bboxes), implicit_vol_ids_), DebugError);
+    EXPECT_THROW(build(std::move(bboxes), {}), DebugError);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -11,8 +11,10 @@
 
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/ParamsDataStore.hh"
+#include "corecel/data/Ref.hh"
 #include "geocel/Types.hh"
 #include "orange/detail/BIHData.hh"
+#include "orange/detail/BIHView.hh"
 
 #include "celeritas_test.hh"
 
@@ -103,73 +105,71 @@ TEST_F(BIHBuilderTest, basic)
     // Test nodes
     auto inner_nodes = bih_tree.inner_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
+    BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(3, inner_nodes.size());
     ASSERT_EQ(4, leaf_nodes.size());
 
     // N0, I0
     {
-        auto node = storage_.inner_nodes[inner_nodes[0]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{0});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(2.8f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(0.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{1}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{2}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(2.8f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(0.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{2}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.8f, 1.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, -1.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({5.f, 1.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N1, I1
     {
-        auto node = storage_.inner_nodes[inner_nodes[1]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{1});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(1.6f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.2f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{3}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{4}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(1.6f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.2f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{3}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{4}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.6f, 1.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.2f, 0.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.8f, 1.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N2, I2
     {
-        auto node = storage_.inner_nodes[inner_nodes[2]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{2});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(5.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(2.8f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{5}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{6}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(5.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(2.8f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{5}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{6}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, -1.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({5.f, 0.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.8f, 0.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({5.f, 1.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N3, L0
@@ -296,139 +296,134 @@ TEST_F(GridTest, basic)
     // Test nodes
     auto inner_nodes = bih_tree.inner_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
+    BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(11, inner_nodes.size());
     ASSERT_EQ(12, leaf_nodes.size());
 
     // N0, I0
     {
-        auto node = storage_.inner_nodes[inner_nodes[0]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{0});
 
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(2.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{1}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{6}, edges[Side::right].child);
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{6}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 2.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 4.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N1, I1
     {
-        auto node = storage_.inner_nodes[inner_nodes[1]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{1});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{2}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{3}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{2}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{3}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N2, I2
     {
-        auto node = storage_.inner_nodes[inner_nodes[2]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{2});
 
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{11}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{12}, edges[Side::right].child);
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{11}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{12}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 1.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 1.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N3, I3
     {
-        auto node = storage_.inner_nodes[inner_nodes[3]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{3});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(2.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{4}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{5}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{4}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{5}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 0.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N4, I4
     {
-        auto node = storage_.inner_nodes[inner_nodes[4]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{4});
 
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{13}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{14}, edges[Side::right].child);
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{13}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{14}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 1.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 1.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N5, I5
     {
-        auto node = storage_.inner_nodes[inner_nodes[5]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{5});
 
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{15}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{16}, edges[Side::right].child);
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{15}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{16}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 1.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 1.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N11, L0
@@ -517,73 +512,71 @@ TEST_F(GridTest, max_leaf_size)
     // Test nodes
     auto inner_nodes = bih_tree.inner_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
+    BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(3, inner_nodes.size());
     ASSERT_EQ(4, leaf_nodes.size());
 
     // N0, I0
     {
-        auto node = storage_.inner_nodes[inner_nodes[0]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{0});
 
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(2.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{1}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{2}, edges[Side::right].child);
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{2}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 2.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 4.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N1, I1
     {
-        auto node = storage_.inner_nodes[inner_nodes[1]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{1});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{3}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{4}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{3}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{4}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N2, I2
     {
-        auto node = storage_.inner_nodes[inner_nodes[2]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{2});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{5}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{6}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{5}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{6}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 2.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 4.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 2.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 4.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N3, L0
@@ -673,95 +666,92 @@ TEST_F(GridTest, depth_limit)
     // Test nodes
     auto inner_nodes = bih_tree.inner_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
+    BIHView view{bih_tree, make_const_ref(storage_)};
     ASSERT_EQ(7, inner_nodes.size());
     ASSERT_EQ(8, leaf_nodes.size());
 
     // N0, I0
     {
-        auto node = storage_.inner_nodes[inner_nodes[0]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{0});
 
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(2.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{1}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{4}, edges[Side::right].child);
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{4}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 2.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 4.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N1, I1
     {
-        auto node = storage_.inner_nodes[inner_nodes[1]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{1});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{2}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{3}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{2}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{3}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N2, I2
     {
-        auto node = storage_.inner_nodes[inner_nodes[2]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{2});
 
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_EQ(Axis{1}, node.axis);
-        EXPECT_SOFT_EQ(1.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(1.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{7}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{8}, edges[Side::right].child);
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_EQ(Axis{1}, node.axis());
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(1.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{7}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{8}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 1.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 1.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N3, I3
     {
-        auto node = storage_.inner_nodes[inner_nodes[3]];
-        auto& edges = node.edges;
+        auto const& node = view.inner_node(BIHNodeId{3});
 
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_EQ(Axis{0}, node.axis);
-        EXPECT_SOFT_EQ(2.f, edges[Side::left].bounding_plane_pos);
-        EXPECT_SOFT_EQ(2.f, edges[Side::right].bounding_plane_pos);
-        EXPECT_EQ(BIHNodeId{9}, edges[Side::left].child);
-        EXPECT_EQ(BIHNodeId{10}, edges[Side::right].child);
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_EQ(Axis{0}, node.axis());
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::left));
+        EXPECT_SOFT_EQ(2.f, node.bounding_plane_pos(Side::right));
+        EXPECT_EQ(BIHNodeId{9}, node.child(Side::left));
+        EXPECT_EQ(BIHNodeId{10}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
-                           edges[Side::left].bbox.lower());
+                           node.bbox(Side::left).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 2.f, 100.f}),
-                           edges[Side::left].bbox.upper());
+                           node.bbox(Side::left).upper());
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 0.f, 0.f}),
-                           edges[Side::right].bbox.lower());
+                           node.bbox(Side::right).lower());
         EXPECT_VEC_SOFT_EQ(VecFastReal({3.f, 2.f, 100.f}),
-                           edges[Side::right].bbox.upper());
+                           node.bbox(Side::right).upper());
     }
 
     // N7, L0

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -78,7 +78,7 @@ class BIHBuilderTest : public ::celeritas::test::Test
  */
 TEST_F(BIHBuilderTest, basic)
 {
-    using Side = BIHInnerNode::Side;
+    using Side = BIHInternalNode::Side;
     using Real3 = FastBBox::Real3;
 
     VecFastBbox bboxes = {
@@ -103,10 +103,10 @@ TEST_F(BIHBuilderTest, basic)
     EXPECT_VEC_SOFT_EQ(Real3({2.8f, 1, 100}), bbox1.upper());
 
     // Test nodes
-    auto inner_nodes = bih_tree.inner_nodes;
+    auto internal_nodes = bih_tree.internal_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(3, inner_nodes.size());
+    ASSERT_EQ(3, internal_nodes.size());
     ASSERT_EQ(4, leaf_nodes.size());
 
     // N0, I0
@@ -232,7 +232,7 @@ class GridTest : public BIHBuilderTest
 {
   protected:
     /// TYPES ///
-    using Side = BIHInnerNode::Side;
+    using Side = BIHInternalNode::Side;
 
     /// METHODS ///
     void SetUp() override
@@ -294,10 +294,10 @@ TEST_F(GridTest, basic)
               storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test nodes
-    auto inner_nodes = bih_tree.inner_nodes;
+    auto internal_nodes = bih_tree.internal_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(11, inner_nodes.size());
+    ASSERT_EQ(11, internal_nodes.size());
     ASSERT_EQ(12, leaf_nodes.size());
 
     // N0, I0
@@ -510,10 +510,10 @@ TEST_F(GridTest, max_leaf_size)
               storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test nodes
-    auto inner_nodes = bih_tree.inner_nodes;
+    auto internal_nodes = bih_tree.internal_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(3, inner_nodes.size());
+    ASSERT_EQ(3, internal_nodes.size());
     ASSERT_EQ(4, leaf_nodes.size());
 
     // N0, I0
@@ -664,10 +664,10 @@ TEST_F(GridTest, depth_limit)
               storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test nodes
-    auto inner_nodes = bih_tree.inner_nodes;
+    auto internal_nodes = bih_tree.internal_nodes;
     auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(7, inner_nodes.size());
+    ASSERT_EQ(7, internal_nodes.size());
     ASSERT_EQ(8, leaf_nodes.size());
 
     // N0, I0
@@ -806,7 +806,7 @@ TEST_F(BIHBuilderTest, single_finite_volume)
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
-    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(0, bih_tree.internal_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
     auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
@@ -830,7 +830,7 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
-    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(0, bih_tree.internal_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
 
     auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
@@ -851,7 +851,7 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
-    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(0, bih_tree.internal_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
     ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
 
@@ -874,7 +874,7 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
-    ASSERT_EQ(0, bih_tree.inner_nodes.size());
+    ASSERT_EQ(0, bih_tree.internal_nodes.size());
     ASSERT_EQ(1, bih_tree.leaf_nodes.size());
     ASSERT_EQ(2, bih_tree.inf_vol_ids.size());
 

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -9,8 +9,7 @@
 #include <limits>
 #include <vector>
 
-#include "corecel/data/CollectionBuilder.hh"
-#include "corecel/data/ParamsDataStore.hh"
+#include "corecel/OpaqueIdUtils.hh"
 #include "corecel/data/Ref.hh"
 #include "geocel/Types.hh"
 #include "orange/detail/BIHData.hh"
@@ -24,6 +23,9 @@ namespace detail
 {
 namespace test
 {
+using celeritas::test::id_to_int;
+using VecInt = std::vector<int>;
+
 //---------------------------------------------------------------------------//
 class BIHBuilderTest : public ::celeritas::test::Test
 {
@@ -103,11 +105,9 @@ TEST_F(BIHBuilderTest, basic)
     EXPECT_VEC_SOFT_EQ(Real3({2.8f, 1, 100}), bbox1.upper());
 
     // Test nodes
-    auto internal_nodes = bih_tree.internal_nodes;
-    auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(3, internal_nodes.size());
-    ASSERT_EQ(4, leaf_nodes.size());
+    ASSERT_EQ(3, view.num_internal_nodes());
+    ASSERT_EQ(4, view.num_leaf_nodes());
 
     // N0, I0
     {
@@ -172,34 +172,10 @@ TEST_F(BIHBuilderTest, basic)
                            node.bbox(Side::right).upper());
     }
 
-    // N3, L0
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N3, L1
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N5, L2
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        EXPECT_EQ(2, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{4}, storage_.local_volume_ids[node.vol_ids[0]]);
-        EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[1]]);
-    }
-
-    // N6, L3
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{3}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
+    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BIHNodeId{3})));
+    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BIHNodeId{4})));
+    EXPECT_VEC_EQ(VecInt({4, 5}), id_to_int(view.leaf_vol_ids(BIHNodeId{5})));
+    EXPECT_VEC_EQ(VecInt({3}), id_to_int(view.leaf_vol_ids(BIHNodeId{6})));
 
     // Metadata
     {
@@ -294,11 +270,9 @@ TEST_F(GridTest, basic)
               storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test nodes
-    auto internal_nodes = bih_tree.internal_nodes;
-    auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(11, internal_nodes.size());
-    ASSERT_EQ(12, leaf_nodes.size());
+    ASSERT_EQ(11, view.num_internal_nodes());
+    ASSERT_EQ(12, view.num_leaf_nodes());
 
     // N0, I0
     {
@@ -426,48 +400,12 @@ TEST_F(GridTest, basic)
                            node.bbox(Side::right).upper());
     }
 
-    // N11, L0
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N12, L1
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N13, L2
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N14, L3
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{6}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N15, L4
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[4]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{9}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N16, L5
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[5]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{10},
-                  storage_.local_volume_ids[node.vol_ids[0]]);
-    }
+    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BIHNodeId{11})));
+    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BIHNodeId{12})));
+    EXPECT_VEC_EQ(VecInt({5}), id_to_int(view.leaf_vol_ids(BIHNodeId{13})));
+    EXPECT_VEC_EQ(VecInt({6}), id_to_int(view.leaf_vol_ids(BIHNodeId{14})));
+    EXPECT_VEC_EQ(VecInt({9}), id_to_int(view.leaf_vol_ids(BIHNodeId{15})));
+    EXPECT_VEC_EQ(VecInt({10}), id_to_int(view.leaf_vol_ids(BIHNodeId{16})));
 
     // Metadata
     {
@@ -510,11 +448,9 @@ TEST_F(GridTest, max_leaf_size)
               storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test nodes
-    auto internal_nodes = bih_tree.internal_nodes;
-    auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(3, internal_nodes.size());
-    ASSERT_EQ(4, leaf_nodes.size());
+    ASSERT_EQ(3, view.num_internal_nodes());
+    ASSERT_EQ(4, view.num_leaf_nodes());
 
     // N0, I0
     {
@@ -579,44 +515,12 @@ TEST_F(GridTest, max_leaf_size)
                            node.bbox(Side::right).upper());
     }
 
-    // N3, L0
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        EXPECT_EQ(2, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
-        EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[1]]);
-    }
-
-    // N4, L1
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        EXPECT_EQ(4, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[0]]);
-        EXPECT_EQ(LocalVolumeId{6}, storage_.local_volume_ids[node.vol_ids[1]]);
-        EXPECT_EQ(LocalVolumeId{9}, storage_.local_volume_ids[node.vol_ids[2]]);
-        EXPECT_EQ(LocalVolumeId{10},
-                  storage_.local_volume_ids[node.vol_ids[3]]);
-    }
-
-    // N5, L2
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        EXPECT_EQ(2, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{3}, storage_.local_volume_ids[node.vol_ids[0]]);
-        EXPECT_EQ(LocalVolumeId{4}, storage_.local_volume_ids[node.vol_ids[1]]);
-    }
-
-    // N6, L3
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        EXPECT_EQ(4, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{7}, storage_.local_volume_ids[node.vol_ids[0]]);
-        EXPECT_EQ(LocalVolumeId{8}, storage_.local_volume_ids[node.vol_ids[1]]);
-        EXPECT_EQ(LocalVolumeId{11},
-                  storage_.local_volume_ids[node.vol_ids[2]]);
-        EXPECT_EQ(LocalVolumeId{12},
-                  storage_.local_volume_ids[node.vol_ids[3]]);
-    }
+    EXPECT_VEC_EQ(VecInt({1, 2}), id_to_int(view.leaf_vol_ids(BIHNodeId{3})));
+    EXPECT_VEC_EQ(VecInt({5, 6, 9, 10}),
+                  id_to_int(view.leaf_vol_ids(BIHNodeId{4})));
+    EXPECT_VEC_EQ(VecInt({3, 4}), id_to_int(view.leaf_vol_ids(BIHNodeId{5})));
+    EXPECT_VEC_EQ(VecInt({7, 8, 11, 12}),
+                  id_to_int(view.leaf_vol_ids(BIHNodeId{6})));
 
     // Metadata
     {
@@ -664,11 +568,9 @@ TEST_F(GridTest, depth_limit)
               storage_.local_volume_ids[bih_tree.inf_vol_ids[0]]);
 
     // Test nodes
-    auto internal_nodes = bih_tree.internal_nodes;
-    auto leaf_nodes = bih_tree.leaf_nodes;
     BIHView view{bih_tree, make_const_ref(storage_)};
-    ASSERT_EQ(7, internal_nodes.size());
-    ASSERT_EQ(8, leaf_nodes.size());
+    ASSERT_EQ(7, view.num_internal_nodes());
+    ASSERT_EQ(8, view.num_leaf_nodes());
 
     // N0, I0
     {
@@ -754,36 +656,10 @@ TEST_F(GridTest, depth_limit)
                            node.bbox(Side::right).upper());
     }
 
-    // N7, L0
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[0]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N8, L1
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[1]];
-        EXPECT_EQ(1, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{2}, storage_.local_volume_ids[node.vol_ids[0]]);
-    }
-
-    // N9, L2
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[2]];
-        EXPECT_EQ(2, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{5}, storage_.local_volume_ids[node.vol_ids[0]]);
-        EXPECT_EQ(LocalVolumeId{6}, storage_.local_volume_ids[node.vol_ids[1]]);
-    }
-
-    // N10, L3
-    {
-        auto node = storage_.leaf_nodes[leaf_nodes[3]];
-        EXPECT_EQ(2, node.vol_ids.size());
-        EXPECT_EQ(LocalVolumeId{9}, storage_.local_volume_ids[node.vol_ids[0]]);
-        EXPECT_EQ(LocalVolumeId{10},
-                  storage_.local_volume_ids[node.vol_ids[1]]);
-    }
+    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BIHNodeId{7})));
+    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BIHNodeId{8})));
+    EXPECT_VEC_EQ(VecInt({5, 6}), id_to_int(view.leaf_vol_ids(BIHNodeId{9})));
+    EXPECT_VEC_EQ(VecInt({9, 10}), id_to_int(view.leaf_vol_ids(BIHNodeId{10})));
 
     // Metadata
     {
@@ -806,12 +682,11 @@ TEST_F(BIHBuilderTest, single_finite_volume)
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
-    ASSERT_EQ(0, bih_tree.internal_nodes.size());
-    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+    BIHView view{bih_tree, make_const_ref(storage_)};
+    ASSERT_EQ(0, view.num_internal_nodes());
+    ASSERT_EQ(1, view.num_leaf_nodes());
 
-    auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
-    EXPECT_EQ(1, node.vol_ids.size());
-    EXPECT_EQ(LocalVolumeId{0}, storage_.local_volume_ids[node.vol_ids[0]]);
+    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.leaf_vol_ids(BIHNodeId{0})));
 
     auto const& md = bih_tree.metadata;
     EXPECT_EQ(1, md.num_finite_bboxes);
@@ -830,13 +705,11 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
     ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
-    ASSERT_EQ(0, bih_tree.internal_nodes.size());
-    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+    BIHView view{bih_tree, make_const_ref(storage_)};
+    ASSERT_EQ(0, view.num_internal_nodes());
+    ASSERT_EQ(1, view.num_leaf_nodes());
 
-    auto node = storage_.leaf_nodes[bih_tree.leaf_nodes[0]];
-    EXPECT_EQ(2, node.vol_ids.size());
-    EXPECT_EQ(LocalVolumeId{0}, storage_.local_volume_ids[node.vol_ids[0]]);
-    EXPECT_EQ(LocalVolumeId{1}, storage_.local_volume_ids[node.vol_ids[1]]);
+    EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.leaf_vol_ids(BIHNodeId{0})));
 
     auto const& md = bih_tree.metadata;
     EXPECT_EQ(2, md.num_finite_bboxes);
@@ -851,8 +724,9 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
-    ASSERT_EQ(0, bih_tree.internal_nodes.size());
-    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+    BIHView view{bih_tree, make_const_ref(storage_)};
+    ASSERT_EQ(0, view.num_internal_nodes());
+    ASSERT_EQ(1, view.num_leaf_nodes());
     ASSERT_EQ(1, bih_tree.inf_vol_ids.size());
 
     EXPECT_EQ(LocalVolumeId{0},
@@ -874,8 +748,9 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
     BIHBuilder build(&storage_, BIHBuilder::Input{1});
     auto bih_tree = build(std::move(bboxes), implicit_vol_ids_);
 
-    ASSERT_EQ(0, bih_tree.internal_nodes.size());
-    ASSERT_EQ(1, bih_tree.leaf_nodes.size());
+    BIHView view{bih_tree, make_const_ref(storage_)};
+    ASSERT_EQ(0, view.num_internal_nodes());
+    ASSERT_EQ(1, view.num_leaf_nodes());
     ASSERT_EQ(2, bih_tree.inf_vol_ids.size());
 
     EXPECT_EQ(LocalVolumeId{0},

--- a/test/orange/detail/BIHBuilder.test.cc
+++ b/test/orange/detail/BIHBuilder.test.cc
@@ -10,7 +10,8 @@
 #include <vector>
 
 #include "corecel/OpaqueIdUtils.hh"
-#include "corecel/data/Ref.hh"
+#include "corecel/Types.hh"
+#include "corecel/data/ParamsDataStore.hh"
 #include "geocel/Types.hh"
 #include "orange/detail/BIHData.hh"
 #include "orange/detail/BIHView.hh"
@@ -31,13 +32,36 @@ class BIHBuilderTest : public ::celeritas::test::Test
   public:
     using VecFastReal = std::vector<fast_real_type>;
     using VecFastBbox = BIHBuilder::VecBBox;
+    using Input = BIHBuilder::Input;
     using VecInt = std::vector<int>;
+    using Side = BIHInternalNode::Side;
+    using Real3 = FastBBox::Real3;
 
   protected:
     static constexpr auto inff
         = std::numeric_limits<fast_real_type>::infinity();
 
-    BIHTreeData<Ownership::value, MemSpace::host> storage_;
+    //! Build BIH tree data with a single tree in it and one volume per leaf
+    void build(VecFastBbox bboxes)
+    {
+        Input input;
+        input.max_leaf_size = 1;
+        return this->build(std::move(bboxes), std::move(input));
+    }
+
+    //! Build BIH tree data with a single tree in it and one volume per leaf
+    void build(VecFastBbox&& bboxes, Input&& input)
+    {
+        HostVal<BIHTreeData> data;
+        BIHBuilder build(&data, std::move(input));
+        tree_ = build(std::move(bboxes), {});
+        store_ = ParamsDataStore<BIHTreeData>{std::move(data)};
+        ASSERT_TRUE(tree_);
+        ASSERT_TRUE(store_);
+    }
+
+    ParamsDataStore<BIHTreeData> store_;
+    BIHTreeRecord tree_;
 };
 
 //---------------------------------------------------------------------------//
@@ -79,23 +103,17 @@ class BIHBuilderTest : public ::celeritas::test::Test
  */
 TEST_F(BIHBuilderTest, basic)
 {
-    using Side = BIHInternalNode::Side;
-    using Real3 = FastBBox::Real3;
-
-    VecFastBbox bboxes = {
+    this->build({
         FastBBox::from_infinite(),
         {{0, 0, 0}, {1.6f, 1, 100}},
         {{1.2f, 0, 0}, {2.8f, 1, 100}},
         {{2.8f, 0, 0}, {5, 1, 100}},
         {{0, -1, 0}, {5, 0, 100}},
         {{0, -1, 0}, {5, 0, 100}},
-    };
-
-    BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), {});
+    });
 
     // Test nodes
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(3, view.num_internal_nodes());
     ASSERT_EQ(4, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
@@ -170,7 +188,7 @@ TEST_F(BIHBuilderTest, basic)
 
     // Metadata
     {
-        auto const& md = bih_tree.metadata;
+        auto const& md = tree_.metadata;
         EXPECT_EQ(5, md.num_finite_bboxes);
         EXPECT_EQ(1, md.num_infinite_bboxes);
         EXPECT_EQ(3, md.depth);
@@ -198,13 +216,9 @@ TEST_F(BIHBuilderTest, basic)
 class GridTest : public BIHBuilderTest
 {
   protected:
-    /// TYPES ///
-    using Side = BIHInternalNode::Side;
-
-    /// METHODS ///
-    void SetUp() override
+    void build_grid(Input&& input)
     {
-        bboxes = {FastBBox::from_infinite()};
+        VecFastBbox bboxes = {FastBBox::from_infinite()};
         for (auto i : range(3))
         {
             for (auto j : range(4))
@@ -214,10 +228,8 @@ class GridTest : public BIHBuilderTest
                 bboxes.push_back({{x, y, 0}, {x + 1, y + 1, 100}});
             }
         }
+        this->build(std::move(bboxes), std::move(input));
     }
-
-    /// DATA ///
-    VecFastBbox bboxes;
 };
 
 //---------------------------------------------------------------------------//
@@ -254,11 +266,14 @@ class GridTest : public BIHBuilderTest
  */
 TEST_F(GridTest, basic)
 {
-    BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), {});
+    this->build_grid([] {
+        Input i;
+        i.max_leaf_size = 1;
+        return i;
+    }());
 
     // Test nodes
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(11, view.num_internal_nodes());
     ASSERT_EQ(12, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
@@ -398,7 +413,7 @@ TEST_F(GridTest, basic)
 
     // Metadata
     {
-        auto const& md = bih_tree.metadata;
+        auto const& md = tree_.metadata;
         EXPECT_EQ(12, md.num_finite_bboxes);
         EXPECT_EQ(1, md.num_infinite_bboxes);
         EXPECT_EQ(5, md.depth);
@@ -430,11 +445,14 @@ TEST_F(GridTest, basic)
  */
 TEST_F(GridTest, max_leaf_size)
 {
-    BIHBuilder build(&storage_, BIHBuilder::Input{4});
-    auto bih_tree = build(std::move(bboxes), {});
+    this->build_grid([] {
+        Input i;
+        i.max_leaf_size = 4;
+        return i;
+    }());
 
     // Test nodes
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(3, view.num_internal_nodes());
     ASSERT_EQ(4, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
@@ -511,7 +529,7 @@ TEST_F(GridTest, max_leaf_size)
 
     // Metadata
     {
-        auto const& md = bih_tree.metadata;
+        auto const& md = tree_.metadata;
         EXPECT_EQ(12, md.num_finite_bboxes);
         EXPECT_EQ(1, md.num_infinite_bboxes);
         EXPECT_EQ(3, md.depth);
@@ -548,11 +566,15 @@ TEST_F(GridTest, max_leaf_size)
  */
 TEST_F(GridTest, depth_limit)
 {
-    BIHBuilder build(&storage_, BIHBuilder::Input{1, 4});
-    auto bih_tree = build(std::move(bboxes), {});
+    this->build_grid([] {
+        Input i;
+        i.max_leaf_size = 1;
+        i.depth_limit = 4;
+        return i;
+    }());
 
     // Test nodes
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(7, view.num_internal_nodes());
     ASSERT_EQ(8, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
@@ -648,7 +670,7 @@ TEST_F(GridTest, depth_limit)
 
     // Metadata
     {
-        auto const& md = bih_tree.metadata;
+        auto const& md = tree_.metadata;
         EXPECT_EQ(12, md.num_finite_bboxes);
         EXPECT_EQ(1, md.num_infinite_bboxes);
         EXPECT_EQ(4, md.depth);
@@ -661,19 +683,16 @@ TEST_F(GridTest, depth_limit)
 //
 TEST_F(BIHBuilderTest, single_finite_volume)
 {
-    VecFastBbox bboxes = {{{0, 0, 0}, {1, 1, 1}}};
+    this->build({{{0, 0, 0}, {1, 1, 1}}});
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), {});
-
-    ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    ASSERT_EQ(0, tree_.inf_vol_ids.size());
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
 
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.leaf_vol_ids(BIHNodeId{0})));
 
-    auto const& md = bih_tree.metadata;
+    auto const& md = tree_.metadata;
     EXPECT_EQ(1, md.num_finite_bboxes);
     EXPECT_EQ(0, md.num_infinite_bboxes);
     EXPECT_EQ(1, md.depth);
@@ -681,22 +700,16 @@ TEST_F(BIHBuilderTest, single_finite_volume)
 
 TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
 {
-    VecFastBbox bboxes = {
-        {{0, 0, 0}, {1, 1, 1}},
-        {{0, 0, 0}, {1, 1, 1}},
-    };
+    this->build({{{0, 0, 0}, {1, 1, 1}}, {{0, 0, 0}, {1, 1, 1}}});
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), {});
-
-    ASSERT_EQ(0, bih_tree.inf_vol_ids.size());
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    ASSERT_EQ(0, tree_.inf_vol_ids.size());
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
 
     EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.leaf_vol_ids(BIHNodeId{0})));
 
-    auto const& md = bih_tree.metadata;
+    auto const& md = tree_.metadata;
     EXPECT_EQ(2, md.num_finite_bboxes);
     EXPECT_EQ(0, md.num_infinite_bboxes);
     EXPECT_EQ(1, md.depth);
@@ -704,17 +717,14 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
 
 TEST_F(BIHBuilderTest, single_infinite_volume)
 {
-    VecFastBbox bboxes = {FastBBox::from_infinite()};
+    this->build({FastBBox::from_infinite()});
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), {});
-
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
-    auto const& md = bih_tree.metadata;
+    auto const& md = tree_.metadata;
     EXPECT_EQ(0, md.num_finite_bboxes);
     EXPECT_EQ(1, md.num_infinite_bboxes);
     EXPECT_EQ(0, md.depth);
@@ -722,20 +732,14 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
 
 TEST_F(BIHBuilderTest, multiple_infinite_volumes)
 {
-    VecFastBbox bboxes = {
-        FastBBox::from_infinite(),
-        FastBBox::from_infinite(),
-    };
+    this->build({FastBBox::from_infinite(), FastBBox::from_infinite()});
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    auto bih_tree = build(std::move(bboxes), {});
-
-    BIHView view{bih_tree, make_const_ref(storage_)};
+    BIHView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.inf_vol_ids()));
 
-    auto const& md = bih_tree.metadata;
+    auto const& md = tree_.metadata;
     EXPECT_EQ(0, md.num_finite_bboxes);
     EXPECT_EQ(2, md.num_infinite_bboxes);
     EXPECT_EQ(0, md.depth);
@@ -743,17 +747,15 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
 
 TEST_F(BIHBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))
 {
-    VecFastBbox bboxes = {
-        {{0, 0, -inff}, {1, 1, inff}},
-        {{1, 0, -inff}, {2, 1, inff}},
-        {{2, 0, -inff}, {4, 1, inff}},
-        {{4, 0, -inff}, {8, 1, inff}},
-        {{0, -inff, -inff}, {1, inff, inff}},
-        {{-inff, 0, 0}, {inff, 1, 1}},
-    };
-
-    BIHBuilder build(&storage_, BIHBuilder::Input{1});
-    EXPECT_THROW(build(std::move(bboxes), {}), DebugError);
+    EXPECT_THROW(this->build({
+                     {{0, 0, -inff}, {1, 1, inff}},
+                     {{1, 0, -inff}, {2, 1, inff}},
+                     {{2, 0, -inff}, {4, 1, inff}},
+                     {{4, 0, -inff}, {8, 1, inff}},
+                     {{0, -inff, -inff}, {1, inff, inff}},
+                     {{-inff, 0, 0}, {inff, 1, 1}},
+                 }),
+                 DebugError);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/orange/detail/BIHEnclosingVolFinder.test.cc
+++ b/test/orange/detail/BIHEnclosingVolFinder.test.cc
@@ -6,9 +6,6 @@
 //---------------------------------------------------------------------------//
 #include "orange/detail/BIHEnclosingVolFinder.hh"
 
-#include "corecel/data/CollectionBuilder.hh"
-#include "corecel/data/ParamsDataStore.hh"
-#include "geocel/Types.hh"
 #include "orange/detail/BIHBuilder.hh"
 #include "orange/detail/BIHData.hh"
 
@@ -29,18 +26,18 @@ class BIHEnclosingVolFinderTest : public Test
     using VecFastBbox = BIHBuilder::VecBBox;
 
   protected:
-    BIHTreeData<Ownership::value, MemSpace::host> storage_;
-    BIHTreeData<Ownership::const_reference, MemSpace::host> ref_storage_;
+    HostVal<detail::BIHTreeData> storage_;
+    HostCRef<detail::BIHTreeData> ref_storage_;
     BIHBuilder::SetLocalVolId implicit_vol_ids_;
 
     static constexpr bool valid_vol_id_(LocalVolumeId vol_id)
     {
         return static_cast<bool>(vol_id);
-    };
+    }
     static constexpr bool odd_vol_id_(LocalVolumeId vol_id)
     {
         return vol_id.unchecked_get() % 2 != 0;
-    };
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/test/orange/detail/BIHEnclosingVolFinder.test.cc
+++ b/test/orange/detail/BIHEnclosingVolFinder.test.cc
@@ -15,7 +15,7 @@
 #include "celeritas_test.hh"
 
 using BIHBuilder = celeritas::detail::BIHBuilder;
-using BIHInnerNode = celeritas::detail::BIHInnerNode;
+using BIHInnerNode = celeritas::detail::BIHInternalNode;
 using BIHLeafNode = celeritas::detail::BIHLeafNode;
 using BIHEnclosingVolFinder = celeritas::detail::BIHEnclosingVolFinder;
 


### PR DESCRIPTION
We should have done this in the first place, but this uses a view to test and access the internal/leaf node data. I also changed the name "interior" to "internal" to reflect standard graph nomenclature. Also now the BIH data lives in the BIH header rather than the ORANGE data header.

There is no change in performance on the A100 (even though we're unrolling into individual edge data rather than edge structs).