### PR TITLE
Add pre-advance to RayleighInteractor

### DIFF
--- a/src/celeritas/optical/interactor/RayleighInteractor.hh
+++ b/src/celeritas/optical/interactor/RayleighInteractor.hh
@@ -6,6 +6,8 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
+#include <type_traits>
+
 #include "corecel/Assert.hh"
 #include "corecel/math/ArrayOperators.hh"
 #include "corecel/math/ArraySoftUnit.hh"
@@ -13,6 +15,7 @@
 #include "corecel/random/distribution/BernoulliDistribution.hh"
 #include "corecel/random/distribution/IsotropicDistribution.hh"
 #include "corecel/random/distribution/RejectionSampler.hh"
+#include "corecel/random/engine/RanluxppRngEngine.hh"
 #include "celeritas/optical/Interaction.hh"
 #include "celeritas/optical/ParticleTrackView.hh"
 
@@ -69,6 +72,13 @@ RayleighInteractor::RayleighInteractor(ParticleTrackView const& particle,
 template<class Engine>
 CELER_FUNCTION Interaction RayleighInteractor::operator()(Engine& rng)
 {
+    if constexpr (std::is_same_v<Engine, RanluxppRngEngine>)
+    {
+        // If using Ranlux++, force the RNG to create a new block of bits
+        // in preparation for taking a bunch of samples
+        rng.advance();
+    }
+
     Real3 new_dir, new_pol;
     do
     {

--- a/src/corecel/random/engine/RanluxppRngEngine.hh
+++ b/src/corecel/random/engine/RanluxppRngEngine.hh
@@ -101,6 +101,9 @@ class RanluxppRngEngine
     // Initialize a state for a new spawned RNG.
     inline CELER_FUNCTION RngStateInitializer_t branch();
 
+    // Force the state to produce the next block of random bits
+    inline CELER_FUNCTION void advance() { this->advance(*state_); }
+
   private:
     /// IMPLEMENTATION ///
 


### PR DESCRIPTION
Pre-advances the Ranlux++ random number generator prior to entering the Rayleigh scattering.  This improves performance and reduces thread divergence since it ensures that the Ranlux++ RNG will start with a fresh block of random bits.