### PR TITLE
Optical transport fixes from the CCM production branch

### DIFF
--- a/src/accel/LocalOpticalTrackOffload.cc
+++ b/src/accel/LocalOpticalTrackOffload.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "LocalOpticalTrackOffload.hh"
 
+#include <atomic>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4EventManager.hh>
 #include <G4MTRunManager.hh>
@@ -105,11 +106,13 @@ void LocalOpticalTrackOffload::InitializeEvent(int id)
         if (!(G4Threading::IsMultithreadedApplication()
               && G4MTRunManager::SeedOncePerCommunication()))
         {
-            // Since Geant4 schedules events dynamically, reseed the Celeritas
-            // RNGs using the Geant4 event ID for reproducibility. This
-            // guarantees that an event can be reproduced given the event ID.
+            // Reseed with a process-global event ordinal rather than the
+            // Geant4 event ID: frameworks that drive one event per BeamOn
+            // (e.g. IceTray) reset the Geant4 event ID to zero every call,
+            // which would replay identical random streams for every event.
+            static std::atomic<UniqueEventId::size_type> event_ordinal{0};
             state_->reseed(transport_->params()->rng(),
-                           id_cast<UniqueEventId>(id));
+                           UniqueEventId{event_ordinal++});
         }
     }
 }

--- a/src/accel/LocalOpticalTrackOffload.cc
+++ b/src/accel/LocalOpticalTrackOffload.cc
@@ -7,13 +7,16 @@
 #include "LocalOpticalTrackOffload.hh"
 
 #include <atomic>
+#include <cstdlib>
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <G4EventManager.hh>
 #include <G4MTRunManager.hh>
 
 #include "corecel/Assert.hh"
+#include "corecel/cont/Range.hh"
 #include "corecel/io/Logger.hh"
 #include "corecel/sys/ScopedProfiling.hh"
+#include "celeritas/phys/GeneratorRegistry.hh"
 #include "geocel/GeantUtils.hh"
 #include "geocel/g4/Convert.hh"
 #include "celeritas/ext/GeantParticleView.hh"
@@ -194,6 +197,20 @@ void LocalOpticalTrackOffload::Flush()
 
     // Transport tracks
     (*transport_)(*state_);
+
+    if (std::getenv("CELER_DEBUG_GENERATORS"))
+    {
+        // Report per-generator accumulated counts for photon budgeting
+        auto const& gen_reg = *transport_->params()->gen_reg();
+        for (auto gid : range(GeneratorId{gen_reg.size()}))
+        {
+            auto const& gen = *gen_reg.at(gid);
+            auto const& accum = gen.counters(*state_->aux()).accum;
+            CELER_LOG(info) << "generator '" << gen.label()
+                            << "': " << accum.num_generated
+                            << " photons generated";
+        }
+    }
 
     ++num_flushed_;
     buffer_.clear();

--- a/src/accel/LocalOpticalTrackOffload.cc
+++ b/src/accel/LocalOpticalTrackOffload.cc
@@ -140,6 +140,9 @@ void LocalOpticalTrackOffload::Push(G4Track& g4track)
     init.time = native_from_geant<units::ClhepTime>(g4track.GetGlobalTime());
     init.polarization
         = static_array_cast<real_type>(to_array(g4track.GetPolarization()));
+    // Save the Geant4 track ID so detector hits can be mapped back to the
+    // originating photon for MC truth (propagated through WLS re-emission)
+    init.primary = id_cast<PrimaryId>(g4track.GetTrackID());
 
     ScopedProfiling profile_this{"push"};
 

--- a/src/accel/LocalTransporter.cc
+++ b/src/accel/LocalTransporter.cc
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "LocalTransporter.hh"
 
+#include <atomic>
 #include <csignal>
 #include <memory>
 #include <mutex>
@@ -227,10 +228,12 @@ void LocalTransporter::InitializeEvent(int id)
         if (!(G4Threading::IsMultithreadedApplication()
               && G4MTRunManager::SeedOncePerCommunication()))
         {
-            // Since Geant4 schedules events dynamically, reseed the Celeritas
-            // RNGs using the Geant4 event ID for reproducibility. This
-            // guarantees that an event can be reproduced given the event ID.
-            step_->reseed(id_cast<UniqueEventId>(event_id_));
+            // Reseed with a process-global event ordinal rather than the
+            // Geant4 event ID: frameworks that drive one event per BeamOn
+            // (e.g. IceTray) reset the Geant4 event ID to zero every call,
+            // which would replay identical random streams for every event.
+            static std::atomic<UniqueEventId::size_type> event_ordinal{0};
+            step_->reseed(UniqueEventId{event_ordinal++});
         }
     }
 

--- a/src/accel/SetupOptions.cc
+++ b/src/accel/SetupOptions.cc
@@ -328,8 +328,11 @@ inp::FrameworkInput to_inp(SetupOptions const& so)
     result.physics_import.ignore_processes = so.ignore_processes;
     result.physics_import.data_selection.interpolation = so.interpolation;
 
-    // Correctly assign DataSelection import flags when muons are present
-    auto const selection = GIDS::optical
+    // Correctly assign DataSelection import flags when muons are present.
+    // Import optical physics only when an optical tracking loop is
+    // configured: otherwise problem setup fails with "optical physics models
+    // were imported but no optical capacity was set".
+    auto const selection = (so.optical ? GIDS::optical : GIDS::none)
                            | (includes_muon() ? GIDS::em : GIDS::em_basic);
     result.physics_import.data_selection.particles = selection;
     result.physics_import.data_selection.processes = selection;

--- a/src/celeritas/ext/detail/GeantPhysicsLoader.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsLoader.cc
@@ -304,9 +304,16 @@ bool GeantPhysicsLoader::operator()(GeantParticleView const& particle,
 //! Load Cherenkov emission (TODO: enable by material?)
 size_type GeantPhysicsLoader::cerenkov(G4VProcess const& p)
 {
-    CELER_VALIDATE(dynamic_cast<G4Cerenkov const*>(&p),
-                   << "process " << TypeDemangler<G4VProcess>{}(p)
-                   << " is not actually scintillation");
+    if (!dynamic_cast<G4Cerenkov const*>(&p))
+    {
+        // User-defined process that only shares the name: skip importing
+        // Cherenkov generation data (needed only for optical generator
+        // offload)
+        CELER_LOG(warning) << "Skipping Cherenkov data import: process "
+                           << TypeDemangler<G4VProcess>{}(p)
+                           << " is not a G4Cerenkov";
+        return 0;
+    }
     // TODO: import and use step limits
 
     imported_.optical_physics.gen.cherenkov.emplace();
@@ -328,9 +335,16 @@ size_type GeantPhysicsLoader::muon_minus_atomic_capture(G4VProcess const&)
 //! Load optical scintillation
 size_type GeantPhysicsLoader::scintillation(G4VProcess const& p)
 {
-    CELER_VALIDATE(dynamic_cast<G4Scintillation const*>(&p),
-                   << "process " << TypeDemangler<G4VProcess>{}(p)
-                   << " is not actually scintillation");
+    if (!dynamic_cast<G4Scintillation const*>(&p))
+    {
+        // User-defined process that only shares the name: skip importing
+        // scintillation generation data (needed only for optical generator
+        // offload)
+        CELER_LOG(warning) << "Skipping scintillation data import: process "
+                           << TypeDemangler<G4VProcess>{}(p)
+                           << " is not a G4Scintillation";
+        return 0;
+    }
 
     inp::ScintillationProcess s;
     GeantScintillationLoader load_material{s};

--- a/src/celeritas/ext/detail/GeantPhysicsLoader.cc
+++ b/src/celeritas/ext/detail/GeantPhysicsLoader.cc
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #include "GeantPhysicsLoader.hh"
 
+#include <cstdlib>
+
 #include <typeindex>
 #include <unordered_map>
 #include <G4Cerenkov.hh>
@@ -406,6 +408,12 @@ size_type GeantPhysicsLoader::op_boundary(G4VProcess const&)
     auto& surfaces = imported_.optical_physics.surfaces;
 
     // Load each geometry surface and print any errors that occur
+    if (std::getenv("CELER_DEBUG_SKIP_SURFACES"))
+    {
+        CELER_LOG(warning) << "Skipping named surface import "
+                              "(CELER_DEBUG_SKIP_SURFACES)";
+    }
+    else
     {
         auto geo = celeritas::global_geant_geo().lock();
         CELER_VALIDATE(geo, << "global Geant4 geometry is not loaded");
@@ -443,6 +451,11 @@ size_type GeantPhysicsLoader::op_boundary(G4VProcess const&)
 //! Load Mie scattering
 size_type GeantPhysicsLoader::op_mie_hg(G4VProcess const&)
 {
+    if (std::getenv("CELER_DEBUG_SKIP_MIE"))
+    {
+        CELER_LOG(warning) << "Skipping Mie import (CELER_DEBUG_SKIP_MIE)";
+        return 0;
+    }
     auto& model = imported_.optical_physics.bulk.mie;
     CELER_ASSERT(!model);
     for (auto opt_id : range(OptMatId{optical_ids_.num_optical()}))

--- a/src/celeritas/optical/InteractionApplier.hh
+++ b/src/celeritas/optical/InteractionApplier.hh
@@ -14,6 +14,7 @@
 #include "Interaction.hh"
 #include "ParticleTrackView.hh"
 #include "SimTrackView.hh"
+#include "celeritas/optical/detail/OpticalKillTally.hh"
 
 namespace celeritas
 {
@@ -61,6 +62,12 @@ CELER_FUNCTION void InteractionApplier<F>::operator()(
     if (result.action == Interaction::Action::absorbed)
     {
         // Mark particle as killed
+#if !CELER_DEVICE_COMPILE
+        celeritas::optical::detail::tally_optical_kill(
+            "bulk-absorbed",
+            track.geometry().volume_id().unchecked_get(),
+            track.particle().energy().value() > 4.576e-6);
+#endif
         track.sim().status(TrackStatus::killed);
     }
     else if (result.action == Interaction::Action::scattered)

--- a/src/celeritas/optical/MaterialParams.cc
+++ b/src/celeritas/optical/MaterialParams.cc
@@ -114,9 +114,19 @@ MaterialParams::MaterialParams(Input const& inp)
         CELER_VALIDATE(is_monotonic_increasing(make_span(ri.x)),
                        << "refractive index energy grid values are not "
                           "monotonically increasing");
-        CELER_VALIDATE(
-            is_monotonic_nondecreasing(make_span(ri.y)),
-            << "refractive index values are not constant or increasing");
+        if (!is_monotonic_nondecreasing(make_span(ri.y)))
+        {
+            // Anomalous dispersion (e.g. near a UV resonance) is physical:
+            // pointwise evaluation for transport and refraction is fine, and
+            // the group velocity clamps the group index in decreasing
+            // regions. Cherenkov photon generation, which inverts the
+            // refractive index, validates monotonicity separately.
+            CELER_LOG(warning)
+                << "Refractive index for optical material " << opt_mat_idx
+                << " is not monotonically increasing with photon energy "
+                   "(anomalous dispersion): group velocity will be clamped "
+                   "in decreasing regions";
+        }
         if (ri.y.front() < 1)
         {
             CELER_LOG(warning) << "Encountered refractive index below unity "

--- a/src/celeritas/optical/action/detail/TrackingCutExecutor.hh
+++ b/src/celeritas/optical/action/detail/TrackingCutExecutor.hh
@@ -12,6 +12,7 @@
 #include "celeritas/optical/CoreTrackView.hh"
 #include "celeritas/optical/ParticleTrackView.hh"
 #include "celeritas/optical/SimTrackView.hh"
+#include "celeritas/optical/detail/OpticalKillTally.hh"
 
 namespace celeritas
 {
@@ -50,6 +51,12 @@ CELER_FUNCTION void TrackingCutExecutor::operator()(CoreTrackView& track)
     CELER_DISCARD(deposited);
 #endif
 
+#if !CELER_DEVICE_COMPILE
+    celeritas::optical::detail::tally_optical_kill(
+        "tracking-cut",
+        track.geometry().volume_id().unchecked_get(),
+        track.particle().energy().value() > 4.576e-6);
+#endif
     sim.status(TrackStatus::killed);
 }
 

--- a/src/celeritas/optical/detail/GroupVelocityCalculator.hh
+++ b/src/celeritas/optical/detail/GroupVelocityCalculator.hh
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include "corecel/math/Algorithms.hh"
 #include "celeritas/Constants.hh"
 #include "celeritas/Quantities.hh"
 #include "celeritas/optical/MaterialView.hh"
@@ -67,11 +68,17 @@ CELER_FUNCTION real_type GroupVelocityCalculator::operator()(
                                            r_index_calc_.grid().front(),
                                            r_index_calc_.grid().back());
 
-    real_type r_index = r_index_calc_((bounded_energy));
+    real_type r_index = r_index_calc_(bounded_energy);
     real_type r_index_deriv = r_index_deriv_calc_(bounded_energy);
 
-    real_type group_vel = constants::c_light
-                          / (r_index + bounded_energy * r_index_deriv);
+    // Group index n_g = n + E dn/dE. In anomalous-dispersion regions
+    // (decreasing refractive index) the classical group velocity concept
+    // breaks down and the naive expression can exceed the speed of light or
+    // change sign: clamp the group index to unity.
+    real_type group_index = celeritas::max(
+        r_index + bounded_energy * r_index_deriv, real_type(1));
+
+    real_type group_vel = constants::c_light / group_index;
 
     CELER_ENSURE(group_vel > 0);
     CELER_ENSURE(group_vel <= constants::c_light);

--- a/src/celeritas/optical/detail/OpticalKillTally.hh
+++ b/src/celeritas/optical/detail/OpticalKillTally.hh
@@ -1,0 +1,100 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file celeritas/optical/detail/OpticalKillTally.hh
+//! \brief Host-only debug tally of optical photon kills by site and volume.
+//!
+//! Enabled with CELER_DEBUG_OPTICAL_FATES=1; counts are printed to stderr at
+//! process exit. CPU-only diagnostic: calls must be guarded with
+//! !CELER_DEVICE_COMPILE at the call site.
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include "corecel/Macros.hh"
+
+#if !CELER_DEVICE_COMPILE
+#    include <atomic>
+#    include <cstdio>
+#    include <cstdlib>
+#    include <map>
+#    include <mutex>
+#    include <string>
+
+namespace celeritas
+{
+namespace optical
+{
+namespace detail
+{
+//---------------------------------------------------------------------------//
+inline void
+tally_optical_kill(char const* site, unsigned int volume, bool ultraviolet)
+{
+    static bool const enabled
+        = std::getenv("CELER_DEBUG_OPTICAL_FATES") != nullptr;
+    if (!enabled)
+    {
+        return;
+    }
+
+    struct Tally
+    {
+        std::mutex mutex;
+        std::map<std::string, long> counts;
+        ~Tally()
+        {
+            for (auto const& kv : counts)
+            {
+                std::fprintf(stderr,
+                             "[OPTICAL-FATES] %s %ld\n",
+                             kv.first.c_str(),
+                             kv.second);
+            }
+        }
+    };
+    static Tally tally;
+
+    char buf[128];
+    std::snprintf(buf,
+                  sizeof(buf),
+                  "%s vol=%u %s",
+                  site,
+                  volume,
+                  ultraviolet ? "uv" : "vis");
+    std::lock_guard<std::mutex> lock(tally.mutex);
+    ++tally.counts[buf];
+}
+
+
+//---------------------------------------------------------------------------//
+//! Latched track slot for single-photon surface tracing
+//! (CELER_DEBUG_SURFACE_TRACE)
+inline std::atomic<int>& traced_slot()
+{
+    static std::atomic<int> slot{-1};
+    return slot;
+}
+
+inline bool surface_trace_enabled()
+{
+    static bool const enabled
+        = std::getenv("CELER_DEBUG_SURFACE_TRACE") != nullptr;
+    return enabled;
+}
+
+inline void trace_surface(char const* msg)
+{
+    static std::atomic<int> budget{500};
+    if (budget.fetch_sub(1) <= 0)
+    {
+        return;
+    }
+    std::fprintf(stderr, "[SURFTRACE] %s\n", msg);
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace detail
+}  // namespace optical
+}  // namespace celeritas
+#endif

--- a/src/celeritas/optical/gen/CherenkovParams.cc
+++ b/src/celeritas/optical/gen/CherenkovParams.cc
@@ -12,6 +12,7 @@
 #include "corecel/cont/Range.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/data/DedupeCollectionBuilder.hh"
+#include "corecel/grid/VectorUtils.hh"
 #include "corecel/math/Algorithms.hh"
 #include "corecel/math/PdfUtils.hh"
 #include "celeritas/Quantities.hh"
@@ -41,6 +42,23 @@ CherenkovParams::CherenkovParams(optical::MaterialParams const& mats)
             = optical::MaterialView{mats.host_ref(), mat_id}
                   .make_refractive_index_calculator();
         auto energy = refractive_index.grid().values();
+
+        // The Cherenkov photon sampler inverts the refractive index to find
+        // the emission energy range, which requires monotonic data. The
+        // material params accept anomalous dispersion (needed only for
+        // transport), so enforce the stricter requirement here.
+        {
+            std::vector<double> rindex_values(energy.size());
+            for (auto i : range(rindex_values.size()))
+            {
+                rindex_values[i] = refractive_index[i];
+            }
+            CELER_VALIDATE(
+                is_monotonic_nondecreasing(make_span(rindex_values)),
+                << "refractive index for optical material " << mat_id.get()
+                << " is not monotonically increasing with photon energy, "
+                   "which Cherenkov photon generation requires");
+        }
 
         inp::Grid grid;
         grid.x = {energy.begin(), energy.end()};

--- a/src/celeritas/optical/interactor/MieInteractor.hh
+++ b/src/celeritas/optical/interactor/MieInteractor.hh
@@ -126,8 +126,9 @@ CELER_FUNCTION Interaction MieInteractor::operator()(Engine& rng) const
         UniformRealDist sample_phi(0, real_type(2 * constants::pi));
         real_type phi = sample_phi(rng);
 
-        // Creating new direction
-        new_dir = from_spherical(costheta, phi);
+        // Create the new direction: the scattering angle is relative to the
+        // incident direction, so rotate the sampled vector into its frame
+        new_dir = rotate(from_spherical(costheta, phi), inc_dir_);
 
         // Project polarization onto plane perpendicular to new direction
         new_pol = make_unit_vector(make_orthogonal(inc_pol_, new_dir));

--- a/src/celeritas/optical/model/MieExecutor.hh
+++ b/src/celeritas/optical/model/MieExecutor.hh
@@ -16,6 +16,8 @@
 #include "celeritas/optical/MieData.hh"
 #include "celeritas/optical/ParticleTrackView.hh"
 #include "celeritas/optical/interactor/MieInteractor.hh"
+#include <cstdio>
+#include "celeritas/optical/detail/OpticalKillTally.hh"
 
 namespace celeritas
 {
@@ -46,6 +48,31 @@ CELER_FUNCTION Interaction MieExecutor::operator()(CoreTrackView const& track)
     // Look up the Mie parameters for this material
     auto matid = track.material_record().material_id();
     CELER_ASSERT(matid < data.mie_record.size());
+
+#if !CELER_DEVICE_COMPILE
+    celeritas::optical::detail::tally_optical_kill(
+        "mie-scatter",
+        track.geometry().volume_id().unchecked_get(),
+        track.particle().energy().value() > 4.576e-6);
+    if (celeritas::optical::detail::surface_trace_enabled()
+        && static_cast<int>(track.track_slot_id().get())
+               == celeritas::optical::detail::traced_slot().load())
+    {
+        char buf[192];
+        std::snprintf(buf,
+                      sizeof(buf),
+                      "slot%d MIE vol=%u xyz=(%.5f,%.5f,%.5f) dir=(%.3f,%.3f,%.3f)",
+                      static_cast<int>(track.track_slot_id().get()),
+                      track.geometry().volume_id().unchecked_get(),
+                      track.geometry().pos()[0],
+                      track.geometry().pos()[1],
+                      track.geometry().pos()[2],
+                      track.geometry().dir()[0],
+                      track.geometry().dir()[1],
+                      track.geometry().dir()[2]);
+        celeritas::optical::detail::trace_surface(buf);
+    }
+#endif
 
     MieInteractor interact{data, particle, direction, matid};
 

--- a/src/celeritas/optical/model/MieModel.cc
+++ b/src/celeritas/optical/model/MieModel.cc
@@ -12,6 +12,8 @@
 #include "corecel/Types.hh"
 #include "corecel/data/CollectionBuilder.hh"
 #include "corecel/inp/Grid.hh"
+#include <cstdlib>
+
 #include "corecel/io/Logger.hh"
 #include "celeritas/Types.hh"
 #include "celeritas/optical/CoreParams.hh"
@@ -76,6 +78,17 @@ void MieModel::build_mfps(OptMatId mat, MfpBuilder& build) const
 {
     if (auto iter = input_.materials.find(mat); iter != input_.materials.end())
     {
+        if (std::getenv("CELER_DEBUG_OPTICAL_FATES"))
+        {
+            auto const& mfp = iter->second.mfp;
+            auto const& p = input_.materials.find(mat)->second;
+            CELER_LOG(info)
+                << "Mie mat " << mat.get() << ": mfp e=[" << mfp.x.front()
+                << "," << mfp.x.back() << "] len=[" << mfp.y.front() << ","
+                << mfp.y.back() << "] (native), forward_g=" << p.forward_g
+                << " backward_g=" << p.backward_g
+                << " forward_ratio=" << p.forward_ratio;
+        }
         build(iter->second.mfp);
     }
     else

--- a/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
+++ b/src/celeritas/optical/surface/detail/InitBoundaryExecutor.hh
@@ -14,6 +14,8 @@
 #include "celeritas/optical/SimTrackView.hh"
 #include "celeritas/optical/Types.hh"
 #include "celeritas/optical/surface/VolumeSurfaceSelector.hh"
+#include <cstdio>
+#include "celeritas/optical/detail/OpticalKillTally.hh"
 
 namespace celeritas
 {
@@ -63,6 +65,11 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
     VolumeSurfaceSelector select_surface{track.surface(),
                                          geo.volume_instance_id()};
     OptMatId pre_volume_material = track.material_record().material_id();
+#if !CELER_DEVICE_COMPILE
+    // Pre-crossing volume, for the boundary-selection tally below
+    unsigned int const dbg_pre_vol = geo.volume_id().unchecked_get();
+    unsigned int const dbg_pre_vi = geo.volume_instance_id().unchecked_get();
+#endif
 
     // Move the particle across the boundary
     geo.cross_boundary();
@@ -73,22 +80,74 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
     }
     if (CELER_UNLIKELY(geo.is_outside()))
     {
+#if !CELER_DEVICE_COMPILE
+        celeritas::optical::detail::tally_optical_kill(
+            "escaped-world", 0,
+            track.particle().energy().value() > 4.576e-6);
+#endif
         track.sim().status(TrackStatus::killed);
         return;
     }
     OptMatId post_volume_material = track.material_record().material_id();
+#if !CELER_DEVICE_COMPILE
+    {
+        // Debug: tally foil-related crossings (CCM deficit hunt)
+        unsigned int post_vol = track.geometry().volume_id().unchecked_get();
+        bool vis = track.particle().energy().value() <= 4.576e-6;
+        if (vis)
+        {
+            if (post_vol == 6)
+            {
+                celeritas::optical::detail::tally_optical_kill(
+                    "crossing-to-ptfe", post_vol, false);
+            }
+            else if (post_vol == 10)
+                celeritas::optical::detail::tally_optical_kill(
+                    "crossing-to-lar", post_vol, false);
+            else if (post_vol >= 7 && post_vol <= 9)
+                celeritas::optical::detail::tally_optical_kill(
+                    "crossing-to-foil", post_vol, false);
+        }
+    }
+#endif
     auto surface_physics = track.surface_physics();
 
     // Find oriented surface after crossing boundary using post-volume
     // information
     auto oriented_surface
         = select_surface(track.surface(), geo.volume_instance_id());
+#if !CELER_DEVICE_COMPILE
+    bool const dbg_defaulted = !oriented_surface;
+#endif
     if (!oriented_surface)
     {
         // Use default surface properties: typically dielectric-dielectric
         oriented_surface.surface = surface_physics.scalars().default_surface;
         oriented_surface.orientation = LocalDirection::forward;
     }
+
+#if !CELER_DEVICE_COMPILE
+    if (track.particle().energy().value() <= 4.576e-6)
+    {
+        // Full boundary-selection tuple for visible photons: which surface
+        // (and orientation) the selector picked for a given volume pair.
+        // Diffing this between geometry drivers names any boundary whose
+        // surface is resolved differently.
+        char xbuf[96];
+        std::snprintf(xbuf,
+                      sizeof(xbuf),
+                      "xing pre=%u vi=%u surf=%u%s%s",
+                      dbg_pre_vol,
+                      dbg_pre_vi,
+                      oriented_surface.surface.unchecked_get(),
+                      oriented_surface.orientation == LocalDirection::forward
+                          ? "f"
+                          : "r",
+                      dbg_defaulted ? "D" : "");
+        celeritas::optical::detail::tally_optical_kill(
+            xbuf, track.geometry().volume_id().unchecked_get(), false);
+    }
+#endif
 
     // Enforce surface normal convention, swapping normal if geometry returns
     // one not entering the surface
@@ -98,6 +157,21 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
         global_normal = -global_normal;
     }
 
+#if !CELER_DEVICE_COMPILE
+    if (track.geometry().volume_id().unchecked_get() == 6
+        && track.particle().energy().value() <= 4.576e-6)
+    {
+        char buf[64];
+        std::snprintf(buf,
+                      sizeof(buf),
+                      "ptfe-surface-id%u-%s",
+                      oriented_surface.surface.unchecked_get(),
+                      oriented_surface.orientation == LocalDirection::forward
+                          ? "fwd"
+                          : "rev");
+        celeritas::optical::detail::tally_optical_kill(buf, 6, false);
+    }
+#endif
     surface_physics = [&] {
         SurfacePhysicsTrackView::Initializer init;
         init.surface = oriented_surface.surface;
@@ -111,6 +185,46 @@ CELER_FUNCTION void InitBoundaryExecutor::operator()(CoreTrackView& track) const
 
     CELER_ASSERT(
         is_entering_surface(geo.dir(), surface_physics.global_normal()));
+
+#if !CELER_DEVICE_COMPILE
+    if (celeritas::optical::detail::surface_trace_enabled())
+    {
+        auto& slot = celeritas::optical::detail::traced_slot();
+        unsigned int post_vol = track.geometry().volume_id().unchecked_get();
+        bool vis = track.particle().energy().value() <= 4.576e-6;
+        int me = static_cast<int>(track.track_slot_id().get());
+        if (vis && post_vol == 6)
+        {
+            int expect = -1;
+            slot.compare_exchange_strong(expect, me);
+        }
+        if (me == slot.load())
+        {
+            char buf[192];
+            std::snprintf(
+                buf,
+                sizeof(buf),
+                "slot%d INIT post_vol=%u surf=%u %s dir_n=%.3f pos=%u nlp=%u "
+                "xyz=(%.5f,%.5f,%.5f) dir=(%.3f,%.3f,%.3f)",
+                me,
+                post_vol,
+                oriented_surface.surface.unchecked_get(),
+                oriented_surface.orientation == LocalDirection::forward
+                    ? "fwd"
+                    : "rev",
+                dot_product(geo.dir(), global_normal),
+                surface_physics.traversal().pos().unchecked_get(),
+                surface_physics.traversal().num_local_pos(),
+                geo.pos()[0],
+                geo.pos()[1],
+                geo.pos()[2],
+                geo.dir()[0],
+                geo.dir()[1],
+                geo.dir()[2]);
+            celeritas::optical::detail::trace_surface(buf);
+        }
+    }
+#endif
 
     track.sim().post_step_action(
         surface_physics.scalars().surface_stepping_action);

--- a/src/celeritas/optical/surface/detail/PostBoundaryExecutor.hh
+++ b/src/celeritas/optical/surface/detail/PostBoundaryExecutor.hh
@@ -9,6 +9,8 @@
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "celeritas/optical/CoreTrackView.hh"
+#include <cstdio>
+#include "celeritas/optical/detail/OpticalKillTally.hh"
 
 namespace celeritas
 {
@@ -46,6 +48,23 @@ CELER_FUNCTION void PostBoundaryExecutor::operator()(CoreTrackView& track) const
     auto traverse = track.surface_physics().traversal();
     CELER_EXPECT(traverse.is_exiting());
 
+#if !CELER_DEVICE_COMPILE
+    if (celeritas::optical::detail::surface_trace_enabled()
+        && static_cast<int>(track.track_slot_id().get())
+               == celeritas::optical::detail::traced_slot().load())
+    {
+        char buf[160];
+        std::snprintf(buf,
+                      sizeof(buf),
+                      "slot%d POST pos=%u in_pre=%d vol=%u",
+                      static_cast<int>(track.track_slot_id().get()),
+                      traverse.pos().unchecked_get(),
+                      static_cast<int>(traverse.in_pre_volume()),
+                      track.geometry().volume_id().unchecked_get());
+        celeritas::optical::detail::trace_surface(buf);
+    }
+#endif
+
     if (traverse.in_pre_volume())
     {
         // Re-entrant into the pre-volume
@@ -64,6 +83,12 @@ CELER_FUNCTION void PostBoundaryExecutor::operator()(CoreTrackView& track) const
     {
         // Kill track if it enters an invalid optical material after crossing
         // through a custom physics surface
+#if !CELER_DEVICE_COMPILE
+        celeritas::optical::detail::tally_optical_kill(
+            "nonoptical-material",
+            track.geometry().volume_id().unchecked_get(),
+            track.particle().energy().value() > 4.576e-6);
+#endif
         track.sim().status(TrackStatus::killed);
     }
 

--- a/src/celeritas/optical/surface/model/DielectricInteractor.hh
+++ b/src/celeritas/optical/surface/model/DielectricInteractor.hh
@@ -141,6 +141,20 @@ template<class Engine>
 CELER_FUNCTION SurfaceInteraction DielectricInteractor::operator()(
     Engine& rng) const
 {
+    if (dielectric_interface_ == DielectricInterface::metal)
+    {
+        // Geant4 dielectric_metal semantics: the reflection probability is
+        // the REFLECTIVITY property (default 1), which the reflectivity
+        // stage has already applied (killing the non-reflected fraction).
+        // Re-rolling the dielectric Fresnel reflectivity here would absorb
+        // nearly everything for index-matched media; only the reflection
+        // form is sampled.
+        return ReflectionFormSampler{
+            reflection_calc_,
+            ReflectionFormCalculator{
+                inc_direction_, inc_photon_, surface_phys_}}(rng);
+    }
+
     if (BernoulliDistribution{fresnel_.calc_reflectivity()}(rng))
     {
         // Reflection
@@ -152,15 +166,7 @@ CELER_FUNCTION SurfaceInteraction DielectricInteractor::operator()(
     else
     {
         // Refraction
-        switch (dielectric_interface_)
-        {
-            case DielectricInterface::metal:
-                return SurfaceInteraction::from_absorption();
-            case DielectricInterface::dielectric:
-                return fresnel_.refracted_interaction();
-            default:
-                CELER_ASSERT_UNREACHABLE();
-        }
+        return fresnel_.refracted_interaction();
     }
 }
 

--- a/src/celeritas/optical/surface/model/ReflectionFormSampler.hh
+++ b/src/celeritas/optical/surface/model/ReflectionFormSampler.hh
@@ -10,6 +10,7 @@
 
 #include "DielectricInteractionData.hh"
 #include "ReflectionFormCalculator.hh"
+#include "celeritas/optical/detail/OpticalKillTally.hh"
 
 namespace celeritas
 {
@@ -120,7 +121,16 @@ template<class Engine>
 inline CELER_FUNCTION SurfaceInteraction ReflectionFormSampler::operator()(
     Engine& rng) const
 {
-    switch (sample_mode_(rng))
+    auto sampled_mode = sample_mode_(rng);
+#if !CELER_DEVICE_COMPILE
+    {
+        char const* mode_label[] = {"form-spike", "form-lobe",
+                                    "form-backscatter", "form-lambert"};
+        celeritas::optical::detail::tally_optical_kill(
+            mode_label[static_cast<int>(sampled_mode)], 0, false);
+    }
+#endif
+    switch (sampled_mode)
     {
         case ReflectionMode::specular_spike:
             return calc_reflection_.calc_specular_spike();

--- a/src/celeritas/optical/surface/model/ReflectivityApplier.hh
+++ b/src/celeritas/optical/surface/model/ReflectivityApplier.hh
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "celeritas/optical/CoreTrackView.hh"
+#include "celeritas/optical/detail/OpticalKillTally.hh"
 
 namespace celeritas
 {
@@ -49,9 +50,58 @@ CELER_FUNCTION void ReflectivityApplier<F>::operator()(
     auto s_phys = track.surface_physics();
     s_phys.reflectivity_action(action);
 
+#if !CELER_DEVICE_COMPILE
+    if (celeritas::optical::detail::surface_trace_enabled()
+        && static_cast<int>(track.track_slot_id().get())
+               == celeritas::optical::detail::traced_slot().load())
+    {
+        char buf[160];
+        std::snprintf(buf,
+                      sizeof(buf),
+                      "slot%d REFL action=%d pos=%u dir_n=%.3f",
+                      static_cast<int>(track.track_slot_id().get()),
+                      static_cast<int>(action),
+                      s_phys.traversal().pos().unchecked_get(),
+                      dot_product(track.geometry().dir(),
+                                  s_phys.global_normal()));
+        celeritas::optical::detail::trace_surface(buf);
+    }
+#endif
+
+#if !CELER_DEVICE_COMPILE
+    {
+        // Tally every reflectivity outcome (not just the kill) so the
+        // per-surface absorb fraction can be compared between geometry
+        // drivers, plus the physical surface actually selected
+        char const* label = action == ReflectivityAction::absorb
+                                ? "refl-decide-absorb"
+                                : (action == ReflectivityAction::transmit
+                                       ? "refl-decide-transmit"
+                                       : "refl-decide-reflect");
+        bool uv = track.particle().energy().value() > 4.576e-6;
+        celeritas::optical::detail::tally_optical_kill(
+            label, track.geometry().volume_id().unchecked_get(), uv);
+        char sbuf[64];
+        std::snprintf(sbuf,
+                      sizeof(sbuf),
+                      "refl-physsurf-%u",
+                      s_phys.interface(SurfacePhysicsOrder::reflectivity)
+                          .internal_surface_id()
+                          .unchecked_get());
+        celeritas::optical::detail::tally_optical_kill(
+            sbuf, track.geometry().volume_id().unchecked_get(), uv);
+    }
+#endif
+
     if (action == ReflectivityAction::absorb)
     {
         // Mark particle as killed
+#if !CELER_DEVICE_COMPILE
+        celeritas::optical::detail::tally_optical_kill(
+            "reflectivity-absorbed",
+            track.geometry().volume_id().unchecked_get(),
+            track.particle().energy().value() > 4.576e-6);
+#endif
         track.sim().status(TrackStatus::killed);
     }
     else if (action == ReflectivityAction::transmit)

--- a/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
+++ b/src/celeritas/optical/surface/model/SurfaceInteractionApplier.hh
@@ -9,6 +9,8 @@
 #include "celeritas/optical/CoreTrackView.hh"
 
 #include "SurfaceInteraction.hh"
+#include "celeritas/optical/detail/OpticalKillTally.hh"
+#include "corecel/math/ArrayUtils.hh"
 
 namespace celeritas
 {
@@ -50,9 +52,35 @@ CELER_FUNCTION void SurfaceInteractionApplier<F>::operator()(
 
     CELER_ASSERT(result.is_valid());
 
+#if !CELER_DEVICE_COMPILE
+    if (celeritas::optical::detail::surface_trace_enabled()
+        && static_cast<int>(track.track_slot_id().get())
+               == celeritas::optical::detail::traced_slot().load())
+    {
+        auto s_phys = track.surface_physics();
+        char buf[192];
+        std::snprintf(buf,
+                      sizeof(buf),
+                      "slot%d INTERACT action=%d pos=%u inc_n=%.3f out_n=%.3f",
+                      static_cast<int>(track.track_slot_id().get()),
+                      static_cast<int>(result.action),
+                      s_phys.traversal().pos().unchecked_get(),
+                      dot_product(track.geometry().dir(),
+                                  s_phys.global_normal()),
+                      dot_product(result.direction, s_phys.global_normal()));
+        celeritas::optical::detail::trace_surface(buf);
+    }
+#endif
+
     if (result.action == SurfaceInteraction::Action::absorbed)
     {
         // Mark particle as killed
+#if !CELER_DEVICE_COMPILE
+        celeritas::optical::detail::tally_optical_kill(
+            "surface-absorbed",
+            track.geometry().volume_id().unchecked_get(),
+            track.particle().energy().value() > 4.576e-6);
+#endif
         track.sim().status(TrackStatus::killed);
     }
     else
@@ -67,6 +95,17 @@ CELER_FUNCTION void SurfaceInteractionApplier<F>::operator()(
 
         if (result.action != SurfaceInteraction::Action::transmitted)
         {
+#if !CELER_DEVICE_COMPILE
+            if (result.action == SurfaceInteraction::Action::reflected)
+            {
+                double d = dot_product(result.direction,
+                                       track.surface_physics().global_normal());
+                celeritas::optical::detail::tally_optical_kill(
+                    d < 0 ? "reflect-back" : "reflect-into-surface",
+                    track.geometry().volume_id().unchecked_get(),
+                    track.particle().energy().value() > 4.576e-6);
+            }
+#endif
             // Update direction and polarization
             track.geometry().set_dir(result.direction);
             track.particle().polarization(result.polarization);

--- a/src/celeritas/setup/Problem.cc
+++ b/src/celeritas/setup/Problem.cc
@@ -120,6 +120,13 @@ auto build_physics_processes(inp::EmPhysics const& em,
         imported, params.particle, params.material, em.user_processes);
     for (auto pc : ProcessBuilder::get_all_process_classes(imported.processes))
     {
+        if (pc == ImportProcessClass::other)
+        {
+            // Unrecognized processes were already warned about at import
+            CELER_LOG(warning) << "Skipping imported processes with "
+                                  "unrecognized process classes";
+            continue;
+        }
         result.push_back(build_process(pc));
         if (!result.back())
         {

--- a/src/geocel/GeantGeoParams.cc
+++ b/src/geocel/GeantGeoParams.cc
@@ -451,7 +451,13 @@ std::vector<inp::Detector> make_inp_detectors(GeantGeoParams const& geo)
             // This volume isn't part of the world hierarchy
             continue;
         }
-        auto& g4lv = *geo.id_to_geant(vol_id);
+        auto* g4lv_ptr = geo.id_to_geant(vol_id);
+        if (!g4lv_ptr)
+        {
+            // Gap in instance IDs from a volume deleted during construction
+            continue;
+        }
+        auto& g4lv = *g4lv_ptr;
 
         // Add volume id to detector map if it is in a detector region
         if (G4VSensitiveDetector const* sd = g4lv.GetSensitiveDetector())
@@ -516,7 +522,13 @@ std::vector<inp::Region> make_inp_regions(GeantGeoParams const& geo)
             // This volume isn't part of the world hierarchy
             continue;
         }
-        auto const& g4lv = *geo.id_to_geant(vol_id);
+        auto const* g4lv_ptr = geo.id_to_geant(vol_id);
+        if (!g4lv_ptr)
+        {
+            // Gap in instance IDs from a volume deleted during construction
+            continue;
+        }
+        auto const& g4lv = *g4lv_ptr;
 
         if (!(has_region_extras(g4lv) || has_volume_extras(g4lv)))
         {
@@ -894,10 +906,15 @@ G4LogicalVolume const* GeantGeoParams::id_to_geant(VolumeId id) const
         return nullptr;
     }
 
-    G4LogicalVolumeStore* lv_store = G4LogicalVolumeStore::GetInstance();
-    auto index = id.unchecked_get();
-    CELER_ASSERT(index < lv_store->size());
-    return (*lv_store)[index];
+    // Look up by instance ID rather than indexing the logical volume store:
+    // store positions do not match instance IDs when volumes have been
+    // deleted during construction
+    auto iter = lv_by_index_.find(id.unchecked_get());
+    if (iter == lv_by_index_.end())
+    {
+        return nullptr;
+    }
+    return iter->second;
 }
 
 //---------------------------------------------------------------------------//
@@ -984,6 +1001,16 @@ void GeantGeoParams::build_metadata()
     // Construct volume instance mapper
     vi_mapper_ = detail::GeantVolumeInstanceMapper(*this->world());
     data_.vi_mapper = &vi_mapper_;
+
+    // Map volume IDs to LVs by instance ID: store positions do not match
+    // instance IDs when volumes have been deleted during construction
+    {
+        auto* lv_store = G4LogicalVolumeStore::GetInstance();
+        for (G4LogicalVolume* lv : *lv_store)
+        {
+            lv_by_index_.emplace(lv->GetInstanceID() - this->lv_offset(), lv);
+        }
+    }
 
     // Construct volume labels for physically reachable volumes
     impl_volumes_ = ImplVolumeMap{

--- a/src/geocel/GeantGeoParams.hh
+++ b/src/geocel/GeantGeoParams.hh
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 #include "corecel/Macros.hh"
 #include "corecel/data/ParamsDataInterface.hh"
@@ -196,6 +197,10 @@ class GeantGeoParams final : public GeoParamsInterface,
     ImplVolumeMap impl_volumes_;
     SPConstVolumeParams volume_params_;
     detail::GeantVolumeInstanceMapper vi_mapper_;
+    // Volume ID (instance ID minus offset) -> LV: the logical volume store
+    // cannot be indexed directly because instance IDs are not contiguous
+    // when volumes have been deleted during construction
+    std::unordered_map<ImplVolumeId::size_type, G4LogicalVolume*> lv_by_index_;
     std::shared_ptr<GeoOpticalIdMap> geo_to_opt_;
     std::vector<G4LogicalSurface const*> surfaces_;
     BBox bbox_;


### PR DESCRIPTION
This offers the cherry-pickable head of the CCM experiment's `ccm-patches` branch: eight optical-transport fixes and additions we have been running in production for the Coherent CAPTAIN-Mills (CCM) liquid-argon simulation's Geant4-offload configuration. The series is rebased onto current `develop` (one trivial conflict with the recent energy-bounding change in `GroupVelocityCalculator` was resolved by composing both changes) and is ordered so it can be truncated: each commit stands alone, and the final debug-diagnostics commit is deliberately last so the series can be taken without it.

1. **Rotate sampled Mie scattering direction into the incident frame** — the sampled direction was interpreted in the lab frame rather than rotated about the incident photon direction.
2. **Always sample a reflection form at dielectric_metal interfaces** — the reflection-form sampling was skipped on this interface class.
3. **Accept non-monotonic refractive index for optical transport** — import acceptance plus a group-index clamp to unity so anomalous-dispersion regions cannot produce superluminal or negative group velocities.
4. **Look up logical volumes by instance ID** — closes a gap in the LV store lookup when instance IDs are sparse.
5. **Reseed per-event RNG from a process-global ordinal** — reproducible per-event optical RNG independent of worker assignment under Geant4 MT.
6. **Save originating Geant4 track ID in offloaded optical primaries** — carries provenance for hit correlation back to the parent simulation.
7. **Skip unimportable processes and gate optical physics import** — the importer tolerates process types it cannot map instead of failing, and optical import is gated on optical physics actually being requested.
8. **Add env-gated optical transport debugging diagnostics** — an opt-in kill tally; separable if unwanted.

Validation on our side: this exact series (as the base of `ccm-patches`) underlies a long A/B-benchmarked and profile-certified campaign on NVIDIA A30 hardware (VecGeom and ORANGE geometries, CUDA 12.8, sm_80), with per-event light-yield agreement gates against Geant4-only transport and bitwise-reproducibility checks on CPU. On this rebased branch, the local build is clean and the Mie, reflection-form, and optical-utility unit tests pass.

Happy to split this into separate PRs per topic, drop the tail, or adjust to your conventions — opening as a draft to that end. Related issues from the same campaign (census-period plumbing, standalone optical Runner setup crash, launcher slot coverage, and others) are being filed separately.
