### PR TITLE
Fix FerrariSolver

### DIFF
--- a/src/corecel/math/FerrariSolver.hh
+++ b/src/corecel/math/FerrariSolver.hh
@@ -327,14 +327,6 @@ FerrariSolver::real_roots_normalized_cubic(real_type b,
         real_type z2 = n2_root_q * std::cos(third_theta - twth_pi) - third_b;
 
         return Real3(z0, z1, z2);
-        // if (2_r * theta < constants::pi)
-        // {
-        //     return Real3(z0, z1, z2);
-        // }
-        // else
-        // {
-        //     return Real3(z1, z0, z2);
-        // }
     }
     else  // One real and two complex roots, solve for real root with Cardano
     {

--- a/src/corecel/math/FerrariSolver.hh
+++ b/src/corecel/math/FerrariSolver.hh
@@ -158,7 +158,7 @@ CELER_FUNCTION auto FerrariSolver::operator()(Real5 const& abcde) const
     // One real root of subsidiary cubic
     Real3 z = FerrariSolver::real_roots_normalized_cubic(
         p, r, p * r - half * ipow<2>(q));
-    real_type z0 = z[0];
+    real_type z0 = (z[1] == no_solution_) ? z[0] : max(z[0], max(z[1], z[2]));
 
     real_type s2 = 2 * p + 2 * z0;
     if (s2 >= 0)
@@ -326,14 +326,15 @@ FerrariSolver::real_roots_normalized_cubic(real_type b,
         real_type z1 = n2_root_q * std::cos(third_theta + twth_pi) - third_b;
         real_type z2 = n2_root_q * std::cos(third_theta - twth_pi) - third_b;
 
-        if (2_r * theta < constants::pi)
-        {
-            return Real3(z0, z1, z2);
-        }
-        else
-        {
-            return Real3(z1, z0, z2);
-        }
+        return Real3(z0, z1, z2);
+        // if (2_r * theta < constants::pi)
+        // {
+        //     return Real3(z0, z1, z2);
+        // }
+        // else
+        // {
+        //     return Real3(z1, z0, z2);
+        // }
     }
     else  // One real and two complex roots, solve for real root with Cardano
     {

--- a/test/corecel/math/QuarticSolver.test.cc
+++ b/test/corecel/math/QuarticSolver.test.cc
@@ -18,7 +18,8 @@ namespace test
 using Real5 = Array<real_type, 5>;
 using Real4 = Array<real_type, 4>;
 using Roots = Array<real_type, 4>;
-static constexpr real_type practical_tolerance = 1e-10;
+static constexpr real_type practical_tolerance
+    = std::is_same_v<real_type, double> ? 1e-10 : 1e-6;
 
 //---------------------------------------------------------------------------//
 /*!

--- a/test/corecel/math/QuarticSolver.test.cc
+++ b/test/corecel/math/QuarticSolver.test.cc
@@ -18,6 +18,7 @@ namespace test
 using Real5 = Array<real_type, 5>;
 using Real4 = Array<real_type, 4>;
 using Roots = Array<real_type, 4>;
+static constexpr real_type practical_tolerance = 1e-10;
 
 //---------------------------------------------------------------------------//
 /*!
@@ -104,6 +105,18 @@ TYPED_TEST(QuarticSolverTest, one_root)
         EXPECT_VEC_SOFT_EQ(make_roots({2.0}),
                            sorted(solve(Real5{1, -3, 2, 2, -4})));
     }
+    // [1.000000, 250.353530, -40111.798938, -6982487.888858,
+    // -174874197.079351] One positive, three negative; taken from runtime
+    // demonstration
+    {
+        EXPECT_VEC_NEAR(make_roots({187.76045963}),
+                        sorted(solve(Real5{1.000000,
+                                           250.353530,
+                                           -40111.798938,
+                                           -6982487.888858,
+                                           -174874197.079351})),
+                        practical_tolerance);
+    }
 }
 
 TYPED_TEST(QuarticSolverTest, two_roots)
@@ -120,6 +133,30 @@ TYPED_TEST(QuarticSolverTest, two_roots)
     {
         EXPECT_VEC_SOFT_EQ(make_roots({1.0, 2.0}),
                            sorted(solve(Real5{1, -6, 13, -12, 4})));
+    }
+    // [1.000000, 19.534611, -48660.891842, -476217.617178, 57126150.652217]
+    // Two positive, two negative; taken from runtime demonstration, unfixed
+    // returned one bogus root
+    {
+        EXPECT_VEC_NEAR(make_roots({30.11797881450676, 213.24217809742103}),
+                        sorted(solve(Real5{1.000000,
+                                           19.534611,
+                                           -48660.891842,
+                                           -476217.617178,
+                                           57126150.652217})),
+                        practical_tolerance);
+    }
+    // [1.000000, 39.057127, -47753.699175, -940008.633992, 54384055.574769]
+    // Also two positive two negative from runtime demonstration; unfixed
+    // returned no roots
+    {
+        EXPECT_VEC_NEAR(make_roots({25.6335352, 207.19825152}),
+                        sorted(solve(Real5{1.000000,
+                                           39.057127,
+                                           -47753.699175,
+                                           -940008.633992,
+                                           54384055.574769})),
+                        practical_tolerance);
     }
 }
 

--- a/test/corecel/math/QuarticSolver.test.cc
+++ b/test/corecel/math/QuarticSolver.test.cc
@@ -136,8 +136,7 @@ TYPED_TEST(QuarticSolverTest, two_roots)
                            sorted(solve(Real5{1, -6, 13, -12, 4})));
     }
     // [1.000000, 19.534611, -48660.891842, -476217.617178, 57126150.652217]
-    // Two positive, two negative; taken from runtime demonstration, unfixed
-    // returned one bogus root
+    // Two positive, two negative; taken from runtime demonstration
     {
         EXPECT_VEC_NEAR(make_roots({30.11797881450676, 213.24217809742103}),
                         sorted(solve(Real5{1.000000,
@@ -148,8 +147,7 @@ TYPED_TEST(QuarticSolverTest, two_roots)
                         practical_tolerance);
     }
     // [1.000000, 39.057127, -47753.699175, -940008.633992, 54384055.574769]
-    // Also two positive two negative from runtime demonstration; unfixed
-    // returned no roots
+    // Also two positive two negative from runtime demonstration
     {
         EXPECT_VEC_NEAR(make_roots({25.6335352, 207.19825152}),
                         sorted(solve(Real5{1.000000,


### PR DESCRIPTION
This PR fixes a critical issue with the implementation of `FerrariSolver.hh`.

The Ferrari method relies on finding the dominant root of a 'resolvent cubic' that factors the quartic polynomial. The existing implementation of the Ferrari-Cardano method (using Cardano's method to solve the cubic) did not guarantee that the greatest root was used for this purpose, leading to incorrect answers which were not caught by the nice, round, test cases in place.

This PR ensures the greatest cubic root is used, and adds a couple of test cases based on runtime intersection calls which ran into the issue.