### PR TITLE
Fix typo in Mie scattering ratio sampling

### DIFF
--- a/src/celeritas/optical/interactor/MieInteractor.hh
+++ b/src/celeritas/optical/interactor/MieInteractor.hh
@@ -75,7 +75,7 @@ MieInteractor::MieInteractor(NativeCRef<MieData> const& shared,
     : inc_dir_(direction)
     , inc_pol_(particle.polarization())
     , mie_params_(shared.mie_record[mat_id])
-    , sample_forward_(mie_params_.forward_g)
+    , sample_forward_(mie_params_.forward_ratio)
 {
     CELER_EXPECT(shared);
     CELER_EXPECT(mat_id < shared.mie_record.size());

--- a/test/celeritas/optical/Mie.test.cc
+++ b/test/celeritas/optical/Mie.test.cc
@@ -94,9 +94,9 @@ TEST_F(MieTest, mie_basic)
     if constexpr (std::is_same_v<real_type, double>)
     {
         static real_type const expected_dir_angle[] = {
-            0.997467127484242,
+            -0.997467127484242,
             0.999530487034177,
-            0.999999642467185,
+            -0.999999642467185,
             0.996187032055894,
         };
         static real_type const expected_pol_angle[] = {
@@ -150,14 +150,14 @@ TEST_F(MieTest, stress_test)
                  || accum_pol.underflow() || accum_pol.overflow());
 
     static double const expected_accum_dir[] = {
-        0.04042,
+        0.792728,
         0.001868,
         0.002324,
         0.002896,
         0.0042,
         0.00708,
         0.0164,
-        3.924812,
+        3.172504,
     };
     static double const expected_accum_pol[] = {
         1.992904,


### PR DESCRIPTION
Changed `forward_g` to `forward_ratio` to be used in the ratio sampling. 