### PR TITLE
Add universe metadata+structure to JSON output, make universe DAG dot graphs

### DIFF
--- a/doc/usage/execution/environment.rst
+++ b/doc/usage/execution/environment.rst
@@ -58,6 +58,8 @@ has a default value but can be overridden with any boolean value.
                                      axis when partitioning a node during BVH
                                      construction
  ORANGE_BVH_STRUCTURE      orange    Include "structure" info in BVH JSON output
+ ORANGE_UNIV_STRUCTURE     orange    Include universe "structure" info in the
+                                     JSON output
  ========================= ========= ==========================================
 
 .. [#pr] See :ref:`profiling`. This should default to 1 when running through

--- a/scripts/user/orange-univ-to-dot.py
+++ b/scripts/user/orange-univ-to-dot.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+Convert universe structure metadata within a JSON file to a GraphViz .dot file.
+
+The structure metadata is only written if the ``ORANGE_UNIV_STRUCTURE``
+environment variable is set when running when generating the JSON.
+
+Behavior:
+
+1. ``-o/--output``: write the universes embedded in the root universe
+   given by ``-u/--universe`` (default: the global universe) to the given
+   file,
+2. No ``-o/--output``: print universe-wise diagnostics only.
+
+.. example::
+
+    # Print diagnostics only
+    ./orange-univ-to-dot.py out.json
+
+    # Write all universes
+    ./orange-univ-to-dot.py out.json -o universes.dot
+
+    # Write the universes embedded in universe 3
+    ./orange-univ-to-dot.py out.json -u 3 -o universes.dot
+"""
+
+import json
+import sys
+from textwrap import dedent
+
+# Fill colors by universe type
+_FILL_COLORS = {
+    "simple": "lightgray",
+    "rect_array": "lightsteelblue",
+}
+
+# Edge colors by daughter transform type
+_EDGE_COLORS = {
+    "no_transformation": "black",
+    "translation": "blue",
+    "transformation": "darkred",
+}
+
+
+def find_embedded(structure, root_id):
+    """Find all universes embedded in the universe given by root_id."""
+    result = set()
+    stack = [root_id]
+    while stack:
+        uid = stack.pop()
+        if uid not in result:
+            result.add(uid)
+            stack.extend(d[1] for d in structure[uid]["daughters"])
+    return result
+
+
+def dump_dot(univ_data, uids, out):
+    structure = univ_data["structure"]
+
+    out.write(
+        dedent("""\
+        digraph "universes" {
+          rankdir=TB
+          node [shape=box style=filled]
+        """)
+    )
+
+    for uid in sorted(uids):
+        univ_type = univ_data["type"][uid]
+        label = (
+            f"uid: {uid}\\l"
+            f"label: {univ_data['label'][uid]}\\l"
+            f"type: {univ_type}\\l"
+            f"vols: {univ_data['num_volumes'][uid]}\\l"
+            f"surfs: {univ_data['num_surfaces'][uid]}\\l"
+        )
+        fill = _FILL_COLORS.get(univ_type, "white")
+        out.write(f'  n{uid} [label="{label}" fillcolor="{fill}"]\n')
+
+        # Count daughters by universe and transform type to reduce edges
+        counts = {}
+        for _, daughter, transform in structure[uid]["daughters"]:
+            key = (daughter, transform)
+            counts[key] = counts.get(key, 0) + 1
+
+        for (daughter, transform), num_vols in sorted(counts.items()):
+            label = f"{transform}\\lvols: {num_vols}\\l"
+            color = _EDGE_COLORS.get(transform, "black")
+            out.write(
+                f'    n{uid} -> n{daughter} [label="{label}"'
+                f' color="{color}" fontcolor="{color}"]\n'
+            )
+    out.write("}\n")
+
+
+def write_diagnostic(outfile, univ_data):
+    univ_type = univ_data["type"]
+    label = univ_data["label"]
+    num_vols = univ_data["num_volumes"]
+    num_surfs = univ_data["num_surfaces"]
+    structure = univ_data["structure"]
+
+    template = "{:>8} {:>10} {:>8} {:>8} {:>11} {}\n"
+    out = template.format("uid", "type", "# vols", "# surfs", "# daughters", "label")
+
+    for i in range(len(univ_type)):
+        num_dtrs = len(structure[i]["daughters"])
+        out += template.format(
+            i, univ_type[i], num_vols[i], num_surfs[i], num_dtrs, label[i]
+        )
+
+    outfile.write(out)
+
+
+def run(args):
+    with open(args.input) as f:
+        data = json.load(f)
+
+    if "internal" in data:
+        print("Assuming app output was given rather than ORANGE output")
+        orange = data["internal"]["orange"]
+    else:
+        orange = data["orange_stats"]
+
+    univ_data = orange["univ_metadata"]
+    if "structure" not in univ_data:
+        sys.exit("Universe structure is missing: run with ORANGE_UNIV_STRUCTURE=1")
+
+    if args.output is None:
+        write_diagnostic(sys.stdout, univ_data)
+        return
+
+    uids = find_embedded(univ_data["structure"], args.universe)
+
+    with open(args.output, "w") as out:
+        dump_dot(univ_data, uids, out)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "input",
+        help="Input JSON filename",
+    )
+    parser.add_argument(
+        "-u",
+        "--universe",
+        type=int,
+        default=0,
+        help="Root universe ID (default: global universe)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output DOT filename (default: print diagnostics only)",
+    )
+
+    run(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orange/OrangeParamsOutput.cc
+++ b/src/orange/OrangeParamsOutput.cc
@@ -12,13 +12,16 @@
 #include "corecel/cont/LdgSpan.hh"
 #include "corecel/cont/Range.hh"
 #include "corecel/io/JsonPimpl.hh"
+#include "corecel/io/LabelIO.json.hh"  // IWYU pragma: keep
 #include "corecel/sys/Environment.hh"
 #include "geocel/BoundingBoxIO.json.hh"
 #include "orange/OrangeTypes.hh"
 
+#include "OrangeData.hh"
 #include "OrangeInputIO.json.hh"  // IWYU pragma: keep
 #include "OrangeParams.hh"  // IWYU pragma: keep
 #include "OrangeTypesIO.json.hh"  // IWYU pragma: keep
+#include "univ/TrackerVisitor.hh"
 
 #include "detail/BvhData.hh"
 #include "detail/BvhView.hh"
@@ -77,6 +80,46 @@ nlohmann::json make_bvh_structure_json(
     return json::object({
         {"tree", std::move(out)},
         {"inf_vol_ids", std::move(inf_vols)},
+    });
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Create JSON representation of the daughter universes embedded in a universe.
+ *
+ * Each daughter consists of a local volume ID, daughter universe ID, and
+ * transform type.
+ */
+nlohmann::json make_univ_structure_json(HostCRef<OrangeParamsData> const& data,
+                                        UnivId uid)
+{
+    using json = nlohmann::json;
+
+    auto daughters = json::array();
+
+    TrackerVisitor visit_tracker{data};
+    visit_tracker(
+        [&](auto const& tracker) {
+            for (auto vol_id : range(LocalVolumeId{tracker.num_volumes()}))
+            {
+                DaughterId daughter_id = tracker.daughter(vol_id);
+                if (!daughter_id)
+                {
+                    continue;
+                }
+                auto const& daughter = data.daughters[daughter_id];
+                auto const& transform = data.transforms[daughter.trans_id];
+                daughters.push_back({
+                    *vol_id,
+                    *daughter.univ_id,
+                    to_cstring(transform.type),
+                });
+            }
+        },
+        uid);
+
+    return json::object({
+        {"daughters", std::move(daughters)},
     });
 }
 
@@ -198,6 +241,49 @@ void OrangeParamsOutput::output(JsonPimpl* j) const
         }
     }
 
+    // Write universe metadata as a struct of arrays
+    {
+        obj["univ_metadata"] = json::object();
+        auto& univ_metadata = obj["univ_metadata"];
+
+        auto insert_array = [&univ_metadata](std::string key) -> json& {
+            univ_metadata[key] = json::array();
+            return univ_metadata[key];
+        };
+
+        auto& type = insert_array("type");
+        auto& label = insert_array("label");
+        auto& num_surfaces = insert_array("num_surfaces");
+        auto& num_volumes = insert_array("num_volumes");
+
+        // Calculate number of surface/volume using universe indexer offsets
+        using SizeId = OpaqueId<size_type>;
+        auto const& uidata = data.univ_indexer_data;
+        auto calc_local_size = [](auto const& offsets, UnivId uid) {
+            CELER_EXPECT(uid && uid.unchecked_get() + 1 < offsets.size());
+            return offsets[SizeId{uid.unchecked_get() + 1}]
+                   - offsets[SizeId{uid.unchecked_get()}];
+        };
+
+        for (auto uid : range(UnivId{data.univ_types.size()}))
+        {
+            type.push_back(to_cstring(data.univ_types[uid]));
+            label.push_back(orange_->universes().at(uid));
+            num_surfaces.push_back(calc_local_size(uidata.surfaces, uid));
+            num_volumes.push_back(calc_local_size(uidata.volumes, uid));
+        }
+
+        // Include structure information if requested by the user
+        if (celeritas::getenv_flag("ORANGE_UNIV_STRUCTURE", false).value)
+        {
+            auto& structure = insert_array("structure");
+            for (auto uid : range(UnivId{data.univ_types.size()}))
+            {
+                structure.push_back(make_univ_structure_json(data, uid));
+            }
+        }
+    }
+
     j->obj = std::move(obj);
 }
 
@@ -209,6 +295,23 @@ std::string dump_bvh_structure(detail::BvhTreeRecord const& tree,
                                NativeCRef<detail::BvhTreeData> const& data)
 {
     return make_bvh_structure_json(tree, data).dump();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Print the universe structure to a JSON string for debugging.
+ *
+ * The result is an array, indexed by universe ID, of the daughters embedded
+ * in each universe.
+ */
+std::string dump_univ_structure(HostCRef<OrangeParamsData> const& data)
+{
+    auto result = nlohmann::json::array();
+    for (auto uid : range(UnivId{data.univ_types.size()}))
+    {
+        result.push_back(make_univ_structure_json(data, uid));
+    }
+    return result.dump();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/orange/OrangeParamsOutput.hh
+++ b/src/orange/OrangeParamsOutput.hh
@@ -14,6 +14,9 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 class OrangeParams;
+template<Ownership W, MemSpace M>
+struct OrangeParamsData;
+
 namespace detail
 {
 template<Ownership W, MemSpace M>
@@ -59,6 +62,9 @@ class OrangeParamsOutput final : public OutputInterface
 // Print a BVH structure to a JSON string for debugging
 std::string dump_bvh_structure(detail::BvhTreeRecord const& tree,
                                NativeCRef<detail::BvhTreeData> const& data);
+
+// Print the universe structure to a JSON string for debugging
+std::string dump_univ_structure(HostCRef<OrangeParamsData> const& data);
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/orange/OrangeTypes.cc
+++ b/src/orange/OrangeTypes.cc
@@ -192,6 +192,19 @@ char const* to_cstring(TransformType value)
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get a string corresponding to a universe type.
+ */
+char const* to_cstring(UnivType value)
+{
+    static EnumStringMapper<UnivType> const to_cstring_impl{
+        "simple",
+        "rect_array",
+    };
+    return to_cstring_impl(value);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Get a string corresponding to a logic notation
  */
 char const* to_cstring(LogicNotation value)

--- a/src/orange/OrangeTypes.hh
+++ b/src/orange/OrangeTypes.hh
@@ -395,6 +395,9 @@ char const* to_cstring(SurfaceType);
 // Get a string corresponding to a transform type
 char const* to_cstring(TransformType);
 
+// Get a string corresponding to a universe type
+char const* to_cstring(UnivType);
+
 // Get a string corresponding to a surface state
 inline char const* to_cstring(SurfaceState s)
 {

--- a/test/orange/OrangeJson.test.cc
+++ b/test/orange/OrangeJson.test.cc
@@ -199,8 +199,12 @@ TEST_F(UniversesTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"max_faces":14,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":12,"internal_nodes":5,"leaf_nodes":8,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"univ_indices":3,"univ_types":3,"universe_indexer":{"surfaces":4,"volumes":4},"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,3,1],"num_finite_bboxes":[4,4,1],"num_infinite_bboxes":[1,0,0]},"scalars":{"max_faces":14,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":12,"internal_nodes":5,"leaf_nodes":8,"local_volume_ids":10},"connectivity_records":25,"daughters":3,"local_surface_ids":55,"local_volume_ids":21,"logic_ints":164,"obz_records":0,"real_ids":25,"reals":24,"rect_arrays":0,"simple_units":3,"surface_types":25,"transforms":3,"univ_indices":3,"univ_types":3,"universe_indexer":{"surfaces":4,"volumes":4},"volume_ids":12,"volume_instance_ids":12,"volume_records":12},"tracking_logic":"infix","univ_metadata":{"label":["outer","inner","most_inner"],"num_surfaces":[14,11,0],"num_volumes":[5,5,2],"type":["simple","simple","simple"]}})json",
         to_string(out));
+
+    EXPECT_JSON_EQ(
+        R"json([{"daughters":[[1,1,"translation"],[2,1,"translation"]]},{"daughters":[[1,2,"translation"]]},{"daughters":[]}])json",
+        dump_univ_structure(this->params().host_ref()));
 }
 
 TEST_F(UniversesTest, initialize_with_multiple_universes)
@@ -659,6 +663,20 @@ TEST_F(NestedRectArraysTest, leaving)
     EXPECT_SOFT_EQ(16, next.distance);
 }
 
+TEST_F(NestedRectArraysTest, TEST_IF_CELERITAS_DOUBLE(output))
+{
+    OrangeParamsOutput out(this->geometry());
+    EXPECT_EQ("orange", out.label());
+
+    EXPECT_JSON_EQ(
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,1,1,1,1],"num_finite_bboxes":[2,1,1,1,1],"num_infinite_bboxes":[1,0,0,0,0]},"scalars":{"max_faces":12,"max_intersections":12,"num_univ_levels":6,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":11,"internal_nodes":0,"leaf_nodes":5,"local_volume_ids":7},"connectivity_records":12,"daughters":11,"local_surface_ids":24,"local_volume_ids":4,"logic_ints":62,"obz_records":0,"real_ids":12,"reals":31,"rect_arrays":2,"simple_units":5,"surface_types":12,"transforms":8,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":19,"volume_instance_ids":19,"volume_records":11},"tracking_logic":"infix","univ_metadata":{"label":["global","parent","parent+","arr","arr+","B","A"],"num_surfaces":[12,0,8,0,8,0,0],"num_volumes":[3,2,4,2,4,2,2],"type":["simple","simple","rect_array","simple","rect_array","simple","simple"]}})json",
+        to_string(out));
+
+    EXPECT_JSON_EQ(
+        R"json([{"daughters":[[1,1,"no_transformation"]]},{"daughters":[[1,2,"no_transformation"]]},{"daughters":[[0,3,"no_transformation"],[1,3,"translation"],[2,3,"translation"],[3,3,"translation"]]},{"daughters":[[1,4,"no_transformation"]]},{"daughters":[[0,5,"no_transformation"],[1,6,"translation"],[2,6,"translation"],[3,5,"translation"]]},{"daughters":[]},{"daughters":[]}])json",
+        dump_univ_structure(this->params().host_ref()));
+}
+
 //---------------------------------------------------------------------------//
 class Geant4Testem15Test : public JsonOrangeTest
 {
@@ -713,7 +731,7 @@ TEST_F(HexArrayTest, TEST_IF_CELERITAS_DOUBLE(output))
     EXPECT_EQ("orange", out.label());
 
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,8,1,1],"num_finite_bboxes":[2,50,1,1],"num_infinite_bboxes":[1,0,0,0]},"scalars":{"max_faces":9,"max_intersections":10,"num_univ_levels":3,"tol":{"abs":1.5e-08,"rel":1.5e-08}},"sizes":{"bvh":{"bboxes":58,"internal_nodes":49,"leaf_nodes":53,"local_volume_ids":55},"connectivity_records":53,"daughters":51,"local_surface_ids":191,"local_volume_ids":348,"logic_ints":500,"obz_records":0,"real_ids":53,"reals":272,"rect_arrays":0,"simple_units":4,"surface_types":53,"transforms":51,"univ_indices":4,"univ_types":4,"universe_indexer":{"surfaces":5,"volumes":5},"volume_ids":58,"volume_instance_ids":58,"volume_records":58},"tracking_logic":"infix","univ_metadata":{"label":["global","rhombarr","c","d"],"num_surfaces":[9,44,0,0],"num_volumes":[3,51,2,2],"type":["simple","simple","simple","simple"]}})json",
         to_string(out));
 }
 
@@ -777,7 +795,7 @@ TEST_F(InputBuilderTest, globalspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"max_faces":2,"max_intersections":4,"num_univ_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"univ_indices":1,"univ_types":1,"universe_indexer":{"surfaces":2,"volumes":2},"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"max_faces":2,"max_intersections":4,"num_univ_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":3,"internal_nodes":0,"leaf_nodes":1,"local_volume_ids":3},"connectivity_records":2,"daughters":0,"local_surface_ids":4,"local_volume_ids":4,"logic_ints":7,"obz_records":0,"real_ids":2,"reals":2,"rect_arrays":0,"simple_units":1,"surface_types":2,"transforms":0,"univ_indices":1,"univ_types":1,"universe_indexer":{"surfaces":2,"volumes":2},"volume_ids":3,"volume_instance_ids":3,"volume_records":3},"tracking_logic":"infix","univ_metadata":{"label":["global"],"num_surfaces":[2],"num_volumes":[3],"type":["simple"]}})json",
         to_string(out));
 }
 
@@ -843,7 +861,7 @@ TEST_F(InputBuilderTest, bgspheres)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"max_faces":3,"max_intersections":2,"num_univ_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"univ_indices":1,"univ_types":1,"universe_indexer":{"surfaces":2,"volumes":2},"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[2],"num_finite_bboxes":[2],"num_infinite_bboxes":[1]},"scalars":{"max_faces":3,"max_intersections":2,"num_univ_levels":1,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":4,"internal_nodes":1,"leaf_nodes":2,"local_volume_ids":3},"connectivity_records":3,"daughters":0,"local_surface_ids":6,"local_volume_ids":3,"logic_ints":5,"obz_records":0,"real_ids":3,"reals":9,"rect_arrays":0,"simple_units":1,"surface_types":3,"transforms":0,"univ_indices":1,"univ_types":1,"universe_indexer":{"surfaces":2,"volumes":2},"volume_ids":4,"volume_instance_ids":4,"volume_records":4},"tracking_logic":"infix","univ_metadata":{"label":["global"],"num_surfaces":[3],"num_volumes":[4],"type":["simple"]}})json",
         to_string(out));
 }
 
@@ -967,8 +985,12 @@ TEST_F(InputBuilderTest, hierarchy)
 
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":24,"internal_nodes":8,"leaf_nodes":15,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[4,0,0,4,2,0,0],"num_finite_bboxes":[6,0,0,4,2,0,0],"num_infinite_bboxes":[1,0,0,0,0,0,0]},"scalars":{"max_faces":8,"max_intersections":14,"num_univ_levels":3,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":24,"internal_nodes":8,"leaf_nodes":15,"local_volume_ids":13},"connectivity_records":13,"daughters":6,"local_surface_ids":20,"local_volume_ids":18,"logic_ints":31,"obz_records":0,"real_ids":13,"reals":46,"rect_arrays":0,"simple_units":7,"surface_types":13,"transforms":6,"univ_indices":7,"univ_types":7,"universe_indexer":{"surfaces":8,"volumes":8},"volume_ids":24,"volume_instance_ids":24,"volume_records":24},"tracking_logic":"infix","univ_metadata":{"label":["global","d1","d2","filled_daughter","leafy","d1","d2"],"num_surfaces":[8,0,0,4,1,0,0],"num_volumes":[7,2,2,6,3,2,2],"type":["simple","simple","simple","simple","simple","simple","simple"]}})json",
         to_string(out));
+
+    EXPECT_JSON_EQ(
+        R"json([{"daughters":[[1,1,"translation"],[2,2,"transformation"],[3,3,"translation"],[4,4,"translation"]]},{"daughters":[]},{"daughters":[]},{"daughters":[[1,5,"translation"],[2,6,"transformation"]]},{"daughters":[]},{"daughters":[]},{"daughters":[]}])json",
+        dump_univ_structure(this->params().host_ref()));
 }
 
 //---------------------------------------------------------------------------//
@@ -976,7 +998,7 @@ TEST_F(InputBuilderTest, incomplete_bb)
 {
     OrangeParamsOutput out(this->geometry());
     EXPECT_JSON_EQ(
-        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":6,"internal_nodes":0,"leaf_nodes":2,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix"})json",
+        R"json({"_category":"internal","_label":"orange","bvh_metadata":{"depth":[1,1],"num_finite_bboxes":[2,2],"num_infinite_bboxes":[1,0]},"scalars":{"max_faces":6,"max_intersections":6,"num_univ_levels":2,"tol":{"abs":1e-05,"rel":1e-05}},"sizes":{"bvh":{"bboxes":6,"internal_nodes":0,"leaf_nodes":2,"local_volume_ids":5},"connectivity_records":8,"daughters":1,"local_surface_ids":10,"local_volume_ids":4,"logic_ints":37,"obz_records":0,"real_ids":8,"reals":26,"rect_arrays":0,"simple_units":2,"surface_types":8,"transforms":1,"univ_indices":2,"univ_types":2,"universe_indexer":{"surfaces":3,"volumes":3},"volume_ids":6,"volume_instance_ids":6,"volume_records":6},"tracking_logic":"infix","univ_metadata":{"label":["global","inner"],"num_surfaces":[2,6],"num_volumes":[3,3],"type":["simple","simple"]}})json",
         to_string(out));
 }
 


### PR DESCRIPTION
This MR adds universe metadata (type, label, number of surfaces, and number of volumes) to the JSON output. Analogous to BVH, a `ORANGE_UNIV_STRUCTURE` flag adds structural information, i.e., the universe DAG. The `orange-univ-to-dot.py` script reads the JSON file and outputs the corresponding dot graph, an example of which is shown below for the DUNE z-wires model.

<img width="509" height="860" alt="Screenshot 2026-09-02 at 8 41 05 PM" src="https://github.com/user-attachments/assets/98f34104-8724-43fd-87f0-603e171a0468" />