### PR TITLE
Skip geometry initialization when locating missing optical material if only one material is present

### DIFF
--- a/src/celeritas/optical/MaterialData.hh
+++ b/src/celeritas/optical/MaterialData.hh
@@ -44,6 +44,9 @@ struct MaterialParamsData
 
     //// MEMBER FUNCTIONS ////
 
+    //! Number of optical materials
+    CELER_FUNCTION size_type size() const { return refractive_index.size(); }
+
     //! Whether all data are assigned and valid
     explicit CELER_FUNCTION operator bool() const
     {

--- a/src/celeritas/optical/MaterialParams.hh
+++ b/src/celeritas/optical/MaterialParams.hh
@@ -88,7 +88,7 @@ class MaterialParams final : public ParamsDataInterface<MaterialParamsData>
  */
 OptMatId::size_type MaterialParams::num_materials() const
 {
-    return this->host_ref().refractive_index.size();
+    return this->host_ref().size();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/MaterialView.hh
+++ b/src/celeritas/optical/MaterialView.hh
@@ -76,7 +76,7 @@ CELER_FUNCTION
 MaterialView::MaterialView(ParamsRef const& params, MatId id)
     : params_(params), mat_id_(id)
 {
-    CELER_EXPECT(id < params_.refractive_index.size());
+    CELER_EXPECT(id < params_.size());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/gen/detail/GeneratorExecutor.hh
+++ b/src/celeritas/optical/gen/detail/GeneratorExecutor.hh
@@ -99,12 +99,21 @@ CELER_FUNCTION void GeneratorExecutor::operator()(TrackSlotId tid) const
 
     if (!dist.material)
     {
-        // If the optical material hasn't been set, initialize a temporary
-        // geometry state at the pre-step point and use it to find the optical
-        // material ID
-        auto geo = vacancy.geometry();
-        geo = GeoTrackInitializer{dist.points[StepPoint::pre].pos, {1, 0, 0}};
-        dist.material = vacancy.material_record(geo).material_id();
+        // Determine the optical material if it hasn't been set
+        if (params->material.size() == 1)
+        {
+            // Only one optical material in the problem
+            dist.material = OptMatId{0};
+        }
+        else
+        {
+            // Initialize a temporary geometry state at the pre-step point and
+            // use it to find the optical material ID
+            auto geo = vacancy.geometry();
+            geo = GeoTrackInitializer{dist.points[StepPoint::pre].pos,
+                                      {1, 0, 0}};
+            dist.material = vacancy.material_record(geo).material_id();
+        }
     }
     CELER_ASSERT(dist.material);
 


### PR DESCRIPTION
This is a little hack to skip the expensive geometry initialization used to find the optical material at the pre-step position when the material ID is missing in the distribution data in the typical DUNE case where there's only one optical material in the problem. For the dune-zwires problem with orange this sped up the `generate` action ~65% and the total time ~5%.