### PR TITLE
Validate G4LEVELGAMMADATA to avoid bizarre crashes in G4 field propagation

### DIFF
--- a/src/celeritas/ext/FtfpBertPhysicsList.cc
+++ b/src/celeritas/ext/FtfpBertPhysicsList.cc
@@ -55,7 +55,11 @@ FtfpBertPhysicsList::FtfpBertPhysicsList(Options const& options)
 
     // TODO: Add a physics constructor equivalent to G4EmExtraPhysics
 
-    // Decays
+    // Decay physics: check environment variables before loading since
+    // Geant4 11.2-11.4 crashes if null
+    CELER_VALIDATE(std::getenv("G4LEVELGAMMADATA") != nullptr,
+                   << "environment variable 'G4LEVELGAMMADATA' is undefined: "
+                      "load G4 photon evaporation environment");
     detail::emplace_physics<G4DecayPhysics>(*this, verbosity);
 
     // Hadron elastic scattering

--- a/src/celeritas/ext/FtfpBertPhysicsList.cc
+++ b/src/celeritas/ext/FtfpBertPhysicsList.cc
@@ -6,14 +6,17 @@
 //---------------------------------------------------------------------------//
 #include "FtfpBertPhysicsList.hh"
 
+#include <filesystem>
 #include <memory>
 #include <G4DecayPhysics.hh>
 #include <G4EmStandardPhysics.hh>
+#include <G4EnvironmentUtils.hh>
 #include <G4HadronElasticPhysics.hh>
 #include <G4HadronPhysicsFTFP_BERT.hh>
 #include <G4IonPhysics.hh>
 #include <G4NeutronTrackingCut.hh>
 #include <G4StoppingPhysics.hh>
+#include <G4Version.hh>
 #include <G4ios.hh>
 
 #include "corecel/io/ScopedStreamRedirect.hh"
@@ -57,9 +60,29 @@ FtfpBertPhysicsList::FtfpBertPhysicsList(Options const& options)
 
     // Decay physics: check environment variables before loading since
     // Geant4 11.2-11.4 crashes if null
-    CELER_VALIDATE(std::getenv("G4LEVELGAMMADATA") != nullptr,
-                   << "environment variable 'G4LEVELGAMMADATA' is undefined: "
-                      "load G4 photon evaporation environment");
+    static char const datavar[] = "G4LEVELGAMMADATA";
+    char const* datadir_env{nullptr};
+#if G4VERSION_NUMBER >= 1110
+    datadir_env = G4FindDataDir(datavar);
+#else
+    datadir_env = std::getenv(datavar);
+#endif
+    CELER_VALIDATE(datadir_env != nullptr,
+                   << "environment variable '" << datavar
+                   << "' is undefined: "
+                      "load 'g4photonevaporation' data");
+
+    // And 11.3 will silently produce garbage if it's null but not valid
+    {
+        namespace fs = std::filesystem;
+        fs::path datadir{datadir_env};
+        // Note: `status` follows symlink; `symlink_status` does not
+        auto stat = fs::status(datadir);
+        CELER_VALIDATE(fs::is_directory(stat),
+                       << "data environment " << datavar << '=' << datadir
+                       << " is not a directory");
+    }
+
     detail::emplace_physics<G4DecayPhysics>(*this, verbosity);
 
     // Hadron elastic scattering

--- a/src/celeritas/g4/MagneticField.hh
+++ b/src/celeritas/g4/MagneticField.hh
@@ -15,7 +15,6 @@
 #include "corecel/cont/Span.hh"
 #include "geocel/g4/Convert.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/ext/GeantUnits.hh"
 
 namespace celeritas
 {
@@ -41,7 +40,7 @@ class MagneticField : public G4MagneticField
 
     // Calculate values of the magnetic field vector
     inline void
-    GetFieldValue(G4double const point[3], G4double* field) const override;
+    GetFieldValue(G4double const xyzt[4], G4double* field) const override;
 
   private:
     SPConstParams params_;
@@ -65,15 +64,17 @@ MagneticField<P, F>::MagneticField(SPConstParams params)
  * Calculate the magnetic field vector at the given position.
  */
 template<class P, class F>
-void MagneticField<P, F>::GetFieldValue(G4double const pos[3],
+void MagneticField<P, F>::GetFieldValue(G4double const xyzt[4],
                                         G4double* field) const
 {
     F calc_field{params_->host_ref()};
 
+    // Get the g4 position
+    Span<G4double const, 3> pos(xyzt, 3);
+
     // Calculate the magnetic field value in the native Celeritas unit system
-    Real3 field_native
-        = calc_field(native_from_geant<units::ClhepLength, real_type>(
-            to_array(Span<G4double const, 3>(pos, 3))));
+    Real3 field_native = calc_field(
+        native_from_geant<units::ClhepLength, real_type>(to_array(pos)));
     for (auto i : range(3))
     {
         // Return values of the field vector in native geant4 units


### PR DESCRIPTION
There's a long chain of bugs that led to this situation, but with some versions of G4 we would see in a *pure g4* run:
```
G4ChordFinder::FindNextChord(): 'GeomField0003' failed
[1/2] Geant4: diagnostic: Momentum Direct - x :           -0.8920009
[2/2] ../src/geocel/ScopedGeantExceptionHandler.cc:124: debug: Handling exception: Geant4 error / Error is negative! / G4RKIntegrationDriver::ComputeNewStepSize: 'GeomField0003' failed
[2/2] ../src/geocel/ScopedGeantExceptionHandler.cc:129: critical: Aborting run due to exception (GeomField0003)
[2/2] ../src/geocel/ScopedGeantExceptionHandler.cc:146: error: Geant4 error: Exceeded maximum number of trials= 75
Current sagita dist= nan
Max sagita dist= 0.25
Step sizes (actual and proposed):
Last trial =         2.84444e-79
Next trial =         2.84444e-80
Proposed for chord = 5.68888e-79
```
there would be a thousand of these, before which was another error:
<details><summary>g4vparticlechange error</summary><pre>
[2/2] Geant4: diagnostic: G4VParticleChange::CheckSecondary :
[2/2] Geant4: diagnostic: the momentum direction (0,0,0) is not unit vector !!
[2/2] Geant4: diagnostic: Difference=1 Ekin(MeV)=5.062192940386e-06  Si29 created by model_nRadCapture
[2/2] Geant4: diagnostic: -----------------------------------------------
[2/2] Geant4: diagnostic: G4VParticleChange Information
[2/2] Geant4: diagnostic: TrackID             : 2794
[2/2] Geant4: diagnostic: ParentID            : 2754
[2/2] Geant4: diagnostic: Particle            : neutron
[2/2] Geant4: diagnostic: Kinetic energy (MeV): 0.0099113024
[2/2] Geant4: diagnostic: Position (mm)       : (680.90327,240.32866,-3412.1027)
[2/2] Geant4: diagnostic: Direction           : (0.10202938,-0.038470019,0.99403725)
[2/2] Geant4: diagnostic: PhysicsVolume       : si_tracker_pv
[2/2] Geant4: diagnostic: Material            : Si
[2/2] Geant4: diagnostic: -----------------------------------------------
[2/2] Geant4: diagnostic: # of secondaries    :                   13
[2/2] Geant4: diagnostic: -----------------------------------------------
[2/2] Geant4: diagnostic: Energy Deposit (MeV):                    0
[1/2] Geant4: diagnostic: G4VParticleChange::CheckSecondary :
[2/2] Geant4: diagnostic: NIEL Energy Deposit (MeV):                    0
[1/2] Geant4: diagnostic: the momentum direction (0,0,-0) is not unit vector !!
[2/2] Geant4: diagnostic: Track Status        :          StopAndKill
[1/2] Geant4: diagnostic: Difference=1 Ekin(MeV)=2.1685518731829e-06  Si29 created by model_nRadCapture
[2/2] Geant4: diagnostic: TruePathLength (mm) :            28.365441
[1/2] Geant4: diagnostic: -----------------------------------------------
[2/2] Geant4: diagnostic: Stepping Control    :                    0
[1/2] Geant4: diagnostic: G4VParticleChange Information
[2/2] Geant4: diagnostic: Mass (GeV)          :           0.93956536
[1/2] Geant4: diagnostic: TrackID             : 5375
[2/2] Geant4: diagnostic: Charge (eplus)      :                    0
[1/2] Geant4: diagnostic: ParentID            : 5360
[2/2] Geant4: diagnostic: MagneticMoment      :       -6.0307744e-11
[1/2] Geant4: diagnostic: Particle            : neutron
[1/2] Geant4: diagnostic: Kinetic energy (MeV): 0.00062633961
[1/2] Geant4: diagnostic: Position (mm)       : (824.46497,838.86924,1174.6831)
[1/2] Geant4: diagnostic: Direction           : (-0.8920009,-0.37930383,-0.24589226)
[1/2] Geant4: diagnostic: PhysicsVolume       : si_tracker_pv
[2/2] Geant4: diagnostic: =  :           -1.9156797*[e hbar]/[2 m]
[1/2] Geant4: diagnostic: Material            : Si
[2/2] Geant4: diagnostic: Position - x (mm)   :            680.90327
[2/2] Geant4: diagnostic: Position - y (mm)   :            240.32866
[1/2] Geant4: diagnostic: -----------------------------------------------
[2/2] Geant4: diagnostic: Position - z (mm)   :           -3412.1027
[1/2] Geant4: diagnostic: # of secondaries    :                   12
[2/2] Geant4: diagnostic: Time (ns)           :            1723.4288
[1/2] Geant4: diagnostic: -----------------------------------------------
[2/2] Geant4: diagnostic: Proper Time (ns)    :            1723.2526
[1/2] Geant4: diagnostic: Energy Deposit (MeV):                    0
[2/2] Geant4: diagnostic: Momentum Direct - x :           0.10202938
[1/2] Geant4: diagnostic: NIEL Energy Deposit (MeV):                    0
[2/2] Geant4: diagnostic: Momentum Direct - y :         -0.038470019
[1/2] Geant4: diagnostic: Track Status        :          StopAndKill
[2/2] Geant4: diagnostic: Momentum Direct - z :           0.99403725
[1/2] Geant4: diagnostic: TruePathLength (mm) :             43.67403
[2/2] Geant4: diagnostic: Kinetic Energy (MeV):                    0
[1/2] Geant4: diagnostic: Stepping Control    :                    0
[2/2] Geant4: diagnostic: Velocity  (/c)      :         0.0045931796
[1/2] Geant4: diagnostic: Mass (GeV)          :           0.93956536
[2/2] Geant4: diagnostic: Polarization - x    :                    0
[1/2] Geant4: diagnostic: Charge (eplus)      :                    0
[2/2] Geant4: diagnostic: Polarization - y    :                    0
[1/2] Geant4: diagnostic: MagneticMoment      :       -6.0307744e-11
[2/2] Geant4: diagnostic: Polarization - z    :                    0
</pre></details>
This somehow is *not* a fatal error in G4, but it led to a "not stopped" particle with zero energy and zero direction, which apparently is not checked for in the various G4 field components.

This somehow stemmed from a bug in G4 11.3 (fixed in 11.4 I think) where an invalid value for `G4LEVELGAMMADATA` would silently lead to garbage data. In g4 11.4, a missing G4LEVELGAMMADATA environment variable results in segfaults.

The broken variable itself is another bug that's a combination of:
- Spack using `"g4photonevaporation@6.1"` in the g4 data dependency to allow  matching with `@6.1.2`
- G4's cmake export script using the "expected" version as part of the filename rather than the "actual" version

To prevent this from causing future problems, we carefully check the environment variable before creating g4 data with our physics lists.