### PR TITLE
Fix missing include path for MPI

### DIFF
--- a/scripts/cmake-presets/executor.json
+++ b/scripts/cmake-presets/executor.json
@@ -82,6 +82,21 @@
       }
     },
     {
+      "name": "mpi",
+      "displayName": "Executor build with MPI",
+      "inherits": [".ccache", ".base", ".debug", "default"],
+      "environment": {
+        "CMAKE_PREFIX_PATH": "$env{SPACK_ROOT}/var/spack/environments/celeritas-mpi/.spack-env/view"
+      },
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD":    {"type": "STRING",   "value": "17"},
+        "CELERITAS_USE_covfie":  {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_HepMC3":  {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_Geant4":  {"type": "BOOL",   "value": "OFF"},
+        "CELERITAS_USE_MPI":     {"type": "BOOL",   "value": "ON"}
+      }
+    },
+    {
       "name": "base",
       "displayName": "Executor default options",
       "inherits": [".ccache", ".spackbase", ".debug", "default"],

--- a/scripts/spack/packages.yaml
+++ b/scripts/spack/packages.yaml
@@ -28,6 +28,9 @@ packages:
       - "20:"
   nlohmann-json:
     require: "@3.7.0:"
+  openmpi:
+    variants:
+      - ~fortran
   py-identify: # needed by py-pre-commit
     require: "@2.6:"
   python:

--- a/src/corecel/CMakeLists.txt
+++ b/src/corecel/CMakeLists.txt
@@ -215,7 +215,7 @@ list(APPEND SOURCES
   io/JsonUtils.json.cc
   io/Label.cc
   io/LogContextException.cc
-  io/LogHandlers.cc
+  io/Logger.cc
   io/LoggerTypes.cc
   io/OpenmpOutput.cc
   io/OutputInterface.cc
@@ -268,7 +268,7 @@ list(APPEND PRIVATE_DEPS corecel_openmp_obj)
 # All these classes depend on MPI if available
 celeritas_add_object_library(corecel_mpi_obj
   Assert.cc
-  io/Logger.cc
+  io/LogHandlers.cc
   sys/Device.cc
   sys/MpiCommunicator.cc
   sys/ScopedMpiInit.cc


### PR DESCRIPTION
@tghaddar found a build error when MPI isn't implicitly part of the include path or spack environment.