### PR TITLE
Work around GCC 8.5 compiler error

### DIFF
--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -122,7 +122,9 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-    static_assert(StackT{}.capacity() == max_bvh_depth);
+    // This local var is necessary for gcc 8.5 compilation
+    constexpr auto capacity = stack.capacity();
+    static_assert(capacity == max_bvh_depth);
     stack.push(BvhNodeId{0});
 
     while (!stack.empty())

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -122,7 +122,7 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-    static_assert(stack.capacity() == max_bvh_depth);
+    static_assert(StackT{}.capacity() == max_bvh_depth);
     stack.push(BvhNodeId{0});
 
     while (!stack.empty())


### PR DESCRIPTION
Building with an old RHEL8 GCC:
```
g++ (GCC) 8.5.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
gives an error:
```
In file included from celeritas/src/orange/univ/SimpleUnitTracker.hh:16                                                                                           from celeritas/src/orange/univ/TrackerVisitor.hh:12,   
from celeritas/src/orange/OrangeTrackView.hh:24,
from celeritas/src/orange/DebugIO.json.cc:16:                                                                                    celeritas/src/orange/detail/BvhIntersectingVolFinder.hh: In member function 'celeritas::detail::Intersection celeritas::detail::BvhIntersectingVolFinder::operator()(celeritas::detail::BvhIntersectingVolFinder::Ray, F&&, celeritas::real_type) const':
celeritas/src/orange/detail/BvhIntersectingVolFinder.hh:125:36: error: non-constant condition for static assertion
     static_assert(stack.capacity() == max_bvh_depth);
                   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
celeritas/src/orange/detail/BvhIntersectingVolFinder.hh:125:36: error: the value of 'stack' is not usable in a constant expression
celeritas/src/orange/detail/BvhIntersectingVolFinder.hh:124:12: note: 'stack' was not declared 'constexpr'
     StackT stack{stack_spill_};
```