### PR TITLE
Fix HIP unused-variable warning

### DIFF
--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -132,7 +132,7 @@ void trace(StepperResult const& track_counts)
             }                                                       \
             else                                                    \
             {                                                       \
-                CELER_RUNTIME_THROW(                                \
+                CELER_RUNTIME_FAIL(                                 \
                     ::celeritas::RuntimeError::validate_err_str,    \
                     celer_runtime_msg_.str(),                       \
                     #COND);                                         \

--- a/src/celeritas/track/detail/StatusCheckExecutor.hh
+++ b/src/celeritas/track/detail/StatusCheckExecutor.hh
@@ -40,14 +40,14 @@ namespace detail
  * \note This macro is defined so that the condition is still checked in
  * "release" mode, and so that checking will work on GPU.
  */
-#define CELER_FAIL_IF(COND, MSG)                               \
-    do                                                         \
-    {                                                          \
-        if (CELER_UNLIKELY((COND)))                            \
-        {                                                      \
-            CELER_PRINT_TRACK(MSG, track)                      \
-            CELER_DEBUG_THROW_(MSG ": '" #COND "'", internal); \
-        }                                                      \
+#define CELER_FAIL_IF(COND, MSG)                             \
+    do                                                       \
+    {                                                        \
+        if (CELER_UNLIKELY((COND)))                          \
+        {                                                    \
+            CELER_PRINT_TRACK(MSG, track)                    \
+            CELER_DEBUG_FAIL(MSG ": '" #COND "'", internal); \
+        }                                                    \
     } while (0)
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -146,8 +146,8 @@
 // Use a special device function to emulate assertion failure if HIP
 // (assertion from multiple threads simultaeously can cause unexpected device
 // failures on AMD hardware) or if NDEBUG is in use with CUDA
-#    define CELER_DEBUG_THROW_(MSG, WHICH) \
-        ::celeritas::device_debug_error(   \
+#    define CELER_DEBUG_THROW_(MSG, WHICH)       \
+        ::celeritas::detail::device_debug_error( \
             ::celeritas::DebugErrorType::WHICH, MSG, __FILE__, __LINE__)
 #endif
 
@@ -237,11 +237,12 @@
             }                                                    \
         } while (0)
 #else
-#    define CELER_VALIDATE(COND, MSG)                \
-        do                                           \
-        {                                            \
-            CELER_DISCARD(COND);                     \
-            CELER_RUNTIME_THROW(nullptr, "", #COND); \
+#    define CELER_VALIDATE(COND, MSG)                                 \
+        do                                                            \
+        {                                                             \
+            CELER_DISCARD(COND);                                      \
+            CELER_DISCARD(::celeritas::detail::DiscardStream {} MSG); \
+            CELER_RUNTIME_THROW(nullptr, "", #COND);                  \
         } while (0)
 #endif
 
@@ -476,6 +477,24 @@ class RichContextException : public std::exception
 //---------------------------------------------------------------------------//
 // INLINE FUNCTION DEFINITIONS
 //---------------------------------------------------------------------------//
+namespace detail
+{
+#if CELER_DEVICE_COMPILE
+/*!
+ * Ignore anything that streams.
+ *
+ * This prevents "unused variable" errors due to CELER_VALIDATE statements
+ * reachable from HIP code.
+ */
+struct DiscardStream
+{
+    template<class T>
+    CELER_CONSTEXPR_FUNCTION DiscardStream& operator<<(T&&)
+    {
+        return *this;
+    }
+};
+#endif
 
 #if defined(__CUDA_ARCH__) && defined(NDEBUG)
 //! Host+device definition for CUDA when \c assert is unavailable
@@ -510,6 +529,8 @@ inline __attribute__((noinline)) __device__ void device_debug_error(
     abort();
 }
 #endif
+
+}  // namespace detail
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -64,7 +64,9 @@
  * Always-on runtime assertion macro. This can check user input and input data
  * consistency, and will raise RuntimeError on failure with a descriptive error
  * message that is streamed as the second argument. This macro cannot be used
- * in \c __device__ -annotated code.
+ * in \c __device__ -annotated code: always-on assertions can affect
+ * performance, especially when calling \c printf, which adds to thread-local
+ * memory.
  *
  * The error message should read: \verbatim
    "<PROBLEM> (<WHY IT'S A PROBLEM>) <SUGGESTION>?"
@@ -88,9 +90,14 @@
 /*!
  * \def CELER_DEBUG_FAIL
  *
- * Throw a debug assertion regardless of the \c CELERITAS_DEBUG setting. This
- * is used internally but is also useful for catching subtle programming errors
- * in downstream code.
+ * Throw a debug exception (or assert on device) regardless of the \c
+ * CELERITAS_DEBUG setting. This can be used in downstream code for custom
+ * assertions.
+ */
+/*!
+ * \def CELER_RUNTIME_FAIL
+ *
+ * Throw a runtime exception including code context (file/line).
  */
 /*!
  * \def CELER_ASSERT_UNREACHABLE
@@ -135,31 +142,31 @@
 
 #if !defined(__HIP__) && !defined(__CUDA_ARCH__)
 // Throw in host code
-#    define CELER_DEBUG_THROW_(MSG, WHICH) \
-        ::celeritas::throw_debug_error(    \
+#    define CELER_DEBUG_FAIL_(MSG, WHICH) \
+        ::celeritas::throw_debug_error(   \
             {::celeritas::DebugErrorType::WHICH, MSG, __FILE__, __LINE__})
 #elif defined(__CUDA_ARCH__) && !defined(NDEBUG)
 // Use the assert macro for CUDA when supported
-#    define CELER_DEBUG_THROW_(MSG, WHICH) \
+#    define CELER_DEBUG_FAIL_(MSG, WHICH) \
         assert(false && sizeof(#WHICH ": " MSG))
 #else
 // Use a special device function to emulate assertion failure if HIP
 // (assertion from multiple threads simultaneously can cause unexpected device
 // failures on AMD hardware) or if NDEBUG is in use with CUDA
-#    define CELER_DEBUG_THROW_(MSG, WHICH)       \
-        ::celeritas::detail::device_debug_error( \
+#    define CELER_DEBUG_FAIL_(MSG, WHICH)       \
+        ::celeritas::detail::device_debug_fail( \
             ::celeritas::DebugErrorType::WHICH, MSG, __FILE__, __LINE__)
 #endif
 
-#define CELER_DEBUG_ASSERT_(COND, WHICH)      \
-    do                                        \
-    {                                         \
-        if (CELER_UNLIKELY(!(COND)))          \
-        {                                     \
-            CELER_DEBUG_THROW_(#COND, WHICH); \
-        }                                     \
+#define CELER_ASSERT_IMPL_(COND, WHICH)      \
+    do                                       \
+    {                                        \
+        if (CELER_UNLIKELY(!(COND)))         \
+        {                                    \
+            CELER_DEBUG_FAIL_(#COND, WHICH); \
+        }                                    \
     } while (0)
-#define CELER_NDEBUG_ASSUME_(COND)      \
+#define CELER_ASSUME_NDEBUG_(COND)      \
     do                                  \
     {                                   \
         if (CELER_UNLIKELY(!(COND)))    \
@@ -181,15 +188,22 @@
 #endif
 //! \endcond
 
-#define CELER_DEBUG_FAIL(MSG, WHICH)    \
-    do                                  \
-    {                                   \
-        CELER_DEBUG_THROW_(MSG, WHICH); \
-        ::celeritas::unreachable();     \
+#define CELER_DEBUG_FAIL(MSG, WHICH)   \
+    do                                 \
+    {                                  \
+        CELER_DEBUG_FAIL_(MSG, WHICH); \
+        ::celeritas::unreachable();    \
+    } while (0)
+
+#define CELER_RUNTIME_FAIL(WHICH, WHAT, COND)   \
+    do                                          \
+    {                                           \
+        CELER_RUNTIME_FAIL_(WHICH, WHAT, COND); \
+        ::celeritas::unreachable();             \
     } while (0)
 
 #if !CELER_DEVICE_COMPILE
-#    define CELER_RUNTIME_THROW(WHICH, WHAT, COND) \
+#    define CELER_RUNTIME_FAIL_(WHICH, WHAT, COND) \
         ::celeritas::throw_runtime_error({         \
             WHICH,                                 \
             WHAT,                                  \
@@ -198,59 +212,48 @@
             __LINE__,                              \
         })
 #elif CELERITAS_DEBUG
-#    define CELER_RUNTIME_THROW(WHICH, WHAT, COND)                           \
-        CELER_DEBUG_FAIL("Runtime errors cannot be thrown from device code", \
-                         unreachable);
+#    define CELER_RUNTIME_FAIL_(WHICH, WHAT, COND)                            \
+        CELER_DEBUG_FAIL_("Runtime errors cannot be thrown from device code", \
+                          unreachable);
 #else
-// Avoid printf statements which can add substantially to local memory
-#    define CELER_RUNTIME_THROW(WHICH, WHAT, COND) ::celeritas::unreachable()
+// Avoid printf statements which can add substantially to local memory: the
+// wrapper CELER_RUNTIME_FAIL will ensure this point is unreachable
+#    define CELER_RUNTIME_FAIL_(WHICH, WHAT, COND)
 #endif
 
 #if (CELERITAS_DEBUG && !CELER_DEVICE_COMPILE) \
     || (CELERITAS_DEVICE_DEBUG && CELER_DEVICE_COMPILE)
-#    define CELER_EXPECT(COND) CELER_DEBUG_ASSERT_(COND, precondition)
-#    define CELER_ASSERT(COND) CELER_DEBUG_ASSERT_(COND, internal)
-#    define CELER_ENSURE(COND) CELER_DEBUG_ASSERT_(COND, postcondition)
-#    define CELER_ASSUME(COND) CELER_DEBUG_ASSERT_(COND, assumption)
+#    define CELER_EXPECT(COND) CELER_ASSERT_IMPL_(COND, precondition)
+#    define CELER_ASSERT(COND) CELER_ASSERT_IMPL_(COND, internal)
+#    define CELER_ENSURE(COND) CELER_ASSERT_IMPL_(COND, postcondition)
+#    define CELER_ASSUME(COND) CELER_ASSERT_IMPL_(COND, assumption)
 #    define CELER_ASSERT_UNREACHABLE() \
         CELER_DEBUG_FAIL("unreachable code point encountered", unreachable)
 #else
 #    define CELER_EXPECT(COND) CELER_NOASSERT_(COND)
 #    define CELER_ASSERT(COND) CELER_NOASSERT_(COND)
 #    define CELER_ENSURE(COND) CELER_NOASSERT_(COND)
-#    define CELER_ASSUME(COND) CELER_NDEBUG_ASSUME_(COND)
+#    define CELER_ASSUME(COND) CELER_ASSUME_NDEBUG_(COND)
 #    define CELER_ASSERT_UNREACHABLE() ::celeritas::unreachable()
 #endif
 
-#if !CELER_DEVICE_COMPILE
-#    define CELER_VALIDATE(COND, MSG)                            \
-        do                                                       \
-        {                                                        \
-            if (CELER_UNLIKELY(!(COND)))                         \
-            {                                                    \
-                std::ostringstream celer_runtime_msg_;           \
-                celer_runtime_msg_ MSG;                          \
-                CELER_RUNTIME_THROW(                             \
-                    ::celeritas::RuntimeError::validate_err_str, \
-                    celer_runtime_msg_.str(),                    \
-                    #COND);                                      \
-            }                                                    \
-        } while (0)
-#else
-#    define CELER_VALIDATE(COND, MSG)                                 \
-        do                                                            \
-        {                                                             \
-            CELER_DISCARD(COND);                                      \
-            CELER_DISCARD(::celeritas::detail::DiscardStream {} MSG); \
-            CELER_RUNTIME_THROW(nullptr, "", #COND);                  \
-        } while (0)
-#endif
+#define CELER_VALIDATE(COND, MSG)                                           \
+    do                                                                      \
+    {                                                                       \
+        if (CELER_UNLIKELY(!(COND)))                                        \
+        {                                                                   \
+            ::celeritas::detail::ValidationStream celer_runtime_msg_;       \
+            celer_runtime_msg_ MSG;                                         \
+            CELER_RUNTIME_FAIL(::celeritas::RuntimeError::validate_err_str, \
+                               celer_runtime_msg_.str(),                    \
+                               #COND);                                      \
+        }                                                                   \
+    } while (0)
 
 #define CELER_NOT_CONFIGURED(WHAT) \
-    CELER_RUNTIME_THROW(           \
-        ::celeritas::RuntimeError::not_config_err_str, WHAT, {})
+    CELER_RUNTIME_FAIL(::celeritas::RuntimeError::not_config_err_str, WHAT, {})
 #define CELER_NOT_IMPLEMENTED(WHAT) \
-    CELER_RUNTIME_THROW(::celeritas::RuntimeError::not_impl_err_str, WHAT, {})
+    CELER_RUNTIME_FAIL(::celeritas::RuntimeError::not_impl_err_str, WHAT, {})
 
 /*!
  * \def CELER_DEVICE_API_CALL
@@ -272,6 +275,8 @@
  * corecel/DeviceRuntimeApi.hh . The \c CorecelDeviceRuntimeApiHh
  * declaration enforces this when CUDA/HIP are disabled, and the absence of
  * \c CELER_DEVICE_API_SYMBOL enforces when enabled.
+ *
+ * \todo Move to DeviceRuntimeApi.hh?
  */
 #if CELERITAS_USE_CUDA || CELERITAS_USE_HIP
 #    define CELER_DEVICE_API_CALL(STMT)                                      \
@@ -282,7 +287,7 @@
             if (CELER_UNLIKELY(result_ != CELER_DEVICE_API_SYMBOL(Success))) \
             {                                                                \
                 result_ = CELER_DEVICE_API_SYMBOL(GetLastError)();           \
-                CELER_RUNTIME_THROW(                                         \
+                CELER_RUNTIME_FAIL(                                          \
                     CELER_DEVICE_PLATFORM_UPPER_STR,                         \
                     CELER_DEVICE_API_SYMBOL(GetErrorString)(result_),        \
                     #STMT);                                                  \
@@ -320,7 +325,7 @@
             int mpi_result_ = (STATEMENT);                                \
             if (CELER_UNLIKELY(mpi_result_ != MPI_SUCCESS))               \
             {                                                             \
-                CELER_RUNTIME_THROW(                                      \
+                CELER_RUNTIME_FAIL(                                       \
                     "MPI", mpi_error_to_string(mpi_result_), #STATEMENT); \
             }                                                             \
         } while (0)
@@ -481,26 +486,38 @@ class RichContextException : public std::exception
 //---------------------------------------------------------------------------//
 namespace detail
 {
-#if CELER_DEVICE_COMPILE
 /*!
  * Ignore anything that streams.
  *
  * This prevents "unused variable" errors due to CELER_VALIDATE statements
  * reachable from HIP code.
  */
-struct DiscardStream
+class DiscardStream
 {
+  public:
+    DiscardStream() = default;
+
+    //! Ignore anything streamed to this class
     template<class T>
-    CELER_CONSTEXPR_FUNCTION DiscardStream& operator<<(T&&)
+    CELER_CONSTEXPR_FUNCTION friend DiscardStream&
+    operator<<(DiscardStream& s, T&&)
     {
-        return *this;
+        return s;
     }
+
+    //! Provide a str() function for ostringstream-like compatibility
+    CELER_FUNCTION void str() const { CELER_UNREACHABLE; }
 };
+
+#if CELER_DEVICE_COMPILE
+using ValidationStream = DiscardStream;
+#else
+using ValidationStream = ::std::ostringstream;
 #endif
 
 #if defined(__CUDA_ARCH__) && defined(NDEBUG)
 //! Host+device definition for CUDA when \c assert is unavailable
-inline __attribute__((noinline)) __host__ __device__ void device_debug_error(
+inline __attribute__((noinline)) __host__ __device__ void device_debug_fail(
     DebugErrorType, char const* condition, char const* file, int line)
 {
     printf("%s:%u:\nceleritas: internal assertion failed: %s\n",
@@ -511,17 +528,17 @@ inline __attribute__((noinline)) __host__ __device__ void device_debug_error(
 }
 #elif defined(__HIP__)
 //! Host-only HIP call (whether or not NDEBUG is in use)
-inline __host__ void device_debug_error(DebugErrorType which,
-                                        char const* condition,
-                                        char const* file,
-                                        int line)
+inline __host__ void device_debug_fail(DebugErrorType which,
+                                       char const* condition,
+                                       char const* file,
+                                       int line)
 {
     return ::celeritas::throw_debug_error({which, condition, file, line});
 }
 
 //! Device-only call for HIP (must always be declared; only used if
 //! NDEBUG)
-inline __attribute__((noinline)) __device__ void device_debug_error(
+inline __attribute__((noinline)) __device__ void device_debug_fail(
     DebugErrorType, char const* condition, char const* file, int line)
 {
     printf("%s:%u:\nceleritas: internal assertion failed: %s\n",

--- a/src/corecel/Assert.hh
+++ b/src/corecel/Assert.hh
@@ -144,7 +144,7 @@
         assert(false && sizeof(#WHICH ": " MSG))
 #else
 // Use a special device function to emulate assertion failure if HIP
-// (assertion from multiple threads simultaeously can cause unexpected device
+// (assertion from multiple threads simultaneously can cause unexpected device
 // failures on AMD hardware) or if NDEBUG is in use with CUDA
 #    define CELER_DEBUG_THROW_(MSG, WHICH)       \
         ::celeritas::detail::device_debug_error( \
@@ -176,7 +176,7 @@
             }                     \
         } while (0)
 #else
-// Delete the code completely to avoid false posistives for coverage
+// Delete the code completely to avoid false positives for coverage
 #    define CELER_NOASSERT_(COND)
 #endif
 //! \endcond
@@ -310,6 +310,8 @@
  * assertion.
  *
  * \note A file that uses this macro must include \c mpi.h.
+ *
+ * \todo Move to sys/MpiOperations.hh
  */
 #if CELERITAS_USE_MPI
 #    define CELER_MPI_CALL(STATEMENT)                                     \

--- a/src/corecel/sys/DeviceEvent.cc
+++ b/src/corecel/sys/DeviceEvent.cc
@@ -135,9 +135,9 @@ bool DeviceEvent::ready() const
     {
         return true;
     }
-    CELER_RUNTIME_THROW(CELER_DEVICE_PLATFORM_UPPER_STR,
-                        CELER_DEVICE_API_SYMBOL(GetErrorString)(result),
-                        "EventQuery");
+    CELER_RUNTIME_FAIL(CELER_DEVICE_PLATFORM_UPPER_STR,
+                       CELER_DEVICE_API_SYMBOL(GetErrorString)(result),
+                       "EventQuery");
 #else
     CELER_ASSERT_UNREACHABLE();
 #endif

--- a/src/geocel/rasterize/ImageWriter.libpng.cc
+++ b/src/geocel/rasterize/ImageWriter.libpng.cc
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <png.h>
 
+#include "corecel/Assert.hh"
 #include "corecel/io/Logger.hh"
 
 namespace celeritas
@@ -91,7 +92,7 @@ ImageWriter::ImageWriter(std::string const& filename, Size2 height_width)
         PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
     if (setjmp(png_jmpbuf(impl_->png)))
     {
-        CELER_RUNTIME_THROW("libpng", "Failed initialization", {});
+        CELER_RUNTIME_FAIL("libpng", "Failed initialization", {});
     }
 
     // Set up warning/error callbacks
@@ -141,7 +142,7 @@ void ImageWriter::operator()(Span<Color const> colors)
 
     if (setjmp(png_jmpbuf(impl_->png)))
     {
-        CELER_RUNTIME_THROW("libpng", "Failed to write line", {});
+        CELER_RUNTIME_FAIL("libpng", "Failed to write line", {});
     }
 
     auto iter = row_buffer_.begin();
@@ -189,7 +190,7 @@ void ImageWriter::close_impl(bool validate)
         {
             if (validate)
             {
-                CELER_RUNTIME_THROW("libpng", "Failed to write file", {});
+                CELER_RUNTIME_FAIL("libpng", "Failed to write file", {});
             }
             CELER_LOG(error) << "libpng failed to write file";
         }

--- a/test/corecel/Assert.test.cc
+++ b/test/corecel/Assert.test.cc
@@ -7,6 +7,7 @@
 #include "corecel/Assert.hh"
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "corecel/cont/Range.hh"
@@ -141,6 +142,16 @@ TEST_F(AssertTest, runtime_error_variations)
     // clang-format on
 
     EXPECT_VEC_EQ(expected_messages, messages);
+}
+
+TEST_F(AssertTest, discard_stream)
+{
+    detail::DiscardStream s;
+    s << "This message is being ignored";
+    s << 123;
+    // NOTE: calling s.str() will abort the program because it's unreachable,
+    // but the method should still exist
+    EXPECT_TRUE(std::is_void_v<decltype(s.str())>);
 }
 
 //---------------------------------------------------------------------------//

--- a/test/corecel/sys/MultiExceptionHandler.test.cc
+++ b/test/corecel/sys/MultiExceptionHandler.test.cc
@@ -50,7 +50,7 @@ TEST_F(MultiExceptionHandlerTest, single)
 {
     MultiExceptionHandler capture_exception;
     EXPECT_TRUE(capture_exception.empty());
-    CELER_TRY_HANDLE(CELER_RUNTIME_THROW("runtime", "first exception", ""),
+    CELER_TRY_HANDLE(CELER_RUNTIME_FAIL("runtime", "first exception", ""),
                      capture_exception);
     EXPECT_FALSE(capture_exception.empty());
 


### PR DESCRIPTION
This replaces "ignoring" a CELER_VALIDATE message with parsing and discarding it, allowing the compiler to see that the included variables are referenced even though nothing is done with them.