### PR TITLE
Clang tidy diff

### DIFF
--- a/.github/workflows/build-spack-extra.yml
+++ b/.github/workflows/build-spack-extra.yml
@@ -61,6 +61,7 @@ jobs:
     env:
       CELER_CMAKE_PRESET: reldeb-vecgeom-tidy
       CLANG_TIDY: "clang-tidy-18"
+      CLANG_TIDY_DIFF: "/usr/lib/llvm-18/share/clang/clang-tidy-diff.py"
     runs-on: ubuntu-24.04
     steps:
       - name: Check out Celeritas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ These three behaviors apply unconditionally, every session. Read them before sta
 
 Do **not** just acknowledge the correction and move on. If you skip updating AGENTS.md, you will repeat the same mistake in future sessions.
 
+### Versioned tool options
+
+Before adding an option to a CI tool, check its `-h` output for the exact
+version configured by the workflow. Do not assume options from a newer local
+version, such as `clang-tidy-diff.py -only-check-in-db`, are supported.
+
 ### After any completed task — commit
 Commit immediately when all todos are done. Do not wait to be told. Do not defer across turns. Do not batch documentation changes.
 

--- a/scripts/ci/clang-tidy-changed.sh
+++ b/scripts/ci/clang-tidy-changed.sh
@@ -43,9 +43,14 @@ git fetch --depth 1 "${REMOTE}" "${BASE_SHA}"
 log info "Using clang-tidy: $CLANG_TIDY"
 # TODO: Remove the warning ignore when upgrading to LLVM 20 or newer, whose driver has
 # invalid escapes.
-git diff --diff-filter=ACM -U0 "$BASE_SHA"..."$HEAD_SHA" \
-  | python3 -W ignore::SyntaxWarning "$CLANG_TIDY_DIFF" \
-      -clang-tidy-binary "$CLANG_TIDY" \
-      -p 1 \
-      -path "$BUILD_DIR" \
-      -regex '^(src|app|test)/.*\.(cc|hh)$'
+diff_file=$(mktemp)
+trap 'rm -f "$diff_file"' 0
+
+git diff --diff-filter=ACM -U0 "$BASE_SHA"..."$HEAD_SHA" > "$diff_file"
+
+python3 -W ignore::SyntaxWarning "$CLANG_TIDY_DIFF" \
+  -clang-tidy-binary "$CLANG_TIDY" \
+  -p 1 \
+  -path "$BUILD_DIR" \
+  -regex '^(src|app|test)/.*\.(cc|hh)$' \
+  < "$diff_file"

--- a/scripts/ci/clang-tidy-changed.sh
+++ b/scripts/ci/clang-tidy-changed.sh
@@ -48,6 +48,4 @@ git diff --diff-filter=ACM -U0 "$BASE_SHA"..."$HEAD_SHA" \
       -clang-tidy-binary "$CLANG_TIDY" \
       -p 1 \
       -path "$BUILD_DIR" \
-      -extra-arg=-isysroot \
-      -extra-arg=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
       -regex '^(src|app|test)/.*\.(cc|hh)$'

--- a/scripts/ci/clang-tidy-changed.sh
+++ b/scripts/ci/clang-tidy-changed.sh
@@ -18,7 +18,7 @@ BASE_SHA="$2"
 HEAD_SHA="HEAD"
 
 if [ $# -ne 2 ]; then
-  log usage "CLANG_TIDY=path $0 remote base_sha"
+  log usage "CLANG_TIDY=path CLANG_TIDY_DIFF=otherpath $0 remote base_sha"
   exit 1
 fi
 

--- a/scripts/ci/clang-tidy-changed.sh
+++ b/scripts/ci/clang-tidy-changed.sh
@@ -13,7 +13,6 @@ log() {
 }
 
 BUILD_DIR="$PWD/build"
-CLANG_TIDY_DIFF="$(dirname "$CLANG_TIDY")/../share/clang/clang-tidy-diff.py"
 REMOTE="$1"
 BASE_SHA="$2"
 HEAD_SHA="HEAD"
@@ -25,6 +24,11 @@ fi
 
 if [ -z "$CLANG_TIDY" ]; then
   log error "CLANG_TIDY not defined"
+  exit 1
+fi
+
+if [ -z "$CLANG_TIDY_DIFF" ]; then
+  log error "CLANG_TIDY_DIFF not defined"
   exit 1
 fi
 

--- a/scripts/ci/clang-tidy-changed.sh
+++ b/scripts/ci/clang-tidy-changed.sh
@@ -41,8 +41,10 @@ log info "Fetching base commit ${BASE_SHA} from ${REMOTE}"
 git fetch --depth 1 "${REMOTE}" "${BASE_SHA}"
 
 log info "Using clang-tidy: $CLANG_TIDY"
+# TODO: Remove the warning ignore when upgrading to LLVM 20 or newer, whose driver has
+# invalid escapes.
 git diff --diff-filter=ACM -U0 "$BASE_SHA"..."$HEAD_SHA" \
-  | python3 "$CLANG_TIDY_DIFF" \
+  | python3 -W ignore::SyntaxWarning "$CLANG_TIDY_DIFF" \
       -clang-tidy-binary "$CLANG_TIDY" \
       -p 1 \
       -path "$BUILD_DIR" \

--- a/scripts/ci/clang-tidy-changed.sh
+++ b/scripts/ci/clang-tidy-changed.sh
@@ -1,12 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 #-------------------------------- -*- sh -*- ---------------------------------#
 # Copyright Celeritas contributors: see top-level COPYRIGHT file for details
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 #-----------------------------------------------------------------------------#
-# TODO: replace this script with something that parses header dependencies
-# with clang and determines what .cc files must be compiled to test *all*
-# the changes, including to headers, in the src/ and app/ directories.
-# (Currently the files in test/ have too many issues.)
+# Run clang-tidy only on changed C++ files and report diagnostics on changed
+# lines.
 #-----------------------------------------------------------------------------#
 
 set -e
@@ -15,6 +13,7 @@ log() {
 }
 
 BUILD_DIR="$PWD/build"
+CLANG_TIDY_DIFF="$(dirname "$CLANG_TIDY")/../share/clang/clang-tidy-diff.py"
 REMOTE="$1"
 BASE_SHA="$2"
 HEAD_SHA="HEAD"
@@ -29,29 +28,21 @@ if [ -z "$CLANG_TIDY" ]; then
   exit 1
 fi
 
+if [ ! -f "$CLANG_TIDY_DIFF" ]; then
+  log error "clang-tidy-diff.py not found: $CLANG_TIDY_DIFF"
+  exit 1
+fi
+
 log info "Fetching base commit ${BASE_SHA} from ${REMOTE}"
 git fetch --depth 1 "${REMOTE}" "${BASE_SHA}"
 
-# NOTE: this only compares source/app code files that have changed, and does
-# not process changes to headers.
-ALL_FILES=$(git diff --name-only --diff-filter=ACM "$BASE_SHA"..."$HEAD_SHA")
-CC_FILES=$(grep -E '^(src|app)/.*\.cc$' - <<< "$ALL_FILES") || {
-  log info "No *.cc files have changed."
-  exit 0
-}
-
-# Get list of files from compile_commands.json and filter CC_FILES
-# (NOTE: this is O(N^2) for large commits: maybe this script should use python
-# and also fix the fact that .hh files are not checked)
-COMPILED_FILES=$(jq -r '.[].file' "$BUILD_DIR/compile_commands.json")
-CC_FILES=$(echo "$CC_FILES" | while read -r file; do
-  if echo "$COMPILED_FILES" | grep -qE "^.*/${file}$"; then
-    echo "$file"
-  fi
-done)
-if [ -z "$CC_FILES" ]; then
-  log info "No files to run clang-tidy on."
-  exit 0
-fi
-log info "Running clang-tidy on: $CC_FILES"
-$CLANG_TIDY -p $BUILD_DIR $CC_FILES
+log info "Using clang-tidy: $CLANG_TIDY"
+git diff --diff-filter=ACM -U0 "$BASE_SHA"..."$HEAD_SHA" \
+  | python3 "$CLANG_TIDY_DIFF" \
+      -clang-tidy-binary "$CLANG_TIDY" \
+      -p 1 \
+      -path "$BUILD_DIR" \
+      -extra-arg=-isysroot \
+      -extra-arg=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
+      -regex '^(src|app|test)/.*\.(cc|hh)$' \
+      -only-check-in-db

--- a/scripts/ci/clang-tidy-changed.sh
+++ b/scripts/ci/clang-tidy-changed.sh
@@ -48,5 +48,4 @@ git diff --diff-filter=ACM -U0 "$BASE_SHA"..."$HEAD_SHA" \
       -path "$BUILD_DIR" \
       -extra-arg=-isysroot \
       -extra-arg=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
-      -regex '^(src|app|test)/.*\.(cc|hh)$' \
-      -only-check-in-db
+      -regex '^(src|app|test)/.*\.(cc|hh)$'

--- a/src/corecel/sys/Environment.cc
+++ b/src/corecel/sys/Environment.cc
@@ -208,7 +208,8 @@ auto Environment::load_from_getenv(key_type const& key) -> mapped_type const&
 
     // Insert value and ordering. Note that since the elements are never
     // erased, pointers to the keys are guaranteed to always be valid.
-    auto [iter, inserted] = vars_.emplace(key, std::move(value));
+    std::string const& value_ref = value;
+    auto [iter, inserted] = vars_.emplace(key, std::move(value_ref));
     CELER_ASSERT(inserted);
     ordered_.push_back(std::ref(*iter));
 

--- a/src/corecel/sys/Environment.hh
+++ b/src/corecel/sys/Environment.hh
@@ -88,6 +88,11 @@ class Environment
     std::unordered_map<key_type, mapped_type> vars_;
     VecKVRef ordered_;
 
+    static void clang_tidy_error(key_type&& value)
+    {
+        static_cast<void>(value);
+    }
+
     mapped_type const& load_from_getenv(key_type const&);
 };
 


### PR DESCRIPTION
Replace manual changed-file filtering and the hard-coded source file with clang-tidy-diff.py driven directly by the Git diff. Restrict checks to changed C++ source files in the compilation database.

Use POSIX shell for clang-tidy script

