### PR TITLE
Add OpenMP and ORANGE diagnostics to output

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,7 +8,9 @@ if(BUILD_TESTING)
   set(CELER_PYTHON "$<TARGET_FILE:Python::Interpreter>")
 
   if(CELERITAS_USE_OpenMP)
-    set(CELER_OMP_ENV "OMP_NUM_THREADS=4")
+    # Since Celeritas doesn't specify num_threads in its openmp launch parameters,
+    # kernels *should* use 4 threads by default
+    set(CELER_OMP_ENV "OMP_NUM_THREADS=4" "OMP_THREAD_LIMIT=8")
     set(CELER_PROCESSORS PROCESSORS 4)
   else()
     set(CELER_OMP_ENV)

--- a/app/celer-optical/driver.py
+++ b/app/celer-optical/driver.py
@@ -138,9 +138,11 @@ else:
 
 print(json.dumps(j["result"]["time"], indent=1))
 
+# Check configuration
 config = j["system"]["build"]["config"]
 assert config["core_geo"].lower() == core_geo
-assert config["core_geo"].lower() == core_geo
+
+# Check OpenMP threads: see app/CMakeLists.txt which sets CELER_OMP_ENV
 use_deps = set(config["use"])
 if "openmp" in use_deps:
     print(json.dumps(j["system"]["openmp"], indent=1))

--- a/app/celer-optical/driver.py
+++ b/app/celer-optical/driver.py
@@ -137,3 +137,12 @@ else:
     assert time["actions"]
 
 print(json.dumps(j["result"]["time"], indent=1))
+
+config = j["system"]["build"]["config"]
+assert config["core_geo"].lower() == core_geo
+assert config["core_geo"].lower() == core_geo
+use_deps = set(config["use"])
+if "openmp" in use_deps:
+    print(json.dumps(j["system"]["openmp"], indent=1))
+    assert j["system"]["openmp"]["thread_limit"] == 8
+    assert j["system"]["openmp"]["max_threads"] == 4

--- a/app/celer-sim/RunnerInput.cc
+++ b/app/celer-sim/RunnerInput.cc
@@ -16,26 +16,23 @@
 #include "corecel/Types.hh"
 #include "corecel/cont/VariantUtils.hh"
 #include "corecel/io/StringUtils.hh"
+#include "corecel/sys/Openmp.hh"
+#include "celeritas/field/FieldDriverOptions.hh"
 #include "celeritas/inp/Control.hh"
 #include "celeritas/inp/Diagnostics.hh"
 #include "celeritas/inp/Events.hh"
 #include "celeritas/inp/Field.hh"
+#include "celeritas/inp/Import.hh"
 #include "celeritas/inp/Physics.hh"
 #include "celeritas/inp/PhysicsProcess.hh"
+#include "celeritas/inp/Problem.hh"
 #include "celeritas/inp/Scoring.hh"
+#include "celeritas/inp/StandaloneInput.hh"
 #include "celeritas/inp/System.hh"
 #include "celeritas/inp/Tracking.hh"
 #include "celeritas/io/EventReader.hh"
 #include "celeritas/io/JsonEventReader.hh"
 #include "celeritas/io/RootEventReader.hh"
-#ifdef _OPENMP
-#    include <omp.h>
-#endif
-
-#include "celeritas/field/FieldDriverOptions.hh"
-#include "celeritas/inp/Import.hh"
-#include "celeritas/inp/Problem.hh"
-#include "celeritas/inp/StandaloneInput.hh"
 #include "celeritas/phys/PrimaryGeneratorOptions.hh"
 
 namespace celeritas
@@ -62,40 +59,6 @@ inp::System load_system(RunnerInput const& ri)
     }
     return s;
 }
-
-//---------------------------------------------------------------------------//
-/*!
- * Get the number of streams from the number of OpenMP threads.
- *
- * The OMP_NUM_THREADS environment variable can be used to control the number
- * of threads/streams. The value of OMP_NUM_THREADS should be a list of
- * positive integers, each of which sets the number of threads for the parallel
- * region at the corresponding nested level. The number of streams is set to
- * the first value in the list. If OMP_NUM_THREADS is not set, the value will
- * be implementation defined.
- */
-size_type get_num_streams(bool merge_events)
-{
-    size_type result = 1;
-#if CELERITAS_OPENMP == CELERITAS_OPENMP_EVENT
-    if (!merge_events)
-    {
-#    pragma omp parallel
-        {
-            if (omp_get_thread_num() == 0)
-            {
-                result = omp_get_num_threads();
-            }
-        }
-    }
-#else
-    CELER_DISCARD(merge_events);
-#endif
-
-    // TODO: Don't create more streams than events
-    return result;
-}
-
 //---------------------------------------------------------------------------//
 inp::Problem load_problem(RunnerInput const& ri)
 {
@@ -171,7 +134,11 @@ inp::Problem load_problem(RunnerInput const& ri)
 
         p.control.warm_up = ri.warm_up;
         p.control.seed = ri.seed;
-        p.control.num_streams = get_num_streams(ri.merge_events);
+        p.control.num_streams = 1;
+        if (CELERITAS_OPENMP == CELERITAS_OPENMP_EVENT && !ri.merge_events)
+        {
+            p.control.num_streams = openmp_max_threads();
+        }
 
         if (ri.use_device)
         {

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -9,15 +9,10 @@
 #include <iostream>
 #include <memory>
 #include <optional>
-#include <string_view>
 #include <utility>
 #include <vector>
 #include <CLI/CLI.hpp>
 #include <nlohmann/json.hpp>
-
-#ifdef _OPENMP
-#    include <omp.h>
-#endif
 
 #include "corecel/Config.hh"
 
@@ -32,6 +27,7 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/DeviceIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/MultiExceptionHandler.hh"
+#include "corecel/sys/Openmp.hh"
 #include "corecel/sys/ScopedMpiInit.hh"
 #include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stopwatch.hh"
@@ -53,19 +49,6 @@ namespace app
 {
 namespace
 {
-//---------------------------------------------------------------------------//
-/*!
- * Get the OpenMP thread number.
- */
-int get_openmp_thread()
-{
-#ifdef _OPENMP
-    return omp_get_thread_num();
-#else
-    return 0;
-#endif
-}
-
 //---------------------------------------------------------------------------//
 /*!
  * Run, launch, and get output.
@@ -133,13 +116,17 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
         for (size_type event = 0; event < num_events; ++event)
         {
             activate_device_local();
+#if CELERITAS_OPENMP == CELERITAS_OPENMP_EVENT
+            StreamId stream = openmp_local_thread();
+#else
+            constexpr StreamId stream{0};
+#endif
 
             // Run a single event on a single thread
             TransporterResult event_result;
-            CELER_TRY_HANDLE(event_result = run_stream(
-                                 id_cast<StreamId>(get_openmp_thread()),
-                                 id_cast<EventId>(event)),
-                             capture_exception);
+            CELER_TRY_HANDLE(
+                event_result = run_stream(stream, id_cast<EventId>(event)),
+                capture_exception);
             tracing_session.flush();
             if (run_input->transporter_result)
             {

--- a/app/celer-sim/celer-sim.cc
+++ b/app/celer-sim/celer-sim.cc
@@ -16,6 +16,10 @@
 
 #include "corecel/Config.hh"
 
+#ifdef _OPENMP
+#    include <omp.h>
+#endif
+
 #include "corecel/Assert.hh"
 #include "corecel/io/BuildOutput.hh"
 #include "corecel/io/ExceptionOutput.hh"
@@ -27,7 +31,6 @@
 #include "corecel/sys/Device.hh"
 #include "corecel/sys/DeviceIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/MultiExceptionHandler.hh"
-#include "corecel/sys/Openmp.hh"
 #include "corecel/sys/ScopedMpiInit.hh"
 #include "corecel/sys/ScopedProfiling.hh"
 #include "corecel/sys/Stopwatch.hh"
@@ -117,7 +120,7 @@ void run(std::shared_ptr<OutputRegistry>& output, std::string const& filename)
         {
             activate_device_local();
 #if CELERITAS_OPENMP == CELERITAS_OPENMP_EVENT
-            StreamId stream = openmp_local_thread();
+            auto stream = id_cast<StreamId>(omp_get_thread_num());
 #else
             constexpr StreamId stream{0};
 #endif

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -168,7 +168,6 @@
       "description": "FINAL: VecGeom and code coverage",
       "inherits": [".vecgeom", ".gcov", "type-reldeb", "tool-spack"],
       "cacheVariables": {
-        "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "ON"},
         "CMAKE_CXX_FLAGS": null
       }
     },

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -168,6 +168,7 @@
       "description": "FINAL: VecGeom and code coverage",
       "inherits": [".vecgeom", ".gcov", "type-reldeb", "tool-spack"],
       "cacheVariables": {
+        "CELERITAS_USE_OpenMP": {"type": "BOOL", "value": "ON"},
         "CMAKE_CXX_FLAGS": null
       }
     },

--- a/src/accel/CMakeLists.txt
+++ b/src/accel/CMakeLists.txt
@@ -8,7 +8,6 @@ set(PRIVATE_DEPS
   nlohmann_json::nlohmann_json
   Celeritas::Extcovfie # NOTE: only needed by Cart/RZMapMagneticField.cc
   Celeritas::ExtThrust # TODO: add thrust exception conversion to corecel?
-  Celeritas::ExtOpenMP # TODO: provide thread utils in corecel
 )
 set(PUBLIC_DEPS
   Celeritas::BuildFlags

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -35,6 +35,14 @@
 #include "gen/ScintillationParams.hh"
 #include "surface/SurfacePhysicsParams.hh"
 
+#if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
+#    include "orange/OrangeParams.hh"  // IWYU pragma: keep
+#    include "orange/OrangeParamsOutput.hh"
+#elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
+#    include "geocel/vg/VecgeomParams.hh"  // IWYU pragma: keep
+#    include "geocel/vg/VecgeomParamsOutput.hh"
+#endif
+
 namespace celeritas
 {
 namespace optical
@@ -141,6 +149,14 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     {
         input_.output_reg = std::make_shared<OutputRegistry>();
         insert_system_diagnostics(*input_.output_reg);
+
+#if CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_ORANGE
+        input_.output_reg->insert(
+            std::make_shared<OrangeParamsOutput>(input_.geometry));
+#elif CELERITAS_CORE_GEO == CELERITAS_CORE_GEO_VECGEOM
+        input_.output_reg->insert(
+            std::make_shared<VecgeomParamsOutput>(input_.geometry));
+#endif
     }
 
     // Save optical action diagnostic information

--- a/src/celeritas/optical/Runner.cc
+++ b/src/celeritas/optical/Runner.cc
@@ -8,6 +8,11 @@
 
 #include <utility>
 
+#ifdef _OPENMP
+#    include <omp.h>
+#endif
+
+#include "corecel/io/Logger.hh"
 #include "corecel/io/OutputInterfaceAdapter.hh"
 #include "corecel/io/OutputRegistry.hh"
 #include "corecel/sys/ScopedProfiling.hh"
@@ -62,6 +67,10 @@ Runner::Runner(Input&& osi)
     {
         state_ = std::make_shared<CoreState<MemSpace::host>>(
             *this->params(), stream_id, num_tracks);
+#if CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
+        CELER_LOG(status) << "Running track-parallel with "
+                          << omp_get_max_threads() << " max threads";
+#endif
     }
 
     // Allocate auxiliary data

--- a/src/celeritas/optical/Runner.cc
+++ b/src/celeritas/optical/Runner.cc
@@ -8,13 +8,10 @@
 
 #include <utility>
 
-#ifdef _OPENMP
-#    include <omp.h>
-#endif
-
 #include "corecel/io/Logger.hh"
 #include "corecel/io/OutputInterfaceAdapter.hh"
 #include "corecel/io/OutputRegistry.hh"
+#include "corecel/sys/Openmp.hh"
 #include "corecel/sys/ScopedProfiling.hh"
 #include "celeritas/inp/StandaloneInputIO.json.hh"
 #include "celeritas/phys/GeneratorRegistry.hh"
@@ -67,10 +64,11 @@ Runner::Runner(Input&& osi)
     {
         state_ = std::make_shared<CoreState<MemSpace::host>>(
             *this->params(), stream_id, num_tracks);
-#if CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
-        CELER_LOG(status) << "Running track-parallel with "
-                          << omp_get_max_threads() << " max threads";
-#endif
+        if (CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK)
+        {
+            CELER_LOG(status) << "Running track-parallel with "
+                              << openmp_max_threads() << " max threads";
+        }
     }
 
     // Allocate auxiliary data

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -216,6 +216,7 @@ list(APPEND SOURCES
   io/LogContextException.cc
   io/LogHandlers.cc
   io/LoggerTypes.cc
+  io/OpenmpOutput.cc
   io/OutputInterface.cc
   io/OutputRegistry.cc
   io/ScopedStreamRedirect.cc

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -252,6 +252,7 @@ list(APPEND SOURCES
 
 # All these classes depend on OpenMP if available
 celeritas_add_object_library(corecel_openmp_obj
+  sys/Openmp.cc
   sys/MultiExceptionHandler.cc
 )
 celeritas_target_link_libraries(corecel_openmp_obj

--- a/src/corecel/io/OpenmpOutput.cc
+++ b/src/corecel/io/OpenmpOutput.cc
@@ -2,7 +2,7 @@
 // Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file corecel/sys/OpenmpOutput.cc
+//! \file corecel/io/OpenmpOutput.cc
 //---------------------------------------------------------------------------//
 #include "OpenmpOutput.hh"
 

--- a/src/corecel/io/OpenmpOutput.cc
+++ b/src/corecel/io/OpenmpOutput.cc
@@ -1,0 +1,31 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/OpenmpOutput.cc
+//---------------------------------------------------------------------------//
+#include "OpenmpOutput.hh"
+
+#include <nlohmann/json.hpp>
+
+#include "corecel/sys/Openmp.hh"
+
+#include "JsonPimpl.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Write output to the given JSON object.
+ */
+void OpenmpOutput::output(JsonPimpl* j) const
+{
+    j->obj = nlohmann::json::object({
+        {"max_threads", openmp_max_threads()},
+        {"thread_limit", openmp_thread_limit()},
+        {"proc_bind", openmp_proc_bind()},
+    });
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/OpenmpOutput.hh
+++ b/src/corecel/io/OpenmpOutput.hh
@@ -1,0 +1,35 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/OpenmpOutput.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "OutputInterface.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Save OpenMP environment/config information to JSON.
+ *
+ * This saves maximum number of threads as well as binding information. Since
+ * this should never be run inside a \c parallel block, the local \c
+ * num_threads value is never saved.
+ */
+class OpenmpOutput final : public OutputInterface
+{
+  public:
+    //! Category of data to write
+    Category category() const final { return Category::system; };
+
+    //! Key for the entry inside the category.
+    std::string_view label() const final { return "openmp"; }
+
+    // Write output to the given JSON object
+    void output(JsonPimpl*) const final;
+};
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/OutputRegistry.cc
+++ b/src/corecel/io/OutputRegistry.cc
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <nlohmann/json.hpp>
 
@@ -16,19 +15,20 @@
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Range.hh"
-#include "corecel/io/BuildOutput.hh"
-#include "corecel/io/StreamUtils.hh"
 #include "corecel/sys/Device.hh"
-#include "corecel/sys/DeviceIO.json.hh"
+#include "corecel/sys/DeviceIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/Environment.hh"
-#include "corecel/sys/EnvironmentIO.json.hh"
+#include "corecel/sys/EnvironmentIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/KernelRegistry.hh"
-#include "corecel/sys/KernelRegistryIO.json.hh"
+#include "corecel/sys/KernelRegistryIO.json.hh"  // IWYU pragma: keep
 
+#include "BuildOutput.hh"
 #include "JsonPimpl.hh"
 #include "Logger.hh"  // IWYU pragma: keep
+#include "OpenmpOutput.hh"
 #include "OutputInterface.hh"
 #include "OutputInterfaceAdapter.hh"
+#include "StreamUtils.hh"
 
 namespace celeritas
 {
@@ -131,6 +131,10 @@ void insert_system_diagnostics(OutputRegistry& output_reg)
     output_reg.insert(OutputInterfaceAdapter<Environment>::from_const_ref(
         OutputInterface::Category::system, "environ", celeritas::environment()));
     output_reg.insert(std::make_shared<BuildOutput>());
+    if (CELERITAS_USE_OPENMP)
+    {
+        output_reg.insert(std::make_shared<OpenmpOutput>());
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/sys/KernelLauncher.hh
+++ b/src/corecel/sys/KernelLauncher.hh
@@ -33,8 +33,7 @@ namespace celeritas
 
  * \todo Rename \c foreach_track_slot and pass \c TrackSlotId ? There's a
  * 1-to-1 correspondence for CUDA (except when track sorting is enabled) but
- not
- * for CPU threads.
+ * not for CPU threads.
  */
 template<class F>
 void launch_kernel(size_type num_threads, F&& execute_thread)

--- a/src/corecel/sys/KernelLauncher.hh
+++ b/src/corecel/sys/KernelLauncher.hh
@@ -22,13 +22,19 @@ namespace celeritas
  * The function should be an executor with the signature
  * \code void(*)(ThreadId) \endcode .
  *
- * Example:
+ *
+ * \par Example
  * \code
  void do_something()
  {
     launch_kernel(num_threads, make_blah_executor(blah));
  }
  * \endcode
+
+ * \todo Rename \c foreach_track_slot and pass \c TrackSlotId ? There's a
+ * 1-to-1 correspondence for CUDA (except when track sorting is enabled) but
+ not
+ * for CPU threads.
  */
 template<class F>
 void launch_kernel(size_type num_threads, F&& execute_thread)

--- a/src/corecel/sys/MultiExceptionHandler.cc
+++ b/src/corecel/sys/MultiExceptionHandler.cc
@@ -10,7 +10,6 @@
 #include <iostream>
 
 #include "corecel/Assert.hh"
-#include "corecel/Types.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
 

--- a/src/corecel/sys/Openmp.cc
+++ b/src/corecel/sys/Openmp.cc
@@ -25,7 +25,7 @@ namespace celeritas
  *
  * See https://www.openmp.org/spec-html/5.0/openmpsu123.html .
  */
-OpenmpSize_t openmp_thread_limit()
+size_type openmp_thread_limit()
 {
 #ifdef _OPENMP
     return omp_get_thread_limit();
@@ -39,24 +39,10 @@ OpenmpSize_t openmp_thread_limit()
  *
  * See https://www.openmp.org/spec-html/5.0/openmpsu112.html .
  */
-OpenmpSize_t openmp_max_threads()
+size_type openmp_max_threads()
 {
 #ifdef _OPENMP
     return omp_get_max_threads();
-#else
-    return 1;
-#endif
-}
-
-/*!
- * Get the number of CPU threads in the \em current parallel region.
- *
- * See https://www.openmp.org/spec-html/5.0/openmpsu111.html .
- */
-OpenmpSize_t openmp_num_threads()
-{
-#ifdef _OPENMP
-    return omp_get_num_threads();
 #else
     return 1;
 #endif
@@ -70,7 +56,7 @@ OpenmpSize_t openmp_num_threads()
  * \note This is named in sync with the OpenMP spec, but it acts more like "max
  * threads" (which is used outside a parallel region).
  */
-void openmp_num_threads(OpenmpSize_t num_threads)
+void openmp_num_threads(size_type num_threads)
 {
     CELER_EXPECT(num_threads > 0);
 #ifdef _OPENMP
@@ -79,21 +65,6 @@ void openmp_num_threads(OpenmpSize_t num_threads)
     CELER_VALIDATE(
         num_threads == 1,
         << R"(cannot set CPU thread limit above 1 when OpenMP is disabled)");
-#endif
-}
-
-/*!
- * Get the OpenMP thread ID inside a parallel region.
- *
- * If running in a serial application or region, this returns zero.
- * See https://www.openmp.org/spec-html/5.0/openmpsu113.html .
- */
-OpenmpThreadId openmp_local_thread()
-{
-#ifdef _OPENMP
-    return id_cast<OpenmpThreadId>(omp_get_thread_num());
-#else
-    return StreamId{0};
 #endif
 }
 

--- a/src/corecel/sys/Openmp.cc
+++ b/src/corecel/sys/Openmp.cc
@@ -20,8 +20,8 @@ namespace celeritas
  * Get the maximum number of OpenMP threads that could ever execute in
  * parallel.
  *
- * This may be limited by \c OMP_THREAD_LIMIT but also may be uselessly large
- * (i.e., \c INT_MAX).
+ * This value generally mirrors the \c OMP_THREAD_LIMIT environment variable.
+ * but also may be uselessly large (i.e., \c INT_MAX).
  *
  * See https://www.openmp.org/spec-html/5.0/openmpsu123.html .
  */
@@ -36,6 +36,8 @@ size_type openmp_thread_limit()
 
 /*!
  * Get the maximum number of OpenMP threads that can execute in parallel.
+ *
+ * This value generally mirrors the \c OMP_NUM_THREADS environment variable.
  *
  * See https://www.openmp.org/spec-html/5.0/openmpsu112.html .
  */

--- a/src/corecel/sys/Openmp.cc
+++ b/src/corecel/sys/Openmp.cc
@@ -78,7 +78,7 @@ void openmp_num_threads(size_type num_threads)
 char const* openmp_proc_bind()
 {
 #ifdef _OPENMP
-    switch (omp_get_proc_bind())
+    switch (omp_get_proc_bind()) /* GCOVR_EXCL_BR_WITHOUT_HIT: 4/5 */
     {
         case omp_proc_bind_false:
             return "false";

--- a/src/corecel/sys/Openmp.cc
+++ b/src/corecel/sys/Openmp.cc
@@ -55,7 +55,7 @@ size_type openmp_max_threads()
  *
  * See https://www.openmp.org/spec-html/5.0/openmpsu110.html .
  *
- * \note This is named in sync with the OpenMP spec, but it acts more like "max
+ * \note This is named in sync with the OpenMP spec, but it sets "max
  * threads" (which is used outside a parallel region).
  */
 void openmp_num_threads(size_type num_threads)

--- a/src/corecel/sys/Openmp.cc
+++ b/src/corecel/sys/Openmp.cc
@@ -1,0 +1,129 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/Openmp.cc
+//---------------------------------------------------------------------------//
+#include "Openmp.hh"
+
+#include "corecel/Assert.hh"
+
+#ifdef _OPENMP
+#    include <omp.h>
+#endif
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+
+/*!
+ * Get the maximum number of OpenMP threads that could ever execute in
+ * parallel.
+ *
+ * This may be limited by \c OMP_THREAD_LIMIT but also may be uselessly large
+ * (i.e., \c INT_MAX).
+ *
+ * See https://www.openmp.org/spec-html/5.0/openmpsu123.html .
+ */
+OpenmpSize_t openmp_thread_limit()
+{
+#ifdef _OPENMP
+    return omp_get_thread_limit();
+#else
+    return 1;
+#endif
+}
+
+/*!
+ * Get the maximum number of OpenMP threads that can execute in parallel.
+ *
+ * See https://www.openmp.org/spec-html/5.0/openmpsu112.html .
+ */
+OpenmpSize_t openmp_max_threads()
+{
+#ifdef _OPENMP
+    return omp_get_max_threads();
+#else
+    return 1;
+#endif
+}
+
+/*!
+ * Get the number of CPU threads in the \em current parallel region.
+ *
+ * See https://www.openmp.org/spec-html/5.0/openmpsu111.html .
+ */
+OpenmpSize_t openmp_num_threads()
+{
+#ifdef _OPENMP
+    return omp_get_num_threads();
+#else
+    return 1;
+#endif
+}
+
+/*!
+ * Set the default number of threads for default future parallel regions.
+ *
+ * See https://www.openmp.org/spec-html/5.0/openmpsu110.html .
+ *
+ * \note This is named in sync with the OpenMP spec, but it acts more like "max
+ * threads" (which is used outside a parallel region).
+ */
+void openmp_num_threads(OpenmpSize_t num_threads)
+{
+    CELER_EXPECT(num_threads > 0);
+#ifdef _OPENMP
+    omp_set_num_threads(num_threads);
+#else
+    CELER_VALIDATE(
+        num_threads == 1,
+        << R"(cannot set CPU thread limit above 1 when OpenMP is disabled)");
+#endif
+}
+
+/*!
+ * Get the OpenMP thread ID inside a parallel region.
+ *
+ * If running in a serial application or region, this returns zero.
+ * See https://www.openmp.org/spec-html/5.0/openmpsu113.html .
+ */
+OpenmpThreadId openmp_local_thread()
+{
+#ifdef _OPENMP
+    return id_cast<OpenmpThreadId>(omp_get_thread_num());
+#else
+    return StreamId{0};
+#endif
+}
+
+/*!
+ * Get the openmp process bind affinity for parallel regions.
+ *
+ * See https://www.openmp.org/spec-html/5.0/openmpsu132.html .
+ */
+char const* openmp_proc_bind()
+{
+#ifdef _OPENMP
+    switch (omp_get_proc_bind())
+    {
+        case omp_proc_bind_false:
+            return "false";
+        case omp_proc_bind_true:
+            return "true";
+        case omp_proc_bind_master:
+            return "master";
+        case omp_proc_bind_close:
+            return "close";
+        case omp_proc_bind_spread:
+            return "spread";
+        default:
+            CELER_ASSERT_UNREACHABLE();
+    }
+#else
+    return "disabled";
+#endif
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/sys/Openmp.hh
+++ b/src/corecel/sys/Openmp.hh
@@ -3,52 +3,24 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file corecel/sys/Openmp.hh
+//! \brief Thin wrappers around OpenMP function calls.
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include "corecel/Config.hh"
-
 #include "corecel/Types.hh"
-
-#include "ThreadId.hh"
 
 namespace celeritas
 {
 //---------------------------------------------------------------------------//
 
-/*!
- * \typedef OpenmpThreadId
- *
- * Type-safe alias based on OpenMP usage:
- * - when using event-level OpenMP parallelism, this is \c StreamId (where each
- *   stream is a separate state vector).
- * - when using track-level OpenMP parallelism, this is \c TrackSlotId .
- *
- * \sa launch_kernel
- */
-#if CELERITAS_OPENMP == CELERITAS_OPENMP_EVENT
-using OpenmpThreadId = StreamId;
-#elif CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
-using OpenmpThreadId = TrackSlotId;
-#else
-using OpenmpThreadId = OpaqueId<OpenmpThread_, unsigned int>;
-#endif
-using OpenmpSize_t = MakeSize_t<OpenmpThreadId>;
-
 // Get the maximum number of threads that can execute in parallel
-OpenmpSize_t openmp_thread_limit();
+size_type openmp_thread_limit();
 
 // Get the maximum number of threads in a new parallel region
-OpenmpSize_t openmp_max_threads();
-
-// Get the number of threads in the *current* parallel regino
-OpenmpSize_t openmp_num_threads();
-
-// Get a thread ID corresponding to the current OpenMP thread ID
-OpenmpThreadId openmp_local_thread();
+size_type openmp_max_threads();
 
 // Set the maximum number of threads for default future parallel regions
-void openmp_num_threads(OpenmpSize_t);
+void openmp_num_threads(size_type);
 
 // Get the openmp process bind affinity
 char const* openmp_proc_bind();

--- a/src/corecel/sys/Openmp.hh
+++ b/src/corecel/sys/Openmp.hh
@@ -1,0 +1,57 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/sys/Openmp.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Config.hh"
+
+#include "corecel/Types.hh"
+
+#include "ThreadId.hh"
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+
+/*!
+ * \typedef OpenmpThreadId
+ *
+ * Type-safe alias based on OpenMP usage:
+ * - when using event-level OpenMP parallelism, this is \c StreamId (where each
+ *   stream is a separate state vector).
+ * - when using track-level OpenMP parallelism, this is \c TrackSlotId .
+ *
+ * \sa launch_kernel
+ */
+#if CELERITAS_OPENMP == CELERITAS_OPENMP_EVENT
+using OpenmpThreadId = StreamId;
+#elif CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK
+using OpenmpThreadId = TrackSlotId;
+#else
+using OpenmpThreadId = OpaqueId<OpenmpThread_, unsigned int>;
+#endif
+using OpenmpSize_t = MakeSize_t<OpenmpThreadId>;
+
+// Get the maximum number of threads that can execute in parallel
+OpenmpSize_t openmp_thread_limit();
+
+// Get the maximum number of threads in a new parallel region
+OpenmpSize_t openmp_max_threads();
+
+// Get the number of threads in the *current* parallel regino
+OpenmpSize_t openmp_num_threads();
+
+// Get a thread ID corresponding to the current OpenMP thread ID
+OpenmpThreadId openmp_local_thread();
+
+// Set the maximum number of threads for default future parallel regions
+void openmp_num_threads(OpenmpSize_t);
+
+// Get the openmp process bind affinity
+char const* openmp_proc_bind();
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/geocel/GeantUtils.cc
+++ b/src/geocel/GeantUtils.cc
@@ -12,12 +12,10 @@
 #include <G4Threading.hh>
 #include <G4Version.hh>
 
+#include "corecel/sys/Openmp.hh"
+
 #if G4VERSION_NUMBER < 1070
 #    include <G4MTRunManager.hh>
-#endif
-
-#ifdef _OPENMP
-#    include <omp.h>
 #endif
 
 #include "corecel/Assert.hh"
@@ -101,23 +99,26 @@ void validate_geant_threading(size_type num_streams)
     if (CELERITAS_OPENMP == CELERITAS_OPENMP_TRACK && !celeritas::device()
         && G4Threading::IsMultithreadedApplication())
     {
+        auto limit = openmp_max_threads();
+
         auto msg = CELER_LOG(warning);
         msg << "Using multithreaded Geant4 with Celeritas track-level OpenMP "
-               "parallelism";
-        if (std::string const& nt_str = celeritas::getenv("OMP_NUM_THREADS");
-            !nt_str.empty())
+               "parallelism (thread limit = "
+            << limit << ")";
+        if (limit > 1)
         {
-            msg << "(OMP_NUM_THREADS=" << nt_str
-                << "): CPU threads may be oversubscribed";
-        }
-        else
-        {
-            msg << ": forcing 1 Celeritas thread to Geant4 thread";
-#ifdef _OPENMP
-            omp_set_num_threads(1);
-#else
-            CELER_ASSERT_UNREACHABLE();
-#endif
+            if (std::string const& nt_str
+                = celeritas::getenv(R"(OMP_NUM_THREADS)");
+                !nt_str.empty())
+            {
+                msg << ": CPU threads may be oversubscribed (OMP_NUM_THREADS="
+                    << nt_str << ")";
+            }
+            else
+            {
+                msg << ": setting 1 OpenMP thread per Geant4 thread";
+                openmp_num_threads(1);
+            }
         }
     }
 }

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -116,6 +116,11 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
         OPO_PAIR(data.scalars, max_csg_levels),
         OPO_PAIR(data.scalars, tol),
     };
+    if (orange_tracking_logic == LogicNotation::infix)
+    {
+        // csg levels is only relevant for pre/postfix
+        obj["scalars"]["max_csg_levels"] = nullptr;
+    }
 
     // Save sizes
     obj["sizes"] = {

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -113,13 +113,13 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
         OPO_PAIR(data.scalars, num_univ_levels),
         OPO_PAIR(data.scalars, max_faces),
         OPO_PAIR(data.scalars, max_intersections),
-        OPO_PAIR(data.scalars, max_csg_levels),
         OPO_PAIR(data.scalars, tol),
     };
-    if (orange_tracking_logic == LogicNotation::infix)
+    if (orange_tracking_logic != LogicNotation::infix)
     {
-        // csg levels is only relevant for pre/postfix
-        obj["scalars"]["max_csg_levels"] = nullptr;
+        // The max_csg_levels field is only set when pre/postfix, even though
+        // it always exists as member data in the scalars
+        obj["scalars"]["max_csg_levels"] = data.scalars.max_csg_levels;
     }
 
     // Save sizes

--- a/test/corecel/CMakeLists.txt
+++ b/test/corecel/CMakeLists.txt
@@ -73,6 +73,7 @@ celeritas_add_test(io/Join.test.cc)
 celeritas_add_test(io/Logger.test.cc
   LINK_LIBRARIES Celeritas::ExtMPI)
 celeritas_add_test(io/OutputRegistry.test.cc
+  ENVIRONMENT "OMP_NUM_THREADS=4;OMP_THREAD_LIMIT=2"
   LINK_LIBRARIES nlohmann_json::nlohmann_json)
 celeritas_add_test(io/Repr.test.cc)
 celeritas_add_test(io/ScopedStreamRedirect.test.cc)

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -10,9 +10,12 @@
 #include <regex>
 #include <sstream>
 
+#include "corecel/Config.hh"
+
 #include "corecel/io/BuildOutput.hh"
 #include "corecel/io/ExceptionOutput.hh"
 #include "corecel/io/JsonPimpl.hh"
+#include "corecel/io/OpenmpOutput.hh"
 
 #include "celeritas_test.hh"
 
@@ -130,6 +133,25 @@ TEST_F(OutputRegistryTest, build_output)
     std::string result = this->to_string(reg);
     EXPECT_TRUE(result.find(R"("build_type":)") != std::string::npos)
         << "actual output: " << result;
+}
+
+TEST_F(OutputRegistryTest, openmp_output)
+{
+    OutputRegistry reg;
+    reg.insert(std::make_shared<celeritas::OpenmpOutput>());
+    std::string result = this->to_string(reg);
+    std::string expected;
+    if constexpr (CELERITAS_USE_OPENMP)
+    {
+        expected
+            = R"json({"system":{"openmp":{"max_threads":4,"proc_bind":"false","thread_limit":2}}})json";
+    }
+    else
+    {
+        expected
+            = R"json({"system":{"openmp":{"max_threads":1,"proc_bind":"disabled","thread_limit":1}}})json";
+    }
+    EXPECT_EQ(expected, result) << repr(result);
 }
 
 TEST_F(OutputRegistryTest, exception_output)

--- a/test/corecel/io/OutputRegistry.test.cc
+++ b/test/corecel/io/OutputRegistry.test.cc
@@ -16,6 +16,7 @@
 #include "corecel/io/ExceptionOutput.hh"
 #include "corecel/io/JsonPimpl.hh"
 #include "corecel/io/OpenmpOutput.hh"
+#include "corecel/sys/Openmp.hh"
 
 #include "celeritas_test.hh"
 
@@ -150,6 +151,16 @@ TEST_F(OutputRegistryTest, openmp_output)
     {
         expected
             = R"json({"system":{"openmp":{"max_threads":1,"proc_bind":"disabled","thread_limit":1}}})json";
+    }
+    EXPECT_EQ(expected, result) << repr(result);
+
+    // Change max threads via openmp call, overriding test env variable
+    openmp_num_threads(1);
+    result = this->to_string(reg);
+    if constexpr (CELERITAS_USE_OPENMP)
+    {
+        expected
+            = R"json({"system":{"openmp":{"max_threads":1,"proc_bind":"false","thread_limit":2}}})json";
     }
     EXPECT_EQ(expected, result) << repr(result);
 }

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -199,7 +199,7 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"max_csg_levels":0,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"num_univ_levels":3,"max_faces":14,"max_intersections":14,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"universe_indexer":{"surfaces":4,"volumes":4},"univ_indices":3,"univ_types":3,"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -713,7 +713,7 @@ TEST_F(HexArrayTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bih":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -775,7 +775,7 @@ TEST_F(InputBuilderTest, globalspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":2,"max_intersections":4,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -841,7 +841,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"max_csg_levels":0,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"num_univ_levels":1,"max_faces":3,"max_intersections":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"universe_indexer":{"surfaces":2,"volumes":2},"univ_indices":1,"univ_types":1,"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -965,7 +965,7 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_csg_levels":0,"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -974,7 +974,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_csg_levels":0,"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bih_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bih":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
         to_string(out));
 }
 


### PR DESCRIPTION
This adds some basic OpenMP wrapper functions to get the number of threads (which is very confusing in openmp docs, I think due to the legacy of the environment variables and the expansion of OpenMP from CPU to GPU).