### PR TITLE
Fix nvcc 13.3 compile error

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To do so, set Spack up its CUDA usage:
 $ spack external find cuda
 # Optionally set the default configuration. Replace "cuda_arch=80"
 # with your target architecture
-$ spack config add packages:all:variants:"cxxstd=17 +cuda cuda_arch=80"
+$ spack config add 'packages:all:variants:["cxxstd=17 +cuda cuda_arch=80"]'
 ```
 and install Celeritas with this configuration:
 ```console

--- a/src/orange/surf/LocalSurfaceVisitor.hh
+++ b/src/orange/surf/LocalSurfaceVisitor.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/Types.hh"
 #include "corecel/math/Algorithms.hh"
 #include "orange/OrangeData.hh"
 
@@ -57,6 +58,7 @@ class LocalSurfaceVisitor
 
     template<class T>
     using Items = Collection<T, Ownership::const_reference, MemSpace::native>;
+    using Reals = Items<real_type>;
 
     //// DATA ////
 
@@ -127,9 +129,8 @@ LocalSurfaceVisitor::operator()(F&& func, LocalSurfaceId id)
 template<class T>
 CELER_FUNCTION T LocalSurfaceVisitor::make_surface(LocalSurfaceId id) const
 {
-    using Reals = decltype(params_.reals);
-    using RealIdT = typename Reals::ItemIdT;
-    using RealRangeT = typename Reals::ItemRangeT;
+    using RealIdT = Reals::ItemIdT;
+    using RealRangeT = Reals::ItemRangeT;
     RealIdT offset = params_.real_ids[surfaces_.data_offsets[id]];
     constexpr size_type size{T::StorageSpan::extent};
     CELER_ASSERT(offset + size <= params_.reals.size());


### PR DESCRIPTION
nvcc doesn't seem to like the `decltype` alias, maybe a regression in the compiler as that should be legal. Failing with the following error:
```
/pscratch/sd/e/esseivaj/dev/celeritas/src/orange/surf/LocalSurfaceVisitor.hh:133:17: error: need ‘typename’ before ‘Reals::ItemIdT’ because ‘Reals’ is a dependent scope
  133 |     using RealIdT = typename Reals::ItemIdT;
      |                 ^~~~~
      |                 typename 
/pscratch/sd/e/esseivaj/dev/celeritas/src/orange/surf/LocalSurfaceVisitor.hh:134:20: error: need ‘typename’ before ‘Reals::ItemRangeT’ because ‘Reals’ is a dependent scope
  134 |     using RealRangeT = typename Reals::ItemRangeT;
      |                    ^~~~~
      |                    typename
 ```
