### PR TITLE
Fix gcc15 + CUDA 13.1 compile error

### DIFF
--- a/src/geocel/vg/detail/VecgeomSetup.cu
+++ b/src/geocel/vg/detail/VecgeomSetup.cu
@@ -201,7 +201,7 @@ void check_other_device_pointers()
  */
 void init_navstate_device(Span<VgNavStateImpl> states, StreamId stream)
 {
-    InplaceNew execute_thread{states.data()};
+    InplaceNew<VgNavStateImpl> execute_thread{states.data()};
     static KernelLauncher<decltype(execute_thread)> const launch_kernel(
         "vecgeom-init-navtuple");
     launch_kernel(states.size(), stream, execute_thread);


### PR DESCRIPTION
ATLAS is switching to gcc15 and CUDA 13.1 which results in a compile error in Celeritas in our nightly build.
