### PR TITLE
Improve few-active-track GPU optical performance

### DIFF
--- a/app/celer-optical/celer-optical.cc
+++ b/app/celer-optical/celer-optical.cc
@@ -74,7 +74,7 @@ void run(std::shared_ptr<OutputRegistry>& output,
 
     // Start profiling
     TracingSession tracing_session{input.problem.perfetto_file};
-    SimulationResult result;
+    auto result = std::make_shared<SimulationResult>();
 
     // Set up optical problem
     Stopwatch get_setup_time;
@@ -109,23 +109,21 @@ void run(std::shared_ptr<OutputRegistry>& output,
                    },
                },
                generator);
-    result.time.setup = get_setup_time();
+    result->time.setup = get_setup_time();
 
     //! \todo Optical loop warmup
 
     Stopwatch get_transport_time;
     auto run_result = run();
-    result.time.total = get_transport_time();
-    result.time.actions = std::move(run_result.action_times);
-    result.time.steps = std::move(run_result.step_times);
-    result.counters = std::move(run_result.counters);
+    result->time.total = get_transport_time();
+    result->time.actions = std::move(run_result.action_times);
+    result->time.steps = std::move(run_result.step_times);
+    result->counters = std::move(run_result.counters);
 
     // Add simulation result to output
     output->insert(
         std::make_shared<celeritas::OutputInterfaceAdapter<SimulationResult>>(
-            OutputInterface::Category::result,
-            "*",
-            std::make_shared<SimulationResult>(result)));
+            OutputInterface::Category::result, "*", result));
 }
 
 void print_config()

--- a/example/offload-template/src/StepDiagnostic.cc
+++ b/example/offload-template/src/StepDiagnostic.cc
@@ -7,7 +7,6 @@
 #include "StepDiagnostic.hh"
 
 #include <type_traits>
-#include <vector>
 #include <celeritas/global/ActionInterface.hh>
 #include <celeritas/global/ActionLauncher.hh>
 #include <celeritas/global/CoreParams.hh>
@@ -99,10 +98,6 @@ StepStatistics StepDiagnostic::GetAndReset(CoreStateInterface& state) const
     // Since the underlying state (and thus the copy methods we have to call)
     // is host/device-dependent, we use a helper lambda
     visit_memspace_derived<CoreState>(state, [&](auto& derived) {
-        // Whether the given state is device/host
-        constexpr MemSpace M
-            = std::remove_reference_t<decltype(derived)>::memspace;
-
         // Get the step data from the core state
         auto& step_state = derived.template aux_data<StepStateData>(aux_id_);
         // Copy it

--- a/scripts/dev/debug-ctest.py
+++ b/scripts/dev/debug-ctest.py
@@ -19,6 +19,7 @@ updated in the future to work for GDB as well.
 ALSO NOTE: the VScode debugger choice ``lldb-dap`` requires an extension to
 work: see
 https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap
+You may need to set the ``lldb-dap.executable-path`` setting on remote systems.
 """
 
 import argparse

--- a/scripts/spack/packages.yaml
+++ b/scripts/spack/packages.yaml
@@ -1,42 +1,47 @@
 packages:
   all:
     prefer:
-    - "generator=ninja build_system=cmake"
-    - "build_type=Release"
-    - "cxxstd=20"
+      - "cxxstd=20"
   cli11:
-    require: '@2.4:'
+    require: "@2.4:"
   cmake:
-    require: '@3.21:'
-  nlohmann-json:
-    require: '@3.7.0:'
-  geant4:
-    require: '@10.5:'
-    prefer:
-    - '@11.3'
-  googletest:
-    require: '@1.10:'
-  py-identify: # needed by py-pre-commit
-    require: '@2.6:'
-  python:
-    require: '@3.9:'
+    require: "@3.21:"
   covfie:
-    require: '@0.13:'
-  g4vg:
-    require: '@1.0.3:'
-  vecgeom:
-    require:
-    - '@1.2.10:'
-    - +gdml
-    prefer:
-    - '@1'
-  root:
-    require:
-    - '@6.28:'
-    prefer:
-    - ~aqua ~davix ~examples ~opengl ~x ~tbb ~webgui +root7
+    require: "@0.13:"
   dd4hep:
     require:
-    - '@1.33:'
-    prefer:
-    - ~utilityapps ~ddeve
+      - "@1.33:"
+    variants:
+      - ~utilityapps ~ddeve
+  g4vg:
+    require: "@1.0.3:"
+  geant4:
+    require: "@10.5:"
+    version:
+      - "11.3"
+  googletest:
+    require: "@1.10:"
+  llvm: # for lldb-dap compatibility
+    variants:
+      - +python
+    version:
+      - "20:"
+  nlohmann-json:
+    require: "@3.7.0:"
+  py-identify: # needed by py-pre-commit
+    require: "@2.6:"
+  python:
+    require: "@3.9:"
+  root:
+    require:
+      - "@6.28:"
+    variants:
+      # These are "default starting values", not required
+      # using it rather than `prefer` prevents `all:prefer:` from being overwritten
+      - ~aqua ~davix ~examples ~opengl ~x ~tbb ~webgui +root7
+  vecgeom:
+    require:
+      - "@1.2.10:"
+      - +gdml
+    version:
+      - "1"

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -177,12 +177,9 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     // TODO: Is there a better place to build this?
     if (input_.optical_detector)
     {
-        auto action = std::make_shared<DetectorAction>(
-            input_.action_reg->next_id(),
-            input_.aux_reg->next_id(),
-            input_.optical_detector.callback);
-        input_.action_reg->insert(action);
-        input_.aux_reg->insert(action);
+        DetectorAction::make_and_insert(input_.action_reg,
+                                        input_.aux_reg,
+                                        input_.optical_detector.callback);
     }
 
     // Save maximum number of streams

--- a/src/celeritas/optical/CoreParams.cc
+++ b/src/celeritas/optical/CoreParams.cc
@@ -177,8 +177,12 @@ CoreParams::CoreParams(Input&& input) : input_(std::move(input))
     // TODO: Is there a better place to build this?
     if (input_.optical_detector)
     {
-        input_.action_reg->insert(std::make_shared<DetectorAction>(
-            input_.action_reg->next_id(), input_.optical_detector.callback));
+        auto action = std::make_shared<DetectorAction>(
+            input_.action_reg->next_id(),
+            input_.aux_reg->next_id(),
+            input_.optical_detector.callback);
+        input_.action_reg->insert(action);
+        input_.aux_reg->insert(action);
     }
 
     // Save maximum number of streams

--- a/src/celeritas/optical/CoreState.cc
+++ b/src/celeritas/optical/CoreState.cc
@@ -60,7 +60,8 @@ CoreState<M>::CoreState(
         ptr_ = make_observer(&this->ref());
     }
 
-    CELER_LOG(status) << "Initialized Celeritas optical state";
+    CELER_LOG(info) << "Initialized Celeritas optical state with "
+                    << num_track_slots << " track slots";
     CELER_ENSURE(states_);
     CELER_ENSURE(ptr_);
 }

--- a/src/celeritas/optical/DetectorData.hh
+++ b/src/celeritas/optical/DetectorData.hh
@@ -6,9 +6,10 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/Types.hh"
 #include "corecel/data/Collection.hh"
+#include "geocel/Types.hh"
 #include "celeritas/Quantities.hh"
-#include "celeritas/optical/Types.hh"
 
 namespace celeritas
 {

--- a/src/celeritas/optical/Runner.cc
+++ b/src/celeritas/optical/Runner.cc
@@ -117,6 +117,7 @@ void Runner::insert(SpanConstTrackInit data)
  */
 void Runner::insert(SpanConstGenDist data)
 {
+    ScopedProfiling profile_this{"insert"};
     auto generate = std::dynamic_pointer_cast<optical::GeneratorAction const>(
         loaded_.problem.generator);
     CELER_VALIDATE(generate,

--- a/src/celeritas/optical/Runner.cc
+++ b/src/celeritas/optical/Runner.cc
@@ -148,20 +148,45 @@ auto Runner::operator()() const -> Result
     (*loaded_.problem.transporter)(*state_);
 
     Result result;
-    result.counters = state_->accum();
+    result.counters = this->get_counters();
+    result.action_times = this->get_action_times();
+    result.step_times = this->get_step_times();
+
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get accumulated track counters.
+ */
+CounterAccumStats Runner::get_counters() const
+{
+    CounterAccumStats counters = state_->accum();
     for (auto gen_id : range(GeneratorId(this->params()->gen_reg()->size())))
     {
         auto const gen = this->params()->gen_reg()->at(gen_id);
         CELER_ASSERT(gen);
-        result.counters.generators.push_back(
-            gen->counters(*state_->aux()).accum);
+        counters.generators.push_back(gen->counters(*state_->aux()).accum);
     }
-    result.action_times
-        = loaded_.problem.transporter->get_action_times(*state_->aux());
-    result.step_times
-        = loaded_.problem.transporter->get_step_times(*state_->aux());
+    return counters;
+}
 
-    return result;
+//---------------------------------------------------------------------------//
+/*!
+ * Get accumulated wall times for each action.
+ */
+ActionTimes::MapStrDbl Runner::get_action_times() const
+{
+    return loaded_.problem.transporter->get_action_times(*state_->aux());
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the wall time for each step iteration.
+ */
+StepTimes::VecDbl Runner::get_step_times() const
+{
+    return loaded_.problem.transporter->get_step_times(*state_->aux());
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/Runner.hh
+++ b/src/celeritas/optical/Runner.hh
@@ -69,6 +69,15 @@ class Runner
     // Generate optical photons and transport to completion
     Result operator()() const;
 
+    // Get accumulated track counters
+    CounterAccumStats get_counters() const;
+
+    // Get accumulated wall times for each action
+    ActionTimes::MapStrDbl get_action_times() const;
+
+    // Get the wall time for each step iteration
+    StepTimes::VecDbl get_step_times() const;
+
     //! Access the shared params
     SPConstParams const& params() const
     {

--- a/src/celeritas/optical/action/DetectorAction.cc
+++ b/src/celeritas/optical/action/DetectorAction.cc
@@ -125,7 +125,16 @@ Span<DetectorHit const> DetectorAction::load_hits_sync(
 {
     auto const& device_hits = state.ref().detectors.detector_hits;
     auto& temp_hits = get<DetectorActionState>(*state.aux(), aux_id_).hits;
-    CELER_ASSERT(temp_hits.size() == device_hits.size());
+    if (CELER_UNLIKELY(temp_hits.size() != device_hits.size()))
+    {
+        // FIXME: we currently share a single aux state between core and optical
+        // tracking loops, but they may have different number of tracks, so this
+        // is an error. It basically amounts to doing a lazy resize.
+        CELER_LOG(warning) << "FIXME: expected optical aux state to be size "
+                           << device_hits.size() << " but is actually size "
+                           << temp_hits.size();
+        temp_hits.resize(device_hits.size());
+    }
 
     {
         // Copy all track hits to host from device

--- a/src/celeritas/optical/action/DetectorAction.cc
+++ b/src/celeritas/optical/action/DetectorAction.cc
@@ -8,10 +8,15 @@
 
 #include <algorithm>
 
+#include "corecel/Assert.hh"
+#include "corecel/data/AuxParamsRegistry.hh"  // IWYU pragma: keep
 #include "corecel/data/AuxStateVec.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/sys/ActionRegistry.hh"  // IWYU pragma: keep
 #include "corecel/sys/ScopedProfiling.hh"
+#include "celeritas/optical/CoreParams.hh"  // IWYU pragma: keep
+#include "celeritas/optical/CoreState.hh"  // IWYU pragma: keep
 
 #include "ActionLauncher.hh"
 #include "TrackSlotExecutor.hh"
@@ -24,11 +29,29 @@ namespace optical
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Create and add to optical params.
+ */
+std::shared_ptr<DetectorAction> DetectorAction::make_and_insert(
+    SPActionRegistry const& action_reg,
+    SPAuxParamsRegistry const& aux_reg,
+    CallbackFunc const& cb)
+{
+    CELER_EXPECT(action_reg);
+    CELER_EXPECT(aux_reg);
+    CELER_EXPECT(cb);
+    auto action = std::make_shared<DetectorAction>(
+        action_reg->next_id(), aux_reg->next_id(), cb);
+    action_reg->insert(action);
+    aux_reg->insert(action);
+    return action;
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Construct with action ID, aux ID, and callback function.
  */
-DetectorAction::DetectorAction(ActionId aid,
-                               AuxId aux_id,
-                               CallbackFunc const& callback)
+DetectorAction::DetectorAction(
+    ActionId aid, AuxId aux_id, CallbackFunc const& callback)
     : sad_(aid, "detector", "Score optical detector hits")
     , aux_id_(aux_id)
     , callback_(callback)
@@ -98,8 +121,8 @@ void DetectorAction::step(CoreParams const&, CoreStateDevice&) const
 /*!
  * Process hits copied from the kernels and send them to the callback.
  */
-Span<DetectorHit const>
-DetectorAction::load_hits_sync(CoreStateDevice const& state) const
+Span<DetectorHit const> DetectorAction::load_hits_sync(
+    CoreStateDevice const& state) const
 {
     auto const& device_hits = state.ref().detectors.detector_hits;
     auto& temp_hits = get<DetectorActionState>(*state.aux(), aux_id_).hits;

--- a/src/celeritas/optical/action/DetectorAction.cc
+++ b/src/celeritas/optical/action/DetectorAction.cc
@@ -8,6 +8,7 @@
 
 #include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/math/Algorithms.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 
 #include "ActionLauncher.hh"
 #include "TrackSlotExecutor.hh"
@@ -48,11 +49,16 @@ void DetectorAction::step(CoreParams const& params, CoreStateHost& state) const
                                                        MemSpace::host>{}];
 
     VecHit temp_hits(all_hits.size());
-    // Copy all valid hits, erasing remaining part of the vector
-    temp_hits.erase(
-        std::copy_if(
-            all_hits.begin(), all_hits.end(), temp_hits.begin(), Identity{}),
-        temp_hits.end());
+    {
+        ScopedProfiling profile_this("copy-prune");
+        // Copy all valid hits, erasing remaining part of the vector
+        temp_hits.erase(std::copy_if(all_hits.begin(),
+                                     all_hits.end(),
+                                     temp_hits.begin(),
+                                     Identity{}),
+                        temp_hits.end());
+    }
+
     this->callback_hits(temp_hits);
 }
 
@@ -77,19 +83,22 @@ auto DetectorAction::load_hits_sync(CoreStateDevice const& state) const
     auto const& native_hits = state.ref().detectors.detector_hits;
     VecHit temp_hits(native_hits.size());
 
-    // Ensure the kernel copied into the device buffer before copying out
-    celeritas::device().stream(state.stream_id()).sync();
+    {
+        // Copy all track hits to host from device
+        ScopedProfiling profile_this("copy");
+        copy_to_host(native_hits, make_span(temp_hits), state.stream_id());
 
-    // Copy all track hits to host from device
-    copy_to_host(native_hits, make_span(temp_hits), state.stream_id());
-
-    // Ensure copy is complete
-    celeritas::device().stream(state.stream_id()).sync();
+        // Ensure copy is complete
+        celeritas::device().stream(state.stream_id()).sync();
+    }
 
     // Erase all hits with invalid detector ID
-    temp_hits.erase(
-        std::remove_if(temp_hits.begin(), temp_hits.end(), LogicalNot{}),
-        temp_hits.end());
+    {
+        ScopedProfiling profile_this("prune");
+        temp_hits.erase(
+            std::remove_if(temp_hits.begin(), temp_hits.end(), LogicalNot{}),
+            temp_hits.end());
+    }
 
     return temp_hits;
 }
@@ -107,6 +116,7 @@ void DetectorAction::callback_hits(VecHit const& hits) const
     // Send hits to the callback function, if there are any
     if (!hits.empty())
     {
+        ScopedProfiling profile_this("callback");
         callback_(make_span(hits));
     }
 }

--- a/src/celeritas/optical/action/DetectorAction.cc
+++ b/src/celeritas/optical/action/DetectorAction.cc
@@ -6,6 +6,9 @@
 //---------------------------------------------------------------------------//
 #include "DetectorAction.hh"
 
+#include <algorithm>
+
+#include "corecel/data/AuxStateVec.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/sys/ScopedProfiling.hh"
@@ -21,21 +24,41 @@ namespace optical
 {
 //---------------------------------------------------------------------------//
 /*!
- * Construct with action ID.
+ * Construct with action ID, aux ID, and callback function.
  */
-DetectorAction::DetectorAction(ActionId aid, CallbackFunc const& callback)
-    : StaticConcreteAction(aid, "detector", "Score optical detector hits")
+DetectorAction::DetectorAction(ActionId aid,
+                               AuxId aux_id,
+                               CallbackFunc const& callback)
+    : sad_(aid, "detector", "Score optical detector hits")
+    , aux_id_(aux_id)
     , callback_(callback)
 {
     CELER_EXPECT(callback);
+    CELER_EXPECT(aux_id_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build auxiliary state data for a stream.
+ *
+ * The pinned hit buffer is allocated and sized here once per stream so that
+ * \c step and \c load_hits_sync never need to reallocate.
+ */
+auto DetectorAction::create_state(MemSpace, StreamId, size_type size) const
+    -> UPState
+{
+    CELER_EXPECT(size > 0);
+
+    auto result = std::make_unique<DetectorActionState>();
+    result->hits.resize(size);
+
+    CELER_ENSURE(result);
+    return result;
 }
 
 //---------------------------------------------------------------------------//
 /*!
  * Launch the detector action on host.
- *
- * \todo avoid reallocating the temporary storage at every step, or as an
- * optimization just call contiguous chunks of hits.
  */
 void DetectorAction::step(CoreParams const& params, CoreStateHost& state) const
 {
@@ -48,18 +71,19 @@ void DetectorAction::step(CoreParams const& params, CoreStateHost& state) const
         = state.ref().detectors.detector_hits[AllItems<DetectorHit,
                                                        MemSpace::host>{}];
 
-    VecHit temp_hits(all_hits.size());
-    {
-        ScopedProfiling profile_this("copy-prune");
-        // Copy all valid hits, erasing remaining part of the vector
-        temp_hits.erase(std::copy_if(all_hits.begin(),
-                                     all_hits.end(),
-                                     temp_hits.begin(),
-                                     Identity{}),
-                        temp_hits.end());
-    }
+    auto& temp_hits = get<DetectorActionState>(*state.aux(), aux_id_).hits;
+    CELER_ASSERT(temp_hits.size() == all_hits.size());
 
-    this->callback_hits(temp_hits);
+    std::size_t num_valid = [&all_hits, &temp_hits] {
+        ScopedProfiling profile_this("copy-prune");
+        // Copy all valid hits into the persistent buffer, keeping only the
+        // valid ones
+        auto end = std::copy_if(
+            all_hits.begin(), all_hits.end(), temp_hits.begin(), Identity{});
+        return std::distance(temp_hits.begin(), end);
+    }();
+
+    this->callback_hits(make_span(temp_hits).first(num_valid));
 }
 
 //---------------------------------------------------------------------------//
@@ -73,34 +97,34 @@ void DetectorAction::step(CoreParams const&, CoreStateDevice&) const
 //---------------------------------------------------------------------------//
 /*!
  * Process hits copied from the kernels and send them to the callback.
- *
- * \todo Replace this with asynchronous calls into pinned memory in aux
- * state, followed by an asynchronous callback.
  */
-auto DetectorAction::load_hits_sync(CoreStateDevice const& state) const
-    -> VecHit
+Span<DetectorHit const>
+DetectorAction::load_hits_sync(CoreStateDevice const& state) const
 {
-    auto const& native_hits = state.ref().detectors.detector_hits;
-    VecHit temp_hits(native_hits.size());
+    auto const& device_hits = state.ref().detectors.detector_hits;
+    auto& temp_hits = get<DetectorActionState>(*state.aux(), aux_id_).hits;
+    CELER_ASSERT(temp_hits.size() == device_hits.size());
 
     {
         // Copy all track hits to host from device
         ScopedProfiling profile_this("copy");
-        copy_to_host(native_hits, make_span(temp_hits), state.stream_id());
+        copy_to_host(device_hits, make_span(temp_hits), state.stream_id());
 
         // Ensure copy is complete
         celeritas::device().stream(state.stream_id()).sync();
     }
 
-    // Erase all hits with invalid detector ID
-    {
+    // Move all hits with a valid detector ID to the front of the buffer,
+    // keeping the buffer itself at its original size
+    std::size_t num_valid = [&temp_hits] {
         ScopedProfiling profile_this("prune");
-        temp_hits.erase(
-            std::remove_if(temp_hits.begin(), temp_hits.end(), LogicalNot{}),
-            temp_hits.end());
-    }
+        auto end
+            = std::remove_if(temp_hits.begin(), temp_hits.end(), LogicalNot{});
+        return std::distance(temp_hits.begin(), end);
+    }();
+    CELER_ASSERT(num_valid <= temp_hits.size());
 
-    return temp_hits;
+    return make_span(temp_hits).first(num_valid);
 }
 
 //---------------------------------------------------------------------------//
@@ -111,13 +135,13 @@ auto DetectorAction::load_hits_sync(CoreStateDevice const& state) const
  * callback function. The callback is only executed when a non-zero number of
  * valid hits occurs.
  */
-void DetectorAction::callback_hits(VecHit const& hits) const
+void DetectorAction::callback_hits(Span<DetectorHit const> hits) const
 {
     // Send hits to the callback function, if there are any
     if (!hits.empty())
     {
         ScopedProfiling profile_this("callback");
-        callback_(make_span(hits));
+        callback_(hits);
     }
 }
 

--- a/src/celeritas/optical/action/DetectorAction.cc
+++ b/src/celeritas/optical/action/DetectorAction.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include "corecel/Assert.hh"
+#include "corecel/Types.hh"
 #include "corecel/data/AuxParamsRegistry.hh"  // IWYU pragma: keep
 #include "corecel/data/AuxStateVec.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
@@ -67,13 +68,16 @@ DetectorAction::DetectorAction(
  * The pinned hit buffer is allocated and sized here once per stream so that
  * \c step and \c load_hits_sync never need to reallocate.
  */
-auto DetectorAction::create_state(MemSpace, StreamId, size_type size) const
+auto DetectorAction::create_state(MemSpace m, StreamId, size_type size) const
     -> UPState
 {
     CELER_EXPECT(size > 0);
 
     auto result = std::make_unique<DetectorActionState>();
-    result->hits.resize(size);
+    if (m == MemSpace::device)
+    {
+        result->hits.resize(size);
+    }
 
     CELER_ENSURE(result);
     return result;
@@ -94,19 +98,14 @@ void DetectorAction::step(CoreParams const& params, CoreStateHost& state) const
         = state.ref().detectors.detector_hits[AllItems<DetectorHit,
                                                        MemSpace::host>{}];
 
-    auto& temp_hits = get<DetectorActionState>(*state.aux(), aux_id_).hits;
-    CELER_ASSERT(temp_hits.size() == all_hits.size());
-
-    std::size_t num_valid = [&all_hits, &temp_hits] {
-        ScopedProfiling profile_this("copy-prune");
-        // Copy all valid hits into the persistent buffer, keeping only the
-        // valid ones
-        auto end = std::copy_if(
-            all_hits.begin(), all_hits.end(), temp_hits.begin(), Identity{});
-        return std::distance(temp_hits.begin(), end);
+    std::size_t num_valid = [&all_hits] {
+        ScopedProfiling profile_this("prune");
+        auto end
+            = std::remove_if(all_hits.begin(), all_hits.end(), LogicalNot{});
+        return std::distance(all_hits.begin(), end);
     }();
 
-    this->callback_hits(make_span(temp_hits).first(num_valid));
+    this->callback_hits(make_span(all_hits).first(num_valid));
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/action/DetectorAction.cc
+++ b/src/celeritas/optical/action/DetectorAction.cc
@@ -123,6 +123,12 @@ void DetectorAction::step(CoreParams const&, CoreStateDevice&) const
 Span<DetectorHit const> DetectorAction::load_hits_sync(
     CoreStateDevice const& state) const
 {
+    if constexpr (!CELER_USE_DEVICE)
+    {
+        // Mark unreachable for optimization and coverage
+        CELER_ASSERT_UNREACHABLE();
+    }
+
     auto const& device_hits = state.ref().detectors.detector_hits;
     auto& temp_hits = get<DetectorActionState>(*state.aux(), aux_id_).hits;
     if (CELER_UNLIKELY(temp_hits.size() != device_hits.size()))

--- a/src/celeritas/optical/action/DetectorAction.hh
+++ b/src/celeritas/optical/action/DetectorAction.hh
@@ -13,14 +13,15 @@
 #include "corecel/data/AuxInterface.hh"
 #include "corecel/data/PinnedAllocator.hh"
 #include "celeritas/inp/Scoring.hh"
-#include "celeritas/optical/CoreParams.hh"
-#include "celeritas/optical/CoreState.hh"
 #include "celeritas/optical/DetectorData.hh"
 
 #include "ActionInterface.hh"
 
 namespace celeritas
 {
+class ActionRegistry;
+class AuxParamsRegistry;
+
 namespace optical
 {
 //---------------------------------------------------------------------------//
@@ -42,12 +43,20 @@ class DetectorAction final : public OpticalStepActionInterface,
   public:
     //!@{
     //! \name Type aliases
+    using SPActionRegistry = std::shared_ptr<ActionRegistry>;
+    using SPAuxParamsRegistry = std::shared_ptr<AuxParamsRegistry>;
     using CallbackFunc = inp::OpticalDetector::HitCallbackFunc;
     //!@}
 
   public:
+    // Create and add to core params
+    static std::shared_ptr<DetectorAction> make_and_insert(
+        SPActionRegistry const&,
+        SPAuxParamsRegistry const&,
+        CallbackFunc const&);
+
     // Construct with action ID, aux ID, and callback function
-    explicit DetectorAction(ActionId, AuxId, CallbackFunc const&);
+    DetectorAction(ActionId, AuxId, CallbackFunc const&);
 
     // Launch kernel with host data
     void step(CoreParams const&, CoreStateHost&) const final;

--- a/src/celeritas/optical/action/DetectorAction.hh
+++ b/src/celeritas/optical/action/DetectorAction.hh
@@ -105,11 +105,14 @@ class DetectorAction final : public OpticalStepActionInterface,
 
 //---------------------------------------------------------------------------//
 /*!
- * Persistent per-stream storage for pruned detector hits.
+ * Persistent per-stream storage for pruned detector hits on device.
  *
  * The pinned buffer is allocated and sized once in \c
  * DetectorAction::create_state so that no reallocation occurs during
  * stepping.
+ *
+ * This is \em only done when running on device; in host memory, we operate
+ * directly on the hit vector.
  */
 struct DetectorActionState : public AuxStateInterface
 {

--- a/src/celeritas/optical/action/DetectorAction.hh
+++ b/src/celeritas/optical/action/DetectorAction.hh
@@ -3,11 +3,15 @@
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
 //! \file celeritas/optical/action/DetectorAction.hh
+//! \sa DetectorAction.test.cc
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <algorithm>
+#include <vector>
 
+#include "corecel/cont/Span.hh"
+#include "corecel/data/AuxInterface.hh"
+#include "corecel/data/PinnedAllocator.hh"
 #include "celeritas/inp/Scoring.hh"
 #include "celeritas/optical/CoreParams.hh"
 #include "celeritas/optical/CoreState.hh"
@@ -26,12 +30,14 @@ namespace optical
  * The \c DetectorExecutor is responsible for copying hit data for every photon
  * into the state buffer at the end of every step on a kernel level. Even if a
  * track was not in a detector, it is still copied into the state buffer with
- * an invalid detector ID. All hits are copied into pinned memory on the host,
- * where invalid hits are erased. A span of only valid hits is then passed into
- * the user provided callback function.
+ * an invalid detector ID. All hits are copied into a persistent pinned-memory
+ * buffer (allocated once as auxiliary state, sized to the number of track
+ * slots), where invalid hits are pruned by slicing a span over the valid
+ * prefix. A span of only valid hits is then passed into the user provided
+ * callback function.
  */
 class DetectorAction final : public OpticalStepActionInterface,
-                             public StaticConcreteAction
+                             public AuxParamsInterface
 {
   public:
     //!@{
@@ -40,8 +46,8 @@ class DetectorAction final : public OpticalStepActionInterface,
     //!@}
 
   public:
-    // Construct with ID and callback function
-    explicit DetectorAction(ActionId, CallbackFunc const&);
+    // Construct with action ID, aux ID, and callback function
+    explicit DetectorAction(ActionId, AuxId, CallbackFunc const&);
 
     // Launch kernel with host data
     void step(CoreParams const&, CoreStateHost&) const final;
@@ -52,22 +58,55 @@ class DetectorAction final : public OpticalStepActionInterface,
     //! Dependency ordering of the action
     StepActionOrder order() const final { return StepActionOrder::post; }
 
+    //!@{
+    //! \name Action interface
+
+    //! ID of the action
+    ActionId action_id() const final { return sad_.action_id(); }
+    //! Short name for the action (also satisfies AuxParamsInterface::label)
+    std::string_view label() const final { return sad_.label(); }
+    //! Description of the action
+    std::string_view description() const final { return sad_.description(); }
+    //!@}
+
+    //!@{
+    //! \name Aux interface
+
+    //! Index of this class instance in its registry
+    AuxId aux_id() const final { return aux_id_; }
+    // Build auxiliary state data for a stream
+    UPState create_state(MemSpace, StreamId, size_type) const final;
+    //!@}
+
   private:
-    //// TYPES ////
-
-    using VecHit = std::vector<DetectorHit>;
-
     //// DATA ////
 
+    StaticActionData sad_;
+    AuxId aux_id_;
     CallbackFunc callback_;
 
     //// HELPER FUNCTIONS ////
 
     // Copy hits from device
-    VecHit load_hits_sync(CoreStateDevice const&) const;
+    Span<DetectorHit const> load_hits_sync(CoreStateDevice const&) const;
 
     // Send hits to the callback
-    void callback_hits(VecHit const&) const;
+    void callback_hits(Span<DetectorHit const>) const;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Persistent per-stream storage for pruned detector hits.
+ *
+ * The pinned buffer is allocated and sized once in \c
+ * DetectorAction::create_state so that no reallocation occurs during
+ * stepping.
+ */
+struct DetectorActionState : public AuxStateInterface
+{
+    using VecHit = std::vector<DetectorHit, PinnedAllocator<DetectorHit>>;
+
+    VecHit hits;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/detail/OpticalLaunchAction.cc
+++ b/src/celeritas/optical/detail/OpticalLaunchAction.cc
@@ -10,17 +10,13 @@
 
 #include "corecel/data/AuxParamsRegistry.hh"
 #include "corecel/data/AuxStateVec.hh"
-#include "corecel/io/Logger.hh"
 #include "corecel/sys/ActionRegistry.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
-#include "celeritas/phys/GeneratorRegistry.hh"
 
 #include "../CoreParams.hh"
 #include "../CoreState.hh"
 #include "../Transporter.hh"
-#include "../action/ActionGroups.hh"
-#include "../gen/GeneratorData.hh"
 
 namespace celeritas
 {

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -276,52 +276,52 @@ auto build_optical_params(
     CELER_EXPECT(p.physics.optical);
     CELER_EXPECT(p.control.optical_capacity);
 
-    optical::CoreParams::Input op_pi;
+    optical::CoreParams::Input pi;
 
     // Validate state capacity and buffer sizes and set default values
-    op_pi.sizes = capacity(*p.control.optical_capacity, p.control.num_streams);
+    pi.sizes = capacity(*p.control.optical_capacity, p.control.num_streams);
 
     // Registries
-    op_pi.action_reg = std::make_shared<ActionRegistry>();
-    op_pi.output_reg = core.output_reg();
-    op_pi.gen_reg = std::make_shared<GeneratorRegistry>();
-    op_pi.aux_reg = std::make_shared<AuxParamsRegistry>();
+    pi.action_reg = std::make_shared<ActionRegistry>();
+    pi.output_reg = core.output_reg();
+    pi.gen_reg = std::make_shared<GeneratorRegistry>();
+    pi.aux_reg = core.aux_reg();
 
     // Geometry, physics, core
-    op_pi.geometry = core.geometry();
-    op_pi.material = optical::MaterialParams::from_import(
+    pi.geometry = core.geometry();
+    pi.material = optical::MaterialParams::from_import(
         imported, *core.geomaterial(), *core.material());
-    op_pi.physics = std::make_shared<optical::PhysicsParams>(
+    pi.physics = std::make_shared<optical::PhysicsParams>(
         imported.optical_physics.bulk,
-        op_pi.material,
+        pi.material,
         core.material(),
-        op_pi.action_reg,
-        op_pi.aux_reg,
-        op_pi.gen_reg,
-        op_pi.sizes.generators);
-    op_pi.rng = core.rng();
-    op_pi.sim = std::make_shared<optical::SimParams>(p.tracking.optical_limits);
-    op_pi.surface = core.surface();
-    op_pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
-        op_pi.action_reg.get(), p.physics.optical.surfaces);
-    op_pi.detectors = core.detectors();
-    op_pi.optical_detector = p.scoring.optical_detector;
-    op_pi.volume = core.volume();
+        pi.action_reg,
+        pi.aux_reg,
+        pi.gen_reg,
+        pi.sizes.generators);
+    pi.rng = core.rng();
+    pi.sim = std::make_shared<optical::SimParams>(p.tracking.optical_limits);
+    pi.surface = core.surface();
+    pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
+        pi.action_reg.get(), p.physics.optical.surfaces);
+    pi.detectors = core.detectors();
+    pi.optical_detector = p.scoring.optical_detector;
+    pi.volume = core.volume();
 
     // Photon generating processes
     if (p.physics.optical.gen.cherenkov)
     {
-        op_pi.cherenkov = std::make_shared<CherenkovParams>(*op_pi.material);
+        pi.cherenkov = std::make_shared<CherenkovParams>(*pi.material);
     }
     if (p.physics.optical.gen.scintillation)
     {
         CELER_ASSERT(imported.optical_physics.gen.scintillation);
-        op_pi.scintillation = std::make_shared<ScintillationParams>(
-            *op_pi.material, *imported.optical_physics.gen.scintillation);
+        pi.scintillation = std::make_shared<ScintillationParams>(
+            *pi.material, *imported.optical_physics.gen.scintillation);
     }
 
-    CELER_ENSURE(op_pi);
-    return std::make_shared<optical::CoreParams>(std::move(op_pi));
+    CELER_ENSURE(pi);
+    return std::make_shared<optical::CoreParams>(std::move(pi));
 }
 
 //---------------------------------------------------------------------------//
@@ -796,13 +796,13 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
     }
 
     // Build optical params
-    auto op_params = build_optical_params(p, std::move(loaded_model), imported);
-    CELER_ASSERT(op_params);
+    auto params = build_optical_params(p, std::move(loaded_model), imported);
+    CELER_ASSERT(params);
 
     // Set up streams
     if (auto& device = celeritas::device())
     {
-        device.create_streams(op_params->sizes().streams);
+        device.create_streams(params->sizes().streams);
     }
 
     OpticalProblemLoaded result;
@@ -827,15 +827,14 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
                             p.offload_file);
                 }
                 return optical::GeneratorAction::make_and_insert(
-                    *op_params, op_params->sizes().generators);
+                    *params, params->sizes().generators);
             },
             [&](inp::OpticalPrimaryGenerator opg) -> SPGeneratorBase {
                 return optical::PrimaryGeneratorAction::make_and_insert(
-                    *op_params, std::move(opg));
+                    *params, std::move(opg));
             },
             [&](inp::OpticalDirectGenerator) -> SPGeneratorBase {
-                return optical::DirectGeneratorAction::make_and_insert(
-                    *op_params);
+                return optical::DirectGeneratorAction::make_and_insert(*params);
             },
         },
         p.generator);
@@ -843,7 +842,7 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
     // Add step diagnostic
     if (p.step)
     {
-        optical::StepDiagnostic::make_and_insert(*op_params, p.step->bins);
+        optical::StepDiagnostic::make_and_insert(*params, p.step->bins);
     }
 
     // Build the optical transporter \em after all optical actions have been
@@ -852,17 +851,16 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
     if (p.timers.action)
     {
         // Create aux data to accumulate optical action times
-        ti.action_times = ActionTimes::make_and_insert(op_params->action_reg(),
-                                                       op_params->aux_reg(),
-                                                       "optical-action-times");
+        ti.action_times = ActionTimes::make_and_insert(
+            params->action_reg(), params->aux_reg(), "optical-action-times");
     }
     if (p.timers.step)
     {
         // Create aux data to record optical step times
-        ti.step_times = StepTimes::make_and_insert(op_params->aux_reg(),
+        ti.step_times = StepTimes::make_and_insert(params->aux_reg(),
                                                    "optical-step-times");
     }
-    ti.params = std::move(op_params);
+    ti.params = std::move(params);
     result.transporter = std::make_shared<optical::Transporter>(std::move(ti));
 
     CELER_ENSURE(result.transporter);

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -276,52 +276,52 @@ auto build_optical_params(
     CELER_EXPECT(p.physics.optical);
     CELER_EXPECT(p.control.optical_capacity);
 
-    optical::CoreParams::Input pi;
+    optical::CoreParams::Input op_pi;
 
     // Validate state capacity and buffer sizes and set default values
-    pi.sizes = capacity(*p.control.optical_capacity, p.control.num_streams);
+    op_pi.sizes = capacity(*p.control.optical_capacity, p.control.num_streams);
 
     // Registries
-    pi.action_reg = std::make_shared<ActionRegistry>();
-    pi.output_reg = core.output_reg();
-    pi.gen_reg = std::make_shared<GeneratorRegistry>();
-    pi.aux_reg = core.aux_reg();
+    op_pi.action_reg = std::make_shared<ActionRegistry>();
+    op_pi.output_reg = core.output_reg();
+    op_pi.gen_reg = std::make_shared<GeneratorRegistry>();
+    op_pi.aux_reg = std::make_shared<AuxParamsRegistry>();
 
     // Geometry, physics, core
-    pi.geometry = core.geometry();
-    pi.material = optical::MaterialParams::from_import(
+    op_pi.geometry = core.geometry();
+    op_pi.material = optical::MaterialParams::from_import(
         imported, *core.geomaterial(), *core.material());
-    pi.physics = std::make_shared<optical::PhysicsParams>(
+    op_pi.physics = std::make_shared<optical::PhysicsParams>(
         imported.optical_physics.bulk,
-        pi.material,
+        op_pi.material,
         core.material(),
-        pi.action_reg,
-        pi.aux_reg,
-        pi.gen_reg,
-        pi.sizes.generators);
-    pi.rng = core.rng();
-    pi.sim = std::make_shared<optical::SimParams>(p.tracking.optical_limits);
-    pi.surface = core.surface();
-    pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
-        pi.action_reg.get(), p.physics.optical.surfaces);
-    pi.detectors = core.detectors();
-    pi.optical_detector = p.scoring.optical_detector;
-    pi.volume = core.volume();
+        op_pi.action_reg,
+        op_pi.aux_reg,
+        op_pi.gen_reg,
+        op_pi.sizes.generators);
+    op_pi.rng = core.rng();
+    op_pi.sim = std::make_shared<optical::SimParams>(p.tracking.optical_limits);
+    op_pi.surface = core.surface();
+    op_pi.surface_physics = std::make_shared<optical::SurfacePhysicsParams>(
+        op_pi.action_reg.get(), p.physics.optical.surfaces);
+    op_pi.detectors = core.detectors();
+    op_pi.optical_detector = p.scoring.optical_detector;
+    op_pi.volume = core.volume();
 
     // Photon generating processes
     if (p.physics.optical.gen.cherenkov)
     {
-        pi.cherenkov = std::make_shared<CherenkovParams>(*pi.material);
+        op_pi.cherenkov = std::make_shared<CherenkovParams>(*op_pi.material);
     }
     if (p.physics.optical.gen.scintillation)
     {
         CELER_ASSERT(imported.optical_physics.gen.scintillation);
-        pi.scintillation = std::make_shared<ScintillationParams>(
-            *pi.material, *imported.optical_physics.gen.scintillation);
+        op_pi.scintillation = std::make_shared<ScintillationParams>(
+            *op_pi.material, *imported.optical_physics.gen.scintillation);
     }
 
-    CELER_ENSURE(pi);
-    return std::make_shared<optical::CoreParams>(std::move(pi));
+    CELER_ENSURE(op_pi);
+    return std::make_shared<optical::CoreParams>(std::move(op_pi));
 }
 
 //---------------------------------------------------------------------------//
@@ -796,13 +796,13 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
     }
 
     // Build optical params
-    auto params = build_optical_params(p, std::move(loaded_model), imported);
-    CELER_ASSERT(params);
+    auto op_params = build_optical_params(p, std::move(loaded_model), imported);
+    CELER_ASSERT(op_params);
 
     // Set up streams
     if (auto& device = celeritas::device())
     {
-        device.create_streams(params->sizes().streams);
+        device.create_streams(op_params->sizes().streams);
     }
 
     OpticalProblemLoaded result;
@@ -827,14 +827,15 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
                             p.offload_file);
                 }
                 return optical::GeneratorAction::make_and_insert(
-                    *params, params->sizes().generators);
+                    *op_params, op_params->sizes().generators);
             },
             [&](inp::OpticalPrimaryGenerator opg) -> SPGeneratorBase {
                 return optical::PrimaryGeneratorAction::make_and_insert(
-                    *params, std::move(opg));
+                    *op_params, std::move(opg));
             },
             [&](inp::OpticalDirectGenerator) -> SPGeneratorBase {
-                return optical::DirectGeneratorAction::make_and_insert(*params);
+                return optical::DirectGeneratorAction::make_and_insert(
+                    *op_params);
             },
         },
         p.generator);
@@ -842,7 +843,7 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
     // Add step diagnostic
     if (p.step)
     {
-        optical::StepDiagnostic::make_and_insert(*params, p.step->bins);
+        optical::StepDiagnostic::make_and_insert(*op_params, p.step->bins);
     }
 
     // Build the optical transporter \em after all optical actions have been
@@ -851,16 +852,17 @@ OpticalProblemLoaded problem(inp::OpticalProblem const& p,
     if (p.timers.action)
     {
         // Create aux data to accumulate optical action times
-        ti.action_times = ActionTimes::make_and_insert(
-            params->action_reg(), params->aux_reg(), "optical-action-times");
+        ti.action_times = ActionTimes::make_and_insert(op_params->action_reg(),
+                                                       op_params->aux_reg(),
+                                                       "optical-action-times");
     }
     if (p.timers.step)
     {
         // Create aux data to record optical step times
-        ti.step_times = StepTimes::make_and_insert(params->aux_reg(),
+        ti.step_times = StepTimes::make_and_insert(op_params->aux_reg(),
                                                    "optical-step-times");
     }
-    ti.params = std::move(params);
+    ti.params = std::move(op_params);
     result.transporter = std::make_shared<optical::Transporter>(std::move(ti));
 
     CELER_ENSURE(result.transporter);

--- a/src/corecel/data/AuxStateVec.cc
+++ b/src/corecel/data/AuxStateVec.cc
@@ -7,6 +7,7 @@
 #include "AuxStateVec.hh"
 
 #include "corecel/cont/Range.hh"
+#include "corecel/io/Logger.hh"
 
 #include "AuxParamsRegistry.hh"
 
@@ -23,6 +24,10 @@ AuxStateVec::AuxStateVec(
     CELER_EXPECT(sid);
     CELER_EXPECT(size > 0);
 
+    CELER_LOG_LOCAL(debug) << "Allocating " << registry.size()
+                           << " aux state classes for " << to_cstring(m)
+                           << " on stream " << sid << " with state size "
+                           << size;
     states_.reserve(registry.size());
 
     for (auto auxid : range(AuxId{registry.size()}))

--- a/src/larceler/LarStandaloneRunner.cc
+++ b/src/larceler/LarStandaloneRunner.cc
@@ -20,6 +20,7 @@
 #include "corecel/io/Logger.hh"
 #include "corecel/math/ArrayQuantity.hh"
 #include "corecel/sys/ScopedProfiling.hh"
+#include "corecel/sys/Stopwatch.hh"
 #include "geocel/DetectorParams.hh"  // IWYU pragma: keep
 #include "geocel/Types.hh"
 #include "geocel/VolumeParams.hh"  // IWYU pragma: keep
@@ -220,6 +221,7 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
 
     // Execute
     runner_->insert(make_span(std::as_const(gdd)));
+    Stopwatch get_transport_time;
     auto result = (*runner_)();
 
     CELER_ASSERT(result.counters.generators.size() == 1);
@@ -228,7 +230,8 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
                      << " optical photons from " << gen.buffer_size
                      << " sim energy deposits with a total of "
                      << result.counters.steps << " steps over "
-                     << result.counters.step_iters << " step iterations";
+                     << result.counters.step_iters << " step iterations in "
+                     << get_transport_time() << "s";
 
     // Convert BTR helpers to BTRs in the LarSoft order
     VecBTR btrs;

--- a/src/larceler/LarStandaloneRunner.cc
+++ b/src/larceler/LarStandaloneRunner.cc
@@ -19,6 +19,7 @@
 #include "corecel/Macros.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/math/ArrayQuantity.hh"
+#include "corecel/sys/ScopedProfiling.hh"
 #include "geocel/DetectorParams.hh"  // IWYU pragma: keep
 #include "geocel/Types.hh"
 #include "geocel/VolumeParams.hh"  // IWYU pragma: keep
@@ -117,6 +118,7 @@ LarStandaloneRunner::LarStandaloneRunner(Input&& i, VecReal3 const& det_coords)
         = [this](SpanCelerHits h) { return this->hit(h); };
     runner_ = std::make_shared<optical::Runner>(std::move(i));
 
+    ScopedProfiling profile_this("setup-channels");
     // Map detector coordinates
     auto geo = runner_->params()->geometry();
     CELER_ASSERT(geo);

--- a/test/accel/IntegrationTestBase.cc
+++ b/test/accel/IntegrationTestBase.cc
@@ -403,6 +403,8 @@ G4RunManager& IntegrationTestBase::run_manager()
 #endif
         };
         CELER_ENSURE(rm);
+        CELER_LOG(info) << "Created run manager type "
+                        << TypeDemangler<G4RunManager>{}(*rm);
         return rm;
     });
 

--- a/test/celeritas/optical/Detector.test.cc
+++ b/test/celeritas/optical/Detector.test.cc
@@ -21,6 +21,7 @@
 #include "celeritas/optical/Runner.hh"
 #include "celeritas/optical/Transporter.hh"
 #include "celeritas/optical/Types.hh"
+#include "celeritas/optical/action/DetectorAction.hh"
 #include "celeritas/optical/gen/DirectGeneratorAction.hh"
 #include "celeritas/optical/gen/PrimaryGeneratorAction.hh"
 #include "celeritas/optical/surface/SurfacePhysicsParams.hh"


### PR DESCRIPTION
It turns out that allocating `sizeof(Hit) * 1M` is quite expensive (30ms) and dominated the tail of the optical tracking loop. Storing it instead in aux data provides a factor of 4 speedup for those steps. The next lowest-hanging fruit here would be to remove invalid hits on device and copy back only the required number.

**IMPORTANT**: this code exposed a bug in how we're managing the aux states: we need to have separate states for the core and optical because they have different sizes, but we currently don't. Creating different aux params currently fails due to the way generators are handled: some of them are expecting aux data from the main loop (offloading scint/cherenkov), and some need data generated in the optical loop (WLS). I'm not immediately sure how to handle this so I'm punting and resizing on-the-fly.

Before / After:

<img width="324" height="390" alt="before" src="https://github.com/user-attachments/assets/68a53c97-d20b-4871-9403-3dceab4e899e" /> 

<img width="93" height="384" alt="after" src="https://github.com/user-attachments/assets/b645974a-36ac-47e6-9c6e-6c2c182ad3de" />
