### PR TITLE
Add LDG support for array, bbox

### DIFF
--- a/doc/implementation/corecel/fundamentals.rst
+++ b/doc/implementation/corecel/fundamentals.rst
@@ -11,6 +11,8 @@ with device code enabled, but is a 64-bit integer on other 64-bit systems.
 .. doxygentypedef:: celeritas::size_type
 .. doxygentypedef:: celeritas::real_type
 
+.. doxygennamespace:: celeritas::literals
+
 .. _debug_assertions:
 
 Debug assertions

--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -9,6 +9,8 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "corecel/data/Ldg.hh"
+
 #include "Assert.hh"
 #include "Macros.hh"
 #include "Types.hh"
@@ -292,6 +294,12 @@ class OpaqueId
     }
     //!@}
 
+    //! Allow loading via \c ldg
+    CELER_CONSTEXPR_FUNCTION friend OpaqueId ldg(OpaqueId const* id)
+    {
+        return OpaqueId{ldg(&id->value_)};
+    }
+
 #undef CELER_DEFINE_OPAQUEID_CMP
 #define CELER_DEFINE_OPAQUEID_CMP(TOKEN)                               \
     template<class J>                                                  \
@@ -354,6 +362,12 @@ template<class I, class V>
 struct MakeSize<OpaqueId<I, V>>
 {
     using type = V;
+};
+
+//! Automatically load read-only OpaqueIDs with LDG
+template<class I, class V>
+struct IsAutoLdg<OpaqueId<I, V>> : std::true_type
+{
 };
 
 //---------------------------------------------------------------------------//
@@ -456,16 +470,6 @@ inline CELER_FUNCTION auto id_cast(J value) noexcept(!CELERITAS_DEBUG)
     -> std::enable_if_t<is_opaque_id_v<IdT> && std::is_integral_v<J>, IdT>
 {
     return IdT{detail::id_cast_impl<typename IdT::value_type, J>(value)};
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Support loading OpaqueId via GPU cache.
- */
-template<class I, class T>
-CELER_CEF T const* ldg_data(OpaqueId<I, T> const* ptr) noexcept
-{
-    return ptr->data();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/Types.hh
+++ b/src/corecel/Types.hh
@@ -134,7 +134,7 @@ using RefPtr = ObserverPtr<S<Ownership::reference, M>, M>;
 
 //---------------------------------------------------------------------------//
 //!@{
-//! \name Type trait utilities, used for VecGeom or elsewhere.
+//! \name Type trait utilities overridable by downstream/user code
 
 //! Switch between host or device type based on memspace
 template<MemSpace M, class HT, class DT>
@@ -155,9 +155,40 @@ struct IsTriviallyCopyable : std::is_trivially_copyable<T>
 {
 };
 
+/*!
+ * Traits class to automatically fetch device data through read-only cache.
+ *
+ * Specialize this on the cv-removed class type.
+ *
+ * \sa AutoLdgSpan
+ */
+template<class T>
+struct IsAutoLdg
+    : std::bool_constant<std::is_arithmetic_v<T> || std::is_enum_v<T>>
+{
+    static_assert(!std::is_const_v<T> && !std::is_reference_v<T>
+                  && !std::is_pointer_v<T>);
+};
+
+//! Get the appropriate size_type for an integer or OpaqueId
+template<class T>
+struct MakeSize : std::make_unsigned_t<T>
+{
+};
+
+//!@}
+
+//---------------------------------------------------------------------------//
+//!@{
+//! \name Type trait values for use by downstream code
+
 //! True if a type can be copied from host/device without UB
 template<class T>
 constexpr inline bool is_trivially_copyable_v = IsTriviallyCopyable<T>::value;
+
+//! Whether a base type should automatically \c ldg: default to false
+template<class T>
+constexpr inline bool is_auto_ldg_v = IsAutoLdg<T>::value;
 
 //! True if an object (functor) is compatible with kernel launchers
 template<class F>
@@ -165,12 +196,6 @@ constexpr inline bool is_launchable_v
     = (is_trivially_copyable_v<F> || CELERITAS_USE_HIP
        || CELER_COMPILER == CELER_COMPILER_CLANG)
       && !std::is_pointer_v<F> && !std::is_reference_v<F>;
-
-//! Get the appropriate size_type for an integer or OpaqueId
-template<class T>
-struct MakeSize : std::make_unsigned_t<T>
-{
-};
 
 //! Get the unsigned integer corresponding to an ID's capacity
 template<class T>
@@ -191,12 +216,14 @@ char const* to_cstring(UnitSystem);
 UnitSystem to_unit_system(std::string const& s);
 
 //---------------------------------------------------------------------------//
+// LITERALS
+//---------------------------------------------------------------------------//
 /*!
  * \name User-defined literals for Celeritas scalar types
  */
 namespace literals
 {
-//---------------------------------------------------------------------------//
+
 //! Convert a literal to the configured \c real_type
 CELER_CONSTEXPR_FUNCTION real_type operator""_r(long double value)
 {

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -187,15 +187,6 @@ class Array
         return result;
     }
 
-#if !CELER_DEVICE_COMPILE
-    //! Write to a stream
-    CELER_CEF friend std::ostream& operator<<(std::ostream& os, Array const& a)
-    {
-        os << StreamableContainer{a.data(), a.size()};
-        return os;
-    }
-#endif
-
   private:
     T d_[N];  //!< Storage
 };
@@ -209,6 +200,23 @@ class Array
 template<class T, class... Us>
 CELER_FUNCTION Array(T, Us...)
     -> Array<std::common_type_t<T, Us...>, 1 + sizeof...(Us)>;
+
+//---------------------------------------------------------------------------//
+// INLINE DEFINITIONS
+
+#if !CELER_DEVICE_COMPILE
+//---------------------------------------------------------------------------//
+/*!
+ * Write the elements of array \a a to stream \a os.
+ */
+template<class T, std::size_t N>
+CELER_FORCEINLINE std::ostream&
+operator<<(std::ostream& os, Array<T, N> const& a)
+{
+    os << StreamableContainer{a.data(), a.size()};
+    return os;
+}
+#endif
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -146,7 +146,7 @@ class Array
     }
     //!@}
 
-    //// FRIENDLY OPERATORS ////
+    //// FRIENDS ////
 
     //! Test equality of two arrays
     template<class U>

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -12,8 +12,11 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/data/Ldg.hh"
 
 #if !CELER_DEVICE_COMPILE
+#    include <ostream>
+
 #    include "corecel/io/StreamableContainer.hh"
 #endif
 
@@ -164,6 +167,17 @@ class Array
         -> std::enable_if_t<std::is_convertible_v<U, T>, bool>
     {
         return !(lhs == rhs);
+    }
+
+    //! Allow loading via ldg
+    CELER_FUNCTION friend Array ldg(Array const* arr)
+    {
+        Array result;
+        for (size_type i = 0; i != N; ++i)
+        {
+            result[i] = ldg(&arr->d_[i]);
+        }
+        return result;
     }
 
   private:

--- a/src/corecel/cont/Array.hh
+++ b/src/corecel/cont/Array.hh
@@ -36,6 +36,7 @@ class Span;
  * This is not fully compatible with std::array:
  * - no support for N=0
  * - zero-initialized by default
+ * - assume noexcept construction/copying of data
  *
  * \note For supplementary functionality, include:
  * - \c corecel/math/ArrayUtils.hh for real-number vector/matrix applications
@@ -64,10 +65,10 @@ class Array
 
   public:
     //! Default construction initializes to zero
-    CELER_CEF Array() : d_{T{}} {}
+    CELER_CEF Array() noexcept : d_{T{}} {}
 
     //! Construct from an array for aggregate initialization of daughters
-    CELER_CEF Array(CArrayConstRef values)
+    CELER_CEF Array(CArrayConstRef values) noexcept
     {
         for (size_type i = 0; i < N; ++i)
         {
@@ -76,11 +77,12 @@ class Array
     }
 
     //! Construct with C-style aggregate initialization
-    CELER_CEF Array(T first) : d_{first} {}
+    CELER_CEF Array(T first) noexcept : d_{first} {}
 
     //! Construct with the array's data
     template<class... Us>
-    CELER_CEF Array(T first, Us... rest) : d_{first, static_cast<T>(rest)...}
+    CELER_CEF Array(T first, Us... rest) noexcept
+        : d_{first, static_cast<T>(rest)...}
     {
         // Protect against leaving off an entry, e.g. Array<int, 2>(1)
         static_assert(sizeof...(rest) + 1 == N,
@@ -91,7 +93,10 @@ class Array
 
     //!@{
     //! \name Element access
-    CELER_CEF const_reference operator[](size_type i) const { return d_[i]; }
+    CELER_CEF const_reference operator[](size_type i) const noexcept
+    {
+        return d_[i];
+    }
     CELER_CEF reference operator[](size_type i) { return d_[i]; }
     CELER_CEF const_reference front() const { return d_[0]; }
     CELER_CEF reference front() { return d_[0]; }
@@ -104,13 +109,13 @@ class Array
     //!@{
     //! Access for structured unpacking
     template<std::size_t I>
-    CELER_CEF T& get()
+    CELER_CEF T& get() noexcept
     {
         static_assert(I < static_cast<std::size_t>(N));
         return d_[I];
     }
     template<std::size_t I>
-    CELER_CEF T const& get() const
+    CELER_CEF T const& get() const noexcept
     {
         static_assert(I < static_cast<std::size_t>(N));
         return d_[I];
@@ -119,25 +124,25 @@ class Array
 
     //!@{
     //! \name Iterators
-    CELER_CEF iterator begin() { return d_; }
-    CELER_CEF iterator end() { return d_ + N; }
-    CELER_CEF const_iterator begin() const { return d_; }
-    CELER_CEF const_iterator end() const { return d_ + N; }
-    CELER_CEF const_iterator cbegin() const { return d_; }
-    CELER_CEF const_iterator cend() const { return d_ + N; }
+    CELER_CEF iterator begin() noexcept { return d_; }
+    CELER_CEF iterator end() noexcept { return d_ + N; }
+    CELER_CEF const_iterator begin() const noexcept { return d_; }
+    CELER_CEF const_iterator end() const noexcept { return d_ + N; }
+    CELER_CEF const_iterator cbegin() const noexcept { return d_; }
+    CELER_CEF const_iterator cend() const noexcept { return d_ + N; }
     //!@}
 
     //!@{
     //! \name Capacity
-    CELER_CEF bool empty() const { return N == 0; }
-    static CELER_CEF size_type size() { return N; }
+    CELER_CEF bool empty() const noexcept { return N == 0; }
+    static CELER_CEF size_type size() noexcept { return N; }
     //!@}
 
     //!@{
     //! \name  Operations
 
     //! Fill the array with a constant value
-    CELER_CEF void fill(const_reference value)
+    CELER_CEF void fill(const_reference value) noexcept
     {
         for (size_type i = 0; i != N; ++i)
         {
@@ -150,7 +155,8 @@ class Array
 
     //! Test equality of two arrays
     template<class U>
-    CELER_CEF friend auto operator==(Array const& lhs, Array<U, N> const& rhs)
+    CELER_CEF friend auto
+    operator==(Array const& lhs, Array<U, N> const& rhs) noexcept
         -> std::enable_if_t<std::is_convertible_v<U, T>, bool>
     {
         for (size_type i = 0; i != N; ++i)
@@ -163,14 +169,15 @@ class Array
 
     //! Test inequality of two arrays
     template<class U>
-    CELER_CEF friend auto operator!=(Array const& lhs, Array<U, N> const& rhs)
+    CELER_CEF friend auto
+    operator!=(Array const& lhs, Array<U, N> const& rhs) noexcept
         -> std::enable_if_t<std::is_convertible_v<U, T>, bool>
     {
         return !(lhs == rhs);
     }
 
     //! Allow loading via ldg
-    CELER_FUNCTION friend Array ldg(Array const* arr)
+    CELER_CEF friend Array ldg(Array const* arr) noexcept
     {
         Array result;
         for (size_type i = 0; i != N; ++i)
@@ -179,6 +186,15 @@ class Array
         }
         return result;
     }
+
+#if !CELER_DEVICE_COMPILE
+    //! Write to a stream
+    CELER_CEF friend std::ostream& operator<<(std::ostream& os, Array const& a)
+    {
+        os << StreamableContainer{a.data(), a.size()};
+        return os;
+    }
+#endif
 
   private:
     T d_[N];  //!< Storage
@@ -193,23 +209,6 @@ class Array
 template<class T, class... Us>
 CELER_FUNCTION Array(T, Us...)
     -> Array<std::common_type_t<T, Us...>, 1 + sizeof...(Us)>;
-
-//---------------------------------------------------------------------------//
-// INLINE DEFINITIONS
-
-#if !CELER_DEVICE_COMPILE
-//---------------------------------------------------------------------------//
-/*!
- * Write the elements of array \a a to stream \a os.
- */
-template<class T, std::size_t N>
-CELER_FORCEINLINE std::ostream&
-operator<<(std::ostream& os, Array<T, N> const& a)
-{
-    os << StreamableContainer{a.data(), a.size()};
-    return os;
-}
-#endif
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS

--- a/src/corecel/cont/EnumArray.hh
+++ b/src/corecel/cont/EnumArray.hh
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file corecel/cont/EnumArray.hh
+//! \sa corecel/cont/Array.test.cc
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/corecel/cont/LdgSpan.hh
+++ b/src/corecel/cont/LdgSpan.hh
@@ -36,9 +36,11 @@ using LdgSpan = Span<detail::LdgWrapper<T>, Extent>;
  * Note that T must be const.
  */
 template<class T, std::size_t Extent = dynamic_extent>
-using AutoLdgSpan = Span<
-    std::conditional_t<detail::is_ldg_supported_v<T>, detail::LdgWrapper<T>, T>,
-    Extent>;
+using AutoLdgSpan
+    = Span<std::conditional_t<is_auto_ldg_v<std::remove_const_t<T>>,
+                              detail::LdgWrapper<T>,
+                              T>,
+           Extent>;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/src/corecel/cont/detail/LdgSpanImpl.hh
+++ b/src/corecel/cont/detail/LdgSpanImpl.hh
@@ -8,7 +8,6 @@
 
 #include <iterator>
 #include <type_traits>
-#include <utility>
 
 #include "corecel/Macros.hh"
 #include "corecel/data/Ldg.hh"
@@ -17,23 +16,6 @@ namespace celeritas
 {
 namespace detail
 {
-//---------------------------------------------------------------------------//
-template<class T, class = void>
-struct IsLdgSupported : std::false_type
-{
-    static_assert(std::is_const_v<T>);
-};
-
-template<class T>
-struct IsLdgSupported<T, std::void_t<decltype(ldg_data(std::declval<T*>()))>>
-    : std::true_type
-{
-};
-
-//! Whether a type is supported by \c ldg
-template<class T>
-inline constexpr bool is_ldg_supported_v = IsLdgSupported<T>::value;
-
 //---------------------------------------------------------------------------//
 /*!
  * Wrapper that loads data safely via \c ldg on conversion.
@@ -51,7 +33,6 @@ template<class T>
 class LdgWrapper
 {
     static_assert(std::is_const_v<T>);
-    static_assert(is_ldg_supported_v<T>, "type is incompatible with ldg");
 
   public:
     //!@{
@@ -105,6 +86,7 @@ class LdgWrapper
     //!@}
 
   private:
+    // Const pointer to global device data
     T* ptr_;
 };
 

--- a/src/corecel/data/Ldg.hh
+++ b/src/corecel/data/Ldg.hh
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <cstddef>
 #include <type_traits>
 
 #include "corecel/Macros.hh"

--- a/src/corecel/data/Ldg.hh
+++ b/src/corecel/data/Ldg.hh
@@ -7,6 +7,10 @@
 #pragma once
 
 #include <type_traits>
+#if CELER_DEVICE_COMPILE
+// Make sure __ldg is available for HIP
+#    include "corecel/DeviceRuntimeApi.hh"
+#endif
 
 #include "corecel/Macros.hh"
 

--- a/src/corecel/data/Ldg.hh
+++ b/src/corecel/data/Ldg.hh
@@ -17,15 +17,16 @@ namespace celeritas
  * \page ldg Cached device loading
  *
  * On GPUs, reading from global memory through the L1/texture cache can improve
- * throughput when many threads access the same address. The \c __ldg
- * intrinsic (CUDA/HIP) performs such a cached load, using L1/texture memory
- * rather than the ordinary data cache. The hardware contract is that the
- * pointed-to memory must be \em read-only for the lifetime of the kernel;
- * this is generally true for \em Params data (physics tables, geometry) but
- * not for \em State data. On the host the \c ldg family of functions falls
- * back to a plain dereference, so no special-casing is needed in caller code.
- * Because \c ldg is only for read-only addresses, all arguments \em must
- * match only \c const types.
+ * throughput when many threads access the same address.
+ * The \c __ldg intrinsic (CUDA/HIP) performs such a cached load, using
+ * L1/texture memory rather than the ordinary data cache.
+ * The hardware contract is that the pointed-to memory must be \em read-only
+ * for the lifetime of the kernel; this is generally true for \em Params data
+ * (physics tables, geometry) but not for \em State data.
+ * On the host the \c ldg family of functions falls back to a plain
+ * dereference, so no special-casing is needed in caller code.
+ * Because \c ldg is only for \em read-only addresses in \em global memory, all
+ * arguments \em must match only \c const_pointer types.
  *
  * \par Scalar values
  *
@@ -35,24 +36,19 @@ namespace celeritas
  *   MaterialId mat   = ldg(&record.material);  // OpaqueId supported
  * \endcode
  *
- * \par Struct members
+ * Built-in implementations cover:
  *
- * Load a single member without reading the whole struct using the
- * two-argument overload or the storable \c LdgMember projector:
- * \code
- *   // Immediate two-argument form
- *   BIHNodeId parent = ldg(node, &BIHLeafNode::parent);
- *
- *   // Storable callable -- useful with algorithms
- *   auto load_parent = LdgMember{&BIHLeafNode::parent};
- *   BIHNodeId parent = load_parent(node);
- * \endcode
+ * - arithmetic types (identity, the default),
+ * - enum types (reinterpret-cast to the underlying integer),
+ * - \c OpaqueId (pointer to the underlying index \c T),
+ * - \c Quantity (pointer to the underlying value \c T),
+ * - \c Array (successive loads to each element).
  *
  * \par Spans and collections
  *
  * \c LdgSpan<T const> (from \c corecel/cont/LdgSpan.hh) is an alias for
- * \c Span whose iterator triggers \c __ldg on every element access. Use it
- * as you would any ordinary span:
+ * \c Span whose iterator triggers \c __ldg on every element access.
+ * Use it as you would any ordinary span:
  * \code
  *   LdgSpan<real_type const> energies = params.get_energies();
  *   for (real_type e : energies)   // each read uses __ldg
@@ -66,27 +62,24 @@ namespace celeritas
  *
  * \par Extending ldg to a new type
  *
- * \c ldg dispatches through the customization point \c ldg_data, found by
- * argument-dependent lookup (ADL). To support a new type, define a free
- * function in its namespace that returns a \c const pointer to an arithmetic
- * type. For a wrapper struct holding a single \c int member:
+ * The \c ldg function is found by argument-dependent lookup (ADL).
+ * Implement a \c friend function \c ldg that takes a const pointer and returns
+ * a value:
  * \code
- *   namespace myns
+ *   template<class T>
+ *   class MyClass
  *   {
- *   struct MyCount { int value; };
+ *     public:
+ *       CELER_CONSTEXPR_FUNCTION friend MyClass ldg(MyClass const* m)
+ *       {
+ *         return MyClass{ldg(&m->value_)};
+ *       }
  *
- *   CELER_CONSTEXPR_FUNCTION int const* ldg_data(MyCount const* p) noexcept
- *   {
- *       return &p->value;
- *   }
- *   }  // namespace myns
+ *     private:
+ *       T value_;
+ *   };
  * \endcode
- *
- * Built-in overloads cover:
- * - arithmetic types (identity, the default),
- * - enum types (reinterpret-cast to the underlying integer),
- * - \c OpaqueId<I,T> (pointer to the underlying index \c T), and
- * - \c Quantity<U,T> (pointer to the underlying value \c T).
+ * See \c OpaqueId, \c Quantity and \c Array for examples.
  *
  * \internal
  *
@@ -98,69 +91,50 @@ namespace celeritas
  * \em value, not a reference, and the load goes through \c __ldg on device.
  *
  * \c detail::LdgIterator<T const> is a random-access iterator whose
- * \c operator* returns an \c LdgWrapper. Wrapping it in \c Span yields
- * \c LdgSpan: range-for loops and standard algorithms transparently trigger
- * \c __ldg on every element access without requiring any change at the
- * call site.
+ * \c operator* returns an \c LdgWrapper.
+ * Wrapping it in \c Span yields \c LdgSpan: range-for loops and standard
+ * algorithms transparently trigger \c __ldg on every element access without
+ * requiring any change at the call site.
  */
-
-//---------------------------------------------------------------------------//
-/*!
- * Get a pointer to the arithmetic data for use with \c __ldg .
- *
- * Default overload for arithmetic types: returns the pointer unchanged.
- */
-template<class T>
-CELER_CONSTEXPR_FUNCTION std::enable_if_t<std::is_arithmetic_v<T>, T const*>
-ldg_data(T const* ptr) noexcept
-{
-    return ptr;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Get a pointer to the underlying integer for an enum type.
- */
-template<class T>
-CELER_CONSTEXPR_FUNCTION
-    std::enable_if_t<std::is_enum_v<T>, std::underlying_type_t<T> const*>
-    ldg_data(T const* ptr) noexcept
-{
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return reinterpret_cast<std::underlying_type_t<T> const*>(ptr);
-}
 
 //---------------------------------------------------------------------------//
 /*!
  * Wrap the low-level CUDA/HIP "load read-only global memory" function.
  *
- * This relies on \c ldg_data found by ADL to obtain a pointer to the
- * underlying arithmetic type; see \ref ldg for usage and extension examples.
- *
  * On CUDA the load is cached in L1/texture memory, improving performance when
  * data is repeatedly read by many threads in a kernel.
  *
- * \warning The target address must be read-only for the lifetime of the
- * kernel. This is generally true for Params data but not State data.
+ * \warning The target must be \c global memory (or else the kernel may crash)
+ * and \c read-only (or else the result may be wrong) for the lifetime of the
+ * kernel.
+ * This is generally true for Params data but not State data.
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION T ldg(T const* ptr)
+CELER_CONSTEXPR_FUNCTION std::enable_if_t<std::is_arithmetic_v<T>, T>
+ldg(T const* ptr) noexcept
 {
-    auto const* data_ptr = ldg_data(ptr);
-    using data_type
-        = std::remove_cv_t<std::remove_pointer_t<decltype(data_ptr)>>;
-    static_assert(std::is_arithmetic_v<data_type>,
-                  R"(Only arithmetic-underlying types are supported by __ldg)");
-
 #if CELER_DEVICE_COMPILE
-    return T{__ldg(data_ptr)};
+    return __ldg(ptr);
 #else
-    return T{*data_ptr};
+    return *ptr;
 #endif
 }
 
 //---------------------------------------------------------------------------//
 //! \cond (CELERITAS_DOC_DEV)
+/*!
+ * Get a pointer to the underlying integer for an enum type.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION std::enable_if_t<std::is_enum_v<T>, T>
+ldg(T const* ptr) noexcept
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto const* data = reinterpret_cast<std::underlying_type_t<T> const*>(ptr);
+    return static_cast<T>(ldg(data));
+}
+
+//---------------------------------------------------------------------------//
 /*!
  * Load a struct member via \c ldg using a pointer-to-member.
  *
@@ -170,7 +144,7 @@ CELER_CONSTEXPR_FUNCTION T ldg(T const* ptr)
  * \endcode
  */
 template<class Class, class T>
-CELER_FUNCTION T ldg(Class const& obj, T Class::* mp)
+CELER_CONSTEXPR_FUNCTION T ldg(Class const& obj, T Class::* mp) noexcept
 {
     return ldg(&(obj.*mp));
 }
@@ -194,7 +168,7 @@ struct LdgMember
 {
     T Class::* mp;
 
-    CELER_FUNCTION T operator()(Class const& obj) const
+    CELER_CONSTEXPR_FUNCTION T operator()(Class const& obj) const
     {
         return ldg(&(obj.*mp));
     }

--- a/src/corecel/data/Ldg.hh
+++ b/src/corecel/data/Ldg.hh
@@ -7,12 +7,12 @@
 #pragma once
 
 #include <type_traits>
+
+#include "corecel/Macros.hh"
 #if CELER_DEVICE_COMPILE
 // Make sure __ldg is available for HIP
 #    include "corecel/DeviceRuntimeApi.hh"
 #endif
-
-#include "corecel/Macros.hh"
 
 namespace celeritas
 {

--- a/src/corecel/math/Quantity.hh
+++ b/src/corecel/math/Quantity.hh
@@ -10,6 +10,7 @@
 
 #include "corecel/Macros.hh"
 #include "corecel/Types.hh"
+#include "corecel/data/Ldg.hh"
 
 #include "detail/QuantityImpl.hh"
 
@@ -183,7 +184,7 @@ class Quantity
     using OtherQuantity = Quantity<UnitT, std::common_type_t<ValueT, T2>>;
 
   public:
-    //// INLINE OPERATOR FRIENDS ////
+    //// INLINE TEMPLATE FRIENDS ////
 
     //!@{
     //! Arithmetic with unitless scalars
@@ -241,6 +242,12 @@ class Quantity
         return Quantity{-q.value()};
     }
 
+    //! Allow loading via \c ldg
+    CELER_CONSTEXPR_FUNCTION friend Quantity ldg(Quantity const* q) noexcept
+    {
+        return Quantity{ldg(&q->value_)};
+    }
+
   private:
     value_type value_{};
 };
@@ -249,6 +256,12 @@ class Quantity
 //! Type alias for a quantity that uses compile-time precision
 template<class UnitT>
 using RealQuantity = Quantity<UnitT, real_type>;
+
+//! Automatically load read-only quantities with LDG
+template<class U, class V>
+struct IsAutoLdg<Quantity<U, V>> : std::true_type
+{
+};
 
 //---------------------------------------------------------------------------//
 // FREE FUNCTIONS
@@ -387,14 +400,6 @@ std::ostream& operator<<(std::ostream& os, Quantity<UnitT, ValueT> const& q)
 //! True if T is a Quantity
 template<class T>
 inline constexpr bool is_quantity_v = detail::IsQuantity<T>::value;
-
-//---------------------------------------------------------------------------//
-//! Cached const global loading support for Quantity
-template<class U, class T>
-CELER_CONSTEXPR_FUNCTION T const* ldg_data(Quantity<U, T> const* ptr) noexcept
-{
-    return ptr->data();
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -50,14 +50,14 @@ class BoundingBox
 
   public:
     // Construct from infinite extents
-    static inline CELER_FUNCTION BoundingBox from_infinite();
+    static inline CELER_FUNCTION BoundingBox from_infinite() noexcept;
 
     // Construct from unchecked lower/upper bounds
     static CELER_CONSTEXPR_FUNCTION BoundingBox
     from_unchecked(Real3 const& lower, Real3 const& upper) noexcept;
 
     // Construct in unassigned state
-    CELER_CONSTEXPR_FUNCTION BoundingBox();
+    CELER_CONSTEXPR_FUNCTION BoundingBox() noexcept;
 
     // Construct from upper and lower points
     inline CELER_FUNCTION BoundingBox(Real3 const& lower, Real3 const& upper);
@@ -171,7 +171,7 @@ is_inside(BoundingBox<T> const& bbox, Array<U, 3> const& point)
  * Create a bounding box with infinite extents.
  */
 template<class T>
-CELER_FUNCTION BoundingBox<T> BoundingBox<T>::from_infinite()
+CELER_FUNCTION BoundingBox<T> BoundingBox<T>::from_infinite() noexcept
 {
     constexpr real_type inf = numeric_limits<real_type>::infinity();
     return {{-inf, -inf, -inf}, {inf, inf, inf}};
@@ -205,7 +205,7 @@ BoundingBox<T>::from_unchecked(Real3 const& lo, Real3 const& hi) noexcept
    \endcode
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox()
+CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox() noexcept
 {
     constexpr real_type inf = numeric_limits<real_type>::infinity();
     points_[to_int(Bound::lo)] = {inf, inf, inf};

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -54,7 +54,7 @@ class BoundingBox
 
     // Construct from unchecked lower/upper bounds
     static CELER_CONSTEXPR_FUNCTION BoundingBox
-    from_unchecked(Real3 const& lower, Real3 const& upper);
+    from_unchecked(Real3 const& lower, Real3 const& upper) noexcept;
 
     // Construct in unassigned state
     CELER_CONSTEXPR_FUNCTION BoundingBox();
@@ -122,12 +122,21 @@ class BoundingBox
         return !(lhs == rhs);
     }
 
+    //! Allow loading via ldg
+    CELER_CONSTEXPR_FUNCTION friend BoundingBox
+    ldg(BoundingBox const* bb) noexcept
+    {
+        return BoundingBox{std::true_type{}, ldg(&bb->points_)};
+    }
+
   private:
-    Array<Real3, 2> points_;  //!< lo/hi points
+    using Points = Array<Real3, 2>;
+
+    Points points_;  //!< lo/hi points
 
     // Implementation of 'from_unchecked' (true type 'tag')
     CELER_CONSTEXPR_FUNCTION
-    BoundingBox(std::true_type, Real3 const& lower, Real3 const& upper);
+    BoundingBox(std::true_type, Points const& points) noexcept;
 };
 
 //---------------------------------------------------------------------------//
@@ -177,9 +186,9 @@ CELER_FUNCTION BoundingBox<T> BoundingBox<T>::from_infinite()
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>
-BoundingBox<T>::from_unchecked(Real3 const& lo, Real3 const& hi)
+BoundingBox<T>::from_unchecked(Real3 const& lo, Real3 const& hi) noexcept
 {
-    return BoundingBox<T>{std::true_type{}, lo, hi};
+    return BoundingBox<T>{std::true_type{}, Points{lo, hi}};
 }
 
 //---------------------------------------------------------------------------//
@@ -231,8 +240,8 @@ CELER_FUNCTION BoundingBox<T>::BoundingBox(Real3 const& lo, Real3 const& hi)
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION
-BoundingBox<T>::BoundingBox(std::true_type, Real3 const& lo, Real3 const& hi)
-    : points_{{lo, hi}}
+BoundingBox<T>::BoundingBox(std::true_type, Points const& points) noexcept
+    : points_{points}
 {
 }
 

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -12,6 +12,7 @@
 #include "corecel/Config.hh"
 
 #include "corecel/Assert.hh"
+#include "corecel/Types.hh"
 
 #include "celeritas_test.hh"
 
@@ -98,6 +99,7 @@ TYPED_TEST(OpaqueIdTypedTest, traits)
     EXPECT_TRUE((std::is_same_v<Int_t, MakeSize_t<Id_t const>>));
     EXPECT_TRUE((std::is_trivially_copyable_v<Id_t>));
     EXPECT_TRUE((std::is_trivially_destructible_v<Id_t>));
+    EXPECT_TRUE((is_auto_ldg_v<Id_t>));
 }
 
 TYPED_TEST(OpaqueIdTypedTest, operators)
@@ -152,6 +154,16 @@ TYPED_TEST(OpaqueIdTypedTest, operators)
     Id_t old{id++};
     EXPECT_EQ(Id_t{1}, id);
     EXPECT_EQ(Id_t{0}, old);
+}
+
+TYPED_TEST(OpaqueIdTypedTest, ldg)
+{
+    using Id_t = OpaqueId<TestInstantiator, TypeParam>;
+
+    Id_t const id{12};
+
+    EXPECT_EQ(Id_t{12}, ldg(&id));
+    EXPECT_TRUE((std::is_same_v<Id_t, decltype(ldg(&id))>));
 }
 
 TEST(OpaqueIdTest, multi_int)

--- a/test/corecel/cont/Array.test.cc
+++ b/test/corecel/cont/Array.test.cc
@@ -132,9 +132,8 @@ TEST(ArrayTest, ldg)
 {
     // Pretend this is in global memory: `ldg(&x)` is x in host code
     Array const arr{1, 2, 3};
-    auto loaded = ldg(&arr);
-    EXPECT_TRUE((std::is_same_v<Array<int, 3>, decltype(loaded)>));
-    EXPECT_VEC_EQ((Array{1, 2, 3}), loaded);
+    EXPECT_TRUE((std::is_same_v<Array<int, 3>, decltype(ldg(&arr))>));
+    EXPECT_VEC_EQ((Array{1, 2, 3}), ldg(&arr));
 }
 
 TEST(ArrayTest, casts)

--- a/test/corecel/cont/Array.test.cc
+++ b/test/corecel/cont/Array.test.cc
@@ -128,6 +128,15 @@ TEST(ArrayTest, to_array)
     EXPECT_VEC_EQ((Array{1, 2, 3}), arr);
 }
 
+TEST(ArrayTest, ldg)
+{
+    // Pretend this is in global memory: `ldg(&x)` is x in host code
+    Array const arr{1, 2, 3};
+    auto loaded = ldg(&arr);
+    EXPECT_TRUE((std::is_same_v<Array<int, 3>, decltype(loaded)>));
+    EXPECT_VEC_EQ((Array{1, 2, 3}), loaded);
+}
+
 TEST(ArrayTest, casts)
 {
     // Test up- and down-casting

--- a/test/corecel/math/Quantity.test.cc
+++ b/test/corecel/math/Quantity.test.cc
@@ -302,6 +302,14 @@ TEST(QuantityTest, io)
     }
 }
 
+TEST(QuantityTest, ldg)
+{
+    // Pretend this is in global memory: `ldg(&x)` is x in host code
+    Dozen const q{10};
+    EXPECT_TRUE((std::is_same_v<Dozen, decltype(ldg(&q))>));
+    EXPECT_EQ((Dozen{10}), ldg(&q));
+}
+
 TEST(QuantityTest, stream)
 {
     EXPECT_EQ("5 [dozen]", stream_to_string(Dozen{5}));

--- a/test/geocel/BoundingBox.test.cc
+++ b/test/geocel/BoundingBox.test.cc
@@ -135,6 +135,16 @@ TEST_F(BoundingBoxTest, is_inside)
     EXPECT_TRUE(is_inside(degenerate, Real3{1, 1, 1}));
 }
 
+TEST_F(BoundingBoxTest, ldg)
+{
+    // Pretend this is in global memory: `ldg(&x)` is x in host code
+    BBox const bbox = {{-5, -2, -100}, {6, 1, 1}};
+    auto loaded = ldg(&bbox);
+    EXPECT_TRUE((std::is_same_v<BBox, decltype(loaded)>));
+    EXPECT_VEC_EQ((Array{-5, -2, -100}), loaded.lower());
+    EXPECT_VEC_EQ((Array{6, 1, 1}), loaded.upper());
+}
+
 TEST_F(BoundingBoxTest, io)
 {
     using BoundingBoxT = BoundingBox<double>;


### PR DESCRIPTION
This is what I promise is a final refactor of how we handle ldg: it's now two things:
- free/friend functions `ldg` that can reconstruct an entire class from a const pointer to global memory
- a traits class `IsAutoLdg` that can be specialized to indicate whether `Collection`-based containers of an object should use `ldg`.

Using friend functions instead of free functions improves error diagnostics and template matching: like with the comparators/stream operators, it means the function definitions will *only* be used in an ADL context.