### PR TITLE
Support for VecGeom IndexedBVH

### DIFF
--- a/src/geocel/vg/VecgeomParams.cc
+++ b/src/geocel/vg/VecgeomParams.cc
@@ -8,7 +8,6 @@
 
 #include <cstddef>
 #include <vector>
-#include <VecGeom/base/BVH.h>
 #include <VecGeom/base/Config.h>
 #include <VecGeom/base/Cuda.h>
 #include <VecGeom/base/Version.h>

--- a/src/geocel/vg/detail/SolidsNavigator.hh
+++ b/src/geocel/vg/detail/SolidsNavigator.hh
@@ -6,7 +6,6 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <VecGeom/base/BVH.h>
 #include <VecGeom/base/Config.h>
 #include <VecGeom/base/Cuda.h>
 #include <VecGeom/base/Global.h>

--- a/src/geocel/vg/detail/VecgeomSetup.hh
+++ b/src/geocel/vg/detail/VecgeomSetup.hh
@@ -6,7 +6,13 @@
 //---------------------------------------------------------------------------//
 #pragma once
 
-#include <VecGeom/base/BVH.h>
+#include <VecGeom/base/Config.h>
+
+#if defined(VECGEOM_NAVIGATION_INDEXED_BVH)
+#    include <VecGeom/base/IndexedBVH.h>
+#else
+#    include <VecGeom/base/BVH.h>
+#endif
 
 #include "corecel/Assert.hh"
 #include "corecel/cont/Span.hh"
@@ -18,7 +24,9 @@ namespace celeritas
 namespace detail
 {
 //---------------------------------------------------------------------------//
-#if VECGEOM_VERSION >= 0x020000
+#if defined(VECGEOM_NAVIGATION_INDEXED_BVH)
+using CudaBVH_t = vecgeom::cuda::IndexedBVH<vgbvh_real_type>;
+#elif VECGEOM_VERSION >= 0x020000
 using CudaBVH_t = vecgeom::cuda::BVH<vgbvh_real_type>;
 #else
 using CudaBVH_t = vecgeom::cuda::BVH;


### PR DESCRIPTION
BVH has been removed in latest `vecgeom@master` following [MR 1471](https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/1471/). This fixes compiler error by checking whether `VECGEOM_NAVIGATION_INDEXED_BVH` is defined and using the `IndexedBVH` if available.

Reported by https://gitlab.cern.ch/atlas/atlasexternals/-/merge_requests/1446