### PR TITLE
Prevent `is_ci_build` from crashing when using built-in CLHEP

### DIFF
--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -61,7 +61,7 @@ bool GeantTestBase::is_ci_build()
     }
     // Check clhep/g4 versions
     if (std::string_view{cmake::clhep_version}.empty()
-      && !std::string_view{cmake::geant4_version}.empty())
+        && !std::string_view{cmake::geant4_version}.empty())
     {
         // G4 build with a built-in CLHEP = non-CI build
         return false;

--- a/test/celeritas/GeantTestBase.cc
+++ b/test/celeritas/GeantTestBase.cc
@@ -60,6 +60,12 @@ bool GeantTestBase::is_ci_build()
         return false;
     }
     // Check clhep/g4 versions
+    if (std::string_view{cmake::clhep_version}.empty()
+      && !std::string_view{cmake::geant4_version}.empty())
+    {
+        // G4 build with a built-in CLHEP = non-CI build
+        return false;
+    }
     auto clhep = Version::from_string(cmake::clhep_version);
     auto g4 = Version::from_string(cmake::geant4_version);
     return clhep >= Version{2, 4, 6} && clhep < Version{2, 5}


### PR DESCRIPTION
Fix the function `Geant4TestBase::is_ci_build()` when CLHEP is builtin inside an external Geant4 build.
In this scenario, an empty string, which was passed to Version::from_string(cmake::clhep_version), resulting in multiple unit tests failing.
