### PR TITLE
Enable profiling through Instruments on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ option(CELERITAS_BUILD_APPS "Build Celeritas executables (strongly recommended)"
 option(CELERITAS_BUILD_DOCS "Build Celeritas documentation" OFF)
 option(CELERITAS_BUILD_TESTS "Build Celeritas unit tests" OFF)
 
+cmake_dependent_option(CELERITAS_CODESIGN_APPS
+  "Use Apple codesign to allow debugging with Instruments" "OFF"
+  "CELERITAS_BUILD_APPS;APPLE" OFF
+)
+
 # Assertion handling
 option(CELERITAS_DEBUG "Enable runtime assertions" OFF)
 
@@ -625,6 +630,10 @@ if(CELERITAS_USE_VecGeom)
   endif()
 endif()
 
+if(CELERITAS_USE_GTest)
+  celeritas_find_or_builtin_package(GTest 1.10)
+endif()
+
 if(CELERITAS_BUILD_DOCS)
   set(_prev_dot "${DOXYGEN_DOT_EXECUTABLE}")
   if(NOT Doxygen_FOUND)
@@ -666,8 +675,22 @@ if(CELERITAS_BUILD_DOCS)
   include(ExternalProject)
 endif()
 
-if(CELERITAS_USE_GTest)
-  celeritas_find_or_builtin_package(GTest 1.10)
+if(CELERITAS_CODESIGN_APPS)
+  find_program(CODESIGN_EXECUTABLE codesign)
+  if(NOT CODESIGN_EXECUTABLE)
+    celeritas_error_incompatible_option(
+      "codesign is required for codesigning but was not found: maybe xcode not installed"
+      CELERITAS_CODESIGN_APPS
+      OFF
+    )
+  endif()
+  set(CELERITAS_CODESIGN_ENTITLEMENTS "${PROJECT_SOURCE_DIR}/cmake/entitlements.plist" CACHE PATH
+    "Entitlements file to use for Celeritas executables"
+  )
+  # NOTE: '-' is "ad hoc" signature
+  set(CELERITAS_CODESIGN_IDENTITY "-" CACHE STRING
+    "Code signing identity used for app building"
+  )
 endif()
 
 #----------------------------------------------------------------------------#

--- a/cmake/CeleritasLibraryUtils.cmake
+++ b/cmake/CeleritasLibraryUtils.cmake
@@ -194,6 +194,15 @@ function(celeritas_add_executable target)
   set_target_properties("${target}" PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CELERITAS_RUNTIME_OUTPUT_DIRECTORY}"
   )
+  if(CELERITAS_CODESIGN_APPS)
+    add_custom_command(TARGET "${target}" POST_BUILD
+      COMMAND "${CODESIGN_EXECUTABLE}"
+        --sign "${CELERITAS_CODESIGN_IDENTITY}"
+        --entitlements "${CELERITAS_CODESIGN_ENTITLEMENTS}"
+        "$<TARGET_FILE:${target}>"
+      COMMENT "Code-signing ${target}"
+    )
+  endif()
 endfunction()
 
 #-----------------------------------------------------------------------------#

--- a/cmake/entitlements.plist
+++ b/cmake/entitlements.plist
@@ -1,0 +1,5 @@
+<!-- entitlements.plist -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>com.apple.security.get-task-allow</key><true/>
+</dict></plist>

--- a/doc/usage/execution/profiling.rst
+++ b/doc/usage/execution/profiling.rst
@@ -204,3 +204,20 @@ Here, :samp:`celeritas@{RANGE}` is the name of the NVTX domain and
 slash-separated range, (e.g. ``run/step/*/propagate``).
 Note that the domain and range are flipped compared to ``nsys`` since the
 kernel profiling allows detailed top-down stack specification.
+
+Using Instruments on macOS
+--------------------------
+
+Celeritas developers on macOS can use Apple's Instruments_ code to analyze CPU
+performance.
+Running against a locally-built app for the first time will usually fail with
+an error "Failed to attach to target process."
+This is because the app built with standard CMake tools does not have a code
+signature with the necessary entitlements.
+When building Celeritas apps on an Apple machine, the CMake option
+``CELERITAS_CODESIGN_APPS`` becomes available.
+Enabling this option will automatically call ``codesign`` after building each
+app executable, which will allow its selection in Instruments.
+
+
+.. _Instruments: https://developer.apple.com/tutorials/instruments


### PR DESCRIPTION
This adds an option to apply apple's code signing with an ad-hoc identity to allow you to locally run macOS Xcode Instruments on Celeritas executables.
<img width="1455" height="999" alt="Screenshot 2026-06-10 at 17 11 36" src="https://github.com/user-attachments/assets/9e6f1e32-723e-4557-9511-4b6a42898ff8" />