### PR TITLE
Improve CI and enable C++23

### DIFF
--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -5,8 +5,8 @@
 # Bootstrap a Spack environment, build/install dependencies, activate it, and
 # configure Celeritas against it.
 #
-# NOTE: run `update-spack-buildcache-local` on a non-github machine to setup
-# the spack buildcache.
+# NOTE: run scripts/ci/update-spack-buildcache-local.sh
+# on a non-github machine to setup the spack buildcache.
 #-----------------------------------------------------------------------------#
 
 name: "Set up Spack environment"

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -127,6 +127,7 @@ runs:
     - name: Push Spack installation to buildcache
       id: push-buildcache
       if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+      continue-on-error: ${{ github.repository != 'celeritas-project/celeritas' }}
       shell: sh
       env:
         GITHUB_USER: ${{github.actor}}

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -26,10 +26,6 @@ inputs:
     description: "Packages to build in a separate environment using the cached core specs"
     required: false
     default: ""
-  push-buildcache:
-    description: "Publish the core environment to the shared buildcache (excludes add-dependent)"
-    required: false
-    default: "false"
 
 runs:
   using: "composite"
@@ -74,7 +70,7 @@ runs:
       run: |
         "${CELER_SOURCE_DIR}/scripts/ci/setup-spack-ci-env.sh" ${{inputs.add}}
 
-        if ! "${{inputs.push-buildcache}}"; then
+        if [ "${{github.event_name}}" = "pull_request" ]; then
           echo "Disabling install prefix padding"
           spack -e . config add "config:install_tree:padded_length:False"
         fi
@@ -130,7 +126,7 @@ runs:
         spack -e . find -lv
     - name: Push Spack installation to buildcache
       id: push-buildcache
-      if: ${{ !cancelled() && fromJSON(inputs.push-buildcache) }}
+      if: ${{ !cancelled() && github.event_name != 'pull_request' }}
       shell: sh
       env:
         GITHUB_USER: ${{github.actor}}

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -52,13 +52,13 @@ runs:
       with:
         repository: spack/spack
         path: ${{env.SPACK_ROOT}}
-        ref: c3426684351723f819abca7335fafd99ffe7c1ef
+        ref: c3426684351723f819abca7335fafd99ffe7c1ef # upstream/develop, 12 September 2026
     - name: Checkout Spack packages
       uses: actions/checkout@v7
       with:
         repository: celeritas-project/spack-packages
         path: ${{env.SPACK_PACKAGES}}
-        ref: 2c1c9409a3828d9d3a3985fd0ae200bd8bd82117 # ci, 9 September 2026
+        ref: 3f034e3f7f3e0e64f94a4761a8c2ba0e8931bc84 # upstream/develop, 12 September 2026
 
     - name: Initialize spack environment
       shell: sh

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -93,7 +93,7 @@ runs:
       id: concretize
       shell: sh
       run: |
-        spack arch --generic
+        spack arch
         spack -e . -v concretize || {
           ERR=$?
           cat spack.yaml
@@ -109,9 +109,9 @@ runs:
     - name: Upload spack config and lockfile
       id: upload
       uses: actions/upload-artifact@v7
-      if: ${{runner.debug && !cancelled() }}
+      if: ${{ !steps.restore.outputs.cache-matched-key }}
       with:
-        name: spack-${{hashFiles('spack.yaml')}}-${{github.run_id}}
+        name: spack-${{hashFiles('spack.config.json')}}-${{github.run_id}}
         path: "spack.*"
         retention-days: 1
 

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -15,6 +15,9 @@ inputs:
   cxxstd:
     description: "C++ standard to concretize Spack with"
     required: true
+  env-file:
+    description: "Base environment file to use (optional, relative to scripts/spack/)"
+    required: false
   add:
     description: "Space-separated list of additional spack packages to add"
     required: false
@@ -65,9 +68,11 @@ runs:
       shell: sh
       env:
         CXXSTD: ${{inputs.cxxstd}}
+        SPACK_ENV_FILE: ${{inputs.env-file}}
+        CELER_SOURCE_DIR: ${{github.workspace}}
       # NOTE: padding MUST NOT be disabled if pushing to buildcache
       run: |
-        "${{github.workspace}}/scripts/ci/setup-spack-ci-env.sh" ${{inputs.add}}
+        "${CELER_SOURCE_DIR}/scripts/ci/setup-spack-ci-env.sh" ${{inputs.add}}
 
         if ! "${{inputs.push-buildcache}}"; then
           echo "Disabling install prefix padding"

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: "C++ standard to concretize Spack with"
     required: true
   env-file:
-    description: "Base environment file to use (optional, relative to scripts/spack/)"
+    description: "Base environment file to use (optionally relative to scripts/spack/)"
     required: false
   add:
     description: "Space-separated list of additional spack packages to add"

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -90,10 +90,10 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: spack.lock
-        key: lock-${{hashFiles('spack.yaml', 'scripts/spack/*.yaml')}}-${{github.run_id}}
-        restore-keys: lock-${{hashFiles('spack.yaml', 'scripts/spack/*.yaml')}}
+        key: lock-${{hashFiles('spack.config.json')}}-${{github.run_id}}
+        restore-keys: lock-${{hashFiles('spack.config.json')}}
     - name: Concretize
-      if: ${{ !steps.restore.outputs.cache-matched-key }}
+      if: ${{ !steps.restore.outputs.cache-matched-key }} # skip if another run provided the same hash
       id: concretize
       shell: sh
       run: |
@@ -108,7 +108,7 @@ runs:
       uses: actions/cache/save@v6
       with:
         path: spack.lock
-        key: lock-${{hashFiles('spack.yaml', 'scripts/spack/*.yaml')}}-${{github.run_id}}
+        key: lock-${{hashFiles('spack.config.json')}}-${{github.run_id}}
 
     - name: Upload spack config and lockfile
       id: upload

--- a/.github/actions/setup-spack/action.yml
+++ b/.github/actions/setup-spack/action.yml
@@ -30,42 +30,50 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set environment variables
+    - name: Set environment and local variables
+      id: vars
       shell: sh
       run: |
-        SPACK_ROOT="$GITHUB_WORKSPACE/spack-src"
-        echo "$SPACK_ROOT/bin" >> "$GITHUB_PATH"
         {
-          echo "CELER_SPACK_VIEW=/opt/view"
+          # These can be overridden by dependent build
           echo "CELER_SPACK_ENV=$GITHUB_WORKSPACE"
-          echo "CELER_SPACK_OPT=/opt/spack"
-          echo "CELER_BASE_IMAGE=ubuntu:24.04"
-          echo "CELER_BUILDCACHE=celeritas"
-          echo "SPACK_PACKAGES=$GITHUB_WORKSPACE/spack-pkg"
-          echo "SPACK_ROOT=$SPACK_ROOT"
+          echo "CELER_SPACK_VIEW=/opt/view"
+          # Used by spack
           echo "SPACK_COLOR=always"
           echo "SPACK_DISABLE_LOCAL_CONFIG=1"
+          echo "SPACK_ROOT=$GITHUB_WORKSPACE/spack-src"
         } >> "$GITHUB_ENV"
-
+        {
+          echo "BASE_IMAGE=ubuntu:24.04"
+          echo "BUILDCACHE=celeritas"
+          echo "SPACK_PKG_REPO=$GITHUB_WORKSPACE/spack-pkg"
+        } >> "$GITHUB_OUTPUT"
+        echo "$SPACK_ROOT/bin" >> "$GITHUB_PATH"
     - name: Checkout Spack
+      id: checkout-spack
       uses: actions/checkout@v7
       with:
         repository: spack/spack
         path: ${{env.SPACK_ROOT}}
         ref: c3426684351723f819abca7335fafd99ffe7c1ef # upstream/develop, 12 September 2026
     - name: Checkout Spack packages
+      id: checkout-spack-pkg
       uses: actions/checkout@v7
       with:
         repository: celeritas-project/spack-packages
-        path: ${{env.SPACK_PACKAGES}}
+        path: ${{steps.vars.outputs.SPACK_PKG_REPO}}
         ref: 3f034e3f7f3e0e64f94a4761a8c2ba0e8931bc84 # upstream/develop, 12 September 2026
 
     - name: Initialize spack environment
+      id: init
       shell: sh
+      working-directory: ${{env.CELER_SPACK_ENV}}
       env:
         CXXSTD: ${{inputs.cxxstd}}
         SPACK_ENV_FILE: ${{inputs.env-file}}
-        CELER_SOURCE_DIR: ${{github.workspace}}
+        CELER_SOURCE_DIR: "${{github.workspace}}"
+        CELER_SPACK_OPT: "/opt/spack"
+        SPACK_PACKAGES_REPO: "${{steps.vars.outputs.SPACK_PKG_REPO}}"
       # NOTE: padding MUST NOT be disabled if pushing to buildcache
       run: |
         "${CELER_SOURCE_DIR}/scripts/ci/setup-spack-ci-env.sh" ${{inputs.add}}
@@ -75,23 +83,31 @@ runs:
           spack -e . config add "config:install_tree:padded_length:False"
         fi
         spack -e . config get --json > spack.config.json
+        {
+          echo "CONFIG_DUMP=$PWD/spack.config.json"a
+          echo "STAGE_DIR=$(spack -e . location -S)"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Dump spack config blame
       if: ${{runner.debug}}
       shell: sh
+      working-directory: ${{env.CELER_SPACK_ENV}}
       run: |
         spack -e . config blame
 
     - name: Restore cached lockfile
       id: restore
+      working-directory: ${{env.CELER_SPACK_ENV}}
       uses: actions/cache/restore@v6
       with:
         path: spack.lock
-        key: lock-${{hashFiles('spack.config.json')}}-${{github.run_id}}
-        restore-keys: lock-${{hashFiles('spack.config.json')}}
+        key: lock-${{hashFiles(steps.init.outputs.CONFIG_DUMP)}}-${{github.run_id}}
+        restore-keys: lock-${{hashFiles(steps.init.outputs.CONFIG_DUMP)}}
     - name: Concretize
       if: ${{ !steps.restore.outputs.cache-matched-key }} # skip if another run provided the same hash
       id: concretize
       shell: sh
+      working-directory: ${{env.CELER_SPACK_ENV}}
       run: |
         spack arch
         spack -e . -v concretize || {
@@ -101,29 +117,43 @@ runs:
         }
     - name: Cache lockfile
       if: ${{ steps.concretize.outcome == 'success' }}
+      working-directory: ${{env.CELER_SPACK_ENV}}
       uses: actions/cache/save@v6
       with:
         path: spack.lock
-        key: lock-${{hashFiles('spack.config.json')}}-${{github.run_id}}
-
+        key: lock-${{hashFiles(steps.init.outputs.CONFIG_DUMP)}}-${{github.run_id}}
+    - name: Install dependencies
+      id: install
+      shell: sh
+      working-directory: ${{env.CELER_SPACK_ENV}}
+      env:
+        USE_BUILDCACHE: ${{ github.event_name == 'pull_request' && 'only' || 'auto' }}
+      run: |
+        spack -e . install -p 8 --use-buildcache="$USE_BUILDCACHE"
     - name: Upload spack config and lockfile
-      id: upload
+      if: >-
+        ${{ !cancelled()
+           && (!steps.restore.outputs.cache-matched-key
+               || steps.concretize.outcome == 'failure'
+               || steps.install.outcome == 'failure')
+        }}
+      working-directory: ${{env.CELER_SPACK_ENV}}
       uses: actions/upload-artifact@v7
-      if: ${{ !steps.restore.outputs.cache-matched-key }}
       with:
-        name: spack-${{hashFiles('spack.config.json')}}-${{github.run_id}}
+        name: spack-${{hashFiles(steps.init.outputs.CONFIG_DUMP)}}-${{github.run_id}}
         path: "spack.*"
         retention-days: 1
-
-    - name: Install dependencies
-      shell: sh
-      run: |
-        spack -e . install -p 8 --use-buildcache=${{ github.event_name == 'pull_request' && 'only' || 'auto' }}
+    - name: Upload logs
+      if: ${{ !cancelled() && steps.install.outcome == 'failure' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: spack-logs-${{hashFiles(steps.init.outputs.CONFIG_DUMP)}}
+        path: ${{steps.init.outputs.STAGE_DIR}}/*.log
     - name: List installed dependencies
-      if: ${{runner.debug}}
+      if: ${{runner.debug || steps.install.outcome == 'failure'}}
       shell: sh
       run: |
-        spack -e . find -lv
+        spack -e $CELER_SPACK_ENV find -lv
     - name: Push Spack installation to buildcache
       id: push-buildcache
       if: ${{ !cancelled() && github.event_name != 'pull_request' }}
@@ -132,13 +162,15 @@ runs:
       env:
         GITHUB_USER: ${{github.actor}}
         GITHUB_TOKEN: ${{github.token}}
+        BUILDCACHE: ${{steps.vars.outputs.BUILDCACHE}}
+        BASE_IMAGE: ${{steps.vars.outputs.BASE_IMAGE}}
       # NOTE: build-only specs that had dependents available through the
-      # buildcache may not be locally available: so allow missing
+      # buildcache may not be locally available: so we must allow missing
       run: |
-        spack -e . buildcache push \
-          --base-image $CELER_BASE_IMAGE --update-index \
+        spack -e $CELER_SPACK_ENV buildcache push \
+          --base-image $BASE_IMAGE --update-index \
           --allow-missing \
-          $CELER_BUILDCACHE
+          $BUILDCACHE
 
     # Keep moving dependencies out of the core manifest and its lockfile cache.
     # Included concrete roots constrain the dependent solve with unify: true.
@@ -148,9 +180,9 @@ runs:
       run: |
         dependent_env="$GITHUB_WORKSPACE/spack-dependent"
         dependent_view="${CELER_SPACK_VIEW}-dependent"
-        spack env create -d "$dependent_env" "$CELER_SPACK_ENV/spack.yaml" \
+        spack env create -d "$dependent_env" "${CELER_SPACK_ENV}/spack.yaml" \
           --with-view "$dependent_view"
-        spack -e "$dependent_env" config add "include:$CELER_SPACK_ENV/spack.lock"
+        spack -e "$dependent_env" config add "include:${CELER_SPACK_ENV}/spack.lock"
         # Only new packages belong in the abstract spec list: the core lockfile
         # already supplies the exact specs for the included roots.
         spack -e "$dependent_env" remove --all

--- a/.github/workflows/build-codecov.yml
+++ b/.github/workflows/build-codecov.yml
@@ -24,7 +24,7 @@ jobs:
   spack:
     name: spack-vecgeom
     env:
-      CELER_CMAKE_PRESET: ndebug-vecgeom-codecov
+      CELER_CMAKE_PRESET: vecgeom-codecov
       LLVM_COV: "llvm-cov-18"
       CC: "clang-18"
       CXX: "clang++-18"
@@ -70,7 +70,7 @@ jobs:
   docker:
     name: docker-vecgeom-cuda
     env:
-      CELER_CMAKE_PRESET: ndebug-vecgeom-codecov
+      CELER_CMAKE_PRESET: vecgeom-codecov
       CELER_DISABLE_DEVICE: 1 # REQUIRED for GHA runners
     runs-on: ubuntu-24.04
     container:

--- a/.github/workflows/build-codecov.yml
+++ b/.github/workflows/build-codecov.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           add: vecgeom@1.2.11 geant4@11.3 g4vg root py-gcovr
           cxxstd: ${{env.CXXSTD}}
-          push-buildcache: ${{github.event_name != 'pull_request'}}
       - name: Configure Celeritas
         uses: ./.github/actions/configure
         with:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         geometry: ["orange", "vecgeom"]
-        buildtype: ["debug", "ndebug"]
+        buildtype: ["debug", "release"]
         image: ["rocky-cuda", "ubuntu-rocm"]
         exclude:
           - geometry: "vecgeom"
@@ -96,11 +96,11 @@ jobs:
           binaries: orange-update celer-export-geant celer-sim celer-g4
 
       - name: Build examples
-        # TODO: rocm+ndebug fails to propagate HIP library link
+        # TODO: rocm+release fails to propagate HIP library link
         if: >-
           ${{
             steps.install.outcome == 'success'
-            && !(matrix.image == 'ubuntu-rocm' && matrix.buildtype == 'ndebug')
+            && !(matrix.image == 'ubuntu-rocm' && matrix.buildtype == 'release')
           }}
         run: |
           . /etc/profile

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -40,6 +40,25 @@ jobs:
     strategy:
       matrix:
         include:
+          - runner: ubuntu-22.04
+            compiler: [gcc, 12]
+            cxxstd: 17
+          - runner: ubuntu-22.04
+            compiler: [clang, 15]
+            cxxstd: 17
+          - runner: ubuntu-24.04
+            compiler: [gcc, 14]
+            cxxstd: 17
+          - runner: ubuntu-24.04
+            compiler: [clang, 18]
+          - runner: ubuntu-26.04
+            compiler: [gcc, 15]
+            cxxstd: 23
+          - runner: ubuntu-26.04
+            compiler: [clang, 22]
+            cxxstd: 23
+          - runner: ubuntu-26.04-arm
+            compiler: [gcc, 15]
           - runner: ubuntu-26.04-arm
             compiler: [clang, 22]
     env:
@@ -93,6 +112,52 @@ jobs:
         with:
           preset: ${{env.CELER_CMAKE_PRESET}}
           name: fast-${{env.CELER_JOB_NAME}}
+          ccache-max-size: 192Mi
+
+      - name: Test
+        id: test
+        uses: ./.github/actions/run-ctest
+        with:
+          preset: ${{env.CELER_CMAKE_PRESET}}
+          split-app: true
+          name: fast-${{env.CELER_JOB_NAME}}
+
+      - name: Install
+        if: ${{ !cancelled() && steps.build.outputs.build-outcome == 'success' }}
+        uses: ./.github/actions/install-and-check
+
+  windows:
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CELER_JOB_NAME: windows
+      CXXSTD: 20
+    runs-on: windows-2025
+    steps:
+      - name: Check out Celeritas
+        uses: actions/checkout@v7
+
+      - name: Install dependencies
+        run: |
+          choco install ninja ccache
+      - name: Set up MSVC
+        uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0, 22 July 2026
+        with:
+          arch: x64
+
+      - name: Configure Celeritas
+        uses: ./.github/actions/configure
+        with:
+          preset: ${{env.CELER_CMAKE_PRESET}}
+          presets-file: ci-windows-github.json
+          version-string: ${{env.CELER_VERSION_STRING}}
+      - name: Build
+        id: build
+        uses: ./.github/actions/build-cached
+        with:
+          preset: ${{env.CELER_CMAKE_PRESET}}
+          name: fast-windows
           ccache-max-size: 192Mi
 
       - name: Test

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -35,25 +35,28 @@ jobs:
           || matrix.runner ==  'ubuntu-26.04-arm' && 'resolute-arm',
         matrix.compiler[0],
         matrix.compiler[1],
-        matrix.cxxstd || 17
+        matrix.cxxstd || 20
       )}}
     strategy:
       matrix:
         include:
           - runner: ubuntu-22.04
             compiler: [gcc, 12]
+            cxxstd: 17
           - runner: ubuntu-22.04
             compiler: [clang, 15]
-            cxxstd: 20
+            cxxstd: 17
           - runner: ubuntu-24.04
             compiler: [gcc, 14]
+            cxxstd: 17
           - runner: ubuntu-24.04
             compiler: [clang, 18]
-            cxxstd: 20
           - runner: ubuntu-26.04
             compiler: [gcc, 15]
+            cxxstd: 23
           - runner: ubuntu-26.04
             compiler: [clang, 22]
+            cxxstd: 23
           - runner: ubuntu-26.04-arm
             compiler: [gcc, 15]
           - runner: ubuntu-26.04-arm
@@ -65,7 +68,7 @@ jobs:
           matrix.runner,
           matrix.compiler[0],
           matrix.compiler[1],
-          matrix.cxxstd || 17
+          matrix.cxxstd || 20
         )}}
       CC: ${{format('{0}-{1}', matrix.compiler[0], matrix.compiler[1])}}
       CXX: >-
@@ -75,7 +78,7 @@ jobs:
            || matrix.compiler[0] == 'clang' && 'clang++'),
           matrix.compiler[1]
         )}}
-      CXXSTD: ${{matrix.cxxstd || 17}}
+      CXXSTD: ${{matrix.cxxstd || 20}}
     runs-on: ${{matrix.runner}}
     steps:
       - name: Check out Celeritas
@@ -129,7 +132,7 @@ jobs:
         shell: pwsh
     env:
       CELER_JOB_NAME: windows
-      CXXSTD: 17
+      CXXSTD: 20
     runs-on: windows-2025
     steps:
       - name: Check out Celeritas

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -91,7 +91,7 @@ jobs:
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
             ccache \
-            nlohmann-json3-dev libgtest-dev libhepmc3-dev libpng-dev libcli11-dev \
+            nlohmann-json3-dev libgtest-dev libhepmc3-dev libpng-dev \
             ${{format('{0}-{1}', matrix.compiler[0], matrix.compiler[1])}} \
             ${{matrix.compiler[0] == 'gcc' && format('g++-{0}', matrix.compiler[1]) || ''}}
           echo "Installed toolchain:"

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -91,7 +91,7 @@ jobs:
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
             ccache \
-            nlohmann-json3-dev libgtest-dev libhepmc3-dev libpng-dev \
+            nlohmann-json3-dev libgtest-dev libhepmc3-dev libpng-dev libcli11-dev \
             ${{format('{0}-{1}', matrix.compiler[0], matrix.compiler[1])}} \
             ${{matrix.compiler[0] == 'gcc' && format('g++-{0}', matrix.compiler[1]) || ''}}
           echo "Installed toolchain:"

--- a/.github/workflows/build-fast.yml
+++ b/.github/workflows/build-fast.yml
@@ -40,25 +40,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: ubuntu-22.04
-            compiler: [gcc, 12]
-            cxxstd: 17
-          - runner: ubuntu-22.04
-            compiler: [clang, 15]
-            cxxstd: 17
-          - runner: ubuntu-24.04
-            compiler: [gcc, 14]
-            cxxstd: 17
-          - runner: ubuntu-24.04
-            compiler: [clang, 18]
-          - runner: ubuntu-26.04
-            compiler: [gcc, 15]
-            cxxstd: 23
-          - runner: ubuntu-26.04
-            compiler: [clang, 22]
-            cxxstd: 23
-          - runner: ubuntu-26.04-arm
-            compiler: [gcc, 15]
           - runner: ubuntu-26.04-arm
             compiler: [clang, 22]
     env:
@@ -112,52 +93,6 @@ jobs:
         with:
           preset: ${{env.CELER_CMAKE_PRESET}}
           name: fast-${{env.CELER_JOB_NAME}}
-          ccache-max-size: 192Mi
-
-      - name: Test
-        id: test
-        uses: ./.github/actions/run-ctest
-        with:
-          preset: ${{env.CELER_CMAKE_PRESET}}
-          split-app: true
-          name: fast-${{env.CELER_JOB_NAME}}
-
-      - name: Install
-        if: ${{ !cancelled() && steps.build.outputs.build-outcome == 'success' }}
-        uses: ./.github/actions/install-and-check
-
-  windows:
-    defaults:
-      run:
-        shell: pwsh
-    env:
-      CELER_JOB_NAME: windows
-      CXXSTD: 20
-    runs-on: windows-2025
-    steps:
-      - name: Check out Celeritas
-        uses: actions/checkout@v7
-
-      - name: Install dependencies
-        run: |
-          choco install ninja ccache
-      - name: Set up MSVC
-        uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9 # v4.1.0, 22 July 2026
-        with:
-          arch: x64
-
-      - name: Configure Celeritas
-        uses: ./.github/actions/configure
-        with:
-          preset: ${{env.CELER_CMAKE_PRESET}}
-          presets-file: ci-windows-github.json
-          version-string: ${{env.CELER_VERSION_STRING}}
-      - name: Build
-        id: build
-        uses: ./.github/actions/build-cached
-        with:
-          preset: ${{env.CELER_CMAKE_PRESET}}
-          name: fast-windows
           ccache-max-size: 192Mi
 
       - name: Test

--- a/.github/workflows/build-spack-extra.yml
+++ b/.github/workflows/build-spack-extra.yml
@@ -34,7 +34,6 @@ jobs:
         uses: ./.github/actions/setup-spack
         with:
           cxxstd: ${{env.CXXSTD}}
-          push-buildcache: ${{github.event_name != 'pull_request'}}
       - name: Configure Celeritas
         id: configure
         uses: ./.github/actions/configure
@@ -75,7 +74,6 @@ jobs:
         with:
           cxxstd: ${{env.CXXSTD}}
           env-file: "${{github.workspace}}/scripts/spack/env-ci-ancient.yaml"
-          push-buildcache: ${{github.event_name != 'pull_request'}}
       - name: Configure Celeritas
         id: configure
         uses: ./.github/actions/configure
@@ -114,7 +112,6 @@ jobs:
         with:
           add: "geant4@11.2 vecgeom@1.2.11:1 g4vg"
           cxxstd: ${{env.CXXSTD}}
-          push-buildcache: ${{github.event_name != 'pull_request'}}
       - name: Configure Celeritas
         uses: ./.github/actions/configure
         with:

--- a/.github/workflows/build-spack-extra.yml
+++ b/.github/workflows/build-spack-extra.yml
@@ -57,6 +57,47 @@ jobs:
           split-app: true
           strict: false
 
+  ancient:
+    name: orange-gcc8
+    env:
+      CELER_CMAKE_PRESET: orange-ancient
+      CC: "/opt/view/bin/gcc"
+      CXX: "/opt/view/bin/g++"
+      CXXSTD: 17
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out Celeritas
+        uses: actions/checkout@v7
+        with:
+          fetch-tags: true # to get version information
+      - name: Set up Spack environment
+        uses: ./.github/actions/setup-spack
+        with:
+          cxxstd: ${{env.CXXSTD}}
+          env-file: "${{github.workspace}}/scripts/spack/env-ci-ancient.yaml"
+          push-buildcache: ${{github.event_name != 'pull_request'}}
+      - name: Configure Celeritas
+        id: configure
+        uses: ./.github/actions/configure
+        with:
+          preset: ${{env.CELER_CMAKE_PRESET}}
+          presets-file: "ci-ubuntu-github.json"
+      - name: Build all
+        id: build
+        uses: ./.github/actions/build-cached
+        with:
+          name: spack-${{env.CELER_CMAKE_PRESET}}
+          preset: spack
+          ccache-max-size: 512Mi
+      - name: Run tests
+        id: test
+        uses: ./.github/actions/run-ctest
+        with:
+          name: spack-${{env.CELER_CMAKE_PRESET}}
+          preset: spack-unit
+          split-app: false
+          strict: false
+
   tidy:
     name: tidy-vecgeom
     env:

--- a/.github/workflows/build-spack-extra.yml
+++ b/.github/workflows/build-spack-extra.yml
@@ -123,9 +123,5 @@ jobs:
           "${{github.workspace}}/scripts/ci/clang-tidy-changed.sh" \
             "origin" \
             "${{ github.event.pull_request.base.sha }}"
-      # NOTE: this was not previously used on develop so will be disabled
-      - name: Build all files with clang-tidy
-        if: ${{github.event_name != 'pull_request'}}
-        run: cmake --build --preset=spack
 
 # vim: set nowrap tw=100:

--- a/.github/workflows/build-spack-extra.yml
+++ b/.github/workflows/build-spack-extra.yml
@@ -21,9 +21,9 @@ env:
 
 jobs:
   asan:
-    name: reldeb-orange-asanlite
+    name: orange-asanlite
     env:
-      CELER_CMAKE_PRESET: reldeb-orange-asanlite
+      CELER_CMAKE_PRESET: orange-asanlite
     runs-on: ubuntu-24.04
     steps:
       - name: Check out Celeritas
@@ -59,7 +59,7 @@ jobs:
   tidy:
     name: tidy-vecgeom
     env:
-      CELER_CMAKE_PRESET: reldeb-vecgeom-tidy
+      CELER_CMAKE_PRESET: vecgeom-tidy
       CLANG_TIDY: "clang-tidy-18"
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -31,7 +31,21 @@ jobs:
       fail-fast: false
       matrix:
         geometry: ["vecgeom"]
-        geant: ["11.3"]
+        geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3"]
+        include:
+          - geometry: "orange"
+            special: "float"
+            geant: "11.3"
+          - geometry: "orange"
+            special: "static"
+            geant: "11.3"
+          - geometry: "vecgeom"
+            special: "clhep"
+            geant: "11.3"
+          - geometry: "vecgeom2"
+            geant: "11.3"
+          - geometry: "geant4"
+            geant: "11.3"
     env:
       CELER_CMAKE_PRESET: >-
         ${{format(

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -74,7 +74,6 @@ jobs:
         uses: ./.github/actions/setup-spack
         with:
           cxxstd: ${{env.CXXSTD}}
-          push-buildcache: ${{github.event_name != 'pull_request'}}
           add: >-
             ${{(matrix.special != 'static'
                 && env.CXXSTD == '20')

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         geometry: ["vecgeom"]
-        geant: ["11.3", "11.4"]
+        geant: ["11.3"]
     env:
       CELER_CMAKE_PRESET: >-
         ${{format(

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -35,7 +35,7 @@ jobs:
         build_type: ["reldeb"]
         geometry: ["vecgeom"]
         special: [""]
-        geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3"]
+        geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3", "11.4"]
         include:
           - build_type: "reldeb"
             geometry: "orange"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -31,21 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         geometry: ["vecgeom"]
-        geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3", "11.4"]
-        include:
-          - geometry: "orange"
-            special: "float"
-            geant: "11.3"
-          - geometry: "orange"
-            special: "static"
-            geant: "11.3"
-          - geometry: "vecgeom"
-            special: "clhep"
-            geant: "11.3"
-          - geometry: "vecgeom2"
-            geant: "11.3"
-          - geometry: "geant4"
-            geant: "11.3"
+        geant: ["11.3", "11.4"]
     env:
       CELER_CMAKE_PRESET: >-
         ${{format(

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -22,63 +22,47 @@ jobs:
   spack:
     name: >-
       ${{format(
-        '{0}{1}{2}{3}{4}',
-        matrix.special,
-        matrix.special && '-' || '',
+        '{0}{1}-g4@{2}',
+        matrix.special && format('{0}-', matrix.special) || '',
         matrix.geometry,
-        matrix.geant && '-g4@' || '',
         matrix.geant
       )}}
     strategy:
       fail-fast: false
       matrix:
-        build_type: ["reldeb"]
         geometry: ["vecgeom"]
-        special: [""]
         geant: ["10.5", "10.6", "10.7", "11.0", "11.1", "11.2", "11.3", "11.4"]
         include:
-          - build_type: "reldeb"
-            geometry: "orange"
-            special: "minimal"
-            geant: ""
-          - build_type: "reldeb"
-            geometry: "orange"
+          - geometry: "orange"
             special: "float"
             geant: "11.3"
-          - build_type: "ndebug"
-            geometry: "orange"
+          - geometry: "orange"
             special: "static"
             geant: "11.3"
-          - build_type: "reldeb"
-            geometry: "vecgeom"
+          - geometry: "vecgeom"
             special: "clhep"
             geant: "11.3"
-          - build_type: "reldeb"
-            geometry: "vecgeom2"
-            special: ""
+          - geometry: "vecgeom2"
             geant: "11.3"
-          - build_type: "reldeb"
-            geometry: "geant4"
-            special: ""
+          - geometry: "geant4"
             geant: "11.3"
     env:
       CELER_CMAKE_PRESET: >-
-        ${{format('{0}-{1}{2}{3}',
-                  matrix.build_type,
-                  matrix.geometry,
-                  matrix.special && '-' || '',
-                  matrix.special)}}
+        ${{format(
+          '{0}{1}',
+          matrix.geometry,
+          matrix.special && format('-{0}', matrix.special) || ''
+        )}}
       CELER_RUN_NAME: >-
-        ${{format('spack-{0}{1}{2}{3}{4}',
-                  matrix.special,
-                  matrix.special && '-' || '',
-                  matrix.geometry,
-                  matrix.geant && '-g4@' || '',
-                  matrix.geant)}}
+        ${{format(
+          'spack-{0}{1}-g4@{2}',
+          matrix.special && format('{0}-', matrix.special) || '',
+          matrix.geometry,
+          matrix.geant
+        )}}
       CC: "clang-18"
       CXX: "clang++-18"
-      CXXSTD: ${{(matrix.geant == '10.5' || matrix.geant == '10.6')
-        && 17 || 20}}
+      CXXSTD: ${{(matrix.geant == '10.5' || matrix.geant == '10.6') && 17 || 20}}
     runs-on: ubuntu-24.04
     steps:
       - name: Check out Celeritas
@@ -91,21 +75,17 @@ jobs:
         with:
           cxxstd: ${{env.CXXSTD}}
           add: >-
-            ${{(matrix.special != 'minimal'
-                && matrix.special != 'static'
+            ${{(matrix.special != 'static'
                 && env.CXXSTD == '20')
                && 'root' || ''
             }}
-            ${{matrix.geant
-               && format('geant4@{0}', matrix.geant) || ''
-            }}
+            ${{format('geant4@{0}', matrix.geant) || ''}}
             ${{matrix.geometry == 'vecgeom' && 'vecgeom@1.2.11'
                || matrix.geometry == 'vecgeom2' && 'vecgeom@2.0.0-rc.7'
                || ''
             }}
             ${{(matrix.geometry == 'vecgeom'
                 || matrix.geometry == 'vecgeom2')
-               && matrix.geant
                && 'g4vg' || ''
             }}
 
@@ -124,7 +104,7 @@ jobs:
         with:
           name: ${{env.CELER_RUN_NAME}}
           preset: spack
-          ccache-max-size: ${{format('{0}Mi', matrix.build_type == 'reldeb' && 512 || 320)}}
+          ccache-max-size: "320Mi"
 
       ### TEST ###
 
@@ -132,7 +112,6 @@ jobs:
         if: >-
           ${{
             matrix.geant == '11.3'
-            && matrix.special != 'minimal'
             && matrix.special != 'static'
           }}
         working-directory: build
@@ -150,7 +129,7 @@ jobs:
           filter-unit: >-
             ${{
               matrix.special == 'static' && 'none'
-              || (matrix.geant && fromJSON(matrix.geant) < 11) && '^accel/'
+              || fromJSON(matrix.geant) < 11 && '^accel/'
              }}
       - name: Test basic downstream compilation against build dir
         if: ${{ !cancelled() && steps.build.outputs.build-outcome == 'success' }}
@@ -169,7 +148,7 @@ jobs:
           binaries: orange-update celer-geo celer-export-geant celer-sim celer-g4
       - name: Build and run examples
         env:
-          CELER_DISABLE_G4_EXAMPLES: ${{(!matrix.geant) && '1' || ''}}
+          CELER_DISABLE_G4_EXAMPLES: "0"
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: |
           export G4VERSION_NUMBER=$(echo "${{matrix.geant}}" | awk '{printf "%.0f", $1 * 100}')

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CELER_CMAKE_PRESET: ultralite
-  CXXSTD: 17
+  CXXSTD: 20
   CELER_VERSION_STRING: >-
     ${{
       github.event.pull_request

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ubuntu"]
+        platform: ["ubuntu", "windows"]
     runs-on: >-
       ${{  matrix.platform == 'ubuntu' && 'ubuntu-24.04'
         || matrix.platform == 'windows' && 'windows-2025'

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -30,9 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: ubuntu
-          - platform: windows
+        platform: ["ubuntu", "windows"]
     runs-on: >-
       ${{  matrix.platform == 'ubuntu' && 'ubuntu-24.04'
         || matrix.platform == 'windows' && 'windows-2025'

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
-            ccache nlohmann-json3-dev libpng-dev libgtest-dev libcli11-dev
+            ccache nlohmann-json3-dev libpng-dev libgtest-dev
       - name: Install dependencies (Windows)
         if: ${{matrix.platform == 'windows'}}
         run: |

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
-            ccache nlohmann-json3-dev libpng-dev libgtest-dev
+            ccache nlohmann-json3-dev libpng-dev libgtest-dev libcli11-dev
       - name: Install dependencies (Windows)
         if: ${{matrix.platform == 'windows'}}
         run: |

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt-get -q -y update
           sudo apt-get -q -y install \
-            ccache nlohmann-json3-dev libpng-dev
+            ccache nlohmann-json3-dev libpng-dev libgtest-dev
       - name: Install dependencies (Windows)
         if: ${{matrix.platform == 'windows'}}
         run: |

--- a/.github/workflows/build-ultralite.yml
+++ b/.github/workflows/build-ultralite.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ubuntu", "windows"]
+        platform: ["ubuntu"]
     runs-on: >-
       ${{  matrix.platform == 'ubuntu' && 'ubuntu-24.04'
         || matrix.platform == 'windows' && 'windows-2025'

--- a/.github/workflows/build-vecgeom-master.yml
+++ b/.github/workflows/build-vecgeom-master.yml
@@ -81,7 +81,6 @@ jobs:
           add-dependent: >-
             g4vg
             vecgeom@${{steps.vecgeom.outputs.sha}}=master~cuda~surface
-          push-buildcache: ${{github.repository == 'celeritas-project/celeritas' && github.event_name != 'pull_request'}}
 
       - name: Configure Celeritas
         id: configure

--- a/.github/workflows/cron_weekly.yml
+++ b/.github/workflows/cron_weekly.yml
@@ -37,19 +37,4 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  all:
-    if: ${{!cancelled()}}
-    needs:
-      - build-ultralite
-      - build-fast
-      - build-spack
-      - build-spack-extra
-      - build-codecov
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check that all jobs succeeded
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{toJSON(needs)}}
-
 # vim: set nowrap tw=100:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,13 +46,10 @@ jobs:
     uses: ./.github/workflows/build-fast.yml
   build-ultralite:
     uses: ./.github/workflows/build-ultralite.yml
-  build-docs:
-    uses: ./.github/workflows/build-docs.yml
   all-prechecks:
     needs:
       - build-fast
       - build-ultralite
-      - build-docs
     runs-on: ubuntu-24.04
     steps:
       - name: Success

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,10 +46,13 @@ jobs:
     uses: ./.github/workflows/build-fast.yml
   build-ultralite:
     uses: ./.github/workflows/build-ultralite.yml
+  build-docs:
+    uses: ./.github/workflows/build-docs.yml
   all-prechecks:
     needs:
       - build-fast
       - build-ultralite
+      - build-docs
     runs-on: ubuntu-24.04
     steps:
       - name: Success

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -78,8 +78,9 @@ jobs:
   # - Otherwise this check fails if any required job did not succeed
 
   all:
-    if: ${{ !cancelled() && github.event.pull_request.draft == false }}
+    if: ${{ always() && github.event.pull_request.draft == false }}
     needs:
+      - all-prechecks
       - build-spack
       - build-spack-extra
       - build-docker

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -54,6 +54,7 @@ jobs:
     steps:
       - name: Success
         run: "true"
+
   build-spack:
     needs: [all-prechecks]
     uses: ./.github/workflows/build-spack.yml
@@ -72,19 +73,25 @@ jobs:
     needs: [all-prechecks]
     uses: ./.github/workflows/build-codecov.yml
 
-  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
-  # - When running in draft mode, or if the job was cancelled,
-  #   this check is skipped so that the commit doesn't have an 'X' next to it
-  # - Otherwise this check fails if any required job did not succeed
+  all-expensive:
+    needs:
+      - build-spack-extra
+      - build-docker
+      - build-codecov
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Success
+        run: "true"
 
+  # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
+  # - When running in draft mode, this check is skipped
+  # - Otherwise this check fails if any required job did not succeed
   all:
     if: ${{ always() && github.event.pull_request.draft == false }}
     needs:
       - all-prechecks
       - build-spack
-      - build-spack-extra
-      - build-docker
-      - build-codecov
+      - all-expensive
     runs-on: ubuntu-24.04
     outputs:
       unsuccessful: ${{ steps.check.outputs.unsuccessful }}
@@ -97,7 +104,7 @@ jobs:
         with:
           script: |
             const needs = JSON.parse(process.env.NEEDS);
-            core.debug(`needs: ${JSON.stringify(needs)}`);
+            core.notice(`needs: ${JSON.stringify(needs)}`); // REVERTME: core.debug
 
             const unsuccessful = Object.entries(needs)
               .filter(([, job]) => job.result !== 'success')

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -76,18 +76,38 @@ jobs:
     uses: ./.github/workflows/build-codecov.yml
 
   # Specifying a dependent job allows us to select a single "requires" check in the project GitHub settings
+  # - When running in draft mode, or if the job was cancelled,
+  #   this check is skipped so that the commit doesn't have an 'X' next to it
+  # - Otherwise this check fails if any required job did not succeed
+
   all:
-    if: ${{!cancelled()}}
+    if: ${{ !cancelled() && github.event.pull_request.draft == false }}
     needs:
       - build-spack
       - build-spack-extra
       - build-docker
       - build-codecov
     runs-on: ubuntu-24.04
+    outputs:
+      unsuccessful: ${{ steps.check.outputs.unsuccessful }}
     steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@v1.3.0 # immutable, 21 Aug 2026
+      - name: Check failures
+        id: check
+        uses: actions/github-script@v9
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         with:
-          jobs: ${{toJSON(needs)}}
+          script: |
+            const needs = JSON.parse(process.env.NEEDS);
+            core.debug(`needs: ${JSON.stringify(needs)}`);
+
+            const unsuccessful = Object.entries(needs)
+              .filter(([, job]) => job.result !== 'success')
+              .map(([name]) => name);
+
+            core.setOutput('unsuccessful', unsuccessful.join(','));
+            if (unsuccessful.length) {
+              core.setFailed(`Jobs did not succeed: ${unsuccessful.join(', ')}`);
+            }
 
 # vim: set nowrap tw=100:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,7 +62,7 @@
     {
       "name": "larsoft",
       "displayName": "deployment: target DUNE analysis with LArSoft",
-      "inherits": [".primary", ".ndebug"],
+      "inherits": [".primary", ".release"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" },
         "CELERITAS_BUILD_APPS": { "type": "BOOL", "value": "OFF" },
@@ -82,7 +82,7 @@
     {
       "name": "lhc",
       "displayName": "deployment: target LHC framework integration",
-      "inherits": [".primary", ".ndebug"],
+      "inherits": [".primary", ".release"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILD_APPS": { "type": "BOOL", "value": "OFF" },
@@ -171,7 +171,7 @@
       }
     },
     {
-      "name": ".ndebug",
+      "name": ".release",
       "hidden": true,
       "description": "Build with optimizations and without debug assertions",
       "cacheVariables": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,7 @@ Preset CMake variables:
 ```
 
 The main `CMakePresets.json` provides not only a handful of user-accessible
-presets (default, full, minimal) but also a set of hidden presets (`.ndebug`,
+presets (default, full, minimal) but also a set of hidden presets (`.release`,
 `.cuda-volta`, `.spack-base`) useful for inheriting in user presets. Make sure
 to put the overrides *before* the base definition in the `inherits` list.
 

--- a/scripts/ci/setup-spack-ci-env.sh
+++ b/scripts/ci/setup-spack-ci-env.sh
@@ -42,12 +42,12 @@ fi
 
 # Configure separate packages repository *first*: otherwise the
 # environment creation will do a lengthy unnecessary checkout
-if [ -n "${SPACK_PACKAGES}" ]; then
-  log info "Using custom builtin spack package repo: ${SPACK_PACKAGES}"
-  $SPACK repo set --destination "${SPACK_PACKAGES}" builtin
+if [ -n "${SPACK_PACKAGES_REPO}" ]; then
+  log info "Using custom builtin spack package repo: ${SPACK_PACKAGES_REPO}"
+  $SPACK repo set --destination "${SPACK_PACKAGES_REPO}" builtin
 else
-  SPACK_PACKAGES=$(spack location -P builtin)
-  log warning "Using default builtin spack repo: ${SPACK_PACKAGES}"
+  SPACK_PACKAGES_REPO=$(spack location -P builtin)
+  log warning "Using default builtin spack repo: ${SPACK_PACKAGES_REPO}"
 fi
 
 # Create environment in current working directory
@@ -87,5 +87,5 @@ fi
 # Add the spack ref so that updating spack will reconcretize
 cat >> spack.yaml <<EOF
 # spack: $(git -C "${SPACK_ROOT}" log -1 --pretty=%H HEAD)
-# packages: $(git -C "${SPACK_PACKAGES}" log -1 --pretty=%H HEAD)
+# packages: $(git -C "${SPACK_PACKAGES_REPO}" log -1 --pretty=%H HEAD)
 EOF

--- a/scripts/ci/setup-spack-ci-env.sh
+++ b/scripts/ci/setup-spack-ci-env.sh
@@ -26,6 +26,20 @@ if [ -n "$SPACK_ENV" ]; then
   exit 1
 fi
 
+if [ -z "$SPACK_ENV_FILE" ]; then
+  SPACK_ENV_FILE="env-ci-base.yaml"
+  log info "Using default SPACK_ENV_FILE: env-ci-base.yaml"
+fi
+if ! [ -e "${SPACK_ENV_FILE}" ]; then
+  # Assume it lives in the spack env directory
+  SPACK_ENV_FILE="${CELER_SOURCE_DIR}/scripts/spack/${SPACK_ENV_FILE}"
+fi
+if ! [ -f "${SPACK_ENV_FILE}" ]; then
+  log error "Environment file ${SPACK_ENV_FILE} does not exist"
+  exit 1
+fi
+
+
 # Configure separate packages repository *first*: otherwise the
 # environment creation will do a lengthy unnecessary checkout
 if [ -n "${SPACK_PACKAGES}" ]; then
@@ -37,8 +51,8 @@ else
 fi
 
 # Create environment in current working directory
-log status "Creating environment"
-$SPACK env create . "${CELER_SOURCE_DIR}/scripts/spack/env-ci-base.yaml"
+log status "Creating environment from ${SPACK_ENV_FILE}"
+$SPACK env create . "${SPACK_ENV_FILE}"
 
 # Configure install prefix
 if [ -n "${CELER_SPACK_OPT}" ]; then

--- a/scripts/ci/test-examples.sh
+++ b/scripts/ci/test-examples.sh
@@ -40,8 +40,8 @@ cd "${CELER_SOURCE_DIR}/example/minimal"
 build_local
 ./minimal
 
-# Run Geant4 app examples
-if [ -z "${CELER_DISABLE_G4_EXAMPLES}" ]; then
+# Run Geant4 app examples unless DISABLE is set to a non-empty, non-zero value
+if [ "0${CELER_DISABLE_G4_EXAMPLES}" -ne 0 ]; then
   G4VERSION_STRING="auto"
   if [ -z "${G4VERSION_NUMBER}" ]; then
     # Get the geant4 version 11.2.3, failing if config isn't found

--- a/scripts/ci/update-spack-buildcache-local.sh
+++ b/scripts/ci/update-spack-buildcache-local.sh
@@ -28,6 +28,7 @@ if [ "${OS}" != "${EXPECTED_OS}" ]; then
   exit 1
 fi
 
+spack debug report
 
 CELER_BASE_IMAGE=ubuntu:24.04
 CELER_BUILDCACHE=celeritas
@@ -42,15 +43,13 @@ WORK_DIR=$PWD
 SCRIPT_DIR=$(cd "$(dirname $0)" && pwd)
 export CELER_SOURCE_DIR=$(cd $SCRIPT_DIR/../.. && pwd)
 
-update_index=false
-
 # Each line is: CXXSTD, followed by the spack packages to add, based on the
 # matrix (and its "include" entries) from .github/workflows/build-spack.yml
 # (missing concretization will require running the build-spack workflows
 # on something *other* than a PR, and missing packages will cause a PR to fail
 # due to the `--use-buildcache` option in `setup-spack/action.yaml`)
 matrix="
-CXXSTD=20 vecgeom@2.1.0 geant4@11.4 g4vg root
+CXXSTD=20 vecgeom@2.1.0 geant4@11.4 g4vg root dd4hep
 CXXSTD=20 vecgeom@2.0.0-rc.7 geant4@11.3 g4vg root
 CXXSTD=20 vecgeom@1.2.11 geant4@11.4 g4vg root py-gcovr
 CXXSTD=20 vecgeom@1.2.11 geant4@11.3 g4vg root
@@ -88,6 +87,7 @@ printf "%s" "$matrix" | while read -r line; do
   log status "Pushing  $envdir..."
   spack -e . buildcache push \
     --base-image $CELER_BASE_IMAGE \
+    --update-index \
+    --allow-missing \
     $CELER_BUILDCACHE
-  spack -e . buildcache update-index $CELER_BUILDCACHE
 done

--- a/scripts/ci/update-spack-buildcache-local.sh
+++ b/scripts/ci/update-spack-buildcache-local.sh
@@ -11,7 +11,7 @@ log() {
   printf "%s: %s\n" "$1" "$2" >&2
 }
 
-if [ -z "${GITHUB_USER}" || -z "${GITHUB_TOKEN}" ]; then
+if [ -z "${GITHUB_USER}" ] || [ -z "${GITHUB_TOKEN}" ]; then
   log error "GITHUB_USER and GITHUB_TOKEN must be set (see scripts/spack/reqs-ci.yaml)"
   exit 1
 fi

--- a/scripts/cmake-presets/_dev_.json
+++ b/scripts/cmake-presets/_dev_.json
@@ -22,9 +22,9 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "dev: with vecgeom in optimized mode and CLHEP units",
-      "inherits": [".ndebug"],
+      "inherits": [".release"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_UNITS": "CLHEP",
@@ -40,7 +40,7 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ],
   "testPresets": [
     {
@@ -54,6 +54,6 @@
       }
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ]
 }

--- a/scripts/cmake-presets/bede.json
+++ b/scripts/cmake-presets/bede.json
@@ -38,9 +38,9 @@
       }
     },
     {
-      "name": ".ndebug-lineinfo",
+      "name": ".release-lineinfo",
       "hidden": true,
-      "description": ".ndebug but without overwriting CMAKE_CXX_FLAGS_RELEASE to allow -lineinfo",
+      "description": ".release but without overwriting CMAKE_CXX_FLAGS_RELEASE to allow -lineinfo",
       "cacheVariables": {
         "CELERITAS_DEBUG": { "type": "BOOL", "value": "OFF" },
         "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
@@ -110,14 +110,14 @@
       "inherits": [".novg", ".reldeb", ".base"]
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "Bede GH200 optimised build (vecgeom)",
-      "inherits": [".vg", ".ndebug-lineinfo", ".base"]
+      "inherits": [".vg", ".release-lineinfo", ".base"]
     },
     {
-      "name": "ndebug-novg",
+      "name": "release-novg",
       "displayName": "Bede GH200 optimised build (orange)",
-      "inherits": [".novg", ".ndebug-lineinfo", ".base"]
+      "inherits": [".novg", ".release-lineinfo", ".base"]
     }
   ],
   "buildPresets": [
@@ -139,10 +139,10 @@
       "configurePreset": "gpudebug-novg",
       "inherits": ".base"
     },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": ".base" },
+    { "name": "release", "configurePreset": "release", "inherits": ".base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": ".base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": ".base" },
@@ -175,10 +175,10 @@
       "configurePreset": "gpudebug-novg",
       "inherits": ".base"
     },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": ".base" },
+    { "name": "release", "configurePreset": "release", "inherits": ".base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": ".base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": ".base" },

--- a/scripts/cmake-presets/ci-rocky-cuda.json
+++ b/scripts/cmake-presets/ci-rocky-cuda.json
@@ -73,7 +73,7 @@
       }
     },
     {
-      "name": "ndebug-vecgeom-codecov",
+      "name": "vecgeom-codecov",
       "description": "Build with code coverage with vecgeom (no CUDA, no assertions)",
       "inherits": [".gcov", ".ndebug", ".vecgeom", "base"],
       "cacheVariables": {

--- a/scripts/cmake-presets/ci-rocky-cuda.json
+++ b/scripts/cmake-presets/ci-rocky-cuda.json
@@ -53,9 +53,9 @@
       "cacheVariables": {}
     },
     {
-      "name": "ndebug-orange",
+      "name": "release-orange",
       "description": "Build with release ORANGE",
-      "inherits": [".ndebug", "base"],
+      "inherits": [".release", "base"],
       "cacheVariables": {
         "CELERITAS_USE_covfie": { "type": "BOOL", "value": "ON" },
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "OFF" },
@@ -63,9 +63,9 @@
       }
     },
     {
-      "name": "ndebug-vecgeom",
+      "name": "release-vecgeom",
       "description": "Build release with vecgeom for testing *only* demos",
-      "inherits": [".ndebug", ".vecgeom", "base"],
+      "inherits": [".release", ".vecgeom", "base"],
       "cacheVariables": {
         "CELERITAS_USE_covfie": { "type": "BOOL", "value": "ON" },
         "BUILD_TESTING": { "type": "BOOL", "value": "ON" },
@@ -75,7 +75,7 @@
     {
       "name": "vecgeom-codecov",
       "description": "Build with code coverage with vecgeom (no CUDA, no assertions)",
-      "inherits": [".gcov", ".ndebug", ".vecgeom", "base"],
+      "inherits": [".gcov", ".release", ".vecgeom", "base"],
       "cacheVariables": {
         "CELERITAS_USE_CUDA": { "type": "BOOL", "value": "OFF" },
         "CMAKE_CXX_FLAGS": null

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -57,7 +57,7 @@
       "cacheVariables": {
         "BUILD_TESTING": { "type": "BOOL", "value": "ON" },
         "CELERITAS_BUILTIN_CLI11": { "type": "BOOL", "value": "ON" },
-        "CELERITAS_BUILTIN_GTest": { "type": "BOOL", "value": "ON" },
+        "CELERITAS_BUILTIN_GTest": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILTIN_covfie": { "type": "BOOL", "value": "ON" }
       }
     },

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -58,7 +58,7 @@
       "displayName": "TOOLCHAIN: build with apt-get dependencies",
       "cacheVariables": {
         "BUILD_TESTING": { "type": "BOOL", "value": "ON" },
-        "CELERITAS_BUILTIN_CLI11": { "type": "BOOL", "value": "ON" },
+        "CELERITAS_BUILTIN_CLI11": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILTIN_GTest": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILTIN_covfie": { "type": "BOOL", "value": "ON" },
         "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" }

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -58,7 +58,7 @@
       "displayName": "TOOLCHAIN: build with apt-get dependencies",
       "cacheVariables": {
         "BUILD_TESTING": { "type": "BOOL", "value": "ON" },
-        "CELERITAS_BUILTIN_CLI11": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_BUILTIN_CLI11": { "type": "BOOL", "value": "ON" },
         "CELERITAS_BUILTIN_GTest": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILTIN_covfie": { "type": "BOOL", "value": "ON" },
         "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" }

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -202,6 +202,7 @@
       "cacheVariables": {
         "CELERITAS_DEBUG": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILD_APPS": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_USE_covfie": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" },

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -16,11 +16,11 @@
         "CELERITAS_BUILTIN_G4VG": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILTIN_GTest": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_BUILTIN_nlohmann_json": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_DEBUG": { "type": "BOOL", "value": "ON" },
         "CELERITAS_TEST_VERBOSE": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_covfie": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_CUDA": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_DD4hep": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_HIP": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_LarSoft": { "type": "BOOL", "value": "OFF" },
@@ -32,6 +32,8 @@
         "CELERITAS_USE_VecGeom": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_HOSTNAME": "ubuntu-github",
         "CELERITAS_TEST_XML": "$env{GITHUB_WORKSPACE}/test-output/google/",
+        "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" },
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
         "CMAKE_CXX_STANDARD": "$env{CXXSTD}",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_EXTENSIONS": { "type": "BOOL", "value": "OFF" },
@@ -58,7 +60,8 @@
         "BUILD_TESTING": { "type": "BOOL", "value": "ON" },
         "CELERITAS_BUILTIN_CLI11": { "type": "BOOL", "value": "ON" },
         "CELERITAS_BUILTIN_GTest": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_BUILTIN_covfie": { "type": "BOOL", "value": "ON" }
+        "CELERITAS_BUILTIN_covfie": { "type": "BOOL", "value": "ON" },
+        "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" }
       }
     },
     {
@@ -118,27 +121,8 @@
       }
     },
     {
-      "name": "type-reldeb",
-      "hidden": true,
-      "description": "TYPE: debug assertions but no debug symbols",
-      "cacheVariables": {
-        "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" },
-        "CELERITAS_DEBUG": { "type": "BOOL", "value": "ON" },
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "type-ndebug",
-      "hidden": true,
-      "description": "TYPE: release build",
-      "cacheVariables": {
-        "CELERITAS_DEBUG": { "type": "BOOL", "value": "OFF" },
-        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
-      }
-    },
-    {
       "name": "fast",
-      "inherits": ["type-reldeb", "tool-system"],
+      "inherits": ["tool-system"],
       "displayName": "FINAL: fast build using apt-get",
       "cacheVariables": {
         "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "ON" }
@@ -146,28 +130,17 @@
     },
     {
       "name": "ultralite",
-      "inherits": [".nogtest", "type-ndebug", "tool-system"],
-      "displayName": "FINAL: ultralite build with only app tests"
-    },
-    {
-      "name": "ultralite-codecov",
-      "inherits": [".nogtest", ".gcov", "type-ndebug", "tool-system"],
-      "displayName": "FINAL: ultralite code coverage with only app tests",
+      "inherits": [".nogtest", "tool-system"],
+      "displayName": "FINAL: ultralite build with only app tests",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": null
+        "CELERITAS_DEBUG": { "type": "BOOL", "value": "OFF" }
       }
     },
     {
-      "name": "reldeb-orange",
-      "description": "FINAL: ORANGE",
-      "inherits": ["type-reldeb", "tool-spack"]
-    },
-    {
-      "name": "reldeb-vecgeom-tidy",
+      "name": "vecgeom-tidy",
       "description": "FINAL: VecGeom and clang-tidy checks",
-      "inherits": [".nogtest", ".vecgeom", "type-reldeb", "tool-spack"],
+      "inherits": [".nogtest", ".vecgeom", "tool-spack"],
       "cacheVariables": {
-        "CELERITAS_DEBUG": { "type": "BOOL", "value": "ON" },
         "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" },
         "CMAKE_CXX_SCAN_FOR_MODULES": { "type": "BOOL", "value": "OFF" },
         "CMAKE_EXPORT_COMPILE_COMMANDS": { "type": "BOOL", "value": "ON" },
@@ -175,42 +148,38 @@
       }
     },
     {
-      "name": "reldeb-vecgeom-clhep",
+      "name": "vecgeom-clhep",
       "description": "FINAL: VecGeom and CLHEP units",
-      "inherits": [".vecgeom", "type-reldeb", "tool-spack"],
+      "inherits": [".vecgeom", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_UNITS": "CLHEP"
       }
     },
     {
-      "name": "reldeb-vecgeom",
+      "name": "vecgeom",
       "description": "FINAL: release, assertions, VecGeom",
-      "inherits": [".vecgeom", "type-reldeb", "tool-spack"]
+      "inherits": [".vecgeom", "tool-spack"]
     },
     {
-      "name": "ndebug-vecgeom-codecov",
-      "description": "FINAL: VecGeom and code coverage",
-      "inherits": [".vecgeom", ".gcov", "type-reldeb", "tool-spack"],
+      "name": "vecgeom-codecov",
+      "description": "FINAL: VecGeom with code coverage (no debug assertions)",
+      "inherits": [".vecgeom", ".gcov", "tool-spack"],
       "cacheVariables": {
         "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "ON" },
         "CMAKE_CXX_FLAGS": null
       }
     },
     {
-      "name": "reldeb-vecgeom2",
+      "name": "vecgeom2",
       "description": "FINAL: release, assertions, VecGeom 2",
-      "inherits": [".vecgeom", "type-reldeb", "tool-spack"]
+      "inherits": [".vecgeom", "tool-spack"]
     },
     {
-      "name": "ndebug-vecgeom",
-      "description": "FINAL: vecgeom app only",
-      "inherits": [".vecgeom", ".nogtest", "type-ndebug", "tool-spack"]
-    },
-    {
-      "name": "ndebug-orange-static",
+      "name": "orange-static",
       "description": "FINAL: static libraries and perfetto, no tests",
-      "inherits": [".nogtest", "type-ndebug", "tool-spack"],
+      "inherits": [".nogtest", "tool-spack"],
       "cacheVariables": {
+        "CELERITAS_DEBUG": { "type": "BOOL", "value": "OFF" },
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_Perfetto": { "type": "BOOL", "value": "ON" },
         "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" },
@@ -218,32 +187,19 @@
       }
     },
     {
-      "name": "reldeb-geant4",
+      "name": "geant4",
       "description": "FINAL: Geant4 geometry",
-      "inherits": ["type-reldeb", "tool-spack"],
+      "inherits": ["tool-spack"],
       "cacheVariables": {
         "CELERITAS_CORE_GEO": "Geant4",
         "CELERITAS_UNITS": "CLHEP"
       }
     },
     {
-      "name": "reldeb-orange-minimal",
-      "description": "FINAL: minimal reasonable dependencies",
-      "inherits": ["type-reldeb", "tool-spack"],
-      "cacheVariables": {
-        "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_USE_OpenMP": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_USE_PNG": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" }
-      }
-    },
-    {
-      "name": "reldeb-orange-asanlite",
+      "name": "orange-asanlite",
       "description": "FINAL: address sanitizer flags and debug symbols",
       "inherits": ["tool-spack"],
       "cacheVariables": {
-        "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" },
         "CELERITAS_DEBUG": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
@@ -265,9 +221,9 @@
       }
     },
     {
-      "name": "reldeb-orange-float",
+      "name": "orange-float",
       "description": "FINAL: single-precision arithmetic",
-      "inherits": ["type-reldeb", "tool-spack"],
+      "inherits": ["tool-spack"],
       "cacheVariables": {
         "CELERITAS_REAL_TYPE": "float"
       }

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -204,7 +204,8 @@
         "CELERITAS_BUILD_APPS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" }
+        "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_USE_PNG": { "type": "BOOL", "value": "OFF" }
       }
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -206,7 +206,8 @@
         "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" },
-        "CELERITAS_USE_PNG": { "type": "BOOL", "value": "OFF" }
+        "CELERITAS_USE_PNG": { "type": "BOOL", "value": "OFF" },
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -pedantic"
       }
     },
     {

--- a/scripts/cmake-presets/ci-ubuntu-github.json
+++ b/scripts/cmake-presets/ci-ubuntu-github.json
@@ -196,6 +196,18 @@
       }
     },
     {
+      "name": "orange-ancient",
+      "description": "FINAL: minimal GCC8 build for SCALE integration",
+      "inherits": ["tool-spack"],
+      "cacheVariables": {
+        "CELERITAS_DEBUG": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_BUILD_APPS": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_USE_Geant4": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
+        "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" }
+      }
+    },
+    {
       "name": "orange-asanlite",
       "description": "FINAL: address sanitizer flags and debug symbols",
       "inherits": ["tool-spack"],

--- a/scripts/cmake-presets/ci-ubuntu-rocm.json
+++ b/scripts/cmake-presets/ci-ubuntu-rocm.json
@@ -31,7 +31,7 @@
       }
     },
     {
-      "name": "ndebug-orange-float",
+      "name": "release-orange-float",
       "description": "Build with single-precision arithmetic and HIP/ROCm",
       "inherits": [".ndebug", "base"],
       "cacheVariables": {
@@ -39,7 +39,7 @@
       }
     },
     {
-      "name": "ndebug-orange",
+      "name": "release-orange",
       "description": "Build with HIP/ROCm for AMD",
       "inherits": [".ndebug", "base"]
     }

--- a/scripts/cmake-presets/ci-ubuntu-rocm.json
+++ b/scripts/cmake-presets/ci-ubuntu-rocm.json
@@ -33,7 +33,7 @@
     {
       "name": "release-orange-float",
       "description": "Build with single-precision arithmetic and HIP/ROCm",
-      "inherits": [".ndebug", "base"],
+      "inherits": [".release", "base"],
       "cacheVariables": {
         "CELERITAS_REAL_TYPE": "float"
       }
@@ -41,7 +41,7 @@
     {
       "name": "release-orange",
       "description": "Build with HIP/ROCm for AMD",
-      "inherits": [".ndebug", "base"]
+      "inherits": [".release", "base"]
     }
   ],
   "buildPresets": [
@@ -53,13 +53,13 @@
       "jobs": 16
     },
     {
-      "name": "ndebug-orange-float",
-      "configurePreset": "ndebug-orange-float",
+      "name": "release-orange-float",
+      "configurePreset": "release-orange-float",
       "inherits": "base"
     },
     {
-      "name": "ndebug-orange",
-      "configurePreset": "ndebug-orange",
+      "name": "release-orange",
+      "configurePreset": "release-orange",
       "inherits": "base",
       "targets": ["all", "install"]
     }
@@ -82,13 +82,13 @@
       }
     },
     {
-      "name": "ndebug-orange-float",
-      "configurePreset": "ndebug-orange-float",
+      "name": "release-orange-float",
+      "configurePreset": "release-orange-float",
       "inherits": "base"
     },
     {
-      "name": "ndebug-orange",
-      "configurePreset": "ndebug-orange",
+      "name": "release-orange",
+      "configurePreset": "release-orange",
       "inherits": "base"
     }
   ]

--- a/scripts/cmake-presets/esseivaj.json
+++ b/scripts/cmake-presets/esseivaj.json
@@ -75,14 +75,14 @@
       "inherits": [".profile", "reldeb-novg"]
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "Vecgeom release",
-      "inherits": [".ndebug", ".base"]
+      "inherits": [".release", ".base"]
     },
     {
-      "name": "ndebug-novg",
+      "name": "release-novg",
       "displayName": "ORANGE release",
-      "inherits": [".no-vg", ".ndebug", ".base"]
+      "inherits": [".no-vg", ".release", ".base"]
     }
   ],
   "buildPresets": [
@@ -93,10 +93,10 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },
@@ -128,10 +128,10 @@
       }
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },

--- a/scripts/cmake-presets/exalearn4.json
+++ b/scripts/cmake-presets/exalearn4.json
@@ -55,14 +55,14 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "Exalearn4 release mode",
-      "inherits": [".ndebug", ".base"]
+      "inherits": [".release", ".base"]
     },
     {
-      "name": "ndebug-serial",
+      "name": "release-serial",
       "displayName": "Exalearn4 release mode (no openmp)",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".release", ".base"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_OpenMP": { "type": "BOOL", "value": "OFF" }
@@ -76,7 +76,7 @@
       "jobs": 8,
       "nativeToolOptions": ["-k0"]
     },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" }
+    { "name": "release", "configurePreset": "release", "inherits": "base" }
   ],
   "testPresets": [
     {
@@ -89,6 +89,6 @@
         "jobs": 8
       }
     },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" }
+    { "name": "release", "configurePreset": "release", "inherits": "base" }
   ]
 }

--- a/scripts/cmake-presets/executor.json
+++ b/scripts/cmake-presets/executor.json
@@ -187,17 +187,17 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "With ORANGE in optimized mode",
-      "inherits": [".ccache", ".ndebug", ".spackbase"],
+      "inherits": [".ccache", ".release", ".spackbase"],
       "cacheVariables": {
         "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" }
       }
     },
     {
-      "name": "ndebug-vecgeom",
+      "name": "release-vecgeom",
       "displayName": "With vecgeom, g4 in optimized mode",
-      "inherits": [".ccache", ".spackbase", ".ndebug", "vecgeom"],
+      "inherits": [".ccache", ".spackbase", ".release", "vecgeom"],
       "cacheVariables": {
         "CELERITAS_USE_HepMC3": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_ROOT": { "type": "BOOL", "value": "OFF" },

--- a/scripts/cmake-presets/faraday.json
+++ b/scripts/cmake-presets/faraday.json
@@ -32,7 +32,7 @@
     {
       "name": "release-orange",
       "displayName": "Build with full optimizations (ORANGE)",
-      "inherits": [".base", ".ndebug"],
+      "inherits": [".base", ".release"],
       "cacheVariables": {}
     },
     {

--- a/scripts/cmake-presets/fnal-dev-el9.json
+++ b/scripts/cmake-presets/fnal-dev-el9.json
@@ -33,7 +33,7 @@
     {
       "name": "release-orange",
       "displayName": "Build with full optimizations (ORANGE)",
-      "inherits": [".base", ".ndebug"],
+      "inherits": [".base", ".release"],
       "cacheVariables": {}
     },
     {

--- a/scripts/cmake-presets/fnal-dev-sl7.json
+++ b/scripts/cmake-presets/fnal-dev-sl7.json
@@ -33,7 +33,7 @@
     {
       "name": "release-orange",
       "displayName": "Build with full optimizations (ORANGE)",
-      "inherits": [".base", ".ndebug"],
+      "inherits": [".base", ".release"],
       "cacheVariables": {}
     },
     {

--- a/scripts/cmake-presets/frontier.json
+++ b/scripts/cmake-presets/frontier.json
@@ -53,18 +53,18 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "Frontier release mode",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".release", ".base"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "OFF" },
         "CMAKE_INSTALL_PREFIX": "/lustre/orion/world-shared/hep143/celeritas/develop"
       }
     },
     {
-      "name": "ndebug-serial",
+      "name": "release-serial",
       "displayName": "Frontier release mode (no openmp)",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".release", ".base"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_USE_OpenMP": { "type": "BOOL", "value": "OFF" },
@@ -79,7 +79,7 @@
       "jobs": 64,
       "nativeToolOptions": ["-k0"]
     },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" }
+    { "name": "release", "configurePreset": "release", "inherits": "base" }
   ],
   "testPresets": [
     {
@@ -92,6 +92,6 @@
         "jobs": 32
       }
     },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" }
+    { "name": "release", "configurePreset": "release", "inherits": "base" }
   ]
 }

--- a/scripts/cmake-presets/hudson.json
+++ b/scripts/cmake-presets/hudson.json
@@ -59,7 +59,7 @@
     {
       "name": "release",
       "displayName": "Build with full optimizations (VecGeom)",
-      "inherits": [".base", ".ndebug"]
+      "inherits": [".base", ".release"]
     },
     {
       "name": "reldeb",

--- a/scripts/cmake-presets/jlse.json
+++ b/scripts/cmake-presets/jlse.json
@@ -37,13 +37,13 @@
     {
       "name": "release",
       "displayName": "Build with optimizations and disable debug assertions",
-      "inherits": [".base", ".ndebug"],
+      "inherits": [".base", ".release"],
       "binaryDir": "${sourceDir}/build-release"
     },
     {
       "name": "release-amd",
       "displayName": "Release build for an AMD device",
-      "inherits": [".base", ".ndebug"],
+      "inherits": [".base", ".release"],
       "binaryDir": "${sourceDir}/build-release-amd",
       "cacheVariables": {
         "CELERITAS_USE_CUDA": { "type": "BOOL", "value": "OFF" },

--- a/scripts/cmake-presets/mac147429.json
+++ b/scripts/cmake-presets/mac147429.json
@@ -22,9 +22,9 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "With vecgeom in optimized mode and CLHEP units",
-      "inherits": [".ndebug"],
+      "inherits": [".release"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_UNITS": "CLHEP",
@@ -40,7 +40,7 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ],
   "testPresets": [
     {
@@ -54,6 +54,6 @@
       }
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ]
 }

--- a/scripts/cmake-presets/milan0.json
+++ b/scripts/cmake-presets/milan0.json
@@ -37,7 +37,7 @@
     {
       "name": "release",
       "displayName": "Build with full optimizations (VecGeom)",
-      "inherits": [".base", ".ndebug"]
+      "inherits": [".base", ".release"]
     },
     {
       "name": "reldeb",

--- a/scripts/cmake-presets/milan1.json
+++ b/scripts/cmake-presets/milan1.json
@@ -37,7 +37,7 @@
     {
       "name": "release",
       "displayName": "Build with full optimizations (VecGeom)",
-      "inherits": [".base", ".ndebug"]
+      "inherits": [".base", ".release"]
     },
     {
       "name": "reldeb",

--- a/scripts/cmake-presets/milan2.json
+++ b/scripts/cmake-presets/milan2.json
@@ -38,7 +38,7 @@
     {
       "name": "release",
       "displayName": "Build with full optimizations (VecGeom)",
-      "inherits": [".base", ".ndebug"]
+      "inherits": [".base", ".release"]
     },
     {
       "name": "reldeb",

--- a/scripts/cmake-presets/morannon.json
+++ b/scripts/cmake-presets/morannon.json
@@ -22,9 +22,9 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "With vecgeom in optimized mode and CLHEP units",
-      "inherits": [".ndebug"],
+      "inherits": [".release"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_UNITS": "CLHEP",
@@ -40,7 +40,7 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ],
   "testPresets": [
     {
@@ -54,6 +54,6 @@
       }
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ]
 }

--- a/scripts/cmake-presets/perlmutter.json
+++ b/scripts/cmake-presets/perlmutter.json
@@ -61,18 +61,18 @@
       "inherits": [".reldeb", ".base"]
     },
     {
-      "name": "ndebug-novg",
+      "name": "release-novg",
       "displayName": "Perlmutter release mode",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".release", ".base"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" },
         "CELERITAS_USE_VecGeom": { "type": "BOOL", "value": "OFF" }
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "Perlmutter release mode",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".release", ".base"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" }
       }
@@ -86,10 +86,10 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },
@@ -111,10 +111,10 @@
       }
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },

--- a/scripts/cmake-presets/rivanna.json
+++ b/scripts/cmake-presets/rivanna.json
@@ -26,7 +26,7 @@
     {
       "name": "rivanna",
       "description": "Build on UVA's Rivanna HPC",
-      "inherits": [".base", ".ndebug"],
+      "inherits": [".base", ".release"],
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-march=x86-64-v3"
       }

--- a/scripts/cmake-presets/scisoftbuild01.json
+++ b/scripts/cmake-presets/scisoftbuild01.json
@@ -22,9 +22,9 @@
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "dev: with vecgeom in optimized mode and CLHEP units",
-      "inherits": [".ndebug"],
+      "inherits": [".release"],
       "cacheVariables": {
         "CELERITAS_BUILD_TESTS": { "type": "BOOL", "value": "OFF" },
         "CELERITAS_UNITS": "CLHEP",
@@ -40,7 +40,7 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ],
   "testPresets": [
     {
@@ -54,6 +54,6 @@
       }
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "dev" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "dev" }
+    { "name": "release", "configurePreset": "release", "inherits": "dev" }
   ]
 }

--- a/scripts/cmake-presets/wildstyle.json
+++ b/scripts/cmake-presets/wildstyle.json
@@ -93,9 +93,9 @@
       "inherits": [".reldeb", ".base"]
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "wildstyle: everything but VecGeom in release mode",
-      "inherits": [".ndebug", ".base"]
+      "inherits": [".release", ".base"]
     },
     {
       "name": "reldeb-single",
@@ -108,9 +108,9 @@
       "inherits": [".reldeb", "vecgeom"]
     },
     {
-      "name": "ndebug-vecgeom",
+      "name": "release-vecgeom",
       "displayName": "wildstyle: everything in release mode",
-      "inherits": [".ndebug", "vecgeom"]
+      "inherits": [".release", "vecgeom"]
     }
   ],
   "buildPresets": [

--- a/scripts/cmake-presets/zenith2.json
+++ b/scripts/cmake-presets/zenith2.json
@@ -38,7 +38,7 @@
     {
       "name": "release",
       "displayName": "Build with full optimizations (VecGeom)",
-      "inherits": [".base", ".ndebug"]
+      "inherits": [".base", ".release"]
     },
     {
       "name": "reldeb",

--- a/scripts/cmake-presets/zeus.json
+++ b/scripts/cmake-presets/zeus.json
@@ -59,18 +59,18 @@
       "inherits": [".reldeb", ".base"]
     },
     {
-      "name": "ndebug-novg",
+      "name": "release-novg",
       "displayName": "Zeus release with Orange",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".release", ".base"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" },
         "CELERITAS_USE_VecGeom": { "type": "BOOL", "value": "OFF" }
       }
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "Zeus release",
-      "inherits": [".ndebug", ".base"],
+      "inherits": [".release", ".base"],
       "cacheVariables": {
         "BUILD_SHARED_LIBS": { "type": "BOOL", "value": "ON" }
       }
@@ -84,10 +84,10 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },
@@ -109,10 +109,10 @@
       }
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },

--- a/scripts/docker/interactive/CMakeUserPresets.json
+++ b/scripts/docker/interactive/CMakeUserPresets.json
@@ -76,14 +76,14 @@
       "inherits": [".profile", "reldeb-novg"]
     },
     {
-      "name": "ndebug",
+      "name": "release",
       "displayName": "Vecgeom release",
-      "inherits": [".ndebug", ".base"]
+      "inherits": [".release", ".base"]
     },
     {
-      "name": "ndebug-novg",
+      "name": "release-novg",
       "displayName": "ORANGE release",
-      "inherits": [".no-vg", ".ndebug", ".base"]
+      "inherits": [".no-vg", ".release", ".base"]
     }
   ],
   "buildPresets": [
@@ -94,10 +94,10 @@
       "nativeToolOptions": ["-k0"]
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },
@@ -129,10 +129,10 @@
       }
     },
     { "name": "base-novg", "configurePreset": "base-novg", "inherits": "base" },
-    { "name": "ndebug", "configurePreset": "ndebug", "inherits": "base" },
+    { "name": "release", "configurePreset": "release", "inherits": "base" },
     {
-      "name": "ndebug-novg",
-      "configurePreset": "ndebug-novg",
+      "name": "release-novg",
+      "configurePreset": "release-novg",
       "inherits": "base"
     },
     { "name": "reldeb", "configurePreset": "reldeb", "inherits": "base" },

--- a/scripts/spack/env-ci-ancient.yaml
+++ b/scripts/spack/env-ci-ancient.yaml
@@ -1,0 +1,54 @@
+#-------------------------------- -*- yaml -*- ---------------------------------#
+# Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#-----------------------------------------------------------------------------#
+# This file is copied into the top-level directory of Celeritas during individual
+# CI build jobs. It's then modified to add packages to the environment
+# in `.github/actions/setup-spack/action.yml`.
+#-----------------------------------------------------------------------------#
+
+spack:
+  include:
+    - reqs-celer.yaml
+    - reqs-ci.yaml
+    - prefs-hep-nogui.yaml
+    - ext-ubuntu24.yaml
+
+  concretizer:
+    reuse: false
+    unify: true
+    targets:
+      granularity: generic
+      host_compatible: true
+    duplicates:
+      strategy: full # necessary for multi-compiler groups
+
+  specs:
+    - group: tools
+      specs:
+        - gcc@=8.5.0
+        - cmake
+        - ccache
+        - ninja
+        - git
+
+    - group: libs
+      needs: [tools]
+      specs:
+        - cli11 %gcc@=8.5.0
+        - nlohmann-json %gcc@=8.5.0
+        - googletest %gcc@=8.5.0
+      override:
+        packages:
+          c:
+            require: []
+          cxx:
+            require: []
+
+  packages:
+    all:
+      prefer:
+        - "cxxstd=17"
+    gcc:
+      buildable: True
+      variants: ["build_type=Release"]

--- a/scripts/spack/ext-ubuntu24.yaml
+++ b/scripts/spack/ext-ubuntu24.yaml
@@ -3,14 +3,6 @@ packages:
     target: [x86_64_v3]
     require:
       - "target=x86_64_v3"
-  # Select providers for language dependencies without adding compiler
-  # dependency constraints to packages reused from a concrete environment.
-  c:
-    require: "llvm@18"
-  cxx:
-    require: "llvm@18"
-  fortran:
-    require: "gcc@13"
   bash:
     buildable: false
     externals:

--- a/scripts/spack/prefs-hep-nogui.yaml
+++ b/scripts/spack/prefs-hep-nogui.yaml
@@ -2,27 +2,34 @@
 # Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #-----------------------------------------------------------------------------#
-# Variants and preferences for building Celeritas when it might be used
+# Suggested variants for building Celeritas when it might be used
 # alongside other HEP software packages including DD4HEP and Allpix^2.
+# Variants are "starting points" for the concretization: they will be overridden
+# by other 'prefer' and 'require'.
 #-----------------------------------------------------------------------------#
 packages:
+  boost:
+    variants:
+      # Requirements from Allpix^2
+      - "+random"
   dd4hep:
     variants:
-      - ~utilityapps ~ddeve
+      # Disable GUI
+      - "~utilityapps ~ddeve"
   hepmc3:
-    variants: # allpix2 requires ROOT IO
-      - +rootio
+    variants:
+      # Requirements from Allpix^2
+      - "+rootio +python"
   llvm:
     variants:
-      - +lldb +python
+      - "+lldb +python"
   root:
     variants:
-      # These are "default starting values", not required:
-      # - we prefer not having GUI for a lighter build
-      # - we generally don't use TBB threading
-      # - examples aren't needed
-      # - edm4hep requires root7
-      # - allpix requires geom, math
+      # Disable GUI for a lighter build
+      # We generally don't use TBB threading
+      # Examples aren't needed
+      # Edm4hep requires root7
+      # Allpix requires geom, math
       - >-
         ~aqua ~opengl ~x ~webgui
         ~davix ~examples ~tbb

--- a/scripts/spack/reqs-celer.yaml
+++ b/scripts/spack/reqs-celer.yaml
@@ -1,7 +1,4 @@
 packages:
-  all:
-    prefer:
-      - "cxxstd=20"
   cli11:
     require: "@2.4:"
   cmake:

--- a/scripts/spack/reqs-ci.yaml
+++ b/scripts/spack/reqs-ci.yaml
@@ -43,6 +43,11 @@ concretizer:
     host_compatible: true
 
 packages:
+  all:
+    prefer:
+      - "cxxstd=20"
+  hdf5:
+    prefer: [~cxx] # override cxxstd preference
   geant4:
     variants:
       - generator=ninja
@@ -59,3 +64,8 @@ packages:
   python:
     version:
       - "3.14" # spack installation July 2026
+  # Use LLVM@18 for CI
+  c:
+    require: "llvm@18"
+  cxx:
+    require: "llvm@18"

--- a/scripts/spack/reqs-ci.yaml
+++ b/scripts/spack/reqs-ci.yaml
@@ -36,25 +36,27 @@ packages:
   all:
     prefer:
       - "cxxstd=20"
+  covfie:
+    variants:
+      - generator=ninja
   hdf5:
     prefer: [~cxx] # override cxxstd preference
   geant4:
     variants:
       - generator=ninja
-  # TODO: use ninja with g4vg: CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS-NOTFOUND
-  covfie:
+  g4vg:
     variants:
       - generator=ninja
+  python:
+    version:
+      - "3.14" # spack installation July 2026
   root:
     variants:
       - generator=ninja
   vecgeom:
     variants:
       - generator=ninja
-  python:
-    version:
-      - "3.14" # spack installation July 2026
-  # Use LLVM@18 for CI
+  # Compilers
   c:
     require: "llvm@18"
   cxx:

--- a/scripts/spack/reqs-ci.yaml
+++ b/scripts/spack/reqs-ci.yaml
@@ -17,16 +17,6 @@ mirrors:
       id_variable: GITHUB_USER
       secret_variable: GITHUB_TOKEN
 
-  # TODO: delete
-  sethrj:
-    url: oci://ghcr.io/sethrj/spack-buildcache
-    binary: true
-    signed: false
-    autopush: false
-    access_pair:
-      id_variable: GITHUB_USER
-      secret_variable: GITHUB_TOKEN
-
 config:
   deprecated: True # needed for old vecgeom rc7
   install_tree:


### PR DESCRIPTION
- Refactor the ci-ubuntu-github presets to eliminate the "build type", which wasn't quite accurate (only asanlite used relwithdebinfo, others used a combination of release with `CELERITAS_DEBUG`).
- Use gtest installed via ubuntu in the `fast` CI (erroneously omitted), unfortunately cli11 is too old to use
- Remove orange-minimal from the test matrix(since the "fast" configs build without G4)
- ~~Enable G4 11.4~~ DEFER: it's not working (see https://github.com/celeritas-project/celeritas/issues/2483)
- Fix missing comment from #2473
- Rename ndebug -> release across the codebase CMakePresets
- Test C++20 and C++23 with newer compilers, leaving C++17 for the older ones
- ~~Rename @esseivaju's docker scripts to indicate it's for performance profiling of ATLAS, not general celeritas interactive use~~
- Change depenodencies so that "skipped" tests in draft mode aren't automatically "failed"
- Add GCC 8.5 build (spack with minimal dependencies) to support SCALE QA (@tghaddar )
- Use fork to bring in unmerged optimization from Breathe (https://github.com/breathe-doc/breathe/pull/1055) to improve user doc generation time by 2.5×

A follow-on will update the docker scripts.