### PR TITLE
Expose OpaqueId hash during device compilation

### DIFF
--- a/src/corecel/OpaqueId.hh
+++ b/src/corecel/OpaqueId.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <type_traits>
 
 #include "corecel/data/Ldg.hh"
@@ -16,7 +17,6 @@
 #include "Types.hh"
 
 #if !CELER_DEVICE_COMPILE
-#    include <functional>
 #    include <ostream>
 #endif
 
@@ -476,7 +476,6 @@ inline CELER_FUNCTION auto id_cast(J value) noexcept(!CELERITAS_DEBUG)
 //---------------------------------------------------------------------------//
 }  // namespace celeritas
 
-#if !CELER_DEVICE_COMPILE
 //! \cond
 namespace std
 {
@@ -491,4 +490,3 @@ struct hash<celeritas::OpaqueId<I, T>>
 };
 }  // namespace std
 //! \endcond
-#endif

--- a/test/corecel/OpaqueId.test.cc
+++ b/test/corecel/OpaqueId.test.cc
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <type_traits>
+#include <unordered_map>
 
 #include "corecel/Config.hh"
 
@@ -99,6 +100,8 @@ TYPED_TEST(OpaqueIdTypedTest, traits)
     EXPECT_TRUE((std::is_same_v<Int_t, MakeSize_t<Id_t const>>));
     EXPECT_TRUE((std::is_trivially_copyable_v<Id_t>));
     EXPECT_TRUE((std::is_trivially_destructible_v<Id_t>));
+    EXPECT_TRUE((std::is_default_constructible_v<std::hash<Id_t>>));
+    EXPECT_TRUE((std::is_copy_constructible_v<std::hash<Id_t>>));
     EXPECT_TRUE((is_auto_ldg_v<Id_t>));
 }
 
@@ -198,6 +201,18 @@ TEST(OpaqueIdTest, multi_int)
         EXPECT_THROW(UId8{3} + Int32{-4}, DebugError);
         // NOTE: UId8{3} + Int32{-256 - 2} is UB
     }
+}
+
+TEST(OpaqueIdTest, unordered_map)
+{
+    using IdT = OpaqueId<TestInstantiator>;
+
+    std::unordered_map<IdT, int> ids;
+    ids[IdT{2}] = 2;
+    ids[IdT{4}] = 4;
+
+    EXPECT_EQ(2, ids[IdT{2}]);
+    EXPECT_EQ(4, ids[IdT{4}]);
 }
 
 TEST(OpaqueIdTest, id_cast)


### PR DESCRIPTION
We are seeing the following compile error with gcc15+CUDA:

```
2026-07-03T15:48:06.936956Z 01O /cvmfs/sft.cern.ch/lcg/releases/gcc/15.2.0-35657/x86_64-el9/include/c++/15.2.0/bits/hashtable.h(210): error: static assertion failed with "hash function must be copy constructible"
2026-07-03T15:48:06.946014Z 01O         static_assert(is_copy_constructible<_Hash>::value,
2026-07-03T15:48:06.946027Z 01O         ^
2026-07-03T15:48:06.946031Z 01O           detected during:
2026-07-03T15:48:06.946054Z 01O             instantiation of class "std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits> [with _Key=celeritas::ParticleId, _Value=std::pair<const celeritas::ParticleId, celeritas::ImportedProcessAdapter::ImportProcessId>, _Alloc=std::allocator<std::pair<const celeritas::ParticleId, celeritas::ImportedProcessAdapter::ImportProcessId>>, _ExtractKey=std::__detail::_Select1st, _Equal=std::equal_to<celeritas::ParticleId>, _Hash=std::hash<celeritas::ParticleId>, _RangeHash=std::__detail::_Mod_range_hashing, _Unused=std::__detail::_Default_ranged_hash, _RehashPolicy=std::__detail::_Prime_rehash_policy, _Traits=std::__detail::_Hashtable_traits<true, false, true>]" at line 115 of /cvmfs/sft.cern.ch/lcg/releases/gcc/15.2.0-35657/x86_64-el9/include/c++/15.2.0/bits/unordered_map.h
2026-07-03T15:48:06.946072Z 01O             instantiation of class "std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc> [with _Key=celeritas::ParticleId, _Tp=celeritas::ImportedModelAdapter::ImportProcessId, _Hash=std::hash<celeritas::ParticleId>, _Pred=std::equal_to<celeritas::ParticleId>, _Alloc=std::allocator<std::pair<const celeritas::ParticleId, celeritas::ImportedProcessAdapter::ImportProcessId>>]" at line 83 of /builds/atlas/atlasexternals/ci_build/src/Celeritas/src/celeritas/phys/ImportedModelAdapter.hh
2026-07-03T15:48:06.946080Z 01O 
2026-07-03T15:48:07.944766Z 01O 1 error detected in the compilation of "/builds/atlas/atlasexternals/ci_build/src/Celeritas/src/celeritas/em/model/BetheHeitlerModel.cu".
2026-07-03T15:48:07.944780Z 01O gmake[5]: *** [src/celeritas/CMakeFiles/celeritas_objects.dir/build.make:2357: src/celeritas/CMakeFiles/celeritas_objects.dir/em/model/BetheHeitlerModel.cu.o] Error 1
2026-07-03T15:48:07.944784Z 01O gmake[5]: *** Waiting for unfinished jobs....
2026-07-03T15:48:32.474673Z 01O gmake[4]: *** [CMakeFiles/Makefile2:1066: src/celeritas/CMakeFiles/celeritas_objects.dir/all] Error 2
2026-07-03T15:48:32.474709Z 01O gmake[3]: *** [Makefile:136: all] Error 2
2026-07-03T15:48:32.474714Z 01O gmake[2]: *** [External/Celeritas/CMakeFiles/Celeritas.dir/build.make:96: src/Celeritas-stamp/Celeritas-build] Error 2
2026-07-03T15:48:32.474721Z 01O gmake[1]: *** [CMakeFiles/Makefile2:2030: External/Celeritas/CMakeFiles/Celeritas.dir/all] Error 2
2026-07-03T15:48:32.474724Z 01O gmake: *** [Makefile:166: all] Error 2
```
`unordered_map` now includes a `static_assert` check that we have valid hasher (including copy constructible). Our hash specialization of OpaqueID was hidden from device code 

