### PR TITLE
Fix stale geometry parent IDs when inserting primaries

### DIFF
--- a/src/celeritas/track/ExtendFromPrimariesAction.cc
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cc
@@ -11,6 +11,7 @@
 #include "corecel/data/AuxParamsRegistry.hh"
 #include "corecel/data/CollectionAlgorithms.hh"
 #include "corecel/data/Copier.hh"
+#include "corecel/math/Algorithms.hh"
 #include "corecel/sys/ActionRegistry.hh"
 #include "celeritas/global/ActionLauncher.hh"
 #include "celeritas/global/CoreParams.hh"
@@ -183,14 +184,13 @@ void ExtendFromPrimariesAction::step_impl(CoreParams const& params,
                                           CoreState<M>& state) const
 {
     auto& primaries = get<PrimaryStateData<M>>(state.aux(), aux_id_);
-    auto counters = state.sync_get_counters();
 
     // Create track initializers from primaries
-    counters.num_initializers += primaries.count;
-    state.sync_put_counters(counters);
     this->process_primaries(params, state, primaries);
 
     // Mark that the primaries have been processed
+    auto counters = state.sync_get_counters();
+    counters.num_initializers += primaries.count;
     counters.num_generated += primaries.count;
     counters.num_pending = 0;
     primaries.count = 0;
@@ -209,7 +209,11 @@ void ExtendFromPrimariesAction::process_primaries(
     auto primaries = pstate.primaries();
     detail::ProcessPrimariesExecutor execute{
         params.ptr<MemSpace::native>(), state.ptr(), primaries};
-    return launch_action(*this, primaries.size(), params, state, execute);
+    if (!primaries.empty())
+    {
+        auto num_threads = max<size_type>(primaries.size(), state.size());
+        return launch_action(*this, num_threads, params, state, execute);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/track/ExtendFromPrimariesAction.cu
+++ b/src/celeritas/track/ExtendFromPrimariesAction.cu
@@ -6,6 +6,7 @@
 //---------------------------------------------------------------------------//
 #include "ExtendFromPrimariesAction.hh"
 
+#include "corecel/math/Algorithms.hh"
 #include "celeritas/global/ActionLauncher.device.hh"
 #include "celeritas/global/CoreParams.hh"
 #include "celeritas/global/CoreState.hh"
@@ -29,7 +30,8 @@ void ExtendFromPrimariesAction::process_primaries(
     static ActionLauncher<decltype(execute_thread)> const launch_kernel(*this);
     if (!primaries.empty())
     {
-        launch_kernel(primaries.size(), state.stream_id(), execute_thread);
+        auto num_threads = max<size_type>(primaries.size(), state.size());
+        launch_kernel(num_threads, state.stream_id(), execute_thread);
     }
 }
 

--- a/src/celeritas/track/detail/InitTracksExecutor.hh
+++ b/src/celeritas/track/detail/InitTracksExecutor.hh
@@ -98,12 +98,6 @@ CELER_FUNCTION void InitTracksExecutor::operator()(ThreadId tid) const
                 index_before(counters->num_vacancies, tid))];
         }()};
 
-    // Clear parent IDs if new primaries were added this step
-    if (counters->num_generated)
-    {
-        init.geo.parent = {};
-    }
-
     vacancy = init;
 }
 

--- a/src/celeritas/track/detail/ProcessPrimariesExecutor.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesExecutor.hh
@@ -54,9 +54,26 @@ struct ProcessPrimariesExecutor
  */
 CELER_FUNCTION void ProcessPrimariesExecutor::operator()(ThreadId tid) const
 {
-    CELER_EXPECT(tid < primaries.size());
-    auto* counters = state->init.counters.data().get();
-    CELER_EXPECT(primaries.size() <= counters->num_initializers + tid.get());
+    CELER_EXPECT(tid < primaries.size() || tid < state->size());
+
+    size_type num_initializers
+        = state->init.counters.data().get()->num_initializers;
+
+    // New primaries can delay existing initializers, so invalidate geometry
+    // parent IDs that assume initialization in the next step
+    if (tid < state->size())
+    {
+        for (size_type i = tid.get(); i < num_initializers; i += state->size())
+        {
+            state->init.initializers[ItemId<TrackInitializer>(i)].geo.parent
+                = {};
+        }
+    }
+
+    if (!(tid < primaries.size()))
+    {
+        return;
+    }
 
     Primary const& primary = primaries[tid.unchecked_get()];
 
@@ -83,7 +100,7 @@ CELER_FUNCTION void ProcessPrimariesExecutor::operator()(ThreadId tid) const
     }
 
     // Store the initializer
-    size_type idx = counters->num_initializers - primaries.size() + tid.get();
+    size_type idx = num_initializers + tid.get();
     state->init.initializers[ItemId<TrackInitializer>(idx)] = ti;
 }
 

--- a/src/celeritas/track/detail/ProcessPrimariesExecutor.hh
+++ b/src/celeritas/track/detail/ProcessPrimariesExecutor.hh
@@ -59,12 +59,16 @@ CELER_FUNCTION void ProcessPrimariesExecutor::operator()(ThreadId tid) const
     size_type num_initializers
         = state->init.counters.data().get()->num_initializers;
 
-    // New primaries can delay existing initializers, so invalidate geometry
-    // parent IDs that assume initialization in the next step
+    // Only state.size() threads participate in this grid-stride loop.
+    // Additional threads may be launched to process a larger set of primaries:
+    // allowing them into the loop would cause overlapping writes to the same
+    // initializers.
     if (tid < state->size())
     {
         for (size_type i = tid.get(); i < num_initializers; i += state->size())
         {
+            // New primaries can delay existing initializers, so invalidate
+            // geometry parent IDs that assume initialization in the next step
             state->init.initializers[ItemId<TrackInitializer>(i)].geo.parent
                 = {};
         }

--- a/test/celeritas/track/TrackInit.test.cc
+++ b/test/celeritas/track/TrackInit.test.cc
@@ -531,6 +531,68 @@ TYPED_TEST(TrackInitTest, extend_from_secondaries)
     }
 }
 
+TYPED_TEST(TrackInitTest, geo_parents)
+{
+    size_type const num_tracks = 8;
+    this->build_states(num_tracks);
+
+    // Fill all track slots with primaries
+    auto primaries = this->make_primaries(num_tracks);
+    this->extend_from_primaries(make_span(primaries));
+    this->init_tracks();
+
+    // Kill four tracks and produce four secondaries. Two secondaries are
+    // initialized immediately and two are buffered with geometry parent IDs
+    std::vector<bool> const alive
+        = {true, false, false, true, true, false, false, true};
+    MockInteractAction interact{
+        ActionId{1}, std::vector<size_type>{1, 1, 2, 0, 0, 0, 0, 0}, alive};
+
+    interact.step(*this->core(), this->state());
+    ExtendFromSecondariesAction{ActionId{2}}.step(*this->core(), this->state());
+
+    {
+        auto result = RunResult::from_state(this->state());
+
+        EXPECT_EQ(2, this->state().sync_get_counters().num_initializers);
+        EXPECT_EQ(2, this->state().sync_get_counters().num_vacancies);
+
+        // Two secondaries expect to be initialized in the next step so have
+        // valid IDs for their parent geometry state
+        static int const expected_geo_parent_ids[] = {0, 2};
+        EXPECT_VEC_EQ(expected_geo_parent_ids, result.geo_parent_ids);
+    }
+
+    // Insert enough primaries to fill all current vacancies
+    primaries = this->make_primaries(2);
+    this->extend_from_primaries(make_span(primaries));
+
+    {
+        auto result = RunResult::from_state(this->state());
+
+        EXPECT_EQ(4, this->state().sync_get_counters().num_initializers);
+
+        // Adding primaries can delay the initialization of existing
+        // initializers, so their geometry parent IDs should be invalidated
+        static int const expected_geo_parent_ids[] = {-1, -1, -1, -1};
+        EXPECT_VEC_EQ(expected_geo_parent_ids, result.geo_parent_ids);
+    }
+
+    // New primaries are initialized first, leaving the original secondaries
+    // buffered for a later step
+    this->init_tracks();
+
+    {
+        auto result = RunResult::from_state(this->state());
+
+        EXPECT_EQ(2, this->state().sync_get_counters().num_initializers);
+
+        // The parent IDs for the deferred secondaries should have been cleared
+        static int const expected_geo_parent_ids[] = {-1, -1};
+        EXPECT_VEC_EQ(expected_geo_parent_ids, result.geo_parent_ids);
+    }
+}
+
 //---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace celeritas


### PR DESCRIPTION
Since #2406 the `TrackingManagerIntegration:WaterSphere` GPU tests were failing:
<details>
<summary>Test failures</summary>

```console
    Start 473: accel/TrackingManagerIntegration:WaterSphere.run_small_flush:gpu:serial
1/2 Test #473: accel/TrackingManagerIntegration:WaterSphere.run_small_flush:gpu:serial ...Subprocess aborted***Exception:   4.90 sec
/home/alund/celeritas_project/celeritas/src/corecel/sys/Device.cc:379: warning: Device 'NVIDIA A40' has CUDA compute capability of 86, but Celeritas was compiled with CMAKE_CUDA_ARCHITECTURES="70+80+90": code may mysteriously die at runtime
Celeritas version 0.7.0-dev.507+develop.be44d7947
Note: Google Test filter = WaterSphere.run_small_flush
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from WaterSphere
[ RUN      ] WaterSphere.run_small_flush
status: Creating run manager
Environment variable "G4RUN_MANAGER_TYPE" enabled with value == Serial. Overriding G4RunManager type...

**************************************************************
 Geant4 version Name: geant4-11-03 [MT]   (6-December-2024)
                       Copyright : Geant4 Collaboration
                      References : NIM A 506 (2003), 250-303
                                 : IEEE-TNS 53 (2006), 270-278
                                 : NIM A 835 (2016), 186-225
                             WWW : http://geant4.org/
**************************************************************

info: Created run manager type G4RunManager
status: Setting run manager initialization
status@/home/alund/celeritas_project/celeritas/test/accel/TrackingManagerIntegration.test.cc:1022: Run initialization
info@/home/alund/celeritas_project/celeritas/src/geocel/GeantGdmlLoader.cc:79: Loading Geant4 geometry from GDML at /home/alund/celeritas_project/celeritas/test/geocel/data/water-sphere.gdml
G4GDML: Reading '/home/alund/celeritas_project/celeritas/test/geocel/data/water-sphere.gdml'...
G4GDML: Reading definitions...
G4GDML: Reading materials...
G4GDML: Reading solids...
G4GDML: Reading structure...
G4GDML: Reading setup...
G4GDML: Reading '/home/alund/celeritas_project/celeritas/test/geocel/data/water-sphere.gdml' done!
info@/home/alund/celeritas_project/celeritas/src/celeritas/g4/DetectorConstruction.cc:133: Constructed SensDet='detshell' and attached to 1 volumes
info@/home/alund/celeritas_project/celeritas/src/accel/TrackingManagerConstructor.cc:147: Built Celeritas tracking managers for e-, e+, gamma
status@/home/alund/celeritas_project/celeritas/test/accel/TrackingManagerIntegration.test.cc:1027: Beam on
info@/home/alund/celeritas_project/celeritas/src/celeritas/setup/FrameworkInput.cc:33: Activating Celeritas version 0.7.0-dev.507+develop.be44d7947 on GPU
warning@/home/alund/celeritas_project/celeritas/src/corecel/sys/Device.cc:379: Device 'NVIDIA A40' has CUDA compute capability of 86, but Celeritas was compiled with CMAKE_CUDA_ARCHITECTURES="70+80+90": code may mysteriously die at runtime
status@/home/alund/celeritas_project/celeritas/src/celeritas/ext/GeantImporter.cc:1007: Transferring data from Geant4
status@/home/alund/celeritas_project/celeritas/src/celeritas/setup/Problem.cc:460: Initializing problem
info@/home/alund/celeritas_project/celeritas/src/corecel/sys/Device.cc:306: Creating 1 device streams
status@/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomParams.cc:399: Loading VecGeom geometry from in-memory Geant4 geometry
status: Converting Geant4 geometry
status@/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomParams.cc:460: Initializing tracking information
info@/home/alund/celeritas_project/celeritas/src/corecel/sys/ScopedLimitSaver.cuda.cc:55: CUDA stack size was changed from 1024 to 8192; restoring to original values
status@/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomParams.cc:464: Constructing metadata
status@/home/alund/celeritas_project/celeritas/src/celeritas/global/CoreParams.cc:331: Celeritas core setup complete
info@/home/alund/celeritas_project/celeritas/src/accel/SharedParams.cc:478: Wrote Geant4 diagnostic output to "watersphere-run-small-flush-1-gpu-serial.out.json"
status@/home/alund/celeritas_project/celeritas/src/celeritas/global/CoreState.cc:81: Celeritas core state initialization complete
pos: (-4.7457017359132294e+01, 5.8392472704445781e+00, 3.0282601553859085e+00), init.pos: (3.7165747855301014e+01, -1.6382541918375448e+01, -5.7660216790258945e+00), tid_: 7, init.parent: 7
/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomTrackView.hh:264:
celeritas: internal assertion failed: this->pos() == init.pos
/home/alund/celeritas_project/celeritas/test/accel/IntegrationTestBase.cc:518: Failure
Failed
GeantExceptionHandler caught runtime error (M,celer.event.flush): from /home/alund/celeritas_project/celeritas/src/corecel/sys/Stream.cc:172: Celeritas CUDA error: unspecified launch failure

critical@/home/alund/celeritas_project/celeritas/src/geocel/ScopedGeantExceptionHandler.cc:129: Aborting run due to exception (celer.event.flush)
/home/alund/celeritas_project/celeritas/test/accel/IntegrationTestBase.cc:518: Failure
Failed
GeantExceptionHandler caught runtime error (M,celer.finalize.local): from /home/alund/celeritas_project/celeritas/src/accel/LocalTransporter.cc:734: Celeritas runtime error: offloaded tracks were not flushed (0 primaries buffered, transport incomplete)

critical@/home/alund/celeritas_project/celeritas/src/geocel/ScopedGeantExceptionHandler.cc:129: Aborting run due to exception (celer.finalize.local)
status@/home/alund/celeritas_project/celeritas/src/accel/detail/IntegrationSingleton.cc:405: Finalizing Celeritas
info@/home/alund/celeritas_project/celeritas/src/accel/SharedParams.cc:478: Wrote Geant4 diagnostic output to "watersphere-run-small-flush-1-gpu-serial.out.json"
Failed to destroy stream: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/Stream.cc:70: 'StreamDestroy(impl->stream)' failed
[  FAILED  ] WaterSphere.run_small_flush (2404 ms)
[----------] 1 test from WaterSphere (2404 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2405 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] WaterSphere.run_small_flush

 1 FAILED TEST
/home/alund/celeritas_project/celeritas/build-reldeb/test/accel/TrackingManagerIntegration: tests FAILED
warning@/home/alund/celeritas_project/celeritas/src/celeritas/ext/GeantTrackReconstruction.cc:142: Geant4 track data was not cleared during the event
Failed to destroy event: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/DeviceEvent.cc:39: 'EventDestroy(impl->event)' failed
Failed to destroy event: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/DeviceEvent.cc:39: 'EventDestroy(impl->event)' failed
corrupted double-linked list

    Start 474: accel/TrackingManagerIntegration:WaterSphere.run_small_flush:gpu:mt
2/2 Test #474: accel/TrackingManagerIntegration:WaterSphere.run_small_flush:gpu:mt .......***Exception: SegFault  0.82 sec
/home/alund/celeritas_project/celeritas/src/corecel/sys/Device.cc:379: warning: Device 'NVIDIA A40' has CUDA compute capability of 86, but Celeritas was compiled with CMAKE_CUDA_ARCHITECTURES="70+80+90": code may mysteriously die at runtime
Celeritas version 0.7.0-dev.507+develop.be44d7947
Note: Google Test filter = WaterSphere.run_small_flush
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from WaterSphere
[ RUN      ] WaterSphere.run_small_flush
status: Creating run manager
Environment variable "G4RUN_MANAGER_TYPE" enabled with value == MT. Overriding G4RunManager type...

**************************************************************
 Geant4 version Name: geant4-11-03 [MT]   (6-December-2024)
  << in Multi-threaded mode >> 
                       Copyright : Geant4 Collaboration
                      References : NIM A 506 (2003), 250-303
                                 : IEEE-TNS 53 (2006), 270-278
                                 : NIM A 835 (2016), 186-225
                             WWW : http://geant4.org/
**************************************************************

info: Created run manager type G4MTRunManager
status: Setting run manager initialization
[M] status@/home/alund/celeritas_project/celeritas/test/accel/TrackingManagerIntegration.test.cc:1022: Run initialization
[M] info@/home/alund/celeritas_project/celeritas/src/geocel/GeantGdmlLoader.cc:79: Loading Geant4 geometry from GDML at /home/alund/celeritas_project/celeritas/test/geocel/data/water-sphere.gdml
G4GDML: Reading '/home/alund/celeritas_project/celeritas/test/geocel/data/water-sphere.gdml'...
G4GDML: Reading definitions...
G4GDML: Reading materials...
G4GDML: Reading solids...
G4GDML: Reading structure...
G4GDML: Reading setup...
G4GDML: Reading '/home/alund/celeritas_project/celeritas/test/geocel/data/water-sphere.gdml' done!
[M] info@/home/alund/celeritas_project/celeritas/src/celeritas/g4/DetectorConstruction.cc:133: Constructed SensDet='detshell' and attached to 1 volumes
G4WT0 > [W] info@/home/alund/celeritas_project/celeritas/src/celeritas/g4/DetectorConstruction.cc:133: Constructed SensDet='detshell' and attached to 1 volumes
G4WT0 > [W] info@/home/alund/celeritas_project/celeritas/src/accel/TrackingManagerConstructor.cc:147: Built Celeritas tracking managers for e-, e+, gamma
[M] status@/home/alund/celeritas_project/celeritas/test/accel/TrackingManagerIntegration.test.cc:1027: Beam on
[M] info@/home/alund/celeritas_project/celeritas/src/celeritas/setup/FrameworkInput.cc:33: Activating Celeritas version 0.7.0-dev.507+develop.be44d7947 on GPU
[M] warning@/home/alund/celeritas_project/celeritas/src/corecel/sys/Device.cc:379: Device 'NVIDIA A40' has CUDA compute capability of 86, but Celeritas was compiled with CMAKE_CUDA_ARCHITECTURES="70+80+90": code may mysteriously die at runtime
[M] status@/home/alund/celeritas_project/celeritas/src/celeritas/ext/GeantImporter.cc:1007: Transferring data from Geant4
[M] status@/home/alund/celeritas_project/celeritas/src/celeritas/setup/Problem.cc:460: Initializing problem
[M] info@/home/alund/celeritas_project/celeritas/src/corecel/sys/Device.cc:306: Creating 2 device streams
[M] status@/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomParams.cc:399: Loading VecGeom geometry from in-memory Geant4 geometry
status: Converting Geant4 geometry
[M] status@/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomParams.cc:460: Initializing tracking information
[M] info@/home/alund/celeritas_project/celeritas/src/corecel/sys/ScopedLimitSaver.cuda.cc:55: CUDA stack size was changed from 1024 to 8192; restoring to original values
[M] status@/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomParams.cc:464: Constructing metadata
[M] status@/home/alund/celeritas_project/celeritas/src/celeritas/global/CoreParams.cc:331: Celeritas core setup complete
[M] info@/home/alund/celeritas_project/celeritas/src/accel/SharedParams.cc:478: Wrote Geant4 diagnostic output to "watersphere-run-small-flush-1-gpu-mt.out.json"
G4WT0 > [W] status@/home/alund/celeritas_project/celeritas/src/celeritas/global/CoreState.cc:81: Celeritas core state initialization complete
pos: (1.7610953772218080e-01, -3.7138599525128173e+00, 2.4720663815134103e-01), init.pos: (-5.1533050604383341e+01, 2.3431348500476652e+01, 1.3106039467495750e+01), tid_: 6, init.parent: 7
/home/alund/celeritas_project/celeritas/src/geocel/vg/VecgeomTrackView.hh:264:
celeritas: internal assertion failed: this->pos() == init.pos
/home/alund/celeritas_project/celeritas/test/accel/IntegrationTestBase.cc:518: Failure
Failed
GeantExceptionHandler caught runtime error (1,celer.event.flush): from Thrust GPU library: copy_if failed to synchronize: cudaErrorLaunchFailure: unspecified launch failure

G4WT1 > [2/2] critical@/home/alund/celeritas_project/celeritas/src/geocel/ScopedGeantExceptionHandler.cc:129: Aborting run due to exception (celer.event.flush)
/home/alund/celeritas_project/celeritas/test/accel/IntegrationTestBase.cc:518: Failure
Failed
GeantExceptionHandler caught runtime error (0,celer.event.flush): from /home/alund/celeritas_project/celeritas/src/corecel/sys/Stream.cc:172: Celeritas CUDA error: unspecified launch failure

G4WT0 > [1/2] critical@/home/alund/celeritas_project/celeritas/src/geocel/ScopedGeantExceptionHandler.cc:129: Aborting run due to exception (celer.event.flush)
/home/alund/celeritas_project/celeritas/test/accel/IntegrationTestBase.cc:518: Failure
Failed
GeantExceptionHandler caught runtime error (0,celer.finalize.local): from /home/alund/celeritas_project/celeritas/src/accel/LocalTransporter.cc:734: Celeritas runtime error: offloaded tracks were not flushed (0 primaries buffered, transport incomplete)

G4WT0 > [1/2] critical@/home/alund/celeritas_project/celeritas/src/geocel/ScopedGeantExceptionHandler.cc:129: Aborting run due to exception (celer.finalize.local)
/home/alund/celeritas_project/celeritas/test/accel/IntegrationTestBase.cc:518: Failure
Failed
GeantExceptionHandler caught runtime error (1,celer.finalize.local): from /home/alund/celeritas_project/celeritas/src/accel/LocalTransporter.cc:734: Celeritas runtime error: offloaded tracks were not flushed (0 primaries buffered, transport incomplete)

G4WT1 > [2/2] critical@/home/alund/celeritas_project/celeritas/src/geocel/ScopedGeantExceptionHandler.cc:129: Aborting run due to exception (celer.finalize.local)
[M] status@/home/alund/celeritas_project/celeritas/src/accel/detail/IntegrationSingleton.cc:405: Finalizing Celeritas
[M] info@/home/alund/celeritas_project/celeritas/src/accel/SharedParams.cc:478: Wrote Geant4 diagnostic output to "watersphere-run-small-flush-1-gpu-mt.out.json"
Failed to destroy stream: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/Stream.cc:70: 'StreamDestroy(impl->stream)' failed
Failed to destroy stream: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/Stream.cc:70: 'StreamDestroy(impl->stream)' failed
[  FAILED  ] WaterSphere.run_small_flush (457 ms)
[----------] 1 test from WaterSphere (457 ms total)

[----------] Global test environment tear-down
[2/2] warning@/home/alund/celeritas_project/celeritas/src/celeritas/ext/GeantTrackReconstruction.cc:142: Geant4 track data was not cleared during the event
[1/2] warning@/home/alund/celeritas_project/celeritas/src/celeritas/ext/GeantTrackReconstruction.cc:142: Geant4 track data was not cleared during the event
Failed to destroy event: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/DeviceEvent.cc:39: 'EventDestroy(impl->event)' failed
Failed to destroy event: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/DeviceEvent.cc:39: 'EventDestroy(impl->event)' failed
Failed to destroy event: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/DeviceEvent.cc:39: 'EventDestroy(impl->event)' failed
Failed to destroy event: CUDA error: unspecified launch failure
/home/alund/celeritas_project/celeritas/src/corecel/sys/DeviceEvent.cc:39: 'EventDestroy(impl->event)' failed
```

</details>

which revealed a bug in how we were initializing the geometry state from an existing parent state. When inserting new primaries before completely transporting the current batch, the new initializers are added to the back of the buffer. Already-buffered secondaries with valid parent IDs that assumed initialization in the next step could therefore have a stale parent track slot ID and incorrectly reuse the geometry state from a different track when they were eventually initialized. This fix addresses the issue by clearing parent IDs for all buffered initializers whenever new primaries are added.