### PR TITLE
Enable autovectorization of bbox intersect and fix logical all

### DIFF
--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -855,5 +855,12 @@ CELER_FORCEINLINE_FUNCTION bool logical_all(Args const&... args)
     return (true && ... && static_cast<bool>(args));
 }
 
+//! Return true if any argument is true, *without* short circuiting
+template<typename... Args>
+CELER_FORCEINLINE_FUNCTION bool logical_any(Args const&... args)
+{
+    return (false | ... | static_cast<bool>(args));
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -852,14 +852,14 @@ CELER_CONSTEXPR_FUNCTION int popcount(T x) noexcept
 template<typename... Args>
 CELER_FORCEINLINE_FUNCTION bool logical_all(Args const&... args)
 {
-    return (true & ... & static_cast<bool>(args));
+    return (1 & ... & (args ? 1 : 0));
 }
 
 //! Return true if any argument is true, *without* short circuiting
 template<typename... Args>
 CELER_FORCEINLINE_FUNCTION bool logical_any(Args const&... args)
 {
-    return (false | ... | static_cast<bool>(args));
+    return (0 | ... | (args ? 1 : 0));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/corecel/math/Algorithms.hh
+++ b/src/corecel/math/Algorithms.hh
@@ -852,7 +852,7 @@ CELER_CONSTEXPR_FUNCTION int popcount(T x) noexcept
 template<typename... Args>
 CELER_FORCEINLINE_FUNCTION bool logical_all(Args const&... args)
 {
-    return (true && ... && static_cast<bool>(args));
+    return (true & ... & static_cast<bool>(args));
 }
 
 //! Return true if any argument is true, *without* short circuiting

--- a/src/orange/BoundingBoxUtils.hh
+++ b/src/orange/BoundingBoxUtils.hh
@@ -303,28 +303,22 @@ inline CELER_FUNCTION bool intersects_segment(BoundingBox<T> const& bbox,
     T const half_distance = distance / 2;
     constexpr T eps = numeric_limits<T>::epsilon();
 
-    bool result = true;
-
     for (auto ax : range(Axis::size_))
     {
-        auto i = to_int(ax);
         T const lower = bbox.point(Bound::lo, ax);
         T const upper = bbox.point(Bound::hi, ax);
         T const center = (lower + upper) / 2;
 
+        auto i = to_int(ax);
         hw[i] = (upper - lower) / 2;
         hseg[i] = dir[i] * half_distance;
         abs_hseg[i] = std::fabs(hseg[i]) + eps;
         mid[i] = pos[i] + hseg[i] - center;
-
-        if (std::fabs(mid[i]) > hw[i] + abs_hseg[i])
-        {
-            result = false;
-        }
     }
 
-    if (!result)
-        return result;
+    // Whether a separable axis was found orthogonal to the faces
+    auto found_sep_ortho_axis
+        = [&](int i) { return std::fabs(mid[i]) > hw[i] + abs_hseg[i]; };
 
     // Find a separating axis normal to the j,k faces and dir
     auto found_sep_axis = [&](int j, int k) {
@@ -335,16 +329,14 @@ inline CELER_FUNCTION bool intersects_segment(BoundingBox<T> const& bbox,
     constexpr auto x = to_int(Axis::x);
     constexpr auto y = to_int(Axis::y);
     constexpr auto z = to_int(Axis::z);
-    if (found_sep_axis(y, z))
-        result = false;
 
-    if (found_sep_axis(z, x))
-        result = false;
-
-    if (found_sep_axis(x, y))
-        result = false;
-
-    return result;
+    // Any separating axis means no intersection
+    return !logical_any(found_sep_ortho_axis(x),
+                        found_sep_ortho_axis(y),
+                        found_sep_ortho_axis(z),
+                        found_sep_axis(y, z),
+                        found_sep_axis(z, x),
+                        found_sep_axis(x, y));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/surf/Plane.hh
+++ b/src/orange/surf/Plane.hh
@@ -67,15 +67,18 @@ class Plane
     //// ACCESSORS ////
 
     //! Normal to the plane
-    CELER_FUNCTION Real3 const& normal() const { return normal_; }
+    CELER_CONSTEXPR_FUNCTION Real3 const& normal() const { return normal_; }
 
     //! Distance from the origin along the normal to the plane
-    CELER_FUNCTION real_type displacement() const { return d_; }
+    CELER_CONSTEXPR_FUNCTION real_type displacement() const { return d_; }
 
     //! Get a view to the data for type-deleted storage
     CELER_FUNCTION StorageSpan data() const { return {&normal_[0], 4}; }
 
     //// CALCULATION ////
+
+    // Calculate outward normal at a position on the surface
+    inline CELER_FUNCTION real_type dot_normal(Real3 const&) const;
 
     // Determine the sense of the position relative to this surface
     inline CELER_FUNCTION SignedSense calc_sense(Real3 const& pos) const;
@@ -85,7 +88,7 @@ class Plane
         Real3 const& pos, Real3 const& dir, SurfaceState on_surface) const;
 
     // Calculate outward normal at a position on the surface
-    inline CELER_FUNCTION Real3 calc_normal(Real3 const&) const;
+    inline CELER_FUNCTION Real3 const& calc_normal(Real3 const&) const;
 
   private:
     // Normal to plane (a,b,c)
@@ -129,11 +132,22 @@ CELER_FUNCTION Plane::Plane(Span<R, StorageSpan::extent> data)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the dot product with the normal.
+ *
+ * This is used for intersection, sense, and combined-plane methods.
+ */
+CELER_FORCEINLINE_FUNCTION real_type Plane::dot_normal(Real3 const& x) const
+{
+    return dot_product(normal_, x);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Determine the sense of the position relative to this surface.
  */
 CELER_FUNCTION SignedSense Plane::calc_sense(Real3 const& pos) const
 {
-    return real_to_sense(dot_product(normal_, pos) - d_);
+    return real_to_sense(this->dot_normal(pos) - this->displacement());
 }
 
 //---------------------------------------------------------------------------//
@@ -145,24 +159,21 @@ CELER_FUNCTION auto Plane::calc_intersections(Real3 const& pos,
                                               SurfaceState on_surface) const
     -> Intersections
 {
-    real_type const n_dir = dot_product(normal_, dir);
-    if (on_surface == SurfaceState::off && n_dir != 0)
-    {
-        real_type const n_pos = dot_product(normal_, pos);
-        real_type dist = (d_ - n_pos) / n_dir;
-        if (dist > 0)
-        {
-            return {dist};
-        }
-    }
-    return {no_intersection()};
+    real_type const n_pos = this->dot_normal(pos);
+    real_type const n_dir = this->dot_normal(dir);
+    real_type const dist = (this->displacement() - n_pos) / n_dir;
+
+    bool valid = celeritas::logical_all(
+        (on_surface == SurfaceState::off), (n_dir != 0), (dist > 0));
+
+    return {valid ? dist : no_intersection()};
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Calculate outward normal at a position on the surface.
  */
-CELER_FORCEINLINE_FUNCTION Real3 Plane::calc_normal(Real3 const&) const
+CELER_FORCEINLINE_FUNCTION Real3 const& Plane::calc_normal(Real3 const&) const
 {
     return normal_;
 }

--- a/src/orange/surf/PlaneAligned.hh
+++ b/src/orange/surf/PlaneAligned.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "corecel/Macros.hh"
+#include "corecel/Types.hh"
 #include "corecel/cont/Array.hh"
 #include "corecel/cont/Span.hh"
 #include "corecel/math/Algorithms.hh"
@@ -40,7 +41,7 @@ class PlaneAligned
   public:
     //// CONSTRUCTORS ////
 
-    // Construct with radius
+    // Construct from axis intercept
     explicit inline CELER_FUNCTION PlaneAligned(real_type position);
 
     // Construct from raw data
@@ -49,16 +50,25 @@ class PlaneAligned
 
     //// ACCESSORS ////
 
-    //! Get the square of the radius
-    CELER_FUNCTION real_type position() const { return position_; }
+    //! Distance from the origin along the normal to the plane (deprecated)
+    CELER_CONSTEXPR_FUNCTION real_type position() const
+    {
+        return this->displacement();
+    }
+
+    //! Distance from the origin along the normal to the plane
+    CELER_CONSTEXPR_FUNCTION real_type displacement() const { return d_; }
 
     //! Get a view to the data for type-deleted storage
-    CELER_FUNCTION StorageSpan data() const { return {&position_, 1}; }
+    CELER_FUNCTION StorageSpan data() const { return {&d_, 1}; }
 
     // Construct outward normal vector
     inline CELER_FUNCTION Real3 calc_normal() const;
 
     //// CALCULATION ////
+
+    // Get the dot product with the normal
+    inline CELER_FUNCTION real_type dot_normal(Real3 const& pos) const;
 
     // Determine the sense of the position relative to this surface
     inline CELER_FUNCTION SignedSense calc_sense(Real3 const& pos) const;
@@ -72,7 +82,7 @@ class PlaneAligned
 
   private:
     //! Intersection with the axis
-    real_type position_;
+    real_type d_;
 };
 
 //---------------------------------------------------------------------------//
@@ -103,8 +113,7 @@ CELER_CONSTEXPR_FUNCTION SurfaceType PlaneAligned<T>::surface_type()
  * Construct from axis intercept.
  */
 template<Axis T>
-CELER_FUNCTION PlaneAligned<T>::PlaneAligned(real_type position)
-    : position_(position)
+CELER_FUNCTION PlaneAligned<T>::PlaneAligned(real_type position) : d_(position)
 {
 }
 
@@ -115,7 +124,7 @@ CELER_FUNCTION PlaneAligned<T>::PlaneAligned(real_type position)
 template<Axis T>
 template<class R>
 CELER_FUNCTION PlaneAligned<T>::PlaneAligned(Span<R, StorageSpan::extent> data)
-    : position_(data[0])
+    : d_(data[0])
 {
 }
 
@@ -134,12 +143,25 @@ CELER_FUNCTION Real3 PlaneAligned<T>::calc_normal() const
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the dot product with the normal.
+ *
+ * This is used for intersection, sense, and combined-plane methods.
+ */
+template<Axis T>
+CELER_FORCEINLINE_FUNCTION real_type
+PlaneAligned<T>::dot_normal(Real3 const& x) const
+{
+    return x[to_int(T)];
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Determine the sense of the position relative to this surface.
  */
 template<Axis T>
 CELER_FUNCTION SignedSense PlaneAligned<T>::calc_sense(Real3 const& pos) const
 {
-    return real_to_sense(pos[to_int(T)] - position_);
+    return real_to_sense(this->dot_normal(pos) - this->displacement());
 }
 
 //---------------------------------------------------------------------------//
@@ -153,8 +175,9 @@ PlaneAligned<T>::calc_intersections(Real3 const& pos,
                                     SurfaceState on_surface) const
     -> Intersections
 {
-    real_type const n_dir = dir[to_int(T)];
-    real_type const dist = (position_ - pos[to_int(T)]) / n_dir;
+    real_type const n_pos = this->dot_normal(pos);
+    real_type const n_dir = this->dot_normal(dir);
+    real_type const dist = (this->displacement() - n_pos) / n_dir;
 
     bool valid = celeritas::logical_all(
         (on_surface == SurfaceState::off), (n_dir != 0), (dist > 0));

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -727,12 +727,32 @@ auto CheckedArray::operator[](size_type i) const -> IndexRef
     return IndexRef{*this, i};
 }
 
+TEST(LogicalTest, all)
+{
+    using Bool3 = CheckedArray::Bool3;
+
+    CheckedArray arr{};
+
+    // None are true
+    EXPECT_FALSE(logical_all(arr[0], arr[1], arr[2]));
+    EXPECT_EQ(Bool3(true, true, true), arr.checked());
+
+    // One is false, but all are checked anyway (no short circuiting)
+    arr = {{false, true, false}};
+    EXPECT_FALSE(logical_all(arr[0], arr[1], arr[2]));
+    EXPECT_EQ(Bool3(true, true, true), arr.checked());
+
+    // All are true; all are checked
+    arr = {{true, true, true}};
+    EXPECT_TRUE(logical_all(arr[0], arr[1], arr[2]));
+    EXPECT_EQ(Bool3(true, true, true), arr.checked());
+}
+
 TEST(LogicalTest, any)
 {
     using Bool3 = CheckedArray::Bool3;
 
     CheckedArray arr{};
-    EXPECT_EQ(Bool3(false, false, false), arr.checked());
 
     // None are true
     EXPECT_FALSE(logical_any(arr[0], arr[1], arr[2]));

--- a/test/corecel/math/Algorithms.test.cc
+++ b/test/corecel/math/Algorithms.test.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "corecel/Constants.hh"
+#include "corecel/cont/Array.hh"
 #include "corecel/data/ParamsDataStore.hh"
 
 #include "Algorithms.test.hh"
@@ -682,6 +683,70 @@ TEST(MathTest, TEST_IF_CELER_DEVICE(device))
             1, 5.55042, 1234, 123.46004995949, 1000.0000555556, 5.3851648071345};
         EXPECT_VEC_SOFT_EQ(expected_hypot, host_output.hypot[threads]);
     }
+}
+
+//---------------------------------------------------------------------------//
+
+//! The accessor returns a wrapper for checking short circuiting
+class CheckedArray
+{
+  public:
+    using Bool3 = Array<bool, 3>;
+    struct IndexRef;
+
+    CheckedArray(Bool3 vals) : vals_{vals} { checked_.fill(false); }
+
+    CheckedArray() : CheckedArray(Bool3{}) {}
+
+    inline IndexRef operator[](size_type i) const;
+
+    Bool3 const& checked() const { return checked_; }
+
+  private:
+    Bool3 vals_;
+    mutable Bool3 checked_;
+};
+
+//! Lazily evaluate, marking when we're accessed
+struct CheckedArray::IndexRef
+{
+    CheckedArray const& arr;
+    size_type idx{};
+
+    // Implicit operator bool
+    operator bool() const
+    {
+        CELER_EXPECT(idx < arr.vals_.size());
+        arr.checked_[idx] = true;
+        return arr.vals_[idx];
+    }
+};
+
+auto CheckedArray::operator[](size_type i) const -> IndexRef
+{
+    return IndexRef{*this, i};
+}
+
+TEST(LogicalTest, any)
+{
+    using Bool3 = CheckedArray::Bool3;
+
+    CheckedArray arr{};
+    EXPECT_EQ(Bool3(false, false, false), arr.checked());
+
+    // None are true
+    EXPECT_FALSE(logical_any(arr[0], arr[1], arr[2]));
+    EXPECT_EQ(Bool3(true, true, true), arr.checked());
+
+    // One is true, but all are checked anyway (no short circuiting)
+    arr = {{false, true, false}};
+    EXPECT_TRUE(logical_any(arr[0], arr[1], arr[2]));
+    EXPECT_EQ(Bool3(true, true, true), arr.checked());
+
+    // All are true; all are checked
+    arr = {{true, true, true}};
+    EXPECT_TRUE(logical_any(arr[0], arr[1], arr[2]));
+    EXPECT_EQ(Bool3(true, true, true), arr.checked());
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
I think my incorrectly entered suggestion for `logical_all` in #2405 got committed by mistake. I've added a test that actually checks short circuiting, and added a `logical_any` operator as well. This is used in an updated implementation of `intersect_segment` (following on to #2422) that actually allows clang to autovectorize with `-O3` (see https://github.com/sethrj/testsnippets/blob/master/_celeritas_code/bbox-intersect-segment/newer.s ) .

I also updated the Plane intersect implementation to use the `logical_all`, and added some methods to make its calculation look identical to AlignedPlane. (In a separate branch I tried unifying the intersect test for the plane to no effect: it's limited during the memory load.)

Anyway it looks like this gives another 1% boost on GPU, no effect seen on CPU, and the code is cleaner and it fixes a bug.