### PR TITLE
BIH -> BVH rename

### DIFF
--- a/doc/implementation/geometry/orange/runtime.rst
+++ b/doc/implementation/geometry/orange/runtime.rst
@@ -11,7 +11,7 @@ ORANGE runtime execution will be described here in greater detail in the future.
 Acceleration structures
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Celeritas uses a bounding interval hierarchy to accelerate volume
+Celeritas uses a bounding volume hierarchy to accelerate volume
 intersections.
 
 Tracking

--- a/doc/usage/execution/environment.rst
+++ b/doc/usage/execution/environment.rst
@@ -46,18 +46,18 @@ has a default value but can be overridden with any boolean value.
  CELER_KILL_OFFLOAD        accel     Flag: kill offloaded tracks [#ko]_
  CELER_NONFATAL_FLUSH      accel     Flag: print and continue on failure [#nf]_
  CELER_STRIP_SOURCEDIR     accel     Flag: clean exception output
- ORANGE_BIH_MAX_LEAF_SIZE  orange    Set BIH ``max_leaf_size``, i.e., the
+ ORANGE_BVH_MAX_LEAF_SIZE  orange    Set BVH ``max_leaf_size``, i.e., the
                                      maximum number of bboxes that can reside on
                                      a leaf node without triggering a
                                      partitioning attempt
- ORAMGE_BIH_DEPTH_LIMIT    orange    Set BIH ``depth_limit``, i.e., the hard
+ ORANGE_BVH_DEPTH_LIMIT    orange    Set BVH ``depth_limit``, i.e., the hard
                                      limit on the depth of most the embedded
                                      node (where 1 is the root node)
- ORANGE_BIH_PART_CANDS     orange    Set BIH ``num_part_cands``, i.e., the
+ ORANGE_BVH_PART_CANDS     orange    Set BVH ``num_part_cands``, i.e., the
                                      number of partition candidates to check per
-                                     axis when partitioning a node during BIH
+                                     axis when partitioning a node during BVH
                                      construction
- ORANGE_BIH_STRUCTURE      orange    Include "structure" info in BIH JSON output
+ ORANGE_BVH_STRUCTURE      orange    Include "structure" info in BVH JSON output
  ========================= ========= ==========================================
 
 .. [#pr] See :ref:`profiling`. This should default to 1 when running through

--- a/scripts/user/orange-bvh-to-dot.py
+++ b/scripts/user/orange-bvh-to-dot.py
@@ -2,12 +2,12 @@
 # Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """
-Convert BIH structure metadata within a JSON file to GraphViz .dot files.
+Convert BVH structure metadata within a JSON file to GraphViz .dot files.
 
 Behavior:
 
-1. ``-u/--universe``: write ``bih_<uid>.dot`` for selected universe IDs,
-2. ``-a/--all``: write ``bih_<uid>.dot`` for all universes,
+1. ``-u/--universe``: write ``bvh_<uid>.dot`` for selected universe IDs,
+2. ``-a/--all``: write ``bvh_<uid>.dot`` for all universes,
 3. Neither ``-u/--universe`` nor ``-a/--all``: print univers-wise diagnostics
    only.
 
@@ -16,13 +16,13 @@ In cases 1 and 2 the output directory can be specified with ``-o/--output``.
 .. example::
 
     # Write selected universes
-    ./orange-bih-to-dot.py out.json -u 0 3
+    ./orange-bvh-to-dot.py out.json -u 0 3
 
     # Write all universes
-    ./orange-bih-to-dot.py out.json --all
+    ./orange-bvh-to-dot.py out.json --all
 
     # Print diagnostics only
-    ./orange-bih-to-dot.py out.json
+    ./orange-bvh-to-dot.py out.json
 """
 
 import json
@@ -103,7 +103,7 @@ def dump_dot(universe_id, tree, out):
 
     out.write(
         dedent(f"""\
-        strict digraph "bih_{universe_id}" {{
+        strict digraph "bvh_{universe_id}" {{
           rankdir=LR
           node [shape=box style=filled]
         """)
@@ -144,10 +144,10 @@ def dump_dot(universe_id, tree, out):
     out.write("}\n")
 
 
-def write_diagnostic(outfile, bih_data):
-    depth = bih_data["depth"]
-    nvol = bih_data["num_finite_bboxes"]
-    ninf = bih_data["num_infinite_bboxes"]
+def write_diagnostic(outfile, bvh_data):
+    depth = bvh_data["depth"]
+    nvol = bvh_data["num_finite_bboxes"]
+    ninf = bvh_data["num_infinite_bboxes"]
 
     template = "{:>8} {:>8} {:>8} {:>8}\n"
     out = template.format("uid", "depth", "num_vols", "num_inf")
@@ -168,19 +168,19 @@ def run(args):
     else:
         orange = data["orange_stats"]
 
-    bih_data = orange["bih_metadata"]
+    bvh_data = orange["bvh_metadata"]
 
     if args.universe:
         uids = args.universe
     elif args.all:
-        uids = list(range(len(bih_data["structure"])))
+        uids = list(range(len(bvh_data["structure"])))
     else:
-        write_diagnostic(sys.stdout, bih_data)
+        write_diagnostic(sys.stdout, bvh_data)
         return
 
     for uid in uids:
-        with open(Path(args.output) / "bih_{}.dot".format(uid), "w") as out:
-            dump_dot(uid, bih_data["structure"][uid]["tree"], out)
+        with open(Path(args.output) / "bvh_{}.dot".format(uid), "w") as out:
+            dump_dot(uid, bvh_data["structure"][uid]["tree"], out)
 
 
 def main():

--- a/src/corecel/data/Ldg.hh
+++ b/src/corecel/data/Ldg.hh
@@ -144,7 +144,7 @@ ldg(T const* ptr) noexcept
  *
  * Convenience overload for when the member is known at the call site.
  * \code
- * BIHNodeId parent = ldg(node, &BIHLeafNode::parent);
+ * BvhNodeId parent = ldg(node, &BvhLeafNode::parent);
  * \endcode
  */
 template<class Class, class T>
@@ -163,8 +163,8 @@ CELER_CONSTEXPR_FUNCTION T ldg(Class const& obj, T Class::* mp) noexcept
  * as a callable; for immediate use prefer the two-argument \c ldg overload.
  *
  * \code
- * auto load_parent = LdgMember{&BIHLeafNode::parent};
- * BIHNodeId parent = load_parent(node);
+ * auto load_parent = LdgMember{&BvhLeafNode::parent};
+ * BvhNodeId parent = load_parent(node);
  * \endcode
  */
 template<class Class, class T>

--- a/src/orange/AGENTS.md
+++ b/src/orange/AGENTS.md
@@ -85,7 +85,7 @@ The `UnitInserter` then flattens the `UnitProto` hierarchy into the flat `Orange
 
 ### Acceleration structure
 
-At runtime, ORANGE uses a **bounding interval hierarchy (BIH)** to accelerate surface intersection queries, avoiding a brute-force search over all surfaces in a unit.
+At runtime, ORANGE uses a **bounding volume hierarchy (BVH)** to accelerate surface intersection queries, avoiding a brute-force search over all surfaces in a unit.
 
 ## Runtime Tracking System
 

--- a/src/orange/CMakeLists.txt
+++ b/src/orange/CMakeLists.txt
@@ -22,8 +22,8 @@ list(APPEND SOURCES
   OrangeTypes.cc
   OrangeTypesIO.json.cc
   SafetyImager.cc
-  detail/BIHBuilder.cc
-  detail/BIHPartitioner.cc
+  detail/BvhBuilder.cc
+  detail/BvhPartitioner.cc
   detail/DepthCalculator.cc
   detail/ConvertLogic.cc
   detail/LogicIO.cc

--- a/src/orange/OrangeData.hh
+++ b/src/orange/OrangeData.hh
@@ -18,7 +18,7 @@
 
 #include "OrangeTypes.hh"
 
-#include "detail/BIHData.hh"
+#include "detail/BvhData.hh"
 
 namespace celeritas
 {
@@ -264,8 +264,8 @@ struct SimpleUnitRecord
     ItemMap<LocalVolumeId, LocalVolumeIdId> local_parent;
     ItemMap<LocalVolumeId, VolDepthUint> local_vol_level;
 
-    // Bounding Interval Hierarchy tree parameters
-    detail::BIHTreeRecord bih_tree;
+    // Bounding Volume Hierarchy tree parameters
+    detail::BvhTreeRecord bvh_tree;
 
     LocalVolumeId background{};  //!< Default if not in any other volume
     bool simple_safety{};
@@ -380,8 +380,8 @@ struct OrangeParamsData
     ImplVolumeItems<VolumeId> volume_ids;
     ImplVolumeItems<VolumeInstanceId> volume_instance_ids;
 
-    // BIH tree storage
-    detail::BIHTreeData<W, M> bih_tree_data;
+    // BVH tree storage
+    detail::BvhTreeData<W, M> bvh_tree_data;
 
     // Low-level storage
     Items<LocalSurfaceId> local_surface_ids;
@@ -407,7 +407,7 @@ struct OrangeParamsData
                && univ_indices.size() == univ_types.size()
                && !volume_ids.empty()
                && volume_ids.size() == volume_instance_ids.size()
-               && (bih_tree_data || !simple_units.empty())
+               && (bvh_tree_data || !simple_units.empty())
                && ((!local_volume_ids.empty() && !logic_ints.empty()
                     && !reals.empty())
                    || surface_types.empty())
@@ -429,7 +429,7 @@ struct OrangeParamsData
         volume_ids = other.volume_ids;
         volume_instance_ids = other.volume_instance_ids;
 
-        bih_tree_data = other.bih_tree_data;
+        bvh_tree_data = other.bvh_tree_data;
 
         local_surface_ids = other.local_surface_ids;
         local_volume_ids = other.local_volume_ids;

--- a/src/orange/OrangeInput.hh
+++ b/src/orange/OrangeInput.hh
@@ -24,7 +24,7 @@
 
 #include "OrangeData.hh"
 #include "OrangeTypes.hh"
-#include "inp/Bih.hh"
+#include "inp/Bvh.hh"
 #include "surf/VariantSurface.hh"
 #include "transform/VariantTransform.hh"
 
@@ -178,11 +178,11 @@ struct RectArrayInput
  */
 struct ConstructionOptions
 {
-    //! Options for Bounding Interval Hierarchy (BIH) construction
-    inp::BIHBuilder bih_options;
+    //! Options for Bounding Volume Hierarchy (BVH) construction
+    inp::BvhBuilder bvh_options;
 
     //! Whether the options are valid
-    explicit operator bool() const { return static_cast<bool>(bih_options); }
+    explicit operator bool() const { return static_cast<bool>(bvh_options); }
 };
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -20,8 +20,8 @@
 #include "OrangeParams.hh"  // IWYU pragma: keep
 #include "OrangeTypesIO.json.hh"  // IWYU pragma: keep
 
-#include "detail/BIHData.hh"
-#include "detail/BIHView.hh"
+#include "detail/BvhData.hh"
+#include "detail/BvhView.hh"
 
 namespace celeritas
 {
@@ -29,23 +29,23 @@ namespace
 {
 //---------------------------------------------------------------------------//
 /*!
- * Create JSON representation of the structure of a BIH tree.
+ * Create JSON representation of the structure of a BVH tree.
  */
 nlohmann::json
-make_bih_structure_json(detail::BIHTreeRecord const& tree,
-                        NativeCRef<detail::BIHTreeData> const& storage)
+make_bvh_structure_json(detail::BvhTreeRecord const& tree,
+                        NativeCRef<detail::BvhTreeData> const& storage)
 {
     using json = nlohmann::json;
 
     auto out = json::array();
 
-    detail::BIHView view{tree, storage};
+    detail::BvhView view{tree, storage};
 
     // Handle internal nodes
-    for (auto i : range(BIHNodeId{view.num_internal_nodes()}))
+    for (auto i : range(BvhNodeId{view.num_internal_nodes()}))
     {
         auto const& inner = view.inner_node(i);
-        using Side = detail::BIHInternalNode::Side;
+        using Side = detail::BvhInternalNode::Side;
 
         out.push_back({
             "i",
@@ -56,8 +56,8 @@ make_bih_structure_json(detail::BIHTreeRecord const& tree,
     }
 
     // Handle leaf nodes
-    for (auto i : range(BIHNodeId{view.num_internal_nodes()},
-                        BIHNodeId{view.num_nodes()}))
+    for (auto i : range(BvhNodeId{view.num_internal_nodes()},
+                        BvhNodeId{view.num_nodes()}))
     {
         auto vols = json::array();
         for (LocalVolumeId id : remove_ldg_wrapper(view.leaf_vol_ids(i)))
@@ -138,12 +138,12 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
         OPO_SIZE_PAIR(data, volume_instance_ids),
         OPO_SIZE_PAIR(data, volume_records),
     };
-    obj["sizes"]["bih"] = [&bihdata = data.bih_tree_data] {
+    obj["sizes"]["bvh"] = [&bvhdata = data.bvh_tree_data] {
         return json::object({
-            OPO_SIZE_PAIR(bihdata, bboxes),
-            OPO_SIZE_PAIR(bihdata, internal_nodes),
-            OPO_SIZE_PAIR(bihdata, leaf_nodes),
-            OPO_SIZE_PAIR(bihdata, local_volume_ids),
+            OPO_SIZE_PAIR(bvhdata, bboxes),
+            OPO_SIZE_PAIR(bvhdata, internal_nodes),
+            OPO_SIZE_PAIR(bvhdata, leaf_nodes),
+            OPO_SIZE_PAIR(bvhdata, local_volume_ids),
         });
     }();
     obj["sizes"]["universe_indexer"] = [&uidata = data.univ_indexer_data] {
@@ -157,14 +157,14 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
 #undef OPO_SIZE_PAIR
 #undef OPO_PAIR
 
-    // Write BIH metadata as a struct of arrays
+    // Write BVH metadata as a struct of arrays
     {
-        obj["bih_metadata"] = json::object();
-        auto& bih_metadata = obj["bih_metadata"];
+        obj["bvh_metadata"] = json::object();
+        auto& bvh_metadata = obj["bvh_metadata"];
 
-        auto insert_array = [&bih_metadata](std::string key) -> json& {
-            bih_metadata[key] = json::array();
-            return bih_metadata[key];
+        auto insert_array = [&bvh_metadata](std::string key) -> json& {
+            bvh_metadata[key] = json::array();
+            return bvh_metadata[key];
         };
 
         auto& finite = insert_array("num_finite_bboxes");
@@ -174,21 +174,21 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
         for (auto i : range(data.simple_units.size()))
         {
             auto const& unit = data.simple_units[SimpleUnitId{i}];
-            auto const& mdi = unit.bih_tree.metadata;
+            auto const& mdi = unit.bvh_tree.metadata;
             finite.push_back(mdi.num_finite_bboxes);
             infinite.push_back(mdi.num_infinite_bboxes);
             depth.push_back(mdi.depth);
         }
 
         // Include structure information if requested by the user
-        if (celeritas::getenv_flag("ORANGE_BIH_STRUCTURE", false).value)
+        if (celeritas::getenv_flag("ORANGE_BVH_STRUCTURE", false).value)
         {
             auto& structure = insert_array("structure");
             for (auto i : range(data.simple_units.size()))
             {
                 auto const& unit = data.simple_units[SimpleUnitId{i}];
-                structure.push_back(make_bih_structure_json(
-                    unit.bih_tree, data.bih_tree_data));
+                structure.push_back(make_bvh_structure_json(
+                    unit.bvh_tree, data.bvh_tree_data));
             }
         }
     }
@@ -198,12 +198,12 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Print a BIH structure to a JSON string for debugging.
+ * Print a BVH structure to a JSON string for debugging.
  */
-std::string dump_bih_structure(detail::BIHTreeRecord const& tree,
-                               NativeCRef<detail::BIHTreeData> const& data)
+std::string dump_bvh_structure(detail::BvhTreeRecord const& tree,
+                               NativeCRef<detail::BvhTreeData> const& data)
 {
-    return make_bih_structure_json(tree, data).dump();
+    return make_bvh_structure_json(tree, data).dump();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParamsOutput.hh
+++ b/src/orange/OrangeParamsOutput.hh
@@ -17,8 +17,8 @@ class OrangeParams;
 namespace detail
 {
 template<Ownership W, MemSpace M>
-struct BIHTreeData;
-struct BIHTreeRecord;
+struct BvhTreeData;
+struct BvhTreeRecord;
 }  // namespace detail
 
 //---------------------------------------------------------------------------//
@@ -56,9 +56,9 @@ class OrangeParamsOutput final : public OutputInterface
 };
 
 //---------------------------------------------------------------------------//
-// Print a BIH structure to a JSON string for debugging
-std::string dump_bih_structure(detail::BIHTreeRecord const& tree,
-                               NativeCRef<detail::BIHTreeData> const& data);
+// Print a BVH structure to a JSON string for debugging
+std::string dump_bvh_structure(detail::BvhTreeRecord const& tree,
+                               NativeCRef<detail::BvhTreeData> const& data);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -43,8 +43,8 @@ using AxisTag = std::integral_constant<Axis, T>;
 
 //// ID TYPES ////
 
-//! Identifier for a BIHNode objects
-using BIHNodeId = OpaqueId<struct BIHNode_>;
+//! Identifier for a BvhNode objects
+using BvhNodeId = OpaqueId<struct BvhNode_>;
 
 //! Identifier for a daughter universe
 using DaughterId = OpaqueId<struct Daughter>;

--- a/src/orange/detail/BvhBuilder.cc
+++ b/src/orange/detail/BvhBuilder.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHBuilder.cc
+//! \file orange/detail/BvhBuilder.cc
 //---------------------------------------------------------------------------//
-#include "BIHBuilder.hh"
+#include "BvhBuilder.hh"
 
 #include <algorithm>
 
@@ -13,9 +13,9 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/cont/VariantUtils.hh"
 #include "corecel/data/Collection.hh"
-#include "orange/detail/BIHData.hh"
+#include "orange/detail/BvhData.hh"
 
-#include "BIHPartitioner.hh"
+#include "BvhPartitioner.hh"
 #include "../BoundingBoxUtils.hh"
 
 namespace celeritas
@@ -27,11 +27,11 @@ namespace detail
  * \brief Constructor.
  *
  * \param[in] storage  Struct containing collections of persistent data for
- *                     all BIH trees
- * \param[in] inp      Input options that govern BIH construction, i.e.,
+ *                     all BVH trees
+ * \param[in] inp      Input options that govern BVH construction, i.e.,
  *                     the maximum leaf size and the recursion depth limit
  */
-BIHBuilder::BIHBuilder(Storage* storage, Input inp)
+BvhBuilder::BvhBuilder(Storage* storage, Input inp)
     : bboxes_{&storage->bboxes}
     , local_volume_ids_{&storage->local_volume_ids}
     , internal_nodes_{&storage->internal_nodes}
@@ -40,33 +40,33 @@ BIHBuilder::BIHBuilder(Storage* storage, Input inp)
 {
     CELER_EXPECT(storage);
     CELER_EXPECT(inp_);
-    CELER_VALIDATE(inp_.depth_limit > 0 && inp_.depth_limit <= max_bih_depth,
-                   << "invalid BIH input depth limit " << inp_.depth_limit
+    CELER_VALIDATE(inp_.depth_limit > 0 && inp_.depth_limit <= max_bvh_depth,
+                   << "invalid BVH input depth limit " << inp_.depth_limit
                    << ": must be positive and no more than compile-time "
                       "maximum "
-                   << max_bih_depth);
+                   << max_bvh_depth);
     CELER_VALIDATE(inp_.max_leaf_size > 0,
-                   << "invalid BIH max leaf size " << inp_.max_leaf_size << ": "
+                   << "invalid BVH max leaf size " << inp_.max_leaf_size << ": "
                    << "must be positive");
     CELER_VALIDATE(inp_.num_part_cands > 0,
-                   << "invalid BIH partition candidate count "
+                   << "invalid BVH partition candidate count "
                    << inp_.num_part_cands << ": "
                    << "must be positive");
 }
 
 //---------------------------------------------------------------------------//
 /*!
- * \brief Build a BIH tree for the supplied bounding boxes.
+ * \brief Build a BVH tree for the supplied bounding boxes.
  *
  * \param[in] bboxes            All bounding boxes to be included in the tree
  * \param[in] implicit_vol_ids  The ids of the "background" volumes, to be
  *                              excluded from the tree
  *
- * \return The record of the resultant BIH tree
+ * \return The record of the resultant BVH tree
  */
-BIHTreeRecord
-BIHBuilder::operator()(VecBBox&& bboxes,
-                       BIHBuilder::SetLocalVolId const& implicit_vol_ids)
+BvhTreeRecord
+BvhBuilder::operator()(VecBBox&& bboxes,
+                       BvhBuilder::SetLocalVolId const& implicit_vol_ids)
 {
     CELER_EXPECT(!bboxes.empty());
 
@@ -107,7 +107,7 @@ BIHBuilder::operator()(VecBBox&& bboxes,
         }
     }
 
-    BIHTreeRecord tree;
+    BvhTreeRecord tree;
 
     tree.bboxes = ItemMap<LocalVolumeId, FastBBoxId>(
         bboxes_.insert_back(temp_.bboxes.begin(), temp_.bboxes.end()));
@@ -138,13 +138,13 @@ BIHBuilder::operator()(VecBBox&& bboxes,
         // Degenerate case where all bounding boxes are infinite. Create a
         // single empty leaf node, so that the existence of leaf nodes does not
         // need to be checked at runtime.
-        BIHLeafNode const empty_nodes[] = {{}};
+        BvhLeafNode const empty_nodes[] = {{}};
         tree.leaf_nodes = leaf_nodes_.insert_back(std::begin(empty_nodes),
                                                   std::end(empty_nodes));
     }
 
     // Assign metadata for diagnostic purposes
-    BIHTreeRecord::Metadata md;
+    BvhTreeRecord::Metadata md;
     md.num_finite_bboxes = indices.size();
     md.num_infinite_bboxes = inf_vol_ids.size();
     md.depth = depth;
@@ -157,7 +157,7 @@ BIHBuilder::operator()(VecBBox&& bboxes,
 // HELPER FUNCTIONS
 //---------------------------------------------------------------------------//
 /*!
- * Recursively construct BIH nodes for a vector of bbox indices.
+ * Recursively construct BVH nodes for a vector of bbox indices.
  *
  * \param[in] indices        The indices of the bboxes that will be partitioned
  *                           or placed on a leaf node in this function call
@@ -166,14 +166,14 @@ BIHBuilder::operator()(VecBBox&& bboxes,
  * \param[in] depth          The maximum recursion depth encountered during the
  *                           full construction process
  */
-void BIHBuilder::construct_tree(VecIndices const& indices,
+void BvhBuilder::construct_tree(VecIndices const& indices,
                                 VecNodes* nodes,
                                 size_type current_depth,
                                 size_type& depth)
 {
     CELER_EXPECT(current_depth < inp_.depth_limit);
 
-    using Side = BIHInternalNode::Side;
+    using Side = BvhInternalNode::Side;
 
     ++current_depth;
     auto current_index = nodes->size();
@@ -182,7 +182,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
     // Create a single leaf containing all bboxes. This lambda is used only
     // once per call to construct_tree.
     auto make_leaf = [&]() {
-        BIHLeafNode node;
+        BvhLeafNode node;
         node.vol_ids
             = local_volume_ids_.insert_back(indices.begin(), indices.end());
         CELER_EXPECT(node);
@@ -199,11 +199,11 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
         return;
     }
 
-    BIHPartitioner partition(temp_.bboxes, temp_.centers, inp_.num_part_cands);
+    BvhPartitioner partition(temp_.bboxes, temp_.centers, inp_.num_part_cands);
     if (auto p = partition(indices))
     {
         // Create internal node
-        BIHInternalNode node;
+        BvhInternalNode node;
         node.axis = p.axis;
 
         // Recursively construct the left and right branches
@@ -211,7 +211,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
         {
             node.edges[side].bbox = p.bboxes[side];
 
-            node.edges[side].child = id_cast<BIHNodeId>(nodes->size());
+            node.edges[side].child = id_cast<BvhNodeId>(nodes->size());
             this->construct_tree(p.indices[side], nodes, current_depth, depth);
         }
 
@@ -233,7 +233,7 @@ void BIHBuilder::construct_tree(VecIndices const& indices,
  *
  * \returns  The separated inner and leaf nodes
  */
-BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
+BvhBuilder::ArrangedNodes BvhBuilder::arrange_nodes(VecNodes const& nodes) const
 {
     VecInnerNodes internal_nodes;
     VecLeafNodes leaf_nodes;
@@ -245,12 +245,12 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
     new_indices.reserve(nodes.size());
 
     auto insert_node
-        = Overload{[&](BIHInternalNode const& node) {
+        = Overload{[&](BvhInternalNode const& node) {
                        new_indices.push_back(internal_nodes.size());
                        internal_nodes.push_back(node);
                        is_leaf.push_back(false);
                    },
-                   [&](BIHLeafNode const& node) {
+                   [&](BvhLeafNode const& node) {
                        new_indices.push_back(leaf_nodes.size());
                        leaf_nodes.push_back(node);
                        is_leaf.push_back(true);
@@ -271,9 +271,9 @@ BIHBuilder::ArrangedNodes BIHBuilder::arrange_nodes(VecNodes const& nodes) const
     }
 
     // Remap IDs
-    auto remapped_id = [&new_indices](BIHNodeId old) {
+    auto remapped_id = [&new_indices](BvhNodeId old) {
         CELER_EXPECT(old < new_indices.size());
-        return id_cast<BIHNodeId>(new_indices[old.unchecked_get()]);
+        return id_cast<BvhNodeId>(new_indices[old.unchecked_get()]);
     };
 
     for (auto& inner_node : internal_nodes)

--- a/src/orange/detail/BvhBuilder.hh
+++ b/src/orange/detail/BvhBuilder.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHBuilder.hh
+//! \file orange/detail/BvhBuilder.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -16,9 +16,9 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "geocel/BoundingBox.hh"  // IWYU pragma: keep
 #include "orange/OrangeTypes.hh"
-#include "orange/detail/BIHData.hh"
+#include "orange/detail/BvhData.hh"
 
-#include "../inp/Bih.hh"
+#include "../inp/Bvh.hh"
 
 namespace celeritas
 {
@@ -26,14 +26,12 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Create a bounding interval hierarchy from the supplied bounding boxes.
+ * Create a bounding volume hierarchy (BVH) from the supplied bounding boxes.
  *
- * This implementation matches the structure proposed in the original paper
- * \citep{wachter-bih-2006, https://doi.org/10.2312/EGWR/EGSR06/139-149}.
- * Construction is done recursively. With each recursion, partitioning is done
- * on the basis of bounding box centers using the "longest dimension"
- * heuristic. Leaf nodes are created when one of the following criteria are
- * met:
+ * The class builds a Bounting Volume Hierarchy \citet{ericson-collision-2004,
+ * https://www.taylorfrancis.com/books/9780080474144} ) using a top-down,
+ * recursive construction method. Leaf nodes are created when one of the
+ * following criteria are met:
  *
  * 1) the number of remaining bounding boxes is max_leaf_size or fewer,
  * 2) the remaining bounding boxes are non-partitionable (i.e., they all have
@@ -52,23 +50,23 @@ namespace detail
  * This eliminates the possibility of accidentally missing a volume during
  * tracking.
  */
-class BIHBuilder
+class BvhBuilder
 {
   public:
     //!@{
     //! \name Type aliases
     using VecBBox = std::vector<FastBBox>;
-    using Storage = BIHTreeData<Ownership::value, MemSpace::host>;
+    using Storage = BvhTreeData<Ownership::value, MemSpace::host>;
     using SetLocalVolId = std::set<LocalVolumeId>;
-    using Input = inp::BIHBuilder;
+    using Input = inp::BvhBuilder;
     //!@}
 
   public:
     // Construct from Storage and Input objects
-    BIHBuilder(Storage* storage, Input inp);
+    BvhBuilder(Storage* storage, Input inp);
 
-    // Create BIH Nodes
-    BIHTreeRecord
+    // Create BVH Nodes
+    BvhTreeRecord
     operator()(VecBBox&& bboxes, SetLocalVolId const& implicit_vol_id);
 
   private:
@@ -76,9 +74,9 @@ class BIHBuilder
 
     using Real3 = Array<fast_real_type, 3>;
     using VecIndices = std::vector<LocalVolumeId>;
-    using VecNodes = std::vector<std::variant<BIHInternalNode, BIHLeafNode>>;
-    using VecInnerNodes = std::vector<BIHInternalNode>;
-    using VecLeafNodes = std::vector<BIHLeafNode>;
+    using VecNodes = std::vector<std::variant<BvhInternalNode, BvhLeafNode>>;
+    using VecInnerNodes = std::vector<BvhInternalNode>;
+    using VecLeafNodes = std::vector<BvhLeafNode>;
     using ArrangedNodes = std::pair<VecInnerNodes, VecLeafNodes>;
 
     struct Temporaries
@@ -92,14 +90,14 @@ class BIHBuilder
 
     CollectionBuilder<FastBBox> bboxes_;
     CollectionBuilder<LocalVolumeId> local_volume_ids_;
-    CollectionBuilder<BIHInternalNode> internal_nodes_;
-    CollectionBuilder<BIHLeafNode> leaf_nodes_;
+    CollectionBuilder<BvhInternalNode> internal_nodes_;
+    CollectionBuilder<BvhLeafNode> leaf_nodes_;
 
     Input inp_;
 
     //// HELPER FUNCTIONS ////
 
-    // Recursively construct BIH nodes for a vector of bbox indices
+    // Recursively construct BVH nodes for a vector of bbox indices
     void construct_tree(VecIndices const& indices,
                         VecNodes* nodes,
                         size_type current_depth,

--- a/src/orange/detail/BvhData.hh
+++ b/src/orange/detail/BvhData.hh
@@ -2,8 +2,8 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHData.hh
-//! \todo move to orange/BihTreeData
+//! \file orange/detail/BvhData.hh
+//! \todo move to orange/BvhTreeData
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -19,12 +19,12 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//!
-// The maximum depth of the BIH tree (single leaf node is 1)
-inline constexpr size_type max_bih_depth = 18;
+// The maximum depth of the BVH tree (single leaf node is 1)
+inline constexpr size_type max_bvh_depth = 18;
 
 //---------------------------------------------------------------------------//
 /*!
- * Data for a single internal node in a Bounding Interval Hierarchy.
+ * Data for a single internal node in a Bounding Volume Hierarchy.
  *
  * As a convention, a node's LEFT edge corresponds to the half space that is
  * less than the partition value. In other words, the LEFT bounding plane
@@ -34,12 +34,12 @@ inline constexpr size_type max_bih_depth = 18;
  * the LEFT bounding plane position could be either left or right of the RIGHT
  * bounding plane position.
  */
-struct BIHInternalNode
+struct BvhInternalNode
 {
     struct Edge
     {
         //! The child node connected to this edge
-        BIHNodeId child;
+        BvhNodeId child;
         //! Bbox created by clipping an inf bbox with the bounding planes
         //! between this edge (inclusive) and the root.
         FastBBox bbox;
@@ -63,9 +63,9 @@ struct BIHInternalNode
 
 //---------------------------------------------------------------------------//
 /*!
- * Data for a single leaf node in a Bounding Interval Hierarchy.
+ * Data for a single leaf node in a Bounding Volume Hierarchy.
  */
-struct BIHLeafNode
+struct BvhLeafNode
 {
     ItemRange<LocalVolumeId> vol_ids;
 
@@ -74,12 +74,12 @@ struct BIHLeafNode
 
 //---------------------------------------------------------------------------//
 /*!
- * Bounding Interval Hierarchy tree.
+ * Bounding Volume Hierarchy tree.
  *
  * Infinite bounding boxes are not included in the tree itself. They are stored
  * separately and checked after traversing the tree.
  */
-struct BIHTreeRecord
+struct BvhTreeRecord
 {
     //// TYPES ////
     struct Metadata
@@ -96,14 +96,14 @@ struct BIHTreeRecord
 
     //// DATA ////
 
-    //! All bounding boxes managed by the BIH
+    //! All bounding boxes managed by the BVH
     ItemMap<LocalVolumeId, FastBBoxId> bboxes;
 
     //! Internal (branch) nodes, the first being the root
-    ItemRange<BIHInternalNode> internal_nodes;
+    ItemRange<BvhInternalNode> internal_nodes;
 
     //! Leaf nodes
-    ItemRange<BIHLeafNode> leaf_nodes;
+    ItemRange<BvhLeafNode> leaf_nodes;
 
     //! Local volumes that have infinite bounding boxes
     ItemRange<LocalVolumeId> inf_vol_ids;
@@ -133,10 +133,10 @@ struct BIHTreeRecord
 
 //---------------------------------------------------------------------------//
 /*!
- * Persistent data used by all BIH trees.
+ * Persistent data used by all BVH trees.
  */
 template<Ownership W, MemSpace M>
-struct BIHTreeData
+struct BvhTreeData
 {
     template<class T>
     using Items = Collection<T, W, M>;
@@ -144,8 +144,8 @@ struct BIHTreeData
     // Low-level storage
     Items<FastBBox> bboxes;
     Items<LocalVolumeId> local_volume_ids;
-    Items<detail::BIHInternalNode> internal_nodes;
-    Items<detail::BIHLeafNode> leaf_nodes;
+    Items<detail::BvhInternalNode> internal_nodes;
+    Items<detail::BvhLeafNode> leaf_nodes;
 
     //! True if assigned
     explicit CELER_FUNCTION operator bool() const
@@ -157,7 +157,7 @@ struct BIHTreeData
 
     //! Assign from another set of data
     template<Ownership W2, MemSpace M2>
-    BIHTreeData& operator=(BIHTreeData<W2, M2> const& other)
+    BvhTreeData& operator=(BvhTreeData<W2, M2> const& other)
     {
         bboxes = other.bboxes;
         local_volume_ids = other.local_volume_ids;

--- a/src/orange/detail/BvhEnclosingVolFinder.hh
+++ b/src/orange/detail/BvhEnclosingVolFinder.hh
@@ -2,14 +2,14 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHEnclosingVolFinder.hh
+//! \file orange/detail/BvhEnclosingVolFinder.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include "corecel/cont/IdStack.hh"
 #include "orange/OrangeTypes.hh"
 
-#include "BIHView.hh"
+#include "BvhView.hh"
 
 namespace celeritas
 {
@@ -17,7 +17,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Traverse the BIH tree to find a volume that contains a point.
+ * Traverse the BVH tree to find a volume that contains a point.
  *
  * Traversal is carried out using a depth-first search and terminated as soon
  * as a suitable volume is found. When visiting a leaf node, the bounding boxes
@@ -30,17 +30,17 @@ namespace detail
  *
  * \todo move to top-level orange directory out of detail namespace
  */
-class BIHEnclosingVolFinder
+class BvhEnclosingVolFinder
 {
   public:
     //!@{
     //! \name Type aliases
-    using Storage = NativeCRef<BIHTreeData>;
+    using Storage = NativeCRef<BvhTreeData>;
     //!@}
 
     // Construct from vector of bounding boxes and storage for LocalVolumeIds
     inline CELER_FUNCTION
-    BIHEnclosingVolFinder(BIHTreeRecord const& tree, Storage const& storage);
+    BvhEnclosingVolFinder(BvhTreeRecord const& tree, Storage const& storage);
 
     // Find a volume that satisfies is_inside
     template<class F>
@@ -49,13 +49,13 @@ class BIHEnclosingVolFinder
 
   private:
     //// DATA ////
-    BIHView view_;
+    BvhView view_;
 
     //// HELPER FUNCTIONS ////
 
     // Determine if any leaf node volumes contain the point
     template<class F>
-    inline CELER_FUNCTION LocalVolumeId visit_leaf(BIHNodeId leaf_id,
+    inline CELER_FUNCTION LocalVolumeId visit_leaf(BvhNodeId leaf_id,
                                                    F&& is_inside) const;
 
     // Determine if any inf_vols contain the point
@@ -74,7 +74,7 @@ class BIHEnclosingVolFinder
  * Construct from vector of bounding boxes and storage.
  */
 CELER_FUNCTION
-BIHEnclosingVolFinder::BIHEnclosingVolFinder(BIHTreeRecord const& tree,
+BvhEnclosingVolFinder::BvhEnclosingVolFinder(BvhTreeRecord const& tree,
                                              Storage const& storage)
     : view_(tree, storage)
 {
@@ -86,15 +86,15 @@ BIHEnclosingVolFinder::BIHEnclosingVolFinder(BIHTreeRecord const& tree,
  */
 template<class F>
 CELER_FUNCTION LocalVolumeId
-BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
+BvhEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
 {
-    using Side = BIHInternalNode::Side;
+    using Side = BvhInternalNode::Side;
 
     // Stack of deferred nodes
-    using StackT = IdStack<BIHNodeId, max_bih_depth - 1>;
-    BIHNodeId stack_spill_[StackT::spill_extent];
+    using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
+    BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-    stack.push(BIHNodeId{0});
+    stack.push(BvhNodeId{0});
 
     while (!stack.empty())
     {
@@ -133,7 +133,7 @@ BIHEnclosingVolFinder::operator()(Real3 const& pos, F&& is_inside_vol) const
  */
 template<class F>
 CELER_FUNCTION LocalVolumeId
-BIHEnclosingVolFinder::visit_leaf(BIHNodeId leaf_id, F&& is_inside) const
+BvhEnclosingVolFinder::visit_leaf(BvhNodeId leaf_id, F&& is_inside) const
 {
     for (auto id : view_.leaf_vol_ids(leaf_id))
     {
@@ -151,7 +151,7 @@ BIHEnclosingVolFinder::visit_leaf(BIHNodeId leaf_id, F&& is_inside) const
  */
 template<class F>
 CELER_FUNCTION LocalVolumeId
-BIHEnclosingVolFinder::visit_inf_vols(F&& is_inside) const
+BvhEnclosingVolFinder::visit_inf_vols(F&& is_inside) const
 {
     for (auto id : view_.inf_vol_ids())
     {
@@ -168,7 +168,7 @@ BIHEnclosingVolFinder::visit_inf_vols(F&& is_inside) const
  * Determinate if a single bbox contains the point.
  */
 CELER_FUNCTION
-bool BIHEnclosingVolFinder::visit_bbox(LocalVolumeId const& id,
+bool BvhEnclosingVolFinder::visit_bbox(LocalVolumeId const& id,
                                        Real3 const& point) const
 {
     return is_inside(view_.bbox(id), point);

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHIntersectingVolFinder.hh
+//! \file orange/detail/BvhIntersectingVolFinder.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -10,7 +10,7 @@
 #include "corecel/math/Algorithms.hh"
 #include "orange/OrangeTypes.hh"
 
-#include "BIHView.hh"
+#include "BvhView.hh"
 #include "../BoundingBoxUtils.hh"
 #include "../univ/detail/Types.hh"
 
@@ -20,7 +20,7 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Traverse the BIH to the find the volume that the ray intersects with first.
+ * Traverse the BVH to the find the volume that the ray intersects with first.
  *
  * Traversal is carried out using a depth first search. During traversal, the
  * minimum intersection is stored. The decision to traverse an edge is done by
@@ -35,12 +35,12 @@ namespace detail
  *
  * \todo move to top-level orange directory out of detail namespace
  */
-class BIHIntersectingVolFinder
+class BvhIntersectingVolFinder
 {
   public:
     //!@{
     //! \name Type aliases
-    using Storage = NativeCRef<BIHTreeData>;
+    using Storage = NativeCRef<BvhTreeData>;
 
     struct Ray
     {
@@ -50,7 +50,7 @@ class BIHIntersectingVolFinder
     //!@}
 
     // Construct from a vector of bounding boxes and storage for LocalVolumeIds
-    inline CELER_FUNCTION BIHIntersectingVolFinder(BIHTreeRecord const& tree,
+    inline CELER_FUNCTION BvhIntersectingVolFinder(BvhTreeRecord const& tree,
                                                    Storage const& storage);
 
     // Calculate the minimum intersection, with supplied maximum search
@@ -61,7 +61,7 @@ class BIHIntersectingVolFinder
 
   private:
     //// DATA ////
-    BIHView view_;
+    BvhView view_;
 
     //// HELPER FUNCTIONS ////
 
@@ -73,7 +73,7 @@ class BIHIntersectingVolFinder
     // Calculate the current min intersection, which may/may not be on this
     // leaf
     template<class F>
-    inline CELER_FUNCTION Intersection visit_leaf(BIHNodeId leaf_node_id,
+    inline CELER_FUNCTION Intersection visit_leaf(BvhNodeId leaf_node_id,
                                                   Intersection intersection,
                                                   F&& visit_vol) const;
 
@@ -90,8 +90,8 @@ class BIHIntersectingVolFinder
  * Construct from vector a of bounding boxes and storage.
  */
 CELER_FUNCTION
-BIHIntersectingVolFinder::BIHIntersectingVolFinder(
-    BIHTreeRecord const& tree, BIHIntersectingVolFinder::Storage const& storage)
+BvhIntersectingVolFinder::BvhIntersectingVolFinder(
+    BvhTreeRecord const& tree, BvhIntersectingVolFinder::Storage const& storage)
     : view_(tree, storage)
 {
     CELER_EXPECT(tree);
@@ -111,21 +111,21 @@ BIHIntersectingVolFinder::BIHIntersectingVolFinder(
  */
 template<class F>
 CELER_FUNCTION auto
-BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
+BvhIntersectingVolFinder::operator()(BvhIntersectingVolFinder::Ray ray,
                                      F&& visit_vol,
                                      real_type max_search_dist) const
     -> Intersection
 {
-    using Side = BIHInternalNode::Side;
+    using Side = BvhInternalNode::Side;
 
     Intersection intersection{OnLocalSurface{}, max_search_dist};
 
     // Stack of deferred nodes
-    using StackT = IdStack<BIHNodeId, max_bih_depth - 1>;
-    BIHNodeId stack_spill_[StackT::spill_extent];
+    using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
+    BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-    static_assert(stack.capacity() == max_bih_depth);
-    stack.push(BIHNodeId{0});
+    static_assert(stack.capacity() == max_bvh_depth);
+    stack.push(BvhNodeId{0});
 
     while (!stack.empty())
     {
@@ -144,9 +144,9 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
         // Guess the better edge to traverse first: unrolled with loads for
         // GPU performance
         FastBBox first_bbox = node.bbox(Side::left);
-        BIHNodeId first_child = node.child(Side::left);
+        BvhNodeId first_child = node.child(Side::left);
         FastBBox second_bbox = node.bbox(Side::right);
-        BIHNodeId second_child = node.child(Side::right);
+        BvhNodeId second_child = node.child(Side::right);
 
         if (ray.pos[ax] > node.bbox(Side::right).lower()[ax])
         {
@@ -174,7 +174,7 @@ BIHIntersectingVolFinder::operator()(BIHIntersectingVolFinder::Ray ray,
  * Determine if the intersection with an edge/vol bbox is less than min_dist.
  */
 CELER_FUNCTION
-bool BIHIntersectingVolFinder::visit_bbox(FastBBox const& bbox,
+bool BvhIntersectingVolFinder::visit_bbox(FastBBox const& bbox,
                                           Ray ray,
                                           real_type min_dist) const
 {
@@ -187,7 +187,7 @@ bool BIHIntersectingVolFinder::visit_bbox(FastBBox const& bbox,
  */
 template<class F>
 CELER_FUNCTION auto
-BIHIntersectingVolFinder::visit_leaf(BIHNodeId leaf_node_id,
+BvhIntersectingVolFinder::visit_leaf(BvhNodeId leaf_node_id,
                                      Intersection min_intersection,
                                      F&& visit_vol) const -> Intersection
 {
@@ -209,7 +209,7 @@ BIHIntersectingVolFinder::visit_leaf(BIHNodeId leaf_node_id,
  */
 template<class F>
 CELER_FUNCTION auto
-BIHIntersectingVolFinder::visit_inf_vols(Intersection min_intersection,
+BvhIntersectingVolFinder::visit_inf_vols(Intersection min_intersection,
                                          F&& visit_vol) const -> Intersection
 {
     for (auto id : view_.inf_vol_ids())

--- a/src/orange/detail/BvhPartitioner.cc
+++ b/src/orange/detail/BvhPartitioner.cc
@@ -2,15 +2,15 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHPartitioner.cc
+//! \file orange/detail/BvhPartitioner.cc
 //---------------------------------------------------------------------------//
-#include "BIHPartitioner.hh"
+#include "BvhPartitioner.hh"
 
 #include <algorithm>
 
 #include "corecel/math/SoftEqual.hh"
 
-#include "BIHUtils.hh"
+#include "BvhUtils.hh"
 #include "../BoundingBoxUtils.hh"
 
 using namespace celeritas::literals;
@@ -46,7 +46,7 @@ namespace detail
  * \param[in] num_part_cands  The number of candidate partitions to check per
  *                            axis
  */
-BIHPartitioner::BIHPartitioner(VecBBox const& bboxes,
+BvhPartitioner::BvhPartitioner(VecBBox const& bboxes,
                                VecReal3 const& centers,
                                size_type num_part_cands)
     : bboxes_(bboxes), centers_(centers), num_part_cands_(num_part_cands)
@@ -62,8 +62,8 @@ BIHPartitioner::BIHPartitioner(VecBBox const& bboxes,
  *
  * If no partition is found, an empty partition is returned
  */
-BIHPartitioner::Partition
-BIHPartitioner::operator()(VecIndices const& indices) const
+BvhPartitioner::Partition
+BvhPartitioner::operator()(VecIndices const& indices) const
 {
     Partition best_partition;
     real_type best_cost = std::numeric_limits<real_type>::infinity();
@@ -106,8 +106,8 @@ BIHPartitioner::operator()(VecIndices const& indices) const
 /*!
  * Create sorted and uniquified X, Y, Z values of bbox centers.
  */
-BIHPartitioner::AxesCenters
-BIHPartitioner::calc_axes_centers(VecIndices const& indices) const
+BvhPartitioner::AxesCenters
+BvhPartitioner::calc_axes_centers(VecIndices const& indices) const
 {
     CELER_EXPECT(!indices.empty());
 
@@ -135,8 +135,8 @@ BIHPartitioner::calc_axes_centers(VecIndices const& indices) const
 /*!
  * Divide bboxes into left and right branches based on a partition.
  */
-BIHPartitioner::Partition
-BIHPartitioner::make_partition(VecIndices const& indices,
+BvhPartitioner::Partition
+BvhPartitioner::make_partition(VecIndices const& indices,
                                Axis axis,
                                real_type position) const
 {
@@ -173,7 +173,7 @@ BIHPartitioner::make_partition(VecIndices const& indices,
 /*!
  * Calculate the cost of partition using a surface area heuristic.
  */
-real_type BIHPartitioner::calc_cost(Partition const& p) const
+real_type BvhPartitioner::calc_cost(Partition const& p) const
 {
     CELER_EXPECT(p);
 

--- a/src/orange/detail/BvhPartitioner.hh
+++ b/src/orange/detail/BvhPartitioner.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHPartitioner.hh
+//! \file orange/detail/BvhPartitioner.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -11,7 +11,7 @@
 #include "corecel/cont/EnumArray.hh"
 #include "geocel/BoundingBox.hh"  // IWYU pragma: keep
 
-#include "BIHData.hh"
+#include "BvhData.hh"
 #include "../OrangeTypes.hh"
 
 namespace celeritas
@@ -24,11 +24,12 @@ namespace detail
  *
  * This class takes a vector of bounding boxes as an input, and outputs a
  * Partition object describing the optional partition (among those tested). To
- * find the optimal partition, candidate partitions along the x, y, nd z axis
+ * find the optimal partition, candidate partitions along the x, y, and z axes
  * are evaluated using a cost function. The cost function is based on a
- * standard surface area heuristic.
+ * surface area heuristic \citep{wald-fastconstruction-2007,
+ * https://10.1109/RT.2007.4342588}.
  */
-class BIHPartitioner
+class BvhPartitioner
 {
   public:
     //!@{
@@ -37,7 +38,7 @@ class BIHPartitioner
     using VecBBox = std::vector<FastBBox>;
     using VecReal3 = std::vector<Real3>;
     using VecIndices = std::vector<LocalVolumeId>;
-    using Side = BIHInternalNode::Side;
+    using Side = BvhInternalNode::Side;
 
     //! Output struct specifying the indices and bboxes of the left and right
     //! sides of the partition
@@ -61,7 +62,7 @@ class BIHPartitioner
 
   public:
     // Construct from all bounding bounding boxes in a universe
-    explicit BIHPartitioner(VecBBox const& bboxes,
+    explicit BvhPartitioner(VecBBox const& bboxes,
                             VecReal3 const& centers,
                             size_type num_part_cands);
 

--- a/src/orange/detail/BvhUtils.hh
+++ b/src/orange/detail/BvhUtils.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHUtils.hh
+//! \file orange/detail/BvhUtils.hh
 //---------------------------------------------------------------------------//
 #pragma once
 

--- a/src/orange/detail/BvhView.hh
+++ b/src/orange/detail/BvhView.hh
@@ -2,13 +2,13 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHView.hh
+//! \file orange/detail/BvhView.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include "orange/OrangeTypes.hh"
 
-#include "BIHData.hh"
+#include "BvhData.hh"
 
 namespace celeritas
 {
@@ -16,57 +16,57 @@ namespace detail
 {
 //---------------------------------------------------------------------------//
 /*!
- * Access data for a BIH internal node.
+ * Access data for a BVH internal node.
  */
-class BIHInternalNodeView
+class BvhInternalNodeView
 {
   public:
     //!@{
     //! \name Type aliases
-    using Side = BIHInternalNode::Side;
+    using Side = BvhInternalNode::Side;
     //!@}
 
     // Construct from internal node data
-    inline CELER_FUNCTION explicit BIHInternalNodeView(
-        BIHInternalNode const& node);
+    inline CELER_FUNCTION explicit BvhInternalNodeView(
+        BvhInternalNode const& node);
 
     // Get partition axis
     inline CELER_FUNCTION Axis axis() const;
 
     // Get child node for a side
-    inline CELER_FUNCTION BIHNodeId child(Side side) const;
+    inline CELER_FUNCTION BvhNodeId child(Side side) const;
 
     // Get edge bounding box for a side
     inline CELER_FUNCTION FastBBox const& bbox(Side side) const;
 
   private:
-    BIHInternalNode const& node_;
+    BvhInternalNode const& node_;
 };
 
 //---------------------------------------------------------------------------//
 /*!
- * Traverse BIH tree using a depth-first search.
+ * Traverse BVH tree using a depth-first search.
  *
  * \todo move to top-level orange directory out of detail namespace
  */
-class BIHView
+class BvhView
 {
   public:
     //!@{
     //! \name Type aliases
-    using Storage = NativeCRef<BIHTreeData>;
+    using Storage = NativeCRef<BvhTreeData>;
     using SpanLocalVol = LdgSpan<LocalVolumeId const>;
     //!@}
 
     // Construct from vector of bounding boxes and storage for LocalVolumeIds
     inline CELER_FUNCTION
-    BIHView(BIHTreeRecord const& tree, Storage const& storage);
+    BvhView(BvhTreeRecord const& tree, Storage const& storage);
 
     // Determine if a node is inner, i.e., not a leaf
-    inline CELER_FUNCTION bool is_internal(BIHNodeId id) const;
+    inline CELER_FUNCTION bool is_internal(BvhNodeId id) const;
 
-    // Get an internal node for a given BIHNodeId
-    inline CELER_FUNCTION BIHInternalNodeView inner_node(BIHNodeId id) const;
+    // Get an internal node for a given BvhNodeId
+    inline CELER_FUNCTION BvhInternalNodeView inner_node(BvhNodeId id) const;
 
     // Get number of internal nodes
     inline CELER_FUNCTION size_type num_internal_nodes() const;
@@ -81,14 +81,14 @@ class BIHView
     inline CELER_FUNCTION FastBBox const& bbox(LocalVolumeId vol_id) const;
 
     // Get the vol_ids on a given leaf node
-    inline CELER_FUNCTION SpanLocalVol leaf_vol_ids(BIHNodeId) const;
+    inline CELER_FUNCTION SpanLocalVol leaf_vol_ids(BvhNodeId) const;
 
     // Get the inf_vol_ids
     inline CELER_FUNCTION SpanLocalVol inf_vol_ids() const;
 
   private:
     //// DATA ////
-    BIHTreeRecord const& tree_;
+    BvhTreeRecord const& tree_;
     Storage const& storage_;
 };
 
@@ -99,7 +99,7 @@ class BIHView
  * Construct from an internal node.
  */
 CELER_FUNCTION
-BIHInternalNodeView::BIHInternalNodeView(BIHInternalNode const& node)
+BvhInternalNodeView::BvhInternalNodeView(BvhInternalNode const& node)
     : node_(node)
 {
     CELER_EXPECT(node_);
@@ -109,7 +109,7 @@ BIHInternalNodeView::BIHInternalNodeView(BIHInternalNode const& node)
 /*!
  * Get partition axis.
  */
-CELER_FUNCTION Axis BIHInternalNodeView::axis() const
+CELER_FUNCTION Axis BvhInternalNodeView::axis() const
 {
     return node_.axis;
 }
@@ -118,8 +118,8 @@ CELER_FUNCTION Axis BIHInternalNodeView::axis() const
 /*!
  * Get child node for a side.
  */
-CELER_FUNCTION BIHNodeId
-BIHInternalNodeView::child(BIHInternalNodeView::Side side) const
+CELER_FUNCTION BvhNodeId
+BvhInternalNodeView::child(BvhInternalNodeView::Side side) const
 {
     return node_.edges[side].child;
 }
@@ -129,7 +129,7 @@ BIHInternalNodeView::child(BIHInternalNodeView::Side side) const
  * Get edge bounding box for a side.
  */
 CELER_FUNCTION FastBBox const&
-BIHInternalNodeView::bbox(BIHInternalNodeView::Side side) const
+BvhInternalNodeView::bbox(BvhInternalNodeView::Side side) const
 {
     return node_.edges[side].bbox;
 }
@@ -139,7 +139,7 @@ BIHInternalNodeView::bbox(BIHInternalNodeView::Side side) const
  * Construct from vector of bounding boxes and storage.
  */
 CELER_FUNCTION
-BIHView::BIHView(BIHTreeRecord const& tree, BIHView::Storage const& storage)
+BvhView::BvhView(BvhTreeRecord const& tree, BvhView::Storage const& storage)
     : tree_(tree), storage_(storage)
 {
     CELER_EXPECT(tree_);
@@ -150,20 +150,20 @@ BIHView::BIHView(BIHTreeRecord const& tree, BIHView::Storage const& storage)
  *  Determine if a node is inner, i.e., not a leaf.
  */
 CELER_FUNCTION
-bool BIHView::is_internal(BIHNodeId id) const
+bool BvhView::is_internal(BvhNodeId id) const
 {
     return id.unchecked_get() < tree_.internal_nodes.size();
 }
 
 //---------------------------------------------------------------------------//
 /*!
- *  Get an internal node for a given BIHNodeId.
+ *  Get an internal node for a given BvhNodeId.
  */
 CELER_FUNCTION
-BIHInternalNodeView BIHView::inner_node(BIHNodeId id) const
+BvhInternalNodeView BvhView::inner_node(BvhNodeId id) const
 {
     CELER_EXPECT(this->is_internal(id));
-    return BIHInternalNodeView{
+    return BvhInternalNodeView{
         storage_.internal_nodes[tree_.internal_nodes[id.unchecked_get()]]};
 }
 
@@ -171,7 +171,7 @@ BIHInternalNodeView BIHView::inner_node(BIHNodeId id) const
 /*!
  *  Get number of internal nodes.
  */
-CELER_FUNCTION auto BIHView::num_internal_nodes() const -> size_type
+CELER_FUNCTION auto BvhView::num_internal_nodes() const -> size_type
 {
     return tree_.internal_nodes.size();
 }
@@ -180,7 +180,7 @@ CELER_FUNCTION auto BIHView::num_internal_nodes() const -> size_type
 /*!
  *  Get number of leaf nodes.
  */
-CELER_FUNCTION auto BIHView::num_leaf_nodes() const -> size_type
+CELER_FUNCTION auto BvhView::num_leaf_nodes() const -> size_type
 {
     return tree_.leaf_nodes.size();
 }
@@ -189,7 +189,7 @@ CELER_FUNCTION auto BIHView::num_leaf_nodes() const -> size_type
 /*!
  *  Get total number of nodes.
  */
-CELER_FUNCTION auto BIHView::num_nodes() const -> size_type
+CELER_FUNCTION auto BvhView::num_nodes() const -> size_type
 {
     return tree_.internal_nodes.size() + tree_.leaf_nodes.size();
 }
@@ -198,7 +198,7 @@ CELER_FUNCTION auto BIHView::num_nodes() const -> size_type
 /*!
  *  Get the bbox for a given vol_id.
  */
-CELER_FUNCTION FastBBox const& BIHView::bbox(LocalVolumeId vol_id) const
+CELER_FUNCTION FastBBox const& BvhView::bbox(LocalVolumeId vol_id) const
 {
     CELER_EXPECT(vol_id.unchecked_get() < tree_.bboxes.size());
     return storage_.bboxes[tree_.bboxes[vol_id]];
@@ -208,11 +208,11 @@ CELER_FUNCTION FastBBox const& BIHView::bbox(LocalVolumeId vol_id) const
 /*!
  *  Get the vol_ids on a given leaf node.
  */
-CELER_FUNCTION auto BIHView::leaf_vol_ids(BIHNodeId id) const -> SpanLocalVol
+CELER_FUNCTION auto BvhView::leaf_vol_ids(BvhNodeId id) const -> SpanLocalVol
 {
-    CELER_EXPECT(id >= BIHNodeId{this->num_internal_nodes()}
+    CELER_EXPECT(id >= BvhNodeId{this->num_internal_nodes()}
                  && id < this->num_nodes());
-    ItemId<BIHLeafNode> leaf_id
+    ItemId<BvhLeafNode> leaf_id
         = tree_.leaf_nodes[*id - this->num_internal_nodes()];
     CELER_ASSERT(leaf_id < storage_.leaf_nodes.size());
     auto&& leaf_node = storage_.leaf_nodes[leaf_id];
@@ -223,7 +223,7 @@ CELER_FUNCTION auto BIHView::leaf_vol_ids(BIHNodeId id) const -> SpanLocalVol
 /*!
  *  Get the inf_vol_ids.
  */
-CELER_FUNCTION auto BIHView::inf_vol_ids() const -> SpanLocalVol
+CELER_FUNCTION auto BvhView::inf_vol_ids() const -> SpanLocalVol
 {
     return storage_.local_volume_ids[tree_.inf_vol_ids];
 }

--- a/src/orange/detail/UnitInserter.cc
+++ b/src/orange/detail/UnitInserter.cc
@@ -371,7 +371,7 @@ make_local_level_vec(std::vector<LocalVolumeId> const& local_parents)
 /*!
  * Adjust the last volume (background) if necessary.
  *
- * "Background" should be spatially unreachable by logic or BIH: ('nowhere'
+ * "Background" should be spatially unreachable by logic or BVH: ('nowhere'
  * logic, null bbox), but it has to have all the surfaces that connect to an
  * interior volume.
  */
@@ -405,7 +405,7 @@ UnitInserter::UnitInserter(UniverseInserter* insert_universe,
                            Data* orange_data,
                            ConstructionOptions const* opts)
     : orange_data_(orange_data)
-    , build_bih_tree_{&orange_data_->bih_tree_data, opts->bih_options}
+    , build_bvh_tree_{&orange_data_->bvh_tree_data, opts->bvh_options}
     , insert_transform_{&orange_data_->transforms, &orange_data_->reals}
     , build_surfaces_{&orange_data_->surface_types,
                       &orange_data_->real_ids,
@@ -455,7 +455,7 @@ UnivId UnitInserter::operator()(UnitInput&& inp)
     std::vector<LocalVolumeRecord> vol_records(inp.volumes.size());
     std::vector<std::set<LocalVolumeId>> connectivity(inp.surfaces.size());
     std::vector<FastBBox> bboxes;
-    BIHBuilder::SetLocalVolId implicit_vol_ids;
+    BvhBuilder::SetLocalVolId implicit_vol_ids;
     for (auto i : range<LocalVolumeId::size_type>(inp.volumes.size()))
     {
         // Only the last volume can be background
@@ -475,7 +475,7 @@ UnivId UnitInserter::operator()(UnitInput&& inp)
             bboxes.push_back(BoundingBox<fast_real_type>::from_infinite());
         }
 
-        // Create a set of background volume ids for BIH construction
+        // Create a set of background volume ids for BVH construction
         if (inp.volumes[i].flags & LocalVolumeRecord::Flags::implicit_vol)
         {
             implicit_vol_ids.insert(id_cast<LocalVolumeId>(i));
@@ -527,7 +527,7 @@ UnivId UnitInserter::operator()(UnitInput&& inp)
     unit.volumes = ItemMap<LocalVolumeId, SimpleUnitRecord::LocalVolumeRecordId>(
         volume_records_.insert_back(vol_records.begin(), vol_records.end()));
 
-    // Create BIH tree
+    // Create BVH tree
     {
         std::vector<size_type> invalid;
         for (auto i : range(bboxes.size()))
@@ -550,7 +550,7 @@ UnivId UnitInserter::operator()(UnitInput&& inp)
                                   << "': " << bboxes[i];
                            }));
     }
-    unit.bih_tree = build_bih_tree_(std::move(bboxes), implicit_vol_ids);
+    unit.bvh_tree = build_bvh_tree_(std::move(bboxes), implicit_vol_ids);
 
     // Save connectivity
     {

--- a/src/orange/detail/UnitInserter.hh
+++ b/src/orange/detail/UnitInserter.hh
@@ -10,7 +10,7 @@
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/DedupeCollectionBuilder.hh"
 
-#include "BIHBuilder.hh"
+#include "BvhBuilder.hh"
 #include "SurfacesRecordBuilder.hh"
 #include "TransformRecordInserter.hh"
 #include "../BoundingBoxUtils.hh"
@@ -54,7 +54,7 @@ class UnitInserter
 
   private:
     Data* orange_data_{nullptr};
-    BIHBuilder build_bih_tree_;
+    BvhBuilder build_bvh_tree_;
     TransformRecordInserter insert_transform_;
     SurfacesRecordBuilder build_surfaces_;
     UniverseInserter* insert_universe_;

--- a/src/orange/inp/Bvh.hh
+++ b/src/orange/inp/Bvh.hh
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/inp/Bih.hh
+//! \file orange/inp/Bvh.hh
 //---------------------------------------------------------------------------//
 #pragma once
 
@@ -14,20 +14,20 @@ namespace inp
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construction options for BIH tree.
+ * Construction options for BVH tree.
  */
-struct BIHBuilder
+struct BvhBuilder
 {
     //! Maximum number of bboxes that can reside on a leaf node without
     //! triggering a partitioning attempt
     size_type max_leaf_size = 1;
 
     //! Hard limit on the depth of most the embedded node (where 1 is the root
-    //! node): see max_bih_depth
+    //! node): see max_bvh_depth
     size_type depth_limit = 16;
 
     //! The number of partition candidates to check per axis when partitioning
-    //! a node during BIH construction
+    //! a node during BVH construction
     size_type num_part_cands = 3;
 
     //! Whether the options are valid

--- a/src/orange/orangeinp/InputBuilder.cc
+++ b/src/orange/orangeinp/InputBuilder.cc
@@ -147,25 +147,25 @@ auto InputBuilder::operator()(ProtoInterface const& global) const -> result_type
         csg_outp.write(opts_.csg_output_file);
     }
 
-    if (std::string var = celeritas::getenv("ORANGE_BIH_MAX_LEAF_SIZE");
+    if (std::string var = celeritas::getenv("ORANGE_BVH_MAX_LEAF_SIZE");
         !var.empty())
     {
         size_type mls = std::stoul(var);
-        result.construction_opts.bih_options.max_leaf_size = mls;
+        result.construction_opts.bvh_options.max_leaf_size = mls;
     }
 
-    if (std::string var = celeritas::getenv("ORANGE_BIH_DEPTH_LIMIT");
+    if (std::string var = celeritas::getenv("ORANGE_BVH_DEPTH_LIMIT");
         !var.empty())
     {
         size_type dl = std::stoul(var);
-        result.construction_opts.bih_options.depth_limit = dl;
+        result.construction_opts.bvh_options.depth_limit = dl;
     }
 
-    if (std::string var = celeritas::getenv("ORANGE_BIH_PART_CANDS");
+    if (std::string var = celeritas::getenv("ORANGE_BVH_PART_CANDS");
         !var.empty())
     {
         size_type dl = std::stoul(var);
-        result.construction_opts.bih_options.num_part_cands = dl;
+        result.construction_opts.bvh_options.num_part_cands = dl;
     }
 
     CELER_ENSURE(result);

--- a/src/orange/univ/SimpleUnitTracker.hh
+++ b/src/orange/univ/SimpleUnitTracker.hh
@@ -12,8 +12,8 @@
 #include "orange/OrangeData.hh"
 #include "orange/OrangeTypes.hh"
 #include "orange/SenseUtils.hh"
-#include "orange/detail/BIHEnclosingVolFinder.hh"
-#include "orange/detail/BIHIntersectingVolFinder.hh"
+#include "orange/detail/BvhEnclosingVolFinder.hh"
+#include "orange/detail/BvhIntersectingVolFinder.hh"
 #include "orange/surf/LocalSurfaceVisitor.hh"
 
 #include "detail/InfixEvaluator.hh"
@@ -187,7 +187,7 @@ SimpleUnitTracker::initialize(LocalState const& state) const -> Initialization
     CELER_EXPECT(params_);
     CELER_EXPECT(!state.surface && !state.volume);
 
-    // Use the BIH to locate a position that's inside, and save whether it's on
+    // Use the BVH to locate a position that's inside, and save whether it's on
     // a surface in the found volume
     detail::OnFace on_surface;
     auto is_inside = [this, &state, &on_surface](LocalVolumeId id) -> bool {
@@ -249,7 +249,7 @@ SimpleUnitTracker::cross_boundary(LocalState const& state) const
     auto neighbors = this->get_neighbors(state.surface.id());
 
     // If this surface has 2 neighbors or fewer (excluding the current cell),
-    // use linear search to check neighbors. Otherwise, traverse the BIH tree.
+    // use linear search to check neighbors. Otherwise, traverse the BVH tree.
     if (neighbors.size() < 3)
     {
         for (LocalVolumeId id : neighbors)
@@ -446,7 +446,7 @@ CELER_FUNCTION auto SimpleUnitTracker::get_neighbors(LocalSurfaceId surf) const
 
 //---------------------------------------------------------------------------//
 /*!
- * Search the BIH to find where the predicate is true for the point.
+ * Search the BVH to find where the predicate is true for the point.
  *
  * The predicate should have the signature \code bool(LocalVolumeId) \endcode.
  */
@@ -454,8 +454,8 @@ template<class F>
 CELER_FUNCTION LocalVolumeId
 SimpleUnitTracker::find_volume_where(Real3 const& pos, F&& predicate) const
 {
-    detail::BIHEnclosingVolFinder find_volume{unit_record_.bih_tree,
-                                              params_.bih_tree_data};
+    detail::BvhEnclosingVolFinder find_volume{unit_record_.bvh_tree,
+                                              params_.bvh_tree_data};
     return find_volume(pos, predicate);
 }
 
@@ -619,7 +619,7 @@ SimpleUnitTracker::complex_intersect(LocalState const& state,
 /*!
  * Calculate distance from the background volume to enter any other volume.
  *
- * This function is accelerated with the BIH.
+ * This function is accelerated with the BVH.
  */
 CELER_FUNCTION auto
 SimpleUnitTracker::background_intersect(LocalState const& state,
@@ -666,8 +666,8 @@ SimpleUnitTracker::background_intersect(LocalState const& state,
             state, vol, num_isect, Sense::inside, cur_max_dist);
     };
 
-    detail::BIHIntersectingVolFinder find_intersection{unit_record_.bih_tree,
-                                                       params_.bih_tree_data};
+    detail::BvhIntersectingVolFinder find_intersection{unit_record_.bvh_tree,
+                                                       params_.bvh_tree_data};
 
     return find_intersection(
         {state.pos, state.dir}, is_intersecting, max_distance);

--- a/test/orange/CMakeLists.txt
+++ b/test/orange/CMakeLists.txt
@@ -53,11 +53,11 @@ celeritas_add_device_test(OrangeShift)
 
 celeritas_add_test(detail/UniverseIndexer.test.cc)
 
-# Bounding interval hierarchy
-celeritas_add_test(detail/BIHBuilder.test.cc)
-celeritas_add_test(detail/BIHEnclosingVolFinder.test.cc)
-celeritas_add_test(detail/BIHIntersectingVolFinder.test.cc)
-celeritas_add_test(detail/BIHUtils.test.cc)
+# Bounding volume hierarchy
+celeritas_add_test(detail/BvhBuilder.test.cc)
+celeritas_add_test(detail/BvhEnclosingVolFinder.test.cc)
+celeritas_add_test(detail/BvhIntersectingVolFinder.test.cc)
+celeritas_add_test(detail/BvhUtils.test.cc)
 
 # Oriented Bounding Zone
 celeritas_add_test(detail/OrientedBoundingZone.test.cc)

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -199,7 +199,7 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"max_faces":14,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"univ_indices":3,"univ_types":3,"universe_indexer":{"surfaces":4,"volumes":4},"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -713,7 +713,7 @@ TEST_F(HexArrayTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -775,7 +775,7 @@ TEST_F(InputBuilderTest, globalspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"max_faces":2,"max_intersections":4,"num_univ_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"univ_indices":1,"univ_types":1,"universe_indexer":{"surfaces":2,"volumes":2},"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -841,7 +841,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"max_faces":3,"max_intersections":2,"num_univ_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"univ_indices":1,"univ_types":1,"universe_indexer":{"surfaces":2,"volumes":2},"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -965,7 +965,7 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -974,7 +974,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
         to_string(out));
 }
 

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -199,7 +199,7 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -713,7 +713,7 @@ TEST_F(HexArrayTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -775,7 +775,7 @@ TEST_F(InputBuilderTest, globalspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -841,7 +841,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -965,7 +965,7 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -974,7 +974,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
         to_string(out));
 }
 

--- a/test/orange/detail/BvhBuilder.test.cc
+++ b/test/orange/detail/BvhBuilder.test.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHBuilder.test.cc
+//! \file orange/detail/BvhBuilder.test.cc
 //---------------------------------------------------------------------------//
-#include "orange/detail/BIHBuilder.hh"
+#include "orange/detail/BvhBuilder.hh"
 
 #include <limits>
 #include <vector>
@@ -13,8 +13,8 @@
 #include "corecel/Types.hh"
 #include "corecel/data/ParamsDataStore.hh"
 #include "geocel/Types.hh"
-#include "orange/detail/BIHData.hh"
-#include "orange/detail/BIHView.hh"
+#include "orange/detail/BvhData.hh"
+#include "orange/detail/BvhView.hh"
 
 #include "celeritas_test.hh"
 
@@ -27,21 +27,21 @@ namespace detail
 namespace test
 {
 //---------------------------------------------------------------------------//
-class BIHBuilderTest : public ::celeritas::test::Test
+class BvhBuilderTest : public ::celeritas::test::Test
 {
   public:
     using VecFastReal = std::vector<fast_real_type>;
-    using VecFastBbox = BIHBuilder::VecBBox;
-    using Input = BIHBuilder::Input;
+    using VecFastBbox = BvhBuilder::VecBBox;
+    using Input = BvhBuilder::Input;
     using VecInt = std::vector<int>;
-    using Side = BIHInternalNode::Side;
+    using Side = BvhInternalNode::Side;
     using Real3 = FastBBox::Real3;
 
   protected:
     static constexpr auto inff
         = std::numeric_limits<fast_real_type>::infinity();
 
-    //! Build BIH tree data with a single tree in it and one volume per leaf
+    //! Build BVH tree data with a single tree in it and one volume per leaf
     void build(VecFastBbox bboxes)
     {
         Input input;
@@ -49,19 +49,19 @@ class BIHBuilderTest : public ::celeritas::test::Test
         return this->build(std::move(bboxes), std::move(input));
     }
 
-    //! Build BIH tree data with a single tree in it and one volume per leaf
+    //! Build BVH tree data with a single tree in it and one volume per leaf
     void build(VecFastBbox&& bboxes, Input&& input)
     {
-        HostVal<BIHTreeData> data;
-        BIHBuilder build(&data, std::move(input));
+        HostVal<BvhTreeData> data;
+        BvhBuilder build(&data, std::move(input));
         tree_ = build(std::move(bboxes), {});
-        store_ = ParamsDataStore<BIHTreeData>{std::move(data)};
+        store_ = ParamsDataStore<BvhTreeData>{std::move(data)};
         ASSERT_TRUE(tree_);
         ASSERT_TRUE(store_);
     }
 
-    ParamsDataStore<BIHTreeData> store_;
-    BIHTreeRecord tree_;
+    ParamsDataStore<BvhTreeData> store_;
+    BvhTreeRecord tree_;
 };
 
 //---------------------------------------------------------------------------//
@@ -82,7 +82,7 @@ class BIHBuilderTest : public ::celeritas::test::Test
 
           x=0                                                x=5
    \endverbatim
- * Resultant tree structure in terms of BIHNodeIds (N) and volumes (V):
+ * Resultant tree structure in terms of BvhNodeIds (N) and volumes (V):
  * \verbatim
                         ___ N0 ___
                       /            \
@@ -91,7 +91,7 @@ class BIHBuilderTest : public ::celeritas::test::Test
                   N3   N4        N5     N6
                   V1   V2       V4,V5   V3
    \endverbatim
- * In terms of BIHInnerNodeIds (I) and BIHLeafNodeIds (L):
+ * In terms of BvhInternalNodeIds (I) and BvhLeafNodeIds (L):
  * \verbatim
                         ___ I0 ___
                       /            \
@@ -101,7 +101,7 @@ class BIHBuilderTest : public ::celeritas::test::Test
                   V1   V2       V4,V5   V3
    \endverbatim
  */
-TEST_F(BIHBuilderTest, basic)
+TEST_F(BvhBuilderTest, basic)
 {
     this->build({
         FastBBox::from_infinite(),
@@ -113,19 +113,19 @@ TEST_F(BIHBuilderTest, basic)
     });
 
     // Test nodes
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(3, view.num_internal_nodes());
     ASSERT_EQ(4, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
-        auto const& node = view.inner_node(BIHNodeId{0});
+        auto const& node = view.inner_node(BvhNodeId{0});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{2}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{2}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -139,12 +139,12 @@ TEST_F(BIHBuilderTest, basic)
 
     // N1, I1
     {
-        auto const& node = view.inner_node(BIHNodeId{1});
+        auto const& node = view.inner_node(BvhNodeId{1});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{3}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{4}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{3}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{4}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -158,12 +158,12 @@ TEST_F(BIHBuilderTest, basic)
 
     // N2, I2
     {
-        auto const& node = view.inner_node(BIHNodeId{2});
+        auto const& node = view.inner_node(BvhNodeId{2});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{5}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{6}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{5}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{6}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, -1.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -175,10 +175,10 @@ TEST_F(BIHBuilderTest, basic)
                            node.bbox(Side::right).upper());
     }
 
-    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BIHNodeId{3})));
-    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BIHNodeId{4})));
-    EXPECT_VEC_EQ(VecInt({4, 5}), id_to_int(view.leaf_vol_ids(BIHNodeId{5})));
-    EXPECT_VEC_EQ(VecInt({3}), id_to_int(view.leaf_vol_ids(BIHNodeId{6})));
+    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BvhNodeId{3})));
+    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BvhNodeId{4})));
+    EXPECT_VEC_EQ(VecInt({4, 5}), id_to_int(view.leaf_vol_ids(BvhNodeId{5})));
+    EXPECT_VEC_EQ(VecInt({3}), id_to_int(view.leaf_vol_ids(BvhNodeId{6})));
 
     // Metadata
     {
@@ -207,7 +207,7 @@ TEST_F(BIHBuilderTest, basic)
                             x
    \endverbatim
  */
-class GridTest : public BIHBuilderTest
+class GridTest : public BvhBuilderTest
 {
   protected:
     void build_grid(Input&& input)
@@ -228,8 +228,8 @@ class GridTest : public BIHBuilderTest
 
 //---------------------------------------------------------------------------//
 /* Test with max_leaf_size = 1 and the default depth limit (large enough to not
- * affect BIH construction here). The resultant tree structure in terms of
- * BIHNodeId (N) and volumes (V) is:
+ * affect BVH construction here). The resultant tree structure in terms of
+ * BvhNodeId (N) and volumes (V) is:
  * \verbatim
                      _______________ N0 ______________
                    /                                   \
@@ -242,7 +242,7 @@ class GridTest : public BIHBuilderTest
                   N13  N14   N15   N16                   N19  N20    N21   N22
                   V5   V6    V9    V10                   V7   V8     V11   V12
    \endverbatim
- * In terms of BIHInnerNodeIds (I) and BIHLeafNodeIds (L):
+ * In terms of BvhInternalNodeIds (I) and BvhLeafNodeIds (L):
  * \verbatim
                      _______________ I0 ______________
                    /                                   \
@@ -267,19 +267,19 @@ TEST_F(GridTest, basic)
     }());
 
     // Test nodes
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(11, view.num_internal_nodes());
     ASSERT_EQ(12, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
-        auto const& node = view.inner_node(BIHNodeId{0});
+        auto const& node = view.inner_node(BvhNodeId{0});
 
         EXPECT_EQ(Axis{1}, node.axis());
         EXPECT_EQ(Axis{1}, node.axis());
-        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{6}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{6}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -293,12 +293,12 @@ TEST_F(GridTest, basic)
 
     // N1, I1
     {
-        auto const& node = view.inner_node(BIHNodeId{1});
+        auto const& node = view.inner_node(BvhNodeId{1});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{2}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{3}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{2}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{3}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -312,12 +312,12 @@ TEST_F(GridTest, basic)
 
     // N2, I2
     {
-        auto const& node = view.inner_node(BIHNodeId{2});
+        auto const& node = view.inner_node(BvhNodeId{2});
 
         EXPECT_EQ(Axis{1}, node.axis());
         EXPECT_EQ(Axis{1}, node.axis());
-        EXPECT_EQ(BIHNodeId{11}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{12}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{11}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{12}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -331,12 +331,12 @@ TEST_F(GridTest, basic)
 
     // N3, I3
     {
-        auto const& node = view.inner_node(BIHNodeId{3});
+        auto const& node = view.inner_node(BvhNodeId{3});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{4}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{5}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{4}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{5}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -350,12 +350,12 @@ TEST_F(GridTest, basic)
 
     // N4, I4
     {
-        auto const& node = view.inner_node(BIHNodeId{4});
+        auto const& node = view.inner_node(BvhNodeId{4});
 
         EXPECT_EQ(Axis{1}, node.axis());
         EXPECT_EQ(Axis{1}, node.axis());
-        EXPECT_EQ(BIHNodeId{13}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{14}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{13}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{14}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -369,12 +369,12 @@ TEST_F(GridTest, basic)
 
     // N5, I5
     {
-        auto const& node = view.inner_node(BIHNodeId{5});
+        auto const& node = view.inner_node(BvhNodeId{5});
 
         EXPECT_EQ(Axis{1}, node.axis());
         EXPECT_EQ(Axis{1}, node.axis());
-        EXPECT_EQ(BIHNodeId{15}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{16}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{15}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{16}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({2.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -386,12 +386,12 @@ TEST_F(GridTest, basic)
                            node.bbox(Side::right).upper());
     }
 
-    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BIHNodeId{11})));
-    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BIHNodeId{12})));
-    EXPECT_VEC_EQ(VecInt({5}), id_to_int(view.leaf_vol_ids(BIHNodeId{13})));
-    EXPECT_VEC_EQ(VecInt({6}), id_to_int(view.leaf_vol_ids(BIHNodeId{14})));
-    EXPECT_VEC_EQ(VecInt({9}), id_to_int(view.leaf_vol_ids(BIHNodeId{15})));
-    EXPECT_VEC_EQ(VecInt({10}), id_to_int(view.leaf_vol_ids(BIHNodeId{16})));
+    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BvhNodeId{11})));
+    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BvhNodeId{12})));
+    EXPECT_VEC_EQ(VecInt({5}), id_to_int(view.leaf_vol_ids(BvhNodeId{13})));
+    EXPECT_VEC_EQ(VecInt({6}), id_to_int(view.leaf_vol_ids(BvhNodeId{14})));
+    EXPECT_VEC_EQ(VecInt({9}), id_to_int(view.leaf_vol_ids(BvhNodeId{15})));
+    EXPECT_VEC_EQ(VecInt({10}), id_to_int(view.leaf_vol_ids(BvhNodeId{16})));
 
     // Metadata
     {
@@ -404,8 +404,8 @@ TEST_F(GridTest, basic)
 
 //---------------------------------------------------------------------------//
 /* Test with max_leaf_size = 4 and the default depth limit (large enough to not
- * affect BIH construction here). The resultant tree structure in terms of
- * BIHNodeId (N) and volumes (V) is:
+ * affect BVH construction here). The resultant tree structure in terms of
+ * BvhNodeId (N) and volumes (V) is:
  * \verbatim
                      _______________ N0 ______________
                    /                                   \
@@ -414,7 +414,7 @@ TEST_F(GridTest, basic)
         N3                N4                 N5                  N6
       V1, V2        V5, V6, V9, V10        V3, V4          V7, V8, V11, V12
    \endverbatim
- * In terms of BIHInnerNodeIds (I) and BIHLeafNodeIds (L):
+ * In terms of BvhInternalNodeIds (I) and BvhLeafNodeIds (L):
  * \verbatim
 
                      _______________ I0 ______________
@@ -434,19 +434,19 @@ TEST_F(GridTest, max_leaf_size)
     }());
 
     // Test nodes
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(3, view.num_internal_nodes());
     ASSERT_EQ(4, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
-        auto const& node = view.inner_node(BIHNodeId{0});
+        auto const& node = view.inner_node(BvhNodeId{0});
 
         EXPECT_EQ(Axis{1}, node.axis());
         EXPECT_EQ(Axis{1}, node.axis());
-        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{2}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{2}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -460,12 +460,12 @@ TEST_F(GridTest, max_leaf_size)
 
     // N1, I1
     {
-        auto const& node = view.inner_node(BIHNodeId{1});
+        auto const& node = view.inner_node(BvhNodeId{1});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{3}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{4}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{3}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{4}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -479,12 +479,12 @@ TEST_F(GridTest, max_leaf_size)
 
     // N2, I2
     {
-        auto const& node = view.inner_node(BIHNodeId{2});
+        auto const& node = view.inner_node(BvhNodeId{2});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{5}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{6}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{5}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{6}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 2.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -496,12 +496,12 @@ TEST_F(GridTest, max_leaf_size)
                            node.bbox(Side::right).upper());
     }
 
-    EXPECT_VEC_EQ(VecInt({1, 2}), id_to_int(view.leaf_vol_ids(BIHNodeId{3})));
+    EXPECT_VEC_EQ(VecInt({1, 2}), id_to_int(view.leaf_vol_ids(BvhNodeId{3})));
     EXPECT_VEC_EQ(VecInt({5, 6, 9, 10}),
-                  id_to_int(view.leaf_vol_ids(BIHNodeId{4})));
-    EXPECT_VEC_EQ(VecInt({3, 4}), id_to_int(view.leaf_vol_ids(BIHNodeId{5})));
+                  id_to_int(view.leaf_vol_ids(BvhNodeId{4})));
+    EXPECT_VEC_EQ(VecInt({3, 4}), id_to_int(view.leaf_vol_ids(BvhNodeId{5})));
     EXPECT_VEC_EQ(VecInt({7, 8, 11, 12}),
-                  id_to_int(view.leaf_vol_ids(BIHNodeId{6})));
+                  id_to_int(view.leaf_vol_ids(BvhNodeId{6})));
 
     // Metadata
     {
@@ -515,7 +515,7 @@ TEST_F(GridTest, max_leaf_size)
 //---------------------------------------------------------------------------//
 /* Test with max_leaf_size = 1 and depth_limit = 4, the later of which causes
  * the tree to be less deep than it otherwise would. The resultant tree
- * structure in terms of BIHNodeId (N) and volumes (V) is:
+ * structure in terms of BvhNodeId (N) and volumes (V) is:
  * \verbatim
                      _______________ N0 ______________
                    /                                   \
@@ -526,7 +526,7 @@ TEST_F(GridTest, max_leaf_size)
     N7     N8         N9      N10       N11      N12       N13     N14
     V1     V2      V5, V6   V9, V10     V3       V4      V7, V8   V11, V12
    \endverbatim
- * In terms of BIHInnerNodeIds (I) and BIHLeafNodeIds (L):
+ * In terms of BvhInternalNodeIds (I) and BvhLeafNodeIds (L):
  * \verbatim
                      _______________ I0 ______________
                    /                                   \
@@ -550,19 +550,19 @@ TEST_F(GridTest, depth_limit)
     }());
 
     // Test nodes
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(7, view.num_internal_nodes());
     ASSERT_EQ(8, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
 
     // N0, I0
     {
-        auto const& node = view.inner_node(BIHNodeId{0});
+        auto const& node = view.inner_node(BvhNodeId{0});
 
         EXPECT_EQ(Axis{1}, node.axis());
         EXPECT_EQ(Axis{1}, node.axis());
-        EXPECT_EQ(BIHNodeId{1}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{4}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{1}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{4}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -576,12 +576,12 @@ TEST_F(GridTest, depth_limit)
 
     // N1, I1
     {
-        auto const& node = view.inner_node(BIHNodeId{1});
+        auto const& node = view.inner_node(BvhNodeId{1});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{2}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{3}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{2}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{3}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -595,12 +595,12 @@ TEST_F(GridTest, depth_limit)
 
     // N2, I2
     {
-        auto const& node = view.inner_node(BIHNodeId{2});
+        auto const& node = view.inner_node(BvhNodeId{2});
 
         EXPECT_EQ(Axis{1}, node.axis());
         EXPECT_EQ(Axis{1}, node.axis());
-        EXPECT_EQ(BIHNodeId{7}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{8}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{7}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{8}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({0.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -614,12 +614,12 @@ TEST_F(GridTest, depth_limit)
 
     // N3, I3
     {
-        auto const& node = view.inner_node(BIHNodeId{3});
+        auto const& node = view.inner_node(BvhNodeId{3});
 
         EXPECT_EQ(Axis{0}, node.axis());
         EXPECT_EQ(Axis{0}, node.axis());
-        EXPECT_EQ(BIHNodeId{9}, node.child(Side::left));
-        EXPECT_EQ(BIHNodeId{10}, node.child(Side::right));
+        EXPECT_EQ(BvhNodeId{9}, node.child(Side::left));
+        EXPECT_EQ(BvhNodeId{10}, node.child(Side::right));
 
         EXPECT_VEC_SOFT_EQ(VecFastReal({1.f, 0.f, 0.f}),
                            node.bbox(Side::left).lower());
@@ -631,10 +631,10 @@ TEST_F(GridTest, depth_limit)
                            node.bbox(Side::right).upper());
     }
 
-    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BIHNodeId{7})));
-    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BIHNodeId{8})));
-    EXPECT_VEC_EQ(VecInt({5, 6}), id_to_int(view.leaf_vol_ids(BIHNodeId{9})));
-    EXPECT_VEC_EQ(VecInt({9, 10}), id_to_int(view.leaf_vol_ids(BIHNodeId{10})));
+    EXPECT_VEC_EQ(VecInt({1}), id_to_int(view.leaf_vol_ids(BvhNodeId{7})));
+    EXPECT_VEC_EQ(VecInt({2}), id_to_int(view.leaf_vol_ids(BvhNodeId{8})));
+    EXPECT_VEC_EQ(VecInt({5, 6}), id_to_int(view.leaf_vol_ids(BvhNodeId{9})));
+    EXPECT_VEC_EQ(VecInt({9, 10}), id_to_int(view.leaf_vol_ids(BvhNodeId{10})));
 
     // Metadata
     {
@@ -649,16 +649,16 @@ TEST_F(GridTest, depth_limit)
 // Degenerate, single leaf cases
 //---------------------------------------------------------------------------//
 //
-TEST_F(BIHBuilderTest, single_finite_volume)
+TEST_F(BvhBuilderTest, single_finite_volume)
 {
     this->build({{{0, 0, 0}, {1, 1, 1}}});
 
     ASSERT_EQ(0, tree_.inf_vol_ids.size());
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
 
-    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.leaf_vol_ids(BIHNodeId{0})));
+    EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.leaf_vol_ids(BvhNodeId{0})));
 
     auto const& md = tree_.metadata;
     EXPECT_EQ(1, md.num_finite_bboxes);
@@ -666,16 +666,16 @@ TEST_F(BIHBuilderTest, single_finite_volume)
     EXPECT_EQ(1, md.depth);
 }
 
-TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
+TEST_F(BvhBuilderTest, multiple_nonpartitionable_volumes)
 {
     this->build({{{0, 0, 0}, {1, 1, 1}}, {{0, 0, 0}, {1, 1, 1}}});
 
     ASSERT_EQ(0, tree_.inf_vol_ids.size());
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
 
-    EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.leaf_vol_ids(BIHNodeId{0})));
+    EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.leaf_vol_ids(BvhNodeId{0})));
 
     auto const& md = tree_.metadata;
     EXPECT_EQ(2, md.num_finite_bboxes);
@@ -683,11 +683,11 @@ TEST_F(BIHBuilderTest, multiple_nonpartitionable_volumes)
     EXPECT_EQ(1, md.depth);
 }
 
-TEST_F(BIHBuilderTest, single_infinite_volume)
+TEST_F(BvhBuilderTest, single_infinite_volume)
 {
     this->build({FastBBox::from_infinite()});
 
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0}), id_to_int(view.inf_vol_ids()));
@@ -698,11 +698,11 @@ TEST_F(BIHBuilderTest, single_infinite_volume)
     EXPECT_EQ(0, md.depth);
 }
 
-TEST_F(BIHBuilderTest, multiple_infinite_volumes)
+TEST_F(BvhBuilderTest, multiple_infinite_volumes)
 {
     this->build({FastBBox::from_infinite(), FastBBox::from_infinite()});
 
-    BIHView view{tree_, store_.host_ref()};
+    BvhView view{tree_, store_.host_ref()};
     ASSERT_EQ(0, view.num_internal_nodes());
     ASSERT_EQ(1, view.num_leaf_nodes());
     EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.inf_vol_ids()));
@@ -713,7 +713,7 @@ TEST_F(BIHBuilderTest, multiple_infinite_volumes)
     EXPECT_EQ(0, md.depth);
 }
 
-TEST_F(BIHBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))
+TEST_F(BvhBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))
 {
     EXPECT_THROW(this->build({
                      {{0, 0, -inff}, {1, 1, inff}},

--- a/test/orange/detail/BvhEnclosingVolFinder.test.cc
+++ b/test/orange/detail/BvhEnclosingVolFinder.test.cc
@@ -2,28 +2,28 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHEnclosingVolFinder.test.cc
+//! \file orange/detail/BvhEnclosingVolFinder.test.cc
 //---------------------------------------------------------------------------//
-#include "orange/detail/BIHEnclosingVolFinder.hh"
+#include "orange/detail/BvhEnclosingVolFinder.hh"
 
-#include "orange/detail/BIHBuilder.hh"
-#include "orange/detail/BIHData.hh"
+#include "orange/detail/BvhBuilder.hh"
+#include "orange/detail/BvhData.hh"
 
 #include "celeritas_test.hh"
 
-using BIHBuilder = celeritas::detail::BIHBuilder;
-using BIHInnerNode = celeritas::detail::BIHInternalNode;
-using BIHLeafNode = celeritas::detail::BIHLeafNode;
-using BIHEnclosingVolFinder = celeritas::detail::BIHEnclosingVolFinder;
+using BvhBuilder = celeritas::detail::BvhBuilder;
+using BvhInternalNode = celeritas::detail::BvhInternalNode;
+using BvhLeafNode = celeritas::detail::BvhLeafNode;
+using BvhEnclosingVolFinder = celeritas::detail::BvhEnclosingVolFinder;
 
 namespace celeritas
 {
 namespace test
 {
-class BIHEnclosingVolFinderTest : public Test
+class BvhEnclosingVolFinderTest : public Test
 {
   public:
-    using VecFastBbox = BIHBuilder::VecBBox;
+    using VecFastBbox = BvhBuilder::VecBBox;
 
   protected:
     //! Accept a volume if the point is inside its bbox
@@ -54,9 +54,9 @@ class BIHEnclosingVolFinderTest : public Test
     };
 
   protected:
-    HostVal<detail::BIHTreeData> storage_;
-    HostCRef<detail::BIHTreeData> ref_storage_;
-    BIHBuilder::SetLocalVolId implicit_vol_ids_;
+    HostVal<detail::BvhTreeData> storage_;
+    HostCRef<detail::BvhTreeData> ref_storage_;
+    BvhBuilder::SetLocalVolId implicit_vol_ids_;
 };
 
 //---------------------------------------------------------------------------//
@@ -79,7 +79,7 @@ class BIHEnclosingVolFinderTest : public Test
           x=0                                                x=5
    \endverbatim
  */
-TEST_F(BIHEnclosingVolFinderTest, basic)
+TEST_F(BvhEnclosingVolFinderTest, basic)
 {
     auto run_test = [&](size_type max_leaf_size) {
         VecFastBbox bboxes = {
@@ -91,11 +91,11 @@ TEST_F(BIHEnclosingVolFinderTest, basic)
             {{0, -1, 0}, {5, 0, 100}},
         };
 
-        BIHBuilder build(&storage_, BIHBuilder::Input{max_leaf_size});
-        auto bih_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
+        BvhBuilder build(&storage_, BvhBuilder::Input{max_leaf_size});
+        auto bvh_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
 
         ref_storage_ = storage_;
-        BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
+        BvhEnclosingVolFinder find_volume(bvh_tree, ref_storage_);
 
         Real3 pos = {0.8, 0.5, 110};
         EXPECT_EQ(LocalVolumeId{0},
@@ -145,7 +145,7 @@ TEST_F(BIHEnclosingVolFinderTest, basic)
                             x
    \endverbatim
  */
-TEST_F(BIHEnclosingVolFinderTest, grid)
+TEST_F(BvhEnclosingVolFinderTest, grid)
 {
     auto run_test = [&](size_type max_leaf_size) {
         VecFastBbox bboxes = {FastBBox::from_infinite()};
@@ -159,11 +159,11 @@ TEST_F(BIHEnclosingVolFinderTest, grid)
             }
         }
 
-        BIHBuilder build(&storage_, BIHBuilder::Input{max_leaf_size});
-        auto bih_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
+        BvhBuilder build(&storage_, BvhBuilder::Input{max_leaf_size});
+        auto bvh_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
 
         ref_storage_ = storage_;
-        BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
+        BvhEnclosingVolFinder find_volume(bvh_tree, ref_storage_);
 
         Real3 outside_pos{0.8, 0.5, 110};
         EXPECT_EQ(LocalVolumeId{0},
@@ -194,33 +194,33 @@ TEST_F(BIHEnclosingVolFinderTest, grid)
 // Degenerate, single leaf cases
 //---------------------------------------------------------------------------//
 
-TEST_F(BIHEnclosingVolFinderTest, single_finite_volume)
+TEST_F(BvhEnclosingVolFinderTest, single_finite_volume)
 {
     VecFastBbox bboxes = {{{0, 0, 0}, {1, 1, 1}}};
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{});
-    auto bih_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
+    BvhBuilder build(&storage_, BvhBuilder::Input{});
+    auto bvh_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
 
     ref_storage_ = storage_;
-    BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
+    BvhEnclosingVolFinder find_volume(bvh_tree, ref_storage_);
 
     Real3 pos{0.5, 0.5, 0.5};
     EXPECT_EQ(LocalVolumeId{0},
               find_volume(pos, IsPointInsideBboxVolume{bboxes, pos}));
 }
 
-TEST_F(BIHEnclosingVolFinderTest, multiple_nonpartitionable_volumes)
+TEST_F(BvhEnclosingVolFinderTest, multiple_nonpartitionable_volumes)
 {
     VecFastBbox bboxes = {
         {{0, 0, 0}, {1, 1, 1}},
         {{0, 0, 0}, {1, 1, 1}},
     };
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{});
-    auto bih_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
+    BvhBuilder build(&storage_, BvhBuilder::Input{});
+    auto bvh_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
 
     ref_storage_ = storage_;
-    BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
+    BvhEnclosingVolFinder find_volume(bvh_tree, ref_storage_);
 
     Real3 pos{0.5, 0.5, 0.5};
     EXPECT_EQ(LocalVolumeId{0},
@@ -229,33 +229,33 @@ TEST_F(BIHEnclosingVolFinderTest, multiple_nonpartitionable_volumes)
               find_volume(pos, IsPointInsideOddBboxVolume{bboxes, pos}));
 }
 
-TEST_F(BIHEnclosingVolFinderTest, single_infinite_volume)
+TEST_F(BvhEnclosingVolFinderTest, single_infinite_volume)
 {
     VecFastBbox bboxes = {FastBBox::from_infinite()};
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{});
-    auto bih_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
+    BvhBuilder build(&storage_, BvhBuilder::Input{});
+    auto bvh_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
 
     ref_storage_ = storage_;
-    BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
+    BvhEnclosingVolFinder find_volume(bvh_tree, ref_storage_);
 
     Real3 pos{0.5, 0.5, 0.5};
     EXPECT_EQ(LocalVolumeId{0},
               find_volume(pos, IsPointInsideBboxVolume{bboxes, pos}));
 }
 
-TEST_F(BIHEnclosingVolFinderTest, multiple_infinite_volumes)
+TEST_F(BvhEnclosingVolFinderTest, multiple_infinite_volumes)
 {
     VecFastBbox bboxes = {
         FastBBox::from_infinite(),
         FastBBox::from_infinite(),
     };
 
-    BIHBuilder build(&storage_, BIHBuilder::Input{});
-    auto bih_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
+    BvhBuilder build(&storage_, BvhBuilder::Input{});
+    auto bvh_tree = build(VecFastBbox{bboxes}, implicit_vol_ids_);
 
     ref_storage_ = storage_;
-    BIHEnclosingVolFinder find_volume(bih_tree, ref_storage_);
+    BvhEnclosingVolFinder find_volume(bvh_tree, ref_storage_);
 
     Real3 pos{0.5, 0.5, 0.5};
     EXPECT_EQ(LocalVolumeId{0},

--- a/test/orange/detail/BvhIntersectingVolFinder.test.cc
+++ b/test/orange/detail/BvhIntersectingVolFinder.test.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHIntersectingVolFinder.test.cc
+//! \file orange/detail/BvhIntersectingVolFinder.test.cc
 //---------------------------------------------------------------------------//
-#include "orange/detail/BIHIntersectingVolFinder.hh"
+#include "orange/detail/BvhIntersectingVolFinder.hh"
 
 #include <limits>
 #include <unordered_map>
@@ -14,7 +14,7 @@
 #include "orange/BoundingBoxUtils.hh"
 #include "orange/OrangeParamsOutput.hh"
 #include "orange/OrangeTypes.hh"
-#include "orange/detail/BIHBuilder.hh"
+#include "orange/detail/BvhBuilder.hh"
 #include "orange/univ/detail/Types.hh"
 
 #include "TestMacros.hh"
@@ -34,8 +34,8 @@ class MockIntersector
 {
   public:
     using DistMap = std::unordered_map<LocalVolumeId, real_type>;
-    using VecBBox = BIHBuilder::VecBBox;
-    using Ray = BIHIntersectingVolFinder::Ray;
+    using VecBBox = BvhBuilder::VecBBox;
+    using Ray = BvhIntersectingVolFinder::Ray;
 
   public:
     MockIntersector(DistMap const& dist_map, VecBBox const& bboxes, Ray ray)
@@ -91,7 +91,7 @@ struct IntersectResult
     LocalSurfaceId intersect_surface;
 
     /*
-     * These vectors, with each element corresponding to the BIH tree
+     * These vectors, with each element corresponding to the BVH tree
      * tested (configured with different leaf size counts), are diagnostics
      * collected by the MockIntersector class: the number of *volume*
      * intersection tests (after the bbox was used to exclude intersections)
@@ -149,45 +149,45 @@ std::ostream& operator<<(std::ostream& os, IntersectResult const& ref)
 
 //---------------------------------------------------------------------------//
 /*!
- * Build a BIH tree and test ray intersections with volumes.
+ * Build a BVH tree and test ray intersections with volumes.
  *
- * This class owns the BIH tree storage and provides intersection testing via
- * a locally-constructed \c BIHIntersectingVolFinder.
+ * This class owns the BVH tree storage and provides intersection testing via
+ * a locally-constructed \c BvhIntersectingVolFinder.
  */
-class LocalBihTreeTester
+class LocalBvhTreeTester
 {
   public:
-    using VecBBox = BIHBuilder::VecBBox;
-    using Ray = BIHIntersectingVolFinder::Ray;
+    using VecBBox = BvhBuilder::VecBBox;
+    using Ray = BvhIntersectingVolFinder::Ray;
 
-    LocalBihTreeTester(VecBBox bboxes, BIHBuilder::Input input)
+    LocalBvhTreeTester(VecBBox bboxes, BvhBuilder::Input input)
     {
-        BIHBuilder build(&storage_, input);
-        BIHBuilder::SetLocalVolId implicit_vol_ids;
-        bih_tree_ = build(std::move(bboxes), implicit_vol_ids);
+        BvhBuilder build(&storage_, input);
+        BvhBuilder::SetLocalVolId implicit_vol_ids;
+        bvh_tree_ = build(std::move(bboxes), implicit_vol_ids);
         ref_storage_ = storage_;
     }
 
     template<class F>
     Intersection operator()(Ray ray, F&& visit_vol, real_type max_dist) const
     {
-        BIHIntersectingVolFinder find_volume{bih_tree_, ref_storage_};
+        BvhIntersectingVolFinder find_volume{bvh_tree_, ref_storage_};
         return find_volume(ray, std::forward<F>(visit_vol), max_dist);
     }
 
-    friend std::string to_string(LocalBihTreeTester const& btt)
+    friend std::string to_string(LocalBvhTreeTester const& btt)
     {
-        return dump_bih_structure(btt.bih_tree_, btt.ref_storage_);
+        return dump_bvh_structure(btt.bvh_tree_, btt.ref_storage_);
     }
 
   private:
-    BIHTreeRecord bih_tree_;
-    BIHTreeData<Ownership::value, MemSpace::host> storage_;
-    BIHTreeData<Ownership::const_reference, MemSpace::host> ref_storage_;
+    BvhTreeRecord bvh_tree_;
+    BvhTreeData<Ownership::value, MemSpace::host> storage_;
+    BvhTreeData<Ownership::const_reference, MemSpace::host> ref_storage_;
 };
 
 //---------------------------------------------------------------------------//
-/* The BIHIntersectingVolFinder class is tested with the following geometry,
+/* The BvhIntersectingVolFinder class is tested with the following geometry,
  * consisting of partial and fully overlapping bounding boxes.
  * \verbatim
 
@@ -207,13 +207,13 @@ class LocalBihTreeTester
           x=0                                                x=5
    \endverbatim
  */
-class BIHIntersectingVolFinderTest : public ::celeritas::test::Test
+class BvhIntersectingVolFinderTest : public ::celeritas::test::Test
 {
   public:
-    using Ray = LocalBihTreeTester::Ray;
+    using Ray = LocalBvhTreeTester::Ray;
     using DistMap = MockIntersector::DistMap;
-    using VecBBox = BIHBuilder::VecBBox;
-    using VecSetup = std::vector<inp::BIHBuilder>;
+    using VecBBox = BvhBuilder::VecBBox;
+    using VecSetup = std::vector<inp::BvhBuilder>;
 
     static constexpr auto large = 10000_r;
 
@@ -221,14 +221,14 @@ class BIHIntersectingVolFinderTest : public ::celeritas::test::Test
     void SetUp() override
     {
         bboxes_ = this->make_bboxes();
-        for (auto&& setup : this->make_bih_setups())
+        for (auto&& setup : this->make_bvh_setups())
         {
             testers_.emplace_back(bboxes_, std::move(setup));
         }
     }
 
-    //! Specify the BIH construction parameters for each tester
-    virtual VecSetup make_bih_setups() const = 0;
+    //! Specify the BVH construction parameters for each tester
+    virtual VecSetup make_bvh_setups() const = 0;
 
     //! Specify the bounding box construction
     virtual VecBBox make_bboxes() const = 0;
@@ -260,7 +260,7 @@ class BIHIntersectingVolFinderTest : public ::celeritas::test::Test
         return result;
     }
 
-    auto get_bih_json_strings() const
+    auto get_bvh_json_strings() const
     {
         std::vector<std::string> result;
         celeritas::test::StringSimplifier simplify{5};
@@ -273,18 +273,18 @@ class BIHIntersectingVolFinderTest : public ::celeritas::test::Test
 
   private:
     VecBBox bboxes_;
-    std::vector<LocalBihTreeTester> testers_;
+    std::vector<LocalBvhTreeTester> testers_;
 };
 
-class BasicBihTest : public BIHIntersectingVolFinderTest
+class BasicBvhTest : public BvhIntersectingVolFinderTest
 {
   public:
-    VecSetup make_bih_setups() const override
+    VecSetup make_bvh_setups() const override
     {
         VecSetup result;
         for (auto leaf_size : {1, 4, 8})
         {
-            inp::BIHBuilder setup;
+            inp::BvhBuilder setup;
             setup.max_leaf_size = leaf_size;
             result.push_back(setup);
         }
@@ -304,9 +304,9 @@ class BasicBihTest : public BIHIntersectingVolFinderTest
     }
 };
 
-TEST_F(BasicBihTest, tree_output)
+TEST_F(BasicBvhTest, tree_output)
 {
-    auto trees = this->get_bih_json_strings();
+    auto trees = this->get_bvh_json_strings();
     ASSERT_EQ(3, trees.size());
     EXPECT_JSON_EQ(
         R"json({"inf_vol_ids":[0],"tree":[["i","x",[1,2],[[[0.0,0.0,0.0],[2.80,1.0,100.0]],[[0.0,-1.0,0.0],[5.0,1.0,100.0]]]],["i","x",[3,4],[[[0.0,0.0,0.0],[1.60,1.0,100.0]],[[1.20,0.0,0.0],[2.80,1.0,100.0]]]],["i","x",[5,6],[[[0.0,-1.0,0.0],[5.0,0.0,100.0]],[[2.80,0.0,0.0],[5.0,1.0,100.0]]]],["l",[1]],["l",[2]],["l",[4,5]],["l",[3]]]})json",
@@ -320,7 +320,7 @@ TEST_F(BasicBihTest, tree_output)
 
 // Test the case where the ray starts outside the bbox and the first bbox
 // intersection yields the first volume intersection.
-TEST_F(BasicBihTest, outside_first)
+TEST_F(BasicBvhTest, outside_first)
 {
     Real3 pos, dir;
     DistMap dist_map;
@@ -438,7 +438,7 @@ TEST_F(BasicBihTest, outside_first)
 
 // Test the case where the ray starts somewhere inside a bbox and this bbox
 // contains first intersecting volume.
-TEST_F(BasicBihTest, inside_first)
+TEST_F(BasicBvhTest, inside_first)
 {
     Real3 pos, dir;
     DistMap dist_map;
@@ -590,7 +590,7 @@ TEST_F(BasicBihTest, inside_first)
 
 // Test the case where the first intersection does not yields the first volume
 // collision
-TEST_F(BasicBihTest, not_first)
+TEST_F(BasicBvhTest, not_first)
 {
     Real3 pos, dir;
     DistMap dist_map;
@@ -678,10 +678,10 @@ TEST_F(BasicBihTest, not_first)
  * boxes less with even indices (`i % 2 == 0`) have pretend volumes in the
  * range z=[0.5, 1] offset by the box.
  */
-class KebabTest : public BIHIntersectingVolFinderTest
+class KebabTest : public BvhIntersectingVolFinderTest
 {
   public:
-    VecSetup make_bih_setups() const override
+    VecSetup make_bvh_setups() const override
     {
         VecSetup result;
         if (false)
@@ -689,7 +689,7 @@ class KebabTest : public BIHIntersectingVolFinderTest
             // FIXME: depth limit is forced cutoff: tree is unbalanced
             for (auto depth_limit : range(8))
             {
-                inp::BIHBuilder setup;
+                inp::BvhBuilder setup;
                 setup.depth_limit = 1 + 4 * depth_limit;
                 result.push_back(setup);
             }
@@ -698,7 +698,7 @@ class KebabTest : public BIHIntersectingVolFinderTest
         {
             for (auto leaf_size : {1, 2, 4, 8, 12, 16, 20, 24})
             {
-                inp::BIHBuilder setup;
+                inp::BvhBuilder setup;
                 setup.max_leaf_size = leaf_size;
                 result.push_back(setup);
             }
@@ -724,7 +724,7 @@ class KebabTest : public BIHIntersectingVolFinderTest
 
 TEST_F(KebabTest, DISABLED_tree_output)
 {
-    for (auto&& s : this->get_bih_json_strings())
+    for (auto&& s : this->get_bvh_json_strings())
     {
         cout << "R\"json(" << s << ")json\"\n\n\n";
     }

--- a/test/orange/detail/BvhUtils.test.cc
+++ b/test/orange/detail/BvhUtils.test.cc
@@ -2,9 +2,9 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file orange/detail/BIHUtils.test.cc
+//! \file orange/detail/BvhUtils.test.cc
 //---------------------------------------------------------------------------//
-#include "orange/detail/BIHUtils.hh"
+#include "orange/detail/BvhUtils.hh"
 
 #include "celeritas_test.hh"
 
@@ -16,7 +16,7 @@ namespace test
 {
 //---------------------------------------------------------------------------//
 
-TEST(BIHUtilsTest, bbox_vector_union)
+TEST(BvhUtilsTest, bbox_vector_union)
 {
     using Real3 = Array<fast_real_type, 3>;
 


### PR DESCRIPTION
With #2410, the BIH tree is now fully a BVH tree. This MR does a global rename, replacing all instances of BIH to BVH and updating doc strings accordingly.
