### PR TITLE
Reduce short-circuiting in intersect_segment

### DIFF
--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -303,6 +303,8 @@ inline CELER_FUNCTION bool intersects_segment(BoundingBox<T> const& bbox,
     T const half_distance = distance / 2;
     constexpr T eps = numeric_limits<T>::epsilon();
 
+    bool result = true;
+
     for (auto ax : range(Axis::size_))
     {
         auto i = to_int(ax);
@@ -317,9 +319,12 @@ inline CELER_FUNCTION bool intersects_segment(BoundingBox<T> const& bbox,
 
         if (std::fabs(mid[i]) > hw[i] + abs_hseg[i])
         {
-            return false;
+            result = false;
         }
     }
+
+    if (!result)
+        return result;
 
     // Find a separating axis normal to the j,k faces and dir
     auto found_sep_axis = [&](int j, int k) {
@@ -331,15 +336,15 @@ inline CELER_FUNCTION bool intersects_segment(BoundingBox<T> const& bbox,
     constexpr auto y = to_int(Axis::y);
     constexpr auto z = to_int(Axis::z);
     if (found_sep_axis(y, z))
-        return false;
+        result = false;
 
     if (found_sep_axis(z, x))
-        return false;
+        result = false;
 
     if (found_sep_axis(x, y))
-        return false;
+        result = false;
 
-    return true;
+    return result;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
@osanstrong and I were profiling `develop` within Nsight Compute and we noticed that a single line in `BoundingBoxUtils::intersects_segment` is responsible for a 24% of divergent branches:

<img width="632" height="507" alt="Screenshot 2026-06-12 at 3 35 27 PM" src="https://github.com/user-attachments/assets/20151dd1-d4bd-4ebc-816c-bc4cbe99bde0" />

We found that by reducing, but not eliminating short circuiting, we get a modest speedup:

<img width="983" height="82" alt="Screenshot 2026-06-12 at 3 51 09 PM" src="https://github.com/user-attachments/assets/3d85569e-dd1d-4c4b-941b-2e734d284715" />