### PR TITLE
Workaround for gcc 8.5 compatibility

### DIFF
--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -122,7 +122,9 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-    static_assert(StackT{}.capacity() == max_bvh_depth);
+    // This local var is necessary for gcc 8.5 compilation
+    constexpr auto capacity = stack.capacity();
+    static_assert(capacity == max_bvh_depth);
     stack.push(BvhNodeId{0});
 
     while (!stack.empty())

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -15,13 +15,13 @@
 #include "../univ/detail/Types.hh"
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
-      // We are using GCC (not Clang, not ICC)
-      #if __GNUC__ < 9
-      #else
-        #define ALLOW_CODE 1
-      #endif
+// We are using GCC (not Clang, not ICC)
+#    if __GNUC__ < 9
+#    else
+#        define ALLOW_CODE 1
+#    endif
 #else
-    #define ALLOW_CODE 1
+#    define ALLOW_CODE 1
 #endif
 
 namespace celeritas
@@ -133,7 +133,7 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
 // This static_assert does not compile with gcc 8.5
-#ifdef ALLOW_CODE 
+#ifdef ALLOW_CODE
     static_assert(stack.capacity() == max_bvh_depth);
 #endif
     stack.push(BvhNodeId{0});

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -122,7 +122,7 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-    static_assert(stack.capacity() == max_bvh_depth);
+    static_assert(StackT{}.capacity() == max_bvh_depth);
     stack.push(BvhNodeId{0});
 
     while (!stack.empty())

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -14,6 +14,16 @@
 #include "../BoundingBoxUtils.hh"
 #include "../univ/detail/Types.hh"
 
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+      // We are using GCC (not Clang, not ICC)
+      #if __GNUC__ < 9
+      #else
+        #define ALLOW_CODE 1
+      #endif
+#else
+    #define ALLOW_CODE 1
+#endif
+
 namespace celeritas
 {
 namespace detail
@@ -123,7 +133,7 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
 // This static_assert does not compile with gcc 8.5
-#if (__GNUC__ >= 9)
+#ifdef ALLOW_CODE 
     static_assert(stack.capacity() == max_bvh_depth);
 #endif
     stack.push(BvhNodeId{0});

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -15,13 +15,13 @@
 #include "../univ/detail/Types.hh"
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
-// We are using GCC (not Clang, not ICC)
 #    if __GNUC__ < 9
+     // We are using GCC (not Clang, not ICC)
 #    else
-#        define ALLOW_CODE 1
+#        define CELER_GCC8_BUGGY_CONSTEXPR 1
 #    endif
 #else
-#    define ALLOW_CODE 1
+#    define CELER_GCC8_BUGGY_CONSTEXPR 1
 #endif
 
 namespace celeritas
@@ -132,8 +132,8 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-// This static_assert does not compile with gcc 8.5
-#ifdef ALLOW_CODE
+#ifdef CELER_GCC8_BUGGY_CONSTEXPR
+    // This static_assert does not compile with gcc 8.5
     static_assert(stack.capacity() == max_bvh_depth);
 #endif
     stack.push(BvhNodeId{0});

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -122,9 +122,10 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-    // This local var is necessary for gcc 8.5 compilation
-    constexpr auto capacity = stack.capacity();
-    static_assert(capacity == max_bvh_depth);
+// This static_assert does not compile with gcc 8.5
+#if (__GNUC__ >= 9)
+    static_assert(stack.capacity() == max_bvh_depth);
+#endif
     stack.push(BvhNodeId{0});
 
     while (!stack.empty())

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -16,7 +16,7 @@
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #    if __GNUC__ < 9
-     // We are using GCC (not Clang, not ICC)
+// We are using GCC (not Clang, not ICC)
 #    else
 #        define CELER_GCC8_BUGGY_CONSTEXPR 1
 #    endif

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -15,11 +15,11 @@
 #include "../univ/detail/Types.hh"
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
-      // We are using GCC (not Clang, not ICC)
-      #if __GNUC__ < 9
-      #else
-        #define ALLOW_CODE 1
-      #endif
+    // We are using GCC (not Clang, not ICC)
+    #if __GNUC__ < 9
+    #else
+      #define ALLOW_CODE 1
+    #endif
 #else
     #define ALLOW_CODE 1
 #endif

--- a/src/orange/detail/BvhIntersectingVolFinder.hh
+++ b/src/orange/detail/BvhIntersectingVolFinder.hh
@@ -17,11 +17,12 @@
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #    if __GNUC__ < 9
 // We are using GCC (not Clang, not ICC)
-#    else
 #        define CELER_GCC8_BUGGY_CONSTEXPR 1
+#    else
+#        define CELER_GCC8_BUGGY_CONSTEXPR 0
 #    endif
 #else
-#    define CELER_GCC8_BUGGY_CONSTEXPR 1
+#    define CELER_GCC8_BUGGY_CONSTEXPR 0
 #endif
 
 namespace celeritas
@@ -132,7 +133,7 @@ CELER_FUNCTION auto BvhIntersectingVolFinder::operator()(
     using StackT = IdStack<BvhNodeId, max_bvh_depth - 1>;
     BvhNodeId stack_spill_[StackT::spill_extent];
     StackT stack{stack_spill_};
-#ifdef CELER_GCC8_BUGGY_CONSTEXPR
+#if !CELER_GCC8_BUGGY_CONSTEXPR
     // This static_assert does not compile with gcc 8.5
     static_assert(stack.capacity() == max_bvh_depth);
 #endif


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please read the [contributing guide](https://celeritas-project.github.io/celeritas/user/development/contributing.html#pr-style)
for requirements on the title, description, and draft status.
If you are a core developer, see also the [review process](https://celeritas-project.github.io/celeritas/user/appendix/administration.html#code-review)
for label requirements.
-->

This PR adds a macro around a `static_assert` statement that does not compile with gcc 8.5. 
