### PR TITLE
Fix C++23 constexpr ODR usage issue in field

### DIFF
--- a/src/celeritas/field/CartMapFieldData.covfie.hh
+++ b/src/celeritas/field/CartMapFieldData.covfie.hh
@@ -71,8 +71,12 @@ struct CartMapFieldParamsData<Ownership::value, MemSpace::device>
         return field.get() && field_view.size() == 1;
     }
 
-    CartMapFieldParamsData& operator=(
-        CartMapFieldParamsData<Ownership::value, MemSpace::host> const& other)
+    template<class other_t>
+    requires
+        std::same_as<other_t,
+                     CartMapFieldParamsData<Ownership::value,
+                                            MemSpace::host>> CartMapFieldParamsData&
+        operator=(other_t const& other)
     {
         using host_field_t = detail::CovfieFieldTraits<MemSpace::host>::field_t;
         if constexpr (!std::is_same_v<field_t, host_field_t>)


### PR DESCRIPTION
This commit fixes a rather obscure issue that surfaces when building Celeritas with C++23 with clang 22. The core problem is that the Cartesian magnetic field map code uses a constexpr condition based on a preprocessor macro:

```
if constexpr (CELERITAS_USE_CUDA) {
    BLOCK_A;
} else {
    BLOCK_B;
}
```

The issue here is that when CELERITAS_USE_CUDA is true, BLOCK_B contains some invalid constructors. Under C++20, this code is never even evaluated at compile time because `std::make_unique` is not constexpr, but under C++23 it is. This means that clang 22 eagerly evaluates the code at compile time and then runs into a series of issues. This issue makes the assignment operator a templated function, avoiding this issue entirely by delaying the evaluation of the function definition until use.

<!--
Thank you for your pull request!

Please read the [contributing guide](https://celeritas-project.github.io/celeritas/user/development/contributing.html#pr-style)
for requirements on the title, description, and draft status.
If you are a core developer, see also the [review process](https://celeritas-project.github.io/celeritas/user/appendix/administration.html#code-review)
for label requirements.
-->
