### PR TITLE
Expand user documentation on input and standalone apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,69 @@ manual.
 
 [integration]: https://celeritas-project.github.io/celeritas/user/usage/integration.html
 
+# Running a standalone Celeritas app
+
+The `celer-sim` application runs electromagnetic particle transport with
+Celeritas directly from a JSON input file. At minimum, the input must specify a
+GDML geometry and a source of primary particles.
+
+For example, the following input generates 100 10 MeV electrons emitted
+isotropically at the origin:
+
+```json
+{
+ "problem": {
+  "model": {
+   "geometry": "/path/to/geometry.gdml"
+  }
+ },
+ "events": {
+  "generator": {
+   "_type": "primary",
+   "angle": {
+    "_type": "isotropic"
+   },
+   "energy": {
+    "_type": "delta",
+    "value": 10.0
+   },
+   "shape": {
+    "_type": "delta",
+    "value": [0.0, 0.0, 0.0]
+   },
+   "pdg": [11],
+   "num_events": 1,
+   "primaries_per_event": 100
+  }
+ }
+}
+```
+
+Save the input as `input.json` and run:
+
+```console
+$ celer-sim input.json
+```
+
+Celeritas uses Geant4 to load the GDML geometry and construct the corresponding
+material and physics data. Additional input options can be used to configure
+the physics, magnetic field, scoring, diagnostics, and runtime parameters.
+
+More details are provided in the [application documentation][applications], and
+an [extended example][celer-sim-example] demonstrates how to configure
+additional options and interpret the output.
+
+The `celer-optical` application provides a standalone interface for simulating
+optical photon transport without running the full electromagnetic problem
+supported by `celer-sim`. It exposes a subset of the standalone functionality
+focused on optical physics; see the [celer-optical
+example][celer-optical-example] and [documentation][applications] for a
+complete input and invocation.
+
+[applicaations]: https://celeritas-project.github.io/celeritas/user/usage/execution/applications.html
+[celer-sim-example]: https://celeritas-project.github.io/celeritas/user/example/celer-sim.html
+[celer-optical-example]: https://celeritas-project.github.io/celeritas/user/example/celer-optical.html
+
 # Installation for developers
 
 Since Celeritas is still under very active development, you may be installing it

--- a/doc/example/celer-optical.rst
+++ b/doc/example/celer-optical.rst
@@ -1,0 +1,9 @@
+.. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _example_celer_optical:
+
+Celeritas optical simulation for standalone profiling
+=====================================================
+
+This section to be completed later.

--- a/doc/implementation/core-physics/propagation.rst
+++ b/doc/implementation/core-physics/propagation.rst
@@ -21,7 +21,7 @@ Substepper
 Propagator
   Given a maximum physics step, advance the geometry state and momentum along
   the field lines, satisfying constraints (see :ref:`field driver
-  options<api_field_data>`) for the maximum geometry error.
+  options<inp_field>`) for the maximum geometry error.
 
 .. _api_propagation:
 
@@ -46,22 +46,3 @@ Magnetic field types
 .. doxygenclass:: celeritas::RZMapField
 .. doxygenclass:: celeritas::CartMapField
 .. doxygenclass:: celeritas::CylMapField
-
-.. _api_field_data:
-
-Field data input and options
-----------------------------
-
-JSON input for the field setup corresponds to the uniform field input
-:cpp:struct:`celeritas::inp::UniformField` and the rz-map field input:
-
-.. celerstruct:: RZMapFieldInput
-
-as well as fully Cartesian or cylindrical input:
-
-.. celerstruct:: inp::CartMapField
-.. celerstruct:: inp::CylMapField
-
-The field driver options are not yet a stable part of the API:
-
-.. celerstruct:: FieldDriverOptions

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -341,6 +341,7 @@ library, in independent and Geant4-integrated contexts.
    example/minimal.rst
    example/geant4.rst
    example/celer-sim.rst
+   example/celer-optical.rst
    example/celer-g4.rst
    example/celer-geo.rst
    example/larceler.rst

--- a/doc/usage/execution.rst
+++ b/doc/usage/execution.rst
@@ -7,15 +7,15 @@
 Execution
 *********
 
-Celeritas has two applications for standalone execution, and a few additional
+Celeritas has three applications for standalone execution, and a few additional
 utilities. The environment variables described here are applicable to *all*
 uses of Celeritas, including as a library and when unit testing.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Execution
 
    execution/applications.rst
+   execution/json-input.rst
    execution/plugins.rst
    execution/utilities.rst
    execution/environment.rst

--- a/doc/usage/execution/applications.rst
+++ b/doc/usage/execution/applications.rst
@@ -21,20 +21,20 @@ Usage:
 
 - :file:`{input}.json` is the path to the input file, or ``-`` to read the
   JSON from ``stdin``.
-- The ``--config`` option prints the contents of the ``["system"]["build"]``
+- The ``config`` option prints the contents of the ``["system"]["build"]``
   diagnostic output. It includes configuration options and the version number.
-- The ``--device`` option prints diagnostic output for the default GPU, similar
+- The ``device`` option prints diagnostic output for the default GPU, similar
   to the output from the ``deviceQuery`` CUDA example.
-- The ``--dump-default`` option prints the default options for the execution.
+- The ``default`` option prints the default options for the execution.
   Not all variables will be shown, because some are conditional on others.
 
 Input
 ^^^^^
 
-.. todo::
-   The input parameters will be documented for version 1 in the :ref:`input`
-   section and :ref:`inp_standalone_input`. Until then, refer to the
-   source code at :file:`app/celer-sim/RunnerInput.hh` .
+The input parameters are documented in the :ref:`input` section, including the
+standalone execution input described in :ref:`inp_standalone_input`. See
+:ref:`json-input` for the JSON encoding conventions and minimal standalone
+input examples.
 
 In addition to these input parameters, :ref:`environment` can be specified to
 change the program behavior.
@@ -43,12 +43,53 @@ Output
 ^^^^^^
 
 The primary output from ``celer-sim`` is a JSON object that includes several
-levels of diagnostic and result data (see :ref:`api_io`). The JSON
-output should be the only data sent to ``stdout``, so it should be suitable for
-piping directly into other executables such as Python or ``jq``.
+levels of diagnostic and result data. The JSON
+output is written either to the configured output file or, if no output
+file is specified, to ``stdout``. When writing to ``stdout``, the JSON output
+should be the only data sent there, so it is suitable for piping directly into
+other executables such as Python or ``jq``.
 
 Additional user-oriented output is sent to ``stderr`` via the Logger facility
-(see :ref:`logging`).
+(see :ref:`api_io` and :ref:`logging`).
+
+.. _celer-optical:
+
+Standalone optical simulation app (celer-optical)
+-------------------------------------------------
+
+The ``celer-optical`` application runs optical photon problems for independent
+validation and performance analysis. It is similar to ``celer-sim``, but it
+executes only the optical photon transport loop. See
+:ref:`example_celer_optical` for an example.
+
+Usage:
+
+.. literalinclude:: _usage/celer-optical.txt
+
+- ``input.json`` is the path to the input file, or ``-`` to read the JSON from
+  ``stdin``.
+- The ``config`` option prints the contents of the ``["system"]["build"]``
+  diagnostic output. It includes configuration options and the version number.
+- The ``device`` option prints diagnostic output for the default GPU, similar
+  to the output from the ``deviceQuery`` CUDA example.
+- The ``default`` option prints the default options for the execution.
+  Not all variables will be shown, because some are conditional on others.
+
+Input
+^^^^^
+
+The input parameters are documented in the :ref:`input` section, including the
+optical standalone execution input
+:cpp:struct:`celeritas::inp::OpticalStandaloneInput` described in
+:ref:`inp_standalone_input`. See :ref:`json-input` for the JSON encoding
+conventions and minimal standalone input examples.
+
+Output
+^^^^^^
+
+Like ``celer-sim``, the output from ``celer-optical`` is a JSON object
+containing diagnostic and result data which can be written either to the
+configured output file or to ``stdout``.
 
 .. _celer-g4:
 
@@ -72,7 +113,7 @@ Physics is set up using the top-level ``physics_option`` key in the JSON input,
 corresponding to :ref:`api_geant4_physics_options`. The magnetic field is
 specified with a combination of the ``field_type``, ``field``, and
 ``field_file`` keys, and detailed field driver configuration options are set
-with ``field_options`` corresponding to the ``FieldOptions`` class in :ref:`api_field_data`.
+with ``field_options`` corresponding to the ``FieldOptions`` class in :ref:`inp_field`.
 
 .. deprecated:: v0.5
 

--- a/doc/usage/execution/environment.rst
+++ b/doc/usage/execution/environment.rst
@@ -106,8 +106,6 @@ Celeritas or its apps:
    thread access the ``celeritas::environment()`` struct (see
    :ref:`api_system`), and call ``insert`` for the desired key/value pairs.
 
-.. doxygenfunction:: celeritas::use_color
-
 .. _logging:
 
 Logging

--- a/doc/usage/execution/json-input.rst
+++ b/doc/usage/execution/json-input.rst
@@ -1,0 +1,262 @@
+.. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _json-input:
+
+JSON input for standalone apps
+==============================
+
+Celeritas standalone applications such as ``celer-sim`` and ``celer-optical``
+accept structured JSON input based on the ``celeritas::inp`` data structures.
+The :ref:`input` documents the underlying C++ types; this page explains how
+those types are represented in JSON and gives minimal working examples.
+
+JSON encoding conventions
+-------------------------
+
+Structs
+^^^^^^^
+
+A C++ struct is represented as a JSON object with matching field names.
+
+For example, a struct like:
+
+.. code-block:: cpp
+
+   struct Timers
+   {
+       bool action{false};
+       bool step{false};
+   };
+
+becomes a JSON object where the keys have the same names as the members:
+
+.. code-block:: json
+
+   {
+     "action": false,
+     "step": false
+   }
+
+Arrays, maps, and sets
+^^^^^^^^^^^^^^^^^^^^^^
+
+``std::vector<T>`` and ``celeritas::Array<T>`` values become JSON arrays.
+``std::unordered_set<T>`` values become JSON arrays of unique values, and
+``std::map<K, V>`` values become JSON objects.
+
+Enums
+^^^^^
+
+Celeritas enumerations are encoded in JSON as strings rather than integer
+values.
+
+For example, the C++ enumeration
+
+.. code-block:: cpp
+
+   enum class InterpolationType
+   {
+       linear,
+       poly_spline,
+       cubic_spline,
+       size_
+   };
+
+is represented in JSON using the corresponding string values: ``"linear"``,
+``"poly_spline"``, and ``"cubic_spline"``. A field ``InterpolationType type``
+whose value is ``InterpolationType::linear`` in JSON becomes:
+
+.. code-block:: json
+
+   {
+     "type": "linear"
+   }
+
+Optional values
+^^^^^^^^^^^^^^^
+
+Fields with type ``std::optional<T>`` support several different JSON behaviors:
+
+* If the field is omitted, the existing value is unchanged. This allows the
+  containing input structure to define a custom default value.
+* If the field is set to ``null``, the optional is reset to
+  ``std::nullopt``.
+* If the field is set to a non-null value, the optional is initialized to the
+  given value.
+* If the field is set to ``{}``, the optional is initialized with a
+  default-constructed ``T``.
+
+For example, omitting the optional ``device`` field in the :ref:`inp_system`
+input preserves the existing value supplied by the containing structure (i.e.,
+the device remains disabled):
+
+.. code-block:: json
+
+   {
+     "system": {}
+   }
+
+Setting the field to ``null`` explicitly clears the optional value (i.e.,
+disables the device):
+
+.. code-block:: json
+
+   {
+     "system": {
+       "device": null
+     }
+   }
+
+Setting the field to an object initializes the optional and reads the nested
+value (i.e., enables the device with custom stack and heap sizes):
+
+.. code-block:: json
+
+   {
+     "system": {
+       "device": {
+         "stack_size": 1024,
+         "heap_size": 8192
+       }
+     }
+   }
+
+Setting the field to an empty object initializes the optional with the
+contained type's default (i.e., enables the device with the default stack and
+heap size):
+
+.. code-block:: json
+
+   {
+     "system": {
+       "device": {}
+     }
+   }
+
+This means omission and ``{}`` are not equivalent: omission preserves the value
+that was already present, while ``{}`` replaces it with an initialized contained
+object using default values.
+
+Variants
+^^^^^^^^
+
+Many Celeritas input types are ``std::variant`` objects. In JSON, these are
+encoded as objects with a required ``_type`` field that identifies the selected
+alternative.
+
+For example, the ``Field`` input type is defined as:
+
+.. code-block:: cpp
+
+   using Field = std::variant<NoField,
+                              UniformField,
+                              RZMapField,
+                              CylMapField,
+                              CartMapField>;
+
+A C++ value such as
+
+.. code-block:: cpp
+
+   inp::Field field = inp::NoField{};
+
+is represented in JSON as:
+
+.. code-block:: json
+
+   {
+     "_type": "none"
+   }
+
+Similarly, a uniform magnetic field can be specified in C++ as:
+
+.. code-block:: cpp
+
+   inp::Field field = [] {
+       inp::UniformField result;
+       result.strength = {0.0, 0.0, 1.0};
+       return result;
+   }();
+
+and in JSON as:
+
+.. code-block:: json
+
+   {
+     "_type": "uniform",
+     "strength": [0.0, 0.0, 1.0]
+   }
+
+The ``_type`` field selects the variant alternative, and the remaining fields
+specify the data for that alternative. The ``_type`` value does not necessarily
+match the C++ type name. Refer to the documented string values for the variant
+being encoded.
+
+See :ref:`json-events-example` for an example combining several variant-valued
+fields.
+
+.. _json-events-example:
+
+Example: encoding ``inp::Events`` in JSON
+-----------------------------------------
+
+The ``inp::Events`` input type is a useful example of Celeritas JSON encoding
+because it combines several common patterns in one place.
+
+A C++ setup constructing a primary generator for ``celer-sim`` might look like:
+
+.. code-block:: cpp
+
+   inp::Events events = [] {
+       inp::CorePrimaryGenerator result;
+       result.shape = inp::PointDistribution{{0.0, 0.0, 0.0}};
+       result.angle = inp::IsotropicDistribution{};
+       result.energy = inp::MonoenergeticDistribution{10.0};
+       result.num_events = 1;
+       result.primaries_per_event = 10000;
+       result.pdg = {PDGNumber{11}};
+   }();
+   events.merge = false;
+
+In JSON, this is represented as:
+
+.. code-block:: json
+
+   {
+     "generator": {
+       "_type": "primary",
+       "shape": {
+         "_type": "delta",
+         "value": [0.0, 0.0, 0.0]
+       },
+       "angle": {
+         "_type": "isotropic"
+       },
+       "energy": {
+         "_type": "delta",
+         "value": 10.0
+       },
+       "num_events": 1,
+       "primaries_per_event": 10000,
+       "pdg": [11]
+     },
+     "merge": false
+   }
+
+This example illustrates several of the JSON encoding conventions used by
+Celeritas:
+
+* ``generator`` is a ``std::variant`` and is encoded with a ``_type`` field.
+* ``shape``, ``angle``, and ``energy`` are also variants and each uses its own
+  ``_type`` field.
+* The ``pdg`` vector is encoded as a JSON array.
+* Scalar fields such as ``num_events`` and ``merge`` are encoded directly as
+  JSON numbers and booleans.
+
+See also
+--------
+
+* :ref:`input`
+* :ref:`celer-sim`
+* :ref:`celer-optical`

--- a/doc/usage/input.rst
+++ b/doc/usage/input.rst
@@ -7,8 +7,9 @@
 Input
 *****
 
-.. note:: This section is a sneak preview of Celeritas 1.0 input. It is *not*
-   currently exposed to users.
+.. note:: This section documents the input interface planned for Celeritas 1.0.
+   It is currently available only through the standalone applications
+   ``celer-sim`` and ``celer-optical``.
 
 .. only:: nobreathe
 
@@ -17,12 +18,12 @@ Input
 
    .. _breathe: https://github.com/michaeljones/breathe#readme
 
-All front ends to Celeritas, and the library interface for external
-integration, use a single interface to define properties about the simulation
-to be run. This interface is a nested set of simple struct objects that are
-used both to enable options and to set up low-level C++ data structures. Many
-of the struct names in the ``inp`` namespace correspond to runtime Celeritas
-classes and objects.
+The standalone applications and, beginning with Celeritas 1.0, the library
+interface for external integration use a single interface to define properties
+about the simulation to be run. This interface is a nested set of simple struct
+objects that are used both to enable options and to set up low-level C++ data
+structures. Many of the struct names in the ``inp`` namespace correspond to
+runtime Celeritas classes and objects.
 
 The following sections describe the members and their configuration options.
 Note that most input classes (namespace ``inp``) match up with the runtime
@@ -37,8 +38,12 @@ Problems are loaded into the framework or application front end via :ref:`api_pr
 
 .. toctree::
    :maxdepth: 2
-   :caption: Input definition
 
+   input/framework.rst
+   input/standalone.rst
+   input/events.rst
+   input/import.rst
+   input/system.rst
    input/problem.rst
    input/model.rst
    input/physics.rst

--- a/doc/usage/input/events.rst
+++ b/doc/usage/input/events.rst
@@ -1,0 +1,71 @@
+.. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _inp_events:
+
+Events
+======
+
+Standalone inputs must specify how the primary particles are generated. These
+events can be generated internally or read from an external file.
+
+Core events
+-----------
+
+.. celerstruct:: inp::Events
+
+The ``generator`` field in :cpp:struct:`Events` selects one of the supported
+event sources.
+
+.. doxygentypedef:: celeritas::inp::Generator
+
+.. celerstruct:: inp::PrimaryGenerator
+.. celerstruct:: inp::SampleFileEvents
+.. celerstruct:: inp::ReadFileEvents
+
+Optical events
+--------------
+
+Optical photons can be generated through several different mechanisms.
+
+.. doxygentypedef:: celeritas::inp::OpticalGenerator
+
+.. celerstruct:: inp::OpticalPrimaryGenerator
+.. celerstruct:: inp::OpticalEmGenerator
+.. celerstruct:: inp::OpticalOffloadGenerator
+.. celerstruct:: inp::OpticalDirectGenerator
+
+The standalone optical application ``celer-optical`` currently supports photon
+generation though a primary generator or from offloaded distribution data read
+from a file.
+
+Primary generators
+------------------
+
+The ``CorePrimaryGenerator`` and ``OpticalPrimaryGenerator`` are analogous to
+Geant4's particle gun and provide distributions for sampling the initial
+particle direction, energy, and position.
+
+.. doxygentypedef:: celeritas::inp::AngleDistribution
+.. doxygentypedef:: celeritas::inp::EnergyDistribution
+.. doxygentypedef:: celeritas::inp::ShapeDistribution
+
+The fixed-value delta distributions for angle, energy, and position are aliased
+by the following types:
+
+.. doxygentypedef:: celeritas::inp::MonodirectionalDistribution
+.. doxygentypedef:: celeritas::inp::MonoenergeticDistribution
+.. doxygentypedef:: celeritas::inp::PointDistribution
+
+Distributions
+-------------
+
+The following distribution types can be used for sampling values. A
+distribution can optionally be truncated to a specified interval, while a delta
+distribution represents a fixed value rather than a sampled quantity.
+
+.. celerstruct:: inp::TruncatedDistribution
+.. celerstruct:: inp::DeltaDistribution
+.. celerstruct:: inp::NormalDistribution
+.. celerstruct:: inp::UniformBoxDistribution
+.. celerstruct:: inp::IsotropicDistribution

--- a/doc/usage/input/field.rst
+++ b/doc/usage/input/field.rst
@@ -6,13 +6,19 @@
 Field
 =====
 
+The field type is selected with a variant:
+
+.. doxygentypedef:: celeritas::inp::Field
+
 The field currently allows a few hard-coded options. It will be extended to
 additional field types and may allow completely custom field implementations.
 
 .. celerstruct:: inp::NoField
 .. celerstruct:: inp::UniformField
-.. doxygentypedef:: celeritas::inp::RZMapField
+.. celerstruct:: inp::CylMapField
+.. celerstruct:: inp::CartMapField
+.. celerstruct:: RZMapFieldInput
 
-The field type is selected with a variant:
+The field driver options are not yet a stable part of the API:
 
-.. doxygentypedef:: celeritas::inp::Field
+.. celerstruct:: FieldDriverOptions

--- a/doc/usage/input/framework.rst
+++ b/doc/usage/input/framework.rst
@@ -1,0 +1,14 @@
+.. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _inp_framework:
+
+User application and framework integration
+==========================================
+
+When integrating with user applications or frameworks, ``FrameworkInput`` is
+used to define the system configuration and select the Celeritas physics to
+enable (via :cpp:struct:`PhysicsFromGeant`). Additional custom physics can be
+added via the ``adjust`` member to set or change any loaded data.
+
+.. celerstruct:: inp::FrameworkInput

--- a/doc/usage/input/import.rst
+++ b/doc/usage/input/import.rst
@@ -1,0 +1,17 @@
+.. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _inp_import:
+
+Loading data into Celeritas
+===========================
+
+Problem data can be imported directly from Geant4 or loaded from a ROOT file.
+
+.. doxygentypedef:: celeritas::inp::PhysicsImport
+
+The following input types select the source of the imported physics data.
+
+.. celerstruct:: inp::PhysicsFromFile
+.. celerstruct:: inp::PhysicsFromGeant
+.. celerstruct:: inp::PhysicsFromGeantFiles

--- a/doc/usage/input/problem.rst
+++ b/doc/usage/input/problem.rst
@@ -7,77 +7,14 @@ Problem setup
 =============
 
 Virtually all attributes of the problem and its execution are defined through
-the Problem input class, which is set up in part by the user and in part by
+the ``Problem`` input class, which is set up in part by the user and in part by
 external applications as directed by the user.
 
 .. celerstruct:: inp::Problem
 
+The ``OpticalProblem`` input class provides the corresponding configuration for
+problems in which only optical photons are transported. It shares the same
+overall structure as ``Problem`` but includes options specific to optical
+simulations.
+
 .. celerstruct:: inp::OpticalProblem
-
-.. _inp_framework:
-
-User application/framework
---------------------------
-
-User applications define the system configuration, as well as what Celeritas
-physics to enable (via :cpp:struct:`GeantImport`). Additional custom physics
-can be added via the ``adjust`` member to set or change any loaded data.
-
-.. celerstruct:: inp::FrameworkInput
-
-Loading data into Celeritas
----------------------------
-
-Import options are read in to load problem input from Geant4 and other sources.
-
-.. celerstruct:: inp::PhysicsFromFile
-.. celerstruct:: inp::PhysicsFromGeant
-.. celerstruct:: inp::PhysicsFromGeantFiles
-
-.. _inp_standalone_input:
-
-Standalone execution
---------------------
-
-Standalone execution describes how to set up Geant4 physics and what events to
-run.
-
-.. celerstruct:: inp::StandaloneInput
-
-Standalone inputs must also specify the mechanism for loading primary
-particles.
-
-.. celerstruct:: inp::Events
-
-The ``generator`` field in :cpp:struct:`Events` is a variant that can be one of
-these structures:
-
-.. celerstruct:: inp::PrimaryGenerator
-.. celerstruct:: inp::SampleFileEvents
-.. celerstruct:: inp::ReadFileEvents
-
-The primary generator, similar to Geant4's "particle gun", has different
-configuration options:
-
-.. doxygentypedef:: celeritas::inp::AngleDistribution
-.. doxygentypedef:: celeritas::inp::EnergyDistribution
-.. doxygentypedef:: celeritas::inp::MonodirectionalDistribution
-.. doxygentypedef:: celeritas::inp::MonoenergeticDistribution
-.. doxygentypedef:: celeritas::inp::PointDistribution
-.. doxygentypedef:: celeritas::inp::ShapeDistribution
-
-.. celerstruct:: inp::UniformBoxDistribution
-.. celerstruct:: inp::IsotropicDistribution
-
-
-.. _inp_system:
-
-System
-------
-
-Some low-level system options, such as enabling GPU, are set up once per program
-execution. They are not loaded by the :cpp:struct:`Problem` definition but
-are used by the standalone/framework inputs.
-
-.. celerstruct:: inp::System
-.. celerstruct:: inp::Device

--- a/doc/usage/input/scoring.rst
+++ b/doc/usage/input/scoring.rst
@@ -22,6 +22,6 @@ by reconstructing Geant4 hits and calling back to user code.
 Independent scoring
 -------------------
 
-This is used to set up :cpp:class:`celeritas::SimpleCalo`.
+This is used to set up :cpp:class:`celeritas::SimpleCalo`, which accumulates energy deposition in the specified volumes.
 
 .. celerstruct:: inp::SimpleCalo

--- a/doc/usage/input/standalone.rst
+++ b/doc/usage/input/standalone.rst
@@ -1,0 +1,16 @@
+.. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _inp_standalone_input:
+
+Standalone execution
+====================
+
+The ``StandaloneInput`` and ``OpticalStandaloneInput`` provide the complete
+configuration required to run a standalone Celeritas simulation, for example,
+using the ``celer-sim`` and ``celer-optical`` applications. They specify the
+system and problem configuration, how the physics data is loaded, and the
+events that are run.
+
+.. celerstruct:: inp::StandaloneInput
+.. celerstruct:: inp::OpticalStandaloneInput

--- a/doc/usage/input/system.rst
+++ b/doc/usage/input/system.rst
@@ -1,0 +1,14 @@
+.. Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _inp_system:
+
+System
+======
+
+Some low-level system options, such as enabling the GPU, are set up once per
+program execution. They are not loaded by the :cpp:struct:`Problem` definition
+but are used by the both framework integrations and standalone applications.
+
+.. celerstruct:: inp::System
+.. celerstruct:: inp::Device

--- a/src/celeritas/inp/Events.hh
+++ b/src/celeritas/inp/Events.hh
@@ -25,7 +25,17 @@ namespace inp
 //! Generate at a single energy value [MeV]
 using MonoenergeticDistribution = DeltaDistribution<double>;
 
-//! Choose an energy distribution for the primary generator
+//---------------------------------------------------------------------------//
+/*!
+ * Choose an energy distribution for the primary generator.
+ *
+ * In the JSON representation, a ``"_type"`` field selects the variant
+ * alternative using one of the following values:
+ *
+ * - "delta": \c MonoenergeticDistribution
+ * - "normal": \c NormalDistribution
+ * - "truncated": \c TruncatedDistribution<NormalDistribution>>
+ */
 using EnergyDistribution
     = std::variant<MonoenergeticDistribution,
                    NormalDistribution,
@@ -38,7 +48,16 @@ using PointDistribution = DeltaDistribution<Array<double, 3>>;
 // TODO: cylinder shape
 // TODO: shape with volume rejection
 
-//! Choose a spatial distribution for the primary generator
+//---------------------------------------------------------------------------//
+/*!
+ * Choose a spatial distribution for the primary generator.
+ *
+ * In the JSON representation, a ``"_type"`` field selects the variant
+ * alternative using one of the following values:
+ *
+ * - "delta": \c PointDistribution
+ * - "uniform_box": \c UniformBoxDistribution
+ */
 using ShapeDistribution
     = std::variant<PointDistribution, UniformBoxDistribution>;
 
@@ -46,7 +65,16 @@ using ShapeDistribution
 //! Generate angles in a single direction
 using MonodirectionalDistribution = DeltaDistribution<Array<double, 3>>;
 
-//! Choose an angular distribution for the primary generator
+//---------------------------------------------------------------------------//
+/*!
+ * Choose an angular distribution for the primary generator.
+ *
+ * In the JSON representation, a ``"_type"`` field selects the variant
+ * alternative using one of the following values:
+ *
+ * - "delta": \c MonodirectionalDistribution
+ * - "isotropic": \c IsotropicDistribution
+ */
 using AngleDistribution
     = std::variant<MonodirectionalDistribution, IsotropicDistribution>;
 
@@ -134,7 +162,17 @@ struct OpticalDirectGenerator
 };
 
 //---------------------------------------------------------------------------//
-//! Mechanism for generating optical photons
+/*!
+ * Mechanism for generating optical photons.
+ *
+ * In the JSON representation, a ``"_type"`` field selects the variant
+ * alternative using one of the following values:
+ *
+ * - "em": \c OpticalEmGenerator
+ * - "offload": \c OpticalOffloadGenerator
+ * - "primary": \c OpticalPriimaryGenerator
+ * - "direct": \c OpticalDirectGenerator
+ */
 using OpticalGenerator = std::variant<OpticalEmGenerator,
                                       OpticalOffloadGenerator,
                                       OpticalPrimaryGenerator,
@@ -168,7 +206,16 @@ struct ReadFileEvents
 };
 
 //---------------------------------------------------------------------------//
-//! Mechanism for generating events for tracking
+/*!
+ * Mechanism for generating events for tracking
+ *
+ * In the JSON representation, a ``"_type"`` field selects the variant
+ * alternative using one of the following values:
+ *
+ * - "primary": \c CorePrimaryGenerator
+ * - "sample": \c SampleFileEvents
+ * - "read": \c ReadFileEvents
+ */
 using Generator
     = std::variant<CorePrimaryGenerator, SampleFileEvents, ReadFileEvents>;
 

--- a/src/celeritas/inp/Field.hh
+++ b/src/celeritas/inp/Field.hh
@@ -161,7 +161,18 @@ struct CartMapField
 using RZMapField = ::celeritas::RZMapFieldInput;
 
 //---------------------------------------------------------------------------//
-//! Field type
+/*!
+ * Magnetic field specification.
+ *
+ * In the JSON representation, a ``"_type"`` field selects the variant
+ * alternative using one of the following values:
+ *
+ * - "none": \c NoField
+ * - "uniform": \c UniformField
+ * - "rzmap": \c RZMapField
+ * - "cylmap": \c CylMapField
+ * - "cartmap": \c CartMapField
+ */
 using Field
     = std::variant<NoField, UniformField, RZMapField, CylMapField, CartMapField>;
 

--- a/src/celeritas/inp/Import.hh
+++ b/src/celeritas/inp/Import.hh
@@ -56,6 +56,16 @@ struct PhysicsFromGeant
     GeantImportDataSelection data_selection;
 };
 
+//---------------------------------------------------------------------------//
+/*!
+ * Physics import specification.
+ *
+ * In the JSON representation, a ``"_type"`` field selects the variant
+ * alternative using one of the following values:
+ *
+ * - "geant": \c PhysicsFromGeant
+ * - "file": \c PhysicsFromFile
+ */
 using PhysicsImport = std::variant<PhysicsFromGeant, PhysicsFromFile>;
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This adds to the user documentation on running the celer-sim and celer-optical standalone applications and creating inputs.