### PR TITLE
Add optical detector callbacks through accel setup

### DIFF
--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -127,6 +127,7 @@ void ProblemSetup::operator()(inp::Problem& p) const
     {
         p.control.optical_capacity = so.optical->capacity;
         p.tracking.optical_limits = so.optical->limits;
+        p.scoring.optical_detector = so.optical->detectors;
     }
 
     if (so.track_order != TrackOrder::size_)
@@ -249,6 +250,7 @@ void OpticalProblemSetup::operator()(inp::OpticalProblem& p) const
     CELER_ASSERT(so.optical);
     p.generator = so.optical->generator;
     p.capacity = so.optical->capacity;
+    p.detectors = so.optical->detectors;
     p.limits = so.optical->limits;
     p.seed = CLHEP::HepRandom::getTheSeed();
     p.timers.action = so.action_times;

--- a/src/accel/SetupOptions.hh
+++ b/src/accel/SetupOptions.hh
@@ -17,6 +17,7 @@
 #include "celeritas/global/ActionInterface.hh"
 #include "celeritas/inp/Control.hh"
 #include "celeritas/inp/Physics.hh"
+#include "celeritas/inp/Scoring.hh"
 #include "celeritas/inp/Tracking.hh"
 
 class G4LogicalVolume;
@@ -128,6 +129,8 @@ struct OpticalSetupOptions
     inp::OpticalGenerator generator;
     //! Limits for the optical stepping loop
     inp::OpticalTrackingLimits limits;
+    //! Callback for optical photon hits
+    inp::OpticalDetector detectors;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/inp/Scoring.hh
+++ b/src/celeritas/inp/Scoring.hh
@@ -140,22 +140,6 @@ struct SimpleCalo
 
 //---------------------------------------------------------------------------//
 /*!
- * Enable scoring of hits or other quantities.
- *
- * If the problem to be executed has no sensitive detectors, \c sd must be
- * \c std::nullopt (unset).
- */
-struct Scoring
-{
-    //! Enable Geant4 sensitive detector integration
-    std::optional<GeantSd> sd;
-
-    //! Add simple on-device calorimeters integrated over events
-    std::optional<SimpleCalo> simple_calo;
-};
-
-//---------------------------------------------------------------------------//
-/*!
  * Enable detector callback for hits in optical physics simulations.
  */
 struct OpticalDetector
@@ -171,6 +155,25 @@ struct OpticalDetector
 
     //! Whether detector input is valid and should be built
     explicit operator bool() const { return static_cast<bool>(callback); }
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Enable scoring of hits or other quantities.
+ *
+ * If the problem to be executed has no sensitive detectors, \c sd must be
+ * \c std::nullopt (unset).
+ */
+struct Scoring
+{
+    //! Enable Geant4 sensitive detector integration
+    std::optional<GeantSd> sd;
+
+    //! Add simple on-device calorimeters integrated over events
+    std::optional<SimpleCalo> simple_calo;
+
+    //! Add callback for optical detector hits
+    OpticalDetector optical_detector;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -338,6 +338,7 @@ auto build_optical_params(inp::Problem const& p,
     pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
         pi.action_reg.get(), p.physics.optical.surfaces);
     pi.detectors = core.detectors();
+    pi.optical_detector = p.scoring.optical_detector;
     pi.volume = core.volume();
 
     // Photon generating processes

--- a/test/accel/TrackingManagerIntegration.test.cc
+++ b/test/accel/TrackingManagerIntegration.test.cc
@@ -31,6 +31,7 @@
 #include "celeritas/global/CoreState.hh"
 #include "celeritas/inp/Events.hh"
 #include "celeritas/optical/CoreState.hh"
+#include "celeritas/optical/DetectorData.hh"
 #include "celeritas/optical/OpticalCollector.hh"
 #include "celeritas/phys/PDGNumber.hh"
 #include "accel/LocalTransporter.hh"
@@ -522,6 +523,7 @@ class LarSphereOptical : public LarSphere
 
   private:
     std::vector<CounterTrackingAction*> tracking_;
+    std::vector<real_type> detector_x_positions_;
 };
 
 //---------------------------------------------------------------------------//
@@ -539,7 +541,14 @@ auto LarSphereOptical::make_setup_options() -> SetupOptions
         opt.capacity.primaries = opt.capacity.generators;
         return opt;
     }();
-
+    // Optical detector hit callback
+    result.optical->detectors.callback
+        = [this](Span<optical::DetectorHit const> hits) {
+              for (auto const& hit : hits)
+              {
+                  detector_x_positions_.push_back(hit.position[0]);
+              }
+          };
     return result;
 }
 
@@ -579,7 +588,7 @@ void LarSphereOptical::EndOfRunAction(G4Run const* run)
             EXPECT_GT(accum_stats.steps, 0);
             EXPECT_GT(accum_stats.step_iters, 0);
             EXPECT_GT(accum_stats.flushes, 0);
-
+            EXPECT_GT(detector_x_positions_.size(), 0);
             auto& aux_state = local_transporter.GetState().aux();
             auto counts = optical_collector->buffer_counts(aux_state);
             EXPECT_EQ(0, counts.buffer_size);  //!< Pending generators


### PR DESCRIPTION
This PR does the following :

- Add optical detector callbacks to scoring.
- Pass the optical detector configuration through setup so it reaches the optical problem at runtime.