### PR TITLE
Add overlap fraction consideration to BVH partitioning

### DIFF
--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -228,6 +228,27 @@ calc_intersection(BoundingBox<T> const& a, BoundingBox<T> const& b)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Calculate the overlap fraction.
+ *
+ * The overlap fraction is the ratio of the volume of the intersection bbox to
+ * the volume of the smaller bbox. The overlap fraction is not defined if both
+ * bboxes are infinite or either/both are degenerate.
+ */
+template<class T>
+inline T calc_overlap_fraction(BoundingBox<T> const& a, BoundingBox<T> const& b)
+{
+    CELER_EXPECT(is_finite(a) || is_finite(b));
+    CELER_EXPECT(!is_degenerate(a) && !is_degenerate(b));
+
+    auto intersection = calc_intersection(a, b);
+    T overlap_vol = intersection ? calc_volume(intersection) : 0;
+    T small_vol = std::min(calc_volume(a), calc_volume(b));
+
+    return overlap_vol / small_vol;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Check if all points inside the small bbox are in the big bbox.
  *
  * All bounding boxes should enclose a "null" bounding box (there are no points

--- a/src/orange/detail/BvhPartitioner.cc
+++ b/src/orange/detail/BvhPartitioner.cc
@@ -60,7 +60,8 @@ BvhPartitioner::BvhPartitioner(VecBBox const& bboxes,
 /*!
  * Find a suitable partition for the given subset of bounding boxes.
  *
- * If no partition is found, an empty partition is returned
+ * If no partition is found, an empty partition is returned. A partition is
+ * also rejected when the subset is small and the child bboxes overlap heavily.
  */
 BvhPartitioner::Partition
 BvhPartitioner::operator()(VecIndices const& indices) const
@@ -95,6 +96,17 @@ BvhPartitioner::operator()(VecIndices const& indices) const
                 best_cost = cost;
             }
         }
+    }
+
+    // If there are fewer than volume_threshold_ volumes and the partition
+    // yields bboxes with an overlap fraction hire than overlap_threshold_,
+    // return an empty partition instead.
+    if (best_partition && indices.size() <= volume_threshold_
+        && calc_overlap_fraction(best_partition.bboxes[Side::left],
+                                 best_partition.bboxes[Side::right])
+               >= overlap_threshold_)
+    {
+        return {};
     }
 
     return best_partition;

--- a/src/orange/detail/BvhPartitioner.hh
+++ b/src/orange/detail/BvhPartitioner.hh
@@ -81,6 +81,10 @@ class BvhPartitioner
     VecReal3 const& centers_;
     //! The number of partition candidates to check per axis
     size_type num_part_cands_{0};
+    //! Min #vols to consider discarding partition based on overlap fraction
+    static constexpr size_type volume_threshold_ = 2;
+    //! Threshold for discarding partitions that yield overlapping children
+    static constexpr real_type overlap_threshold_ = real_type{0.5};
 
     //// HELPER FUNCTIONS ////
 

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -196,6 +196,52 @@ TEST_F(BoundingBoxUtilsTest, bbox_intersection)
     }
 }
 
+TEST_F(BoundingBoxUtilsTest, bbox_overlap_fraction)
+{
+    auto inf = std::numeric_limits<real_type>::infinity();
+
+    {
+        SCOPED_TRACE("nonintersecting");
+        real_type overlap = calc_overlap_fraction(
+            BBox{{-1, -1, -1}, {1, 1, 1}}, BBox{{1.1, 0, 0}, {2, 1, 1}});
+        EXPECT_SOFT_EQ(0, overlap);
+    }
+
+    {
+        SCOPED_TRACE("partial overlap");
+        real_type overlap = calc_overlap_fraction(
+            BBox{{-1, -1, -1}, {1, 1, 1}}, BBox{{0, -1, -1}, {2, 1, 1}});
+        EXPECT_SOFT_EQ(0.5, overlap);
+    }
+
+    {
+        SCOPED_TRACE("full overlap");
+        real_type overlap = calc_overlap_fraction(
+            BBox{{-1, -1, -1}, {1, 1, 1}}, BBox{{-2, -2, -2}, {2, 2, 2}});
+        EXPECT_SOFT_EQ(1, overlap);
+    }
+
+    {
+        SCOPED_TRACE("overlap with semiinfinite");
+        real_type overlap
+            = calc_overlap_fraction(BBox{{-inf, -inf, -inf}, {inf, inf, 0}},
+                                    BBox{{-1, -1, -0.25}, {1, 1, 0.75}});
+        EXPECT_SOFT_EQ(0.25, overlap);
+    }
+    {
+        SCOPED_TRACE("both infinite");
+        BBox a{{-1, -1, -inf}, {1, 1, 1}};
+        BBox b{{1.1, 0, 0}, {2, 1, inf}};
+        EXPECT_THROW(calc_overlap_fraction(a, b), DebugError);
+    }
+    {
+        SCOPED_TRACE("degenerate");
+        BBox a{{1, 1, 1}, {2, 2, 1}};
+        BBox b{{1.1, 0, 0}, {2, 1, 10}};
+        EXPECT_THROW(calc_overlap_fraction(a, b), DebugError);
+    }
+}
+
 using IntersectsSegmentTest = Test;
 
 TEST_F(IntersectsSegmentTest, basic)

--- a/test/orange/BoundingBoxUtils.test.cc
+++ b/test/orange/BoundingBoxUtils.test.cc
@@ -228,12 +228,16 @@ TEST_F(BoundingBoxUtilsTest, bbox_overlap_fraction)
                                     BBox{{-1, -1, -0.25}, {1, 1, 0.75}});
         EXPECT_SOFT_EQ(0.25, overlap);
     }
+
+    if (CELERITAS_DEBUG)
     {
         SCOPED_TRACE("both infinite");
         BBox a{{-1, -1, -inf}, {1, 1, 1}};
         BBox b{{1.1, 0, 0}, {2, 1, inf}};
         EXPECT_THROW(calc_overlap_fraction(a, b), DebugError);
     }
+
+    if (CELERITAS_DEBUG)
     {
         SCOPED_TRACE("degenerate");
         BBox a{{1, 1, 1}, {2, 2, 1}};

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -199,7 +199,7 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"max_faces":14,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":12,"internal_nodes":6,"leaf_nodes":9,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"univ_indices":3,"univ_types":3,"universe_indexer":{"surfaces":4,"volumes":4},"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"max_faces":14,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":12,"internal_nodes":5,"leaf_nodes":8,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"univ_indices":3,"univ_types":3,"universe_indexer":{"surfaces":4,"volumes":4},"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -965,7 +965,7 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[5,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":24,"internal_nodes":9,"leaf_nodes":16,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":24,"internal_nodes":8,"leaf_nodes":15,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
         to_string(out));
 }
 
@@ -974,7 +974,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":6,"internal_nodes":1,"leaf_nodes":3,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":6,"internal_nodes":0,"leaf_nodes":2,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
         to_string(out));
 }
 

--- a/test/orange/detail/BvhBuilder.test.cc
+++ b/test/orange/detail/BvhBuilder.test.cc
@@ -648,7 +648,7 @@ TEST_F(GridTest, depth_limit)
 //---------------------------------------------------------------------------//
 // Degenerate, single leaf cases
 //---------------------------------------------------------------------------//
-//
+
 TEST_F(BvhBuilderTest, single_finite_volume)
 {
     this->build({{{0, 0, 0}, {1, 1, 1}}});
@@ -724,6 +724,30 @@ TEST_F(BvhBuilderTest, TEST_IF_CELERITAS_DEBUG(semi_finite_volumes))
                      {{-inff, 0, 0}, {inff, 1, 1}},
                  }),
                  DebugError);
+}
+
+//---------------------------------------------------------------------------//
+// Other tests
+//---------------------------------------------------------------------------//
+
+TEST_F(BvhBuilderTest, overlap_fraction)
+{
+    // Make two bounding boxes that overlap by 60%
+    this->build({{{0, 0, 0}, {1, 1, 1}}, {{0.4, 0, 0}, {1.4, 1, 1}}});
+
+    // The overlap fraction dictates only a single leaf node should be created,
+    // even though the bboxes are partitionable
+    ASSERT_EQ(0, tree_.inf_vol_ids.size());
+    BvhView view{tree_, store_.host_ref()};
+    ASSERT_EQ(0, view.num_internal_nodes());
+    ASSERT_EQ(1, view.num_leaf_nodes());
+
+    EXPECT_VEC_EQ(VecInt({0, 1}), id_to_int(view.leaf_vol_ids(BvhNodeId{0})));
+
+    auto const& md = tree_.metadata;
+    EXPECT_EQ(2, md.num_finite_bboxes);
+    EXPECT_EQ(0, md.num_infinite_bboxes);
+    EXPECT_EQ(1, md.depth);
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This MR adds an additional criterion for BVH partition that eliminates cases where inner nodes for a small number of volumes (two) with significantly overlapping bounding boxes (by 50% or more). These cases are shown to be eliminated from the DUNE Z-wires dot graph:

<img width="1514" height="563" alt="Screenshot 2026-06-09 at 9 46 22 AM" src="https://github.com/user-attachments/assets/4972db79-cd25-40db-a35d-ea979ff962ff" />

Speepup results are underwhelming, but there may be other geometries where this makes a more significant impact.

<img width="1113" height="79" alt="Screenshot 2026-06-09 at 10 13 10 AM" src="https://github.com/user-attachments/assets/002a29de-f24a-4b66-8eec-8c66e12702f1" />