### PR TITLE
Refactor bbox to allow performance testing of transpose storage

### DIFF
--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -116,11 +116,10 @@ class BoundingBox
     //// MUTATORS ////
 
     // Reduce the bounding box's extent along an axis
-    CELER_CONSTEXPR_FUNCTION void
-    shrink(Bound bnd, Axis ax, real_type position);
+    CELER_CONSTEXPR_FUNCTION void shrink(Bound b, Axis ax, real_type position);
 
     // Increase the bounding box's extent along an axis
-    CELER_CONSTEXPR_FUNCTION void grow(Bound bnd, Axis ax, real_type position);
+    CELER_CONSTEXPR_FUNCTION void grow(Bound b, Axis ax, real_type position);
 
     // Increase the bounding box's extent on both bounds
     CELER_CONSTEXPR_FUNCTION void grow(Axis ax, real_type position);
@@ -167,11 +166,19 @@ class BoundingBox
 
     Points points_;  //!< lo/hi points
 
+    //// PRIVATE HELPERS ////
+
     // Construct internally without validation (using tag type)
     CELER_CONSTEXPR_FUNCTION
     BoundingBox(std::true_type, Points const& points) noexcept;
     CELER_CONSTEXPR_FUNCTION
     BoundingBox(std::true_type, Extents3 const& extents) noexcept;
+
+    //! Set a bounding point coordinate (different signature to allow private)
+    CELER_CONSTEXPR_FUNCTION void point(Bound b, Axis ax, real_type p) &
+    {
+        points_[to_int(b)][to_int(ax)] = p;
+    }
 };
 
 //---------------------------------------------------------------------------//
@@ -254,8 +261,11 @@ template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox() noexcept
 {
     constexpr real_type inf = numeric_limits<real_type>::infinity();
-    points_[to_int(Bound::lo)] = {inf, inf, inf};
-    points_[to_int(Bound::hi)] = {-inf, -inf, -inf};
+    for (auto ax : {Axis::x, Axis::y, Axis::z})
+    {
+        this->point(Bound::lo, ax, inf);
+        this->point(Bound::hi, ax, -inf);
+    }
     CELER_ENSURE(!*this);
 }
 
@@ -307,7 +317,7 @@ BoundingBox<T>::BoundingBox(std::true_type, Extents3 const& extents) noexcept
     {
         for (auto b : {Bound::lo, Bound::hi})
         {
-            points_[to_int(b)][to_int(ax)] = extents[to_int(ax)][to_int(b)];
+            this->point(b, ax, extents[to_int(ax)][to_int(b)]);
         }
     }
 }
@@ -338,10 +348,10 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION void
-BoundingBox<T>::shrink(Bound bnd, Axis ax, real_type position)
+BoundingBox<T>::shrink(Bound b, Axis ax, real_type position)
 {
-    real_type p = this->point(bnd, ax);
-    if (bnd == Bound::lo)
+    real_type p = this->point(b, ax);
+    if (b == Bound::lo)
     {
         p = std::fmax(p, position);
     }
@@ -349,7 +359,7 @@ BoundingBox<T>::shrink(Bound bnd, Axis ax, real_type position)
     {
         p = std::fmin(p, position);
     }
-    points_[to_int(bnd)][to_int(ax)] = p;
+    this->point(b, ax, p);
 }
 
 //---------------------------------------------------------------------------//
@@ -361,10 +371,10 @@ BoundingBox<T>::shrink(Bound bnd, Axis ax, real_type position)
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION void
-BoundingBox<T>::grow(Bound bnd, Axis ax, real_type position)
+BoundingBox<T>::grow(Bound b, Axis ax, real_type position)
 {
-    real_type p = this->point(bnd, ax);
-    if (bnd == Bound::lo)
+    real_type p = this->point(b, ax);
+    if (b == Bound::lo)
     {
         p = std::fmin(p, position);
     }
@@ -372,7 +382,7 @@ BoundingBox<T>::grow(Bound bnd, Axis ax, real_type position)
     {
         p = std::fmax(p, position);
     }
-    points_[to_int(bnd)][to_int(ax)] = p;
+    this->point(b, ax, p);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -79,29 +79,34 @@ class BoundingBox
     //// ACCESSORS ////
 
     //! Lower bbox coordinate
-    CELER_CONSTEXPR_FUNCTION Real3 const& lower() const
+    CELER_CONSTEXPR_FUNCTION Real3 lower() const
     {
         return this->point(Bound::lo);
     }
 
     //! Upper bbox coordinate
-    CELER_CONSTEXPR_FUNCTION Real3 const& upper() const
+    CELER_CONSTEXPR_FUNCTION Real3 upper() const
     {
         return this->point(Bound::hi);
     }
 
     //! Access a bounding point
-    CELER_CONSTEXPR_FUNCTION Real3 const& point(Bound b) const
+    CELER_CONSTEXPR_FUNCTION Real3 point(Bound b) const
     {
         CELER_EXPECT(b != Bound::size_);
-        return points_[to_int(b)];
+        Real3 result;
+        for (auto ax : {Axis::x, Axis::y, Axis::z})
+        {
+            result[to_int(ax)] = extents_[to_int(ax)][to_int(b)];
+        }
+        return result;
     }
 
     //! Access a bounding point coordinate (const ref to support LDG)
     CELER_CONSTEXPR_FUNCTION real_type const& point(Bound b, Axis ax) const&
     {
         CELER_EXPECT(ax != Axis::size_);
-        return points_[to_int(b)][to_int(ax)];
+        return extents_[to_int(ax)][to_int(b)];
     }
 
     //! Access a bounding point coordinate
@@ -131,7 +136,7 @@ class BoundingBox
     CELER_CONSTEXPR_FUNCTION friend bool
     operator==(BoundingBox const& lhs, BoundingBox const& rhs)
     {
-        return lhs.points_ == rhs.points_;
+        return lhs.extents_ == rhs.extents_;
     }
 
     //! Test inequality of two bounding boxes
@@ -145,13 +150,13 @@ class BoundingBox
     CELER_CONSTEXPR_FUNCTION friend BoundingBox
     ldg(BoundingBox const* bb) noexcept
     {
-        return BoundingBox{std::true_type{}, ldg(&bb->points_)};
+        return BoundingBox{std::true_type{}, ldg(&bb->extents_)};
     }
 
   private:
     using Points = Array<Real3, 2>;
 
-    Points points_;  //!< lo/hi points
+    Extents3 extents_;  //!< Extents for x, y, z axes
 
     // Construct internally without validation (using tag type)
     CELER_CONSTEXPR_FUNCTION
@@ -240,8 +245,11 @@ template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox() noexcept
 {
     constexpr real_type inf = numeric_limits<real_type>::infinity();
-    points_[to_int(Bound::lo)] = {inf, inf, inf};
-    points_[to_int(Bound::hi)] = {-inf, -inf, -inf};
+    for (auto ax : {Axis::x, Axis::y, Axis::z})
+    {
+        extents_[to_int(ax)][to_int(Bound::lo)] = inf;
+        extents_[to_int(ax)][to_int(Bound::hi)] = -inf;
+    }
     CELER_ENSURE(!*this);
 }
 
@@ -277,8 +285,14 @@ CELER_FUNCTION BoundingBox<T>::BoundingBox(Extents3 const& extents)
 template<class T>
 CELER_CONSTEXPR_FUNCTION
 BoundingBox<T>::BoundingBox(std::true_type, Points const& points) noexcept
-    : points_{points}
 {
+    for (auto b : {Bound::lo, Bound::hi})
+    {
+        for (auto ax : {Axis::x, Axis::y, Axis::z})
+        {
+            extents_[to_int(ax)][to_int(b)] = points[to_int(b)][to_int(ax)];
+        }
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -288,14 +302,8 @@ BoundingBox<T>::BoundingBox(std::true_type, Points const& points) noexcept
 template<class T>
 CELER_CONSTEXPR_FUNCTION
 BoundingBox<T>::BoundingBox(std::true_type, Extents3 const& extents) noexcept
+    : extents_{extents}
 {
-    for (auto ax : {Axis::x, Axis::y, Axis::z})
-    {
-        for (auto b : {Bound::lo, Bound::hi})
-        {
-            points_[to_int(b)][to_int(ax)] = extents[to_int(ax)][to_int(b)];
-        }
-    }
 }
 
 //---------------------------------------------------------------------------//
@@ -335,7 +343,7 @@ BoundingBox<T>::shrink(Bound bnd, Axis ax, real_type position)
     {
         p = std::fmin(p, position);
     }
-    points_[to_int(bnd)][to_int(ax)] = p;
+    extents_[to_int(ax)][to_int(bnd)] = p;
 }
 
 //---------------------------------------------------------------------------//
@@ -358,7 +366,7 @@ BoundingBox<T>::grow(Bound bnd, Axis ax, real_type position)
     {
         p = std::fmax(p, position);
     }
-    points_[to_int(bnd)][to_int(ax)] = p;
+    extents_[to_int(ax)][to_int(bnd)] = p;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -116,13 +116,13 @@ class BoundingBox
     //// MUTATORS ////
 
     // Reduce the bounding box's extent along an axis
-    CELER_CONSTEXPR_FUNCTION void shrink(Bound b, Axis ax, real_type position);
+    CELER_CONSTEXPR_FUNCTION void shrink(Bound b, Axis ax, real_type p);
 
     // Increase the bounding box's extent along an axis
-    CELER_CONSTEXPR_FUNCTION void grow(Bound b, Axis ax, real_type position);
+    CELER_CONSTEXPR_FUNCTION void grow(Bound b, Axis ax, real_type p);
 
     // Increase the bounding box's extent on both bounds
-    CELER_CONSTEXPR_FUNCTION void grow(Axis ax, real_type position);
+    CELER_CONSTEXPR_FUNCTION void grow(Axis ax, real_type p);
 
     //// FRIENDS ////
 
@@ -348,16 +348,16 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION void
-BoundingBox<T>::shrink(Bound b, Axis ax, real_type position)
+BoundingBox<T>::shrink(Bound b, Axis ax, real_type v)
 {
     real_type p = this->point(b, ax);
     if (b == Bound::lo)
     {
-        p = std::fmax(p, position);
+        p = std::fmax(p, v);
     }
     else
     {
-        p = std::fmin(p, position);
+        p = std::fmin(p, v);
     }
     this->point(b, ax, p);
 }
@@ -371,18 +371,18 @@ BoundingBox<T>::shrink(Bound b, Axis ax, real_type position)
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION void
-BoundingBox<T>::grow(Bound b, Axis ax, real_type position)
+BoundingBox<T>::grow(Bound b, Axis ax, real_type v)
 {
     real_type p = this->point(b, ax);
     if (b == Bound::lo)
     {
-        p = std::fmin(p, position);
+        p = std::fmin(p, v);
     }
     else
     {
-        p = std::fmax(p, position);
+        p = std::fmax(p, v);
     }
-    this->point(b, ax, p);
+    this->point(b, ax, v);
 }
 
 //---------------------------------------------------------------------------//
@@ -391,12 +391,15 @@ BoundingBox<T>::grow(Bound b, Axis ax, real_type position)
  *
  * If the point is outside the box, the box is expanded so the given boundary
  * is on that point. Otherwise no change is made.
+ *
+ * \post If the box is non-null, some point on the axis \c is_inside the
+ * bounding box.
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION void BoundingBox<T>::grow(Axis ax, real_type position)
+CELER_CONSTEXPR_FUNCTION void BoundingBox<T>::grow(Axis ax, real_type p)
 {
-    this->grow(Bound::lo, ax, position);
-    this->grow(Bound::hi, ax, position);
+    this->grow(Bound::lo, ax, p);
+    this->grow(Bound::hi, ax, p);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -28,11 +28,12 @@ namespace celeritas
 /*!
  * Axis-aligned bounding box.
  *
- * Bounding boxes "contain" all points inside \em and on their faces. See \c
- * is_inside in \c BoundingBoxUtils.hh .
+ * Bounding boxes "contain" all points inside \em and on their faces.
+ * See \c is_inside in \c BoundingBoxUtils.hh .
  *
  * The default bounding box is "null", which has at least one \c lower
- * coordinate greater than its \c upper coordinate: it evaluates to \c false .
+ * coordinate strictly greater than its \c upper coordinate: it evaluates to
+ * \c false .
  * A null bounding box still has the ability to be unioned and intersected with
  * other bounding boxes with the expected effect, but geometrical operations on
  * it (center, surface area, volume) are prohibited.
@@ -50,6 +51,8 @@ class BoundingBox
     //! \name Type aliases
     using real_type = T;
     using Real3 = Array<real_type, 3>;
+    using Extents = Array<real_type, 2>;
+    using Extents3 = Array<Extents, 3>;
     //!@}
 
   public:
@@ -60,11 +63,18 @@ class BoundingBox
     static CELER_CONSTEXPR_FUNCTION BoundingBox
     from_unchecked(Real3 const& lower, Real3 const& upper) noexcept;
 
+    // Construct from unchecked lo/hi extents
+    static CELER_CONSTEXPR_FUNCTION BoundingBox
+    from_unchecked(Extents3 const&) noexcept;
+
     // Construct in unassigned state
     CELER_CONSTEXPR_FUNCTION BoundingBox() noexcept;
 
     // Construct from upper and lower points
     inline CELER_FUNCTION BoundingBox(Real3 const& lower, Real3 const& upper);
+
+    // Construct from lo/hi extents (transposed layout)
+    inline CELER_FUNCTION BoundingBox(Extents3 const& extents);
 
     //// ACCESSORS ////
 
@@ -87,11 +97,17 @@ class BoundingBox
         return points_[to_int(b)];
     }
 
-    //! Access a bounding point
-    CELER_CONSTEXPR_FUNCTION real_type point(Bound b, Axis ax) const
+    //! Access a bounding point coordinate (const ref to support LDG)
+    CELER_CONSTEXPR_FUNCTION real_type const& point(Bound b, Axis ax) const&
     {
         CELER_EXPECT(ax != Axis::size_);
-        return this->point(b)[to_int(ax)];
+        return points_[to_int(b)][to_int(ax)];
+    }
+
+    //! Access a bounding point coordinate
+    CELER_CONSTEXPR_FUNCTION real_type point(Bound b, Axis ax) const&&
+    {
+        return this->point(b, ax);
     }
 
     // Whether the bbox is non-null
@@ -101,22 +117,21 @@ class BoundingBox
 
     // Reduce the bounding box's extent along an axis
     CELER_CONSTEXPR_FUNCTION void
-    shrink(Bound bnd, Axis axis, real_type position);
+    shrink(Bound bnd, Axis ax, real_type position);
 
     // Increase the bounding box's extent along an axis
-    CELER_CONSTEXPR_FUNCTION void
-    grow(Bound bnd, Axis axis, real_type position);
+    CELER_CONSTEXPR_FUNCTION void grow(Bound bnd, Axis ax, real_type position);
 
     // Increase the bounding box's extent on both bounds
-    CELER_CONSTEXPR_FUNCTION void grow(Axis axis, real_type position);
+    CELER_CONSTEXPR_FUNCTION void grow(Axis ax, real_type position);
 
-    //// FRIENDLY COMPARATORS ////
+    //// FRIENDS ////
 
     //! Test equality of two bounding boxes
     CELER_CONSTEXPR_FUNCTION friend bool
     operator==(BoundingBox const& lhs, BoundingBox const& rhs)
     {
-        return lhs.lower() == rhs.lower() && lhs.upper() == rhs.upper();
+        return lhs.points_ == rhs.points_;
     }
 
     //! Test inequality of two bounding boxes
@@ -138,9 +153,11 @@ class BoundingBox
 
     Points points_;  //!< lo/hi points
 
-    // Implementation of 'from_unchecked' (true type 'tag')
+    // Construct internally without validation (using tag type)
     CELER_CONSTEXPR_FUNCTION
     BoundingBox(std::true_type, Points const& points) noexcept;
+    CELER_CONSTEXPR_FUNCTION
+    BoundingBox(std::true_type, Extents3 const& extents) noexcept;
 };
 
 //---------------------------------------------------------------------------//
@@ -161,11 +178,14 @@ using BBox = BoundingBox<>;
  */
 template<class T, class U>
 CELER_CONSTEXPR_FUNCTION bool
-is_inside(BoundingBox<T> const& bbox, Array<U, 3> const& point)
+is_inside(BoundingBox<T> const& bb, Array<U, 3> const& p)
 {
-    return bbox.lower()[0] <= point[0] && point[0] <= bbox.upper()[0]
-           && bbox.lower()[1] <= point[1] && point[1] <= bbox.upper()[1]
-           && bbox.lower()[2] <= point[2] && point[2] <= bbox.upper()[2];
+    // clang-format off
+    using B = Bound; using A = Axis;
+    return    bb.point(B::lo, A::x) <= p[0] && p[0] <= bb.point(B::hi, A::x)
+           && bb.point(B::lo, A::y) <= p[1] && p[1] <= bb.point(B::hi, A::y)
+           && bb.point(B::lo, A::z) <= p[2] && p[2] <= bb.point(B::hi, A::z);
+    // clang-format on
 }
 
 //---------------------------------------------------------------------------//
@@ -183,16 +203,24 @@ CELER_FUNCTION BoundingBox<T> BoundingBox<T>::from_infinite() noexcept
 
 //---------------------------------------------------------------------------//
 /*!
- * Create a bounding box from unchecked lower/upper bounds.
- *
- * This should be used exclusively for utilities that understand the
- * "null" implementation of the bounding box.
+ * Create a bounding box from unchecked lower/upper points.
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>
 BoundingBox<T>::from_unchecked(Real3 const& lo, Real3 const& hi) noexcept
 {
-    return BoundingBox<T>{std::true_type{}, Points{lo, hi}};
+    return BoundingBox{std::true_type{}, Points{lo, hi}};
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a bounding box from unchecked lo/hi extents.
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION BoundingBox<T>
+BoundingBox<T>::from_unchecked(Extents3 const& extents) noexcept
+{
+    return BoundingBox{std::true_type{}, extents};
 }
 
 //---------------------------------------------------------------------------//
@@ -214,6 +242,7 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox() noexcept
     constexpr real_type inf = numeric_limits<real_type>::infinity();
     points_[to_int(Bound::lo)] = {inf, inf, inf};
     points_[to_int(Bound::hi)] = {-inf, -inf, -inf};
+    CELER_ENSURE(!*this);
 }
 
 //---------------------------------------------------------------------------//
@@ -225,22 +254,25 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox() noexcept
  */
 template<class T>
 CELER_FUNCTION BoundingBox<T>::BoundingBox(Real3 const& lo, Real3 const& hi)
-    : points_{{lo, hi}}
+    : BoundingBox{std::true_type{}, Points{lo, hi}}
 {
-    if constexpr (CELERITAS_DEBUG)
-    {
-        for (auto ax : {Axis::x, Axis::y, Axis::z})
-        {
-            CELER_EXPECT(this->lower()[to_int(ax)]
-                         <= this->upper()[to_int(ax)]);
-        }
-    }
-    CELER_ENSURE(*this);
+    CELER_EXPECT(*this);
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * Create a possibly null bounding box from two points.
+ * Create a non-null bounding box from lo/hi extents.
+ */
+template<class T>
+CELER_FUNCTION BoundingBox<T>::BoundingBox(Extents3 const& extents)
+    : BoundingBox{std::true_type{}, extents}
+{
+    CELER_EXPECT(*this);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create a bounding box from points without validation (internal).
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION
@@ -251,18 +283,36 @@ BoundingBox<T>::BoundingBox(std::true_type, Points const& points) noexcept
 
 //---------------------------------------------------------------------------//
 /*!
+ * Create a bounding box from extents without validation (internal).
+ */
+template<class T>
+CELER_CONSTEXPR_FUNCTION
+BoundingBox<T>::BoundingBox(std::true_type, Extents3 const& extents) noexcept
+{
+    for (auto ax : {Axis::x, Axis::y, Axis::z})
+    {
+        for (auto b : {Bound::lo, Bound::hi})
+        {
+            points_[to_int(b)][to_int(ax)] = extents[to_int(ax)][to_int(b)];
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Whether the bbox contains any point in space.
  *
- * \todo This is inconsistent with the edge case: bounding boxes contain
- * points on their faces. A bounding box with `lower == upper` should be an
- * infinitesimal but "true" box, containing just that one point.
+ * A null box contains no points, and a degenerate point/edge/face contains
+ * that point.
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const
 {
-    return this->lower()[0] <= this->upper()[0]
-           && this->lower()[1] <= this->upper()[1]
-           && this->lower()[2] <= this->upper()[2];
+    // clang-format off
+    return this->point(Bound::lo, Axis::x) <= this->point(Bound::hi, Axis::x)
+        && this->point(Bound::lo, Axis::y) <= this->point(Bound::hi, Axis::y)
+        && this->point(Bound::lo, Axis::z) <= this->point(Bound::hi, Axis::z);
+    // clang-format on
 }
 
 //---------------------------------------------------------------------------//
@@ -274,9 +324,9 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION void
-BoundingBox<T>::shrink(Bound bnd, Axis axis, real_type position)
+BoundingBox<T>::shrink(Bound bnd, Axis ax, real_type position)
 {
-    real_type p = points_[to_int(bnd)][to_int(axis)];
+    real_type p = this->point(bnd, ax);
     if (bnd == Bound::lo)
     {
         p = std::fmax(p, position);
@@ -285,7 +335,7 @@ BoundingBox<T>::shrink(Bound bnd, Axis axis, real_type position)
     {
         p = std::fmin(p, position);
     }
-    points_[to_int(bnd)][to_int(axis)] = p;
+    points_[to_int(bnd)][to_int(ax)] = p;
 }
 
 //---------------------------------------------------------------------------//
@@ -297,9 +347,9 @@ BoundingBox<T>::shrink(Bound bnd, Axis axis, real_type position)
  */
 template<class T>
 CELER_CONSTEXPR_FUNCTION void
-BoundingBox<T>::grow(Bound bnd, Axis axis, real_type position)
+BoundingBox<T>::grow(Bound bnd, Axis ax, real_type position)
 {
-    real_type p = points_[to_int(bnd)][to_int(axis)];
+    real_type p = this->point(bnd, ax);
     if (bnd == Bound::lo)
     {
         p = std::fmin(p, position);
@@ -308,7 +358,7 @@ BoundingBox<T>::grow(Bound bnd, Axis axis, real_type position)
     {
         p = std::fmax(p, position);
     }
-    points_[to_int(bnd)][to_int(axis)] = p;
+    points_[to_int(bnd)][to_int(ax)] = p;
 }
 
 //---------------------------------------------------------------------------//
@@ -319,11 +369,10 @@ BoundingBox<T>::grow(Bound bnd, Axis axis, real_type position)
  * is on that point. Otherwise no change is made.
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION void
-BoundingBox<T>::grow(Axis axis, real_type position)
+CELER_CONSTEXPR_FUNCTION void BoundingBox<T>::grow(Axis ax, real_type position)
 {
-    this->grow(Bound::lo, axis, position);
-    this->grow(Bound::hi, axis, position);
+    this->grow(Bound::lo, ax, position);
+    this->grow(Bound::hi, ax, position);
 }
 
 #if !CELER_DEVICE_COMPILE

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -382,7 +382,7 @@ BoundingBox<T>::grow(Bound b, Axis ax, real_type v)
     {
         p = std::fmax(p, v);
     }
-    this->point(b, ax, v);
+    this->point(b, ax, p);
 }
 
 //---------------------------------------------------------------------------//

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -71,10 +71,13 @@ class BoundingBox
     CELER_CONSTEXPR_FUNCTION BoundingBox() noexcept;
 
     // Construct from upper and lower points
-    inline CELER_FUNCTION BoundingBox(Real3 const& lower, Real3 const& upper);
+    inline CELER_FUNCTION
+    BoundingBox(Real3 const& lower,
+                Real3 const& upper) noexcept(!CELERITAS_DEBUG);
 
     // Construct from lo/hi extents (transposed layout)
-    inline CELER_FUNCTION BoundingBox(Extents3 const& extents);
+    inline CELER_FUNCTION
+    BoundingBox(Extents3 const& extents) noexcept(!CELERITAS_DEBUG);
 
     //// ACCESSORS ////
 
@@ -92,26 +95,29 @@ class BoundingBox
 
     //! Access a bounding point
     CELER_CONSTEXPR_FUNCTION Real3 const& point(Bound b) const
+        noexcept(!CELERITAS_DEBUG)
     {
         CELER_EXPECT(b != Bound::size_);
         return points_[to_int(b)];
     }
 
     //! Access a bounding point coordinate (const ref to support LDG)
-    CELER_CONSTEXPR_FUNCTION real_type const& point(Bound b, Axis ax) const&
+    CELER_CONSTEXPR_FUNCTION real_type const&
+    point(Bound b, Axis ax) const& noexcept(!CELERITAS_DEBUG)
     {
         CELER_EXPECT(ax != Axis::size_);
         return points_[to_int(b)][to_int(ax)];
     }
 
     //! Access a bounding point coordinate
-    CELER_CONSTEXPR_FUNCTION real_type point(Bound b, Axis ax) const&&
+    CELER_CONSTEXPR_FUNCTION real_type
+    point(Bound b, Axis ax) const&& noexcept(!CELERITAS_DEBUG)
     {
         return this->point(b, ax);
     }
 
     // Whether the bbox is non-null
-    CELER_CONSTEXPR_FUNCTION explicit operator bool() const;
+    CELER_CONSTEXPR_FUNCTION explicit operator bool() const noexcept;
 
     //// MUTATORS ////
 
@@ -175,7 +181,8 @@ class BoundingBox
     BoundingBox(std::true_type, Extents3 const& extents) noexcept;
 
     //! Set a bounding point coordinate (different signature to allow private)
-    CELER_CONSTEXPR_FUNCTION void point(Bound b, Axis ax, real_type p) &
+    CELER_CONSTEXPR_FUNCTION void
+    point(Bound b, Axis ax, real_type p) & noexcept
     {
         points_[to_int(b)][to_int(ax)] = p;
     }
@@ -199,7 +206,7 @@ using BBox = BoundingBox<>;
  */
 template<class T, class U>
 CELER_CONSTEXPR_FUNCTION bool
-is_inside(BoundingBox<T> const& bb, Array<U, 3> const& p)
+is_inside(BoundingBox<T> const& bb, Array<U, 3> const& p) noexcept
 {
     // clang-format off
     using B = Bound; using A = Axis;
@@ -277,7 +284,9 @@ CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox() noexcept
  * at a single point) but upper must not be less than lower.
  */
 template<class T>
-CELER_FUNCTION BoundingBox<T>::BoundingBox(Real3 const& lo, Real3 const& hi)
+CELER_FUNCTION
+BoundingBox<T>::BoundingBox(Real3 const& lo,
+                            Real3 const& hi) noexcept(!CELERITAS_DEBUG)
     : BoundingBox{std::true_type{}, Points{lo, hi}}
 {
     CELER_EXPECT(*this);
@@ -288,7 +297,8 @@ CELER_FUNCTION BoundingBox<T>::BoundingBox(Real3 const& lo, Real3 const& hi)
  * Create a non-null bounding box from lo/hi extents.
  */
 template<class T>
-CELER_FUNCTION BoundingBox<T>::BoundingBox(Extents3 const& extents)
+CELER_FUNCTION
+BoundingBox<T>::BoundingBox(Extents3 const& extents) noexcept(!CELERITAS_DEBUG)
     : BoundingBox{std::true_type{}, extents}
 {
     CELER_EXPECT(*this);
@@ -330,7 +340,7 @@ BoundingBox<T>::BoundingBox(std::true_type, Extents3 const& extents) noexcept
  * that point.
  */
 template<class T>
-CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const
+CELER_CONSTEXPR_FUNCTION BoundingBox<T>::operator bool() const noexcept
 {
     // clang-format off
     return this->point(Bound::lo, Axis::x) <= this->point(Bound::hi, Axis::x)

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -18,6 +18,10 @@
 
 #include "Types.hh"
 
+#if !CELER_DEVICE_COMPILE
+#    include <ostream>
+#endif
+
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
@@ -321,6 +325,24 @@ BoundingBox<T>::grow(Axis axis, real_type position)
     this->grow(Bound::lo, axis, position);
     this->grow(Bound::hi, axis, position);
 }
+
+#if !CELER_DEVICE_COMPILE
+//---------------------------------------------------------------------------//
+/*!
+ * Write a bounding box to a stream.
+ */
+template<class T>
+inline std::ostream& operator<<(std::ostream& os, BoundingBox<T> const& bbox)
+{
+    os << '{';
+    if (bbox)
+    {
+        os << bbox.lower() << ", " << bbox.upper();
+    }
+    os << '}';
+    return os;
+}
+#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -148,6 +148,20 @@ class BoundingBox
         return BoundingBox{std::true_type{}, ldg(&bb->points_)};
     }
 
+#if !CELER_DEVICE_COMPILE
+    //! Write box to a stream
+    friend std::ostream& operator<<(std::ostream& os, BoundingBox const& bbox)
+    {
+        os << '{';
+        if (bbox)
+        {
+            os << bbox.lower() << ", " << bbox.upper();
+        }
+        os << '}';
+        return os;
+    }
+#endif
+
   private:
     using Points = Array<Real3, 2>;
 
@@ -374,24 +388,6 @@ CELER_CONSTEXPR_FUNCTION void BoundingBox<T>::grow(Axis ax, real_type position)
     this->grow(Bound::lo, ax, position);
     this->grow(Bound::hi, ax, position);
 }
-
-#if !CELER_DEVICE_COMPILE
-//---------------------------------------------------------------------------//
-/*!
- * Write a bounding box to a stream.
- */
-template<class T>
-inline std::ostream& operator<<(std::ostream& os, BoundingBox<T> const& bbox)
-{
-    os << '{';
-    if (bbox)
-    {
-        os << bbox.lower() << ", " << bbox.upper();
-    }
-    os << '}';
-    return os;
-}
-#endif
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/geocel/BoundingBox.hh
+++ b/src/geocel/BoundingBox.hh
@@ -79,34 +79,29 @@ class BoundingBox
     //// ACCESSORS ////
 
     //! Lower bbox coordinate
-    CELER_CONSTEXPR_FUNCTION Real3 lower() const
+    CELER_CONSTEXPR_FUNCTION Real3 const& lower() const
     {
         return this->point(Bound::lo);
     }
 
     //! Upper bbox coordinate
-    CELER_CONSTEXPR_FUNCTION Real3 upper() const
+    CELER_CONSTEXPR_FUNCTION Real3 const& upper() const
     {
         return this->point(Bound::hi);
     }
 
     //! Access a bounding point
-    CELER_CONSTEXPR_FUNCTION Real3 point(Bound b) const
+    CELER_CONSTEXPR_FUNCTION Real3 const& point(Bound b) const
     {
         CELER_EXPECT(b != Bound::size_);
-        Real3 result;
-        for (auto ax : {Axis::x, Axis::y, Axis::z})
-        {
-            result[to_int(ax)] = extents_[to_int(ax)][to_int(b)];
-        }
-        return result;
+        return points_[to_int(b)];
     }
 
     //! Access a bounding point coordinate (const ref to support LDG)
     CELER_CONSTEXPR_FUNCTION real_type const& point(Bound b, Axis ax) const&
     {
         CELER_EXPECT(ax != Axis::size_);
-        return extents_[to_int(ax)][to_int(b)];
+        return points_[to_int(b)][to_int(ax)];
     }
 
     //! Access a bounding point coordinate
@@ -136,7 +131,7 @@ class BoundingBox
     CELER_CONSTEXPR_FUNCTION friend bool
     operator==(BoundingBox const& lhs, BoundingBox const& rhs)
     {
-        return lhs.extents_ == rhs.extents_;
+        return lhs.points_ == rhs.points_;
     }
 
     //! Test inequality of two bounding boxes
@@ -150,13 +145,13 @@ class BoundingBox
     CELER_CONSTEXPR_FUNCTION friend BoundingBox
     ldg(BoundingBox const* bb) noexcept
     {
-        return BoundingBox{std::true_type{}, ldg(&bb->extents_)};
+        return BoundingBox{std::true_type{}, ldg(&bb->points_)};
     }
 
   private:
     using Points = Array<Real3, 2>;
 
-    Extents3 extents_;  //!< Extents for x, y, z axes
+    Points points_;  //!< lo/hi points
 
     // Construct internally without validation (using tag type)
     CELER_CONSTEXPR_FUNCTION
@@ -245,11 +240,8 @@ template<class T>
 CELER_CONSTEXPR_FUNCTION BoundingBox<T>::BoundingBox() noexcept
 {
     constexpr real_type inf = numeric_limits<real_type>::infinity();
-    for (auto ax : {Axis::x, Axis::y, Axis::z})
-    {
-        extents_[to_int(ax)][to_int(Bound::lo)] = inf;
-        extents_[to_int(ax)][to_int(Bound::hi)] = -inf;
-    }
+    points_[to_int(Bound::lo)] = {inf, inf, inf};
+    points_[to_int(Bound::hi)] = {-inf, -inf, -inf};
     CELER_ENSURE(!*this);
 }
 
@@ -285,14 +277,8 @@ CELER_FUNCTION BoundingBox<T>::BoundingBox(Extents3 const& extents)
 template<class T>
 CELER_CONSTEXPR_FUNCTION
 BoundingBox<T>::BoundingBox(std::true_type, Points const& points) noexcept
+    : points_{points}
 {
-    for (auto b : {Bound::lo, Bound::hi})
-    {
-        for (auto ax : {Axis::x, Axis::y, Axis::z})
-        {
-            extents_[to_int(ax)][to_int(b)] = points[to_int(b)][to_int(ax)];
-        }
-    }
 }
 
 //---------------------------------------------------------------------------//
@@ -302,8 +288,14 @@ BoundingBox<T>::BoundingBox(std::true_type, Points const& points) noexcept
 template<class T>
 CELER_CONSTEXPR_FUNCTION
 BoundingBox<T>::BoundingBox(std::true_type, Extents3 const& extents) noexcept
-    : extents_{extents}
 {
+    for (auto ax : {Axis::x, Axis::y, Axis::z})
+    {
+        for (auto b : {Bound::lo, Bound::hi})
+        {
+            points_[to_int(b)][to_int(ax)] = extents[to_int(ax)][to_int(b)];
+        }
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -343,7 +335,7 @@ BoundingBox<T>::shrink(Bound bnd, Axis ax, real_type position)
     {
         p = std::fmin(p, position);
     }
-    extents_[to_int(ax)][to_int(bnd)] = p;
+    points_[to_int(bnd)][to_int(ax)] = p;
 }
 
 //---------------------------------------------------------------------------//
@@ -366,7 +358,7 @@ BoundingBox<T>::grow(Bound bnd, Axis ax, real_type position)
     {
         p = std::fmax(p, position);
     }
-    extents_[to_int(ax)][to_int(bnd)] = p;
+    points_[to_int(bnd)][to_int(ax)] = p;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/BoundingBoxUtils.cc
+++ b/src/orange/BoundingBoxUtils.cc
@@ -101,23 +101,4 @@ BBox calc_transform(Transformation const& tr, BBox const& a)
 }
 
 //---------------------------------------------------------------------------//
-/*!
- * Write a bounding box to a stream.
- */
-template<class T>
-std::ostream& operator<<(std::ostream& os, BoundingBox<T> const& bbox)
-{
-    os << '{';
-    if (bbox)
-    {
-        os << bbox.lower() << ", " << bbox.upper();
-    }
-    os << '}';
-    return os;
-}
-
-template std::ostream& operator<<(std::ostream&, BoundingBox<float> const&);
-template std::ostream& operator<<(std::ostream&, BoundingBox<double> const&);
-
-//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -12,6 +12,7 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
+#include "corecel/grid/GridTypes.hh"
 #include "corecel/math/Algorithms.hh"
 #include "geocel/BoundingBox.hh"
 
@@ -30,13 +31,12 @@ class Transformation;
 template<class T>
 inline bool is_infinite(BoundingBox<T> const& bbox)
 {
-    auto all_equal = [](Array<T, 3> const& values, T rhs) {
-        return all_of(
-            values.begin(), values.end(), [rhs](T lhs) { return lhs == rhs; });
-    };
-    constexpr T inf = numeric_limits<T>::infinity();
-
-    return all_equal(bbox.lower(), -inf) && all_equal(bbox.upper(), inf);
+    auto axes = range(Axis::size_);
+    return all_of(axes.begin(), axes.end(), [&bbox](Axis ax) {
+        constexpr T inf = numeric_limits<T>::infinity();
+        return bbox.point(Bound::lo, ax) == -inf
+               && bbox.point(Bound::hi, ax) == inf;
+    });
 }
 
 //---------------------------------------------------------------------------//
@@ -50,9 +50,11 @@ inline bool is_finite(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
-    auto isinf = [](T value) { return std::isinf(value); };
-    return !any_of(bbox.lower().begin(), bbox.lower().end(), isinf)
-           && !any_of(bbox.upper().begin(), bbox.upper().end(), isinf);
+    auto axes = range(Axis::size_);
+    return all_of(axes.begin(), axes.end(), [&bbox](Axis ax) {
+        return !std::isinf(bbox.point(Bound::lo, ax))
+               && !std::isinf(bbox.point(Bound::hi, ax));
+    });
 }
 
 //---------------------------------------------------------------------------//
@@ -66,9 +68,9 @@ inline bool is_degenerate(BoundingBox<T> const& bbox)
 {
     CELER_EXPECT(bbox);
 
-    auto axes = range(to_int(Axis::size_));
-    return any_of(axes.begin(), axes.end(), [&bbox](int ax) {
-        return bbox.lower()[ax] == bbox.upper()[ax];
+    auto axes = range(Axis::size_);
+    return any_of(axes.begin(), axes.end(), [&bbox](Axis ax) {
+        return bbox.point(Bound::lo, ax) == bbox.point(Bound::hi, ax);
     });
 }
 
@@ -79,9 +81,10 @@ inline bool is_degenerate(BoundingBox<T> const& bbox)
 template<class T>
 inline bool is_half_inf(BoundingBox<T> const& bbox)
 {
-    auto axes = range(to_int(Axis::size_));
-    return any_of(axes.begin(), axes.end(), [&bbox](int ax) {
-        return std::isinf(bbox.lower()[ax]) != std::isinf(bbox.upper()[ax]);
+    auto axes = range(Axis::size_);
+    return any_of(axes.begin(), axes.end(), [&bbox](Axis ax) {
+        return std::isinf(bbox.point(Bound::lo, ax))
+               != std::isinf(bbox.point(Bound::hi, ax));
     });
 }
 
@@ -100,13 +103,14 @@ inline Array<T, 3> calc_center(BoundingBox<T> const& bbox)
     CELER_EXPECT(!is_half_inf(bbox));
 
     Array<T, 3> center;
-    for (auto ax : range(to_int(Axis::size_)))
+    for (auto ax : range(Axis::size_))
     {
-        center[ax] = (bbox.lower()[ax] + bbox.upper()[ax]) / 2;
-        if (CELER_UNLIKELY(std::isnan(center[ax])))
+        center[to_int(ax)]
+            = (bbox.point(Bound::lo, ax) + bbox.point(Bound::hi, ax)) / 2;
+        if (CELER_UNLIKELY(std::isnan(center[to_int(ax)])))
         {
             // Infinite or half-infinite
-            center[ax] = 0;
+            center[to_int(ax)] = 0;
         }
     }
 
@@ -125,9 +129,10 @@ inline Array<T, 3> calc_half_widths(BoundingBox<T> const& bbox)
     CELER_EXPECT(bbox);
 
     Array<T, 3> hw;
-    for (auto ax : range(to_int(Axis::size_)))
+    for (auto ax : range(Axis::size_))
     {
-        hw[ax] = (bbox.upper()[ax] - bbox.lower()[ax]) / 2;
+        hw[to_int(ax)]
+            = (bbox.point(Bound::hi, ax) - bbox.point(Bound::lo, ax)) / 2;
     }
 
     return hw;
@@ -146,9 +151,10 @@ inline T calc_surface_area(BoundingBox<T> const& bbox)
 
     Array<T, 3> lengths;
 
-    for (auto ax : range(to_int(Axis::size_)))
+    for (auto ax : range(Axis::size_))
     {
-        lengths[ax] = bbox.upper()[ax] - bbox.lower()[ax];
+        lengths[to_int(ax)] = bbox.point(Bound::hi, ax)
+                              - bbox.point(Bound::lo, ax);
     }
 
     return 2
@@ -170,9 +176,9 @@ inline T calc_volume(BoundingBox<T> const& bbox)
 
     T result{1};
 
-    for (auto ax : range(to_int(Axis::size_)))
+    for (auto ax : range(Axis::size_))
     {
-        result *= bbox.upper()[ax] - bbox.lower()[ax];
+        result *= bbox.point(Bound::hi, ax) - bbox.point(Bound::lo, ax);
     }
 
     return result;
@@ -186,16 +192,16 @@ template<class T>
 inline constexpr BoundingBox<T>
 calc_union(BoundingBox<T> const& a, BoundingBox<T> const& b)
 {
-    Array<T, 3> lower{};
-    Array<T, 3> upper{};
-
-    for (auto ax : range(to_int(Axis::size_)))
+    typename BoundingBox<T>::Extents3 extents;
+    for (auto ax : range(Axis::size_))
     {
-        lower[ax] = celeritas::min(a.lower()[ax], b.lower()[ax]);
-        upper[ax] = celeritas::max(a.upper()[ax], b.upper()[ax]);
+        extents[to_int(ax)][to_int(Bound::lo)]
+            = celeritas::min(a.point(Bound::lo, ax), b.point(Bound::lo, ax));
+        extents[to_int(ax)][to_int(Bound::hi)]
+            = celeritas::max(a.point(Bound::hi, ax), b.point(Bound::hi, ax));
     }
 
-    return BoundingBox<T>::from_unchecked(lower, upper);
+    return BoundingBox<T>::from_unchecked(extents);
 }
 
 //---------------------------------------------------------------------------//
@@ -208,16 +214,16 @@ template<class T>
 inline constexpr BoundingBox<T>
 calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
 {
-    Array<T, 3> lower{};
-    Array<T, 3> upper{};
-
-    for (auto ax : range(to_int(Axis::size_)))
+    typename BoundingBox<T>::Extents3 extents;
+    for (auto ax : range(Axis::size_))
     {
-        lower[ax] = celeritas::max(a.lower()[ax], b.lower()[ax]);
-        upper[ax] = celeritas::min(a.upper()[ax], b.upper()[ax]);
+        extents[to_int(ax)][to_int(Bound::lo)]
+            = celeritas::max(a.point(Bound::lo, ax), b.point(Bound::lo, ax));
+        extents[to_int(ax)][to_int(Bound::hi)]
+            = celeritas::min(a.point(Bound::hi, ax), b.point(Bound::hi, ax));
     }
 
-    return BoundingBox<T>::from_unchecked(lower, upper);
+    return BoundingBox<T>::from_unchecked(extents);
 }
 
 //---------------------------------------------------------------------------//
@@ -234,10 +240,10 @@ inline bool encloses(BoundingBox<T> const& big, BoundingBox<T> const& small)
 {
     CELER_EXPECT(big || small);
 
-    auto axes = range(to_int(Axis::size_));
-    return all_of(axes.begin(), axes.end(), [&big, &small](int ax) {
-        return big.lower()[ax] <= small.lower()[ax]
-               && big.upper()[ax] >= small.upper()[ax];
+    auto axes = range(Axis::size_);
+    return all_of(axes.begin(), axes.end(), [&big, &small](Axis ax) {
+        return big.point(Bound::lo, ax) <= small.point(Bound::lo, ax)
+               && big.point(Bound::hi, ax) >= small.point(Bound::hi, ax);
     });
 }
 
@@ -350,16 +356,17 @@ class BoundingBoxBumper
     //! Return the expanded and converted bounding box
     result_type operator()(argument_type const& bbox)
     {
-        Array<T, 3> lower;
-        Array<T, 3> upper;
+        typename result_type::Extents3 extents;
 
-        for (auto ax : range(to_int(Axis::size_)))
+        for (auto ax : range(Axis::size_))
         {
-            lower[ax] = this->bumped<-1>(bbox.lower()[ax]);
-            upper[ax] = this->bumped<+1>(bbox.upper()[ax]);
+            extents[to_int(ax)][to_int(Bound::lo)]
+                = this->bumped<-1>(bbox.point(Bound::lo, ax));
+            extents[to_int(ax)][to_int(Bound::hi)]
+                = this->bumped<+1>(bbox.point(Bound::hi, ax));
         }
 
-        return result_type::from_unchecked(lower, upper);
+        return result_type::from_unchecked(extents);
     }
 
   private:

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -383,8 +383,4 @@ BBox calc_transform(Translation const& tr, BBox const& a);
 BBox calc_transform(Transformation const& tr, BBox const& a);
 
 //---------------------------------------------------------------------------//
-template<class T>
-std::ostream& operator<<(std::ostream&, BoundingBox<T> const& bbox);
-
-//---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/test/geocel/BoundingBox.test.cc
+++ b/test/geocel/BoundingBox.test.cc
@@ -115,6 +115,9 @@ TEST_F(BoundingBoxTest, standard)
     EXPECT_VEC_SOFT_EQ((Real3{3, 0, 6}), bb.upper());
     EXPECT_REAL_EQ(-1, bb.point(Bound::lo, Axis::x));
     EXPECT_REAL_EQ(6, bb.point(Bound::hi, Axis::z));
+
+    // Test point-by-value
+    EXPECT_REAL_EQ(-1, BBox{bb}.point(Bound::lo, Axis::x));
 }
 
 TEST_F(BoundingBoxTest, is_inside)

--- a/test/geocel/BoundingBox.test.cc
+++ b/test/geocel/BoundingBox.test.cc
@@ -166,6 +166,9 @@ TEST_F(BoundingBoxTest, io)
     EXPECT_EQ("[[-1.0,-2.0,-3.0],[3.0,2.0,1.0]]", to_json_string(bboxes[0]));
     EXPECT_EQ("null", to_json_string(BoundingBoxT{}));
 
+    EXPECT_EQ("{{-1,-2,-3}, {3,2,1}}", stream_to_string(bboxes[0]));
+    EXPECT_EQ("{}", stream_to_string(BoundingBoxT{}));
+
     // Test round tripping
     for (BoundingBoxT const& bb : bboxes)
     {

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -446,20 +446,6 @@ TEST_F(BoundingBoxUtilsTest, bbox_transform)
     }
 }
 
-TEST_F(BoundingBoxUtilsTest, stream)
-{
-    {
-        std::ostringstream os;
-        os << BBox{};
-        EXPECT_EQ("{}", os.str());
-    }
-    {
-        std::ostringstream os;
-        os << BBox{{1, 2, 3}, {4, 5, 6}};
-        EXPECT_EQ("{{1,2,3}, {4,5,6}}", os.str());
-    }
-}
-
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas

--- a/test/orange/orangeinp/CsgTestUtils.cc
+++ b/test/orange/orangeinp/CsgTestUtils.cc
@@ -264,8 +264,11 @@ std::vector<real_type> flattened(BoundingZone const& bz)
     std::vector<real_type> result;
     for (auto const* bb : {&bz.interior, &bz.exterior})
     {
-        result.insert(result.end(), bb->lower().begin(), bb->lower().end());
-        result.insert(result.end(), bb->upper().begin(), bb->upper().end());
+        auto append = [&result](Real3 v) {
+            result.insert(result.end(), v.begin(), v.end());
+        };
+        append(bb->lower());
+        append(bb->upper());
     }
     result.push_back(bz.negated ? -1 : 1);
     return result;


### PR DESCRIPTION
Many/most of the runtime bounding box algorithms loop over axes on the outside and bounds on the inside. This updates the bounding box internals to allow us to switch the axis/bound storage in the bounding box by writing most code as `box.point(bound, axis)`.
- Add `Extents3` type to allow construction/use by lo/hi pairs for each axis
- Use `point(b, ax)` in algorithms
- Add separate const ref and rvalue ref `point` accessors to allow `ldg(&bbox.point(b, ax))` in future testing