### PR TITLE
Fix VecGeom@master+cuda build

### DIFF
--- a/src/geocel/vg/detail/VecgeomSetup.cu
+++ b/src/geocel/vg/detail/VecgeomSetup.cu
@@ -13,6 +13,10 @@
 #    include <VecGeom/management/DeviceGlobals.h>
 #endif
 
+#if CELER_VGNAV == CELER_VGNAV_TUPLE
+#    include <VecGeom/navigation/NavStateTuple.h>
+#endif
+
 #include "corecel/Assert.hh"
 #include "corecel/Macros.hh"
 #include "corecel/data/DeviceVector.hh"


### PR DESCRIPTION
There was still one more incomplete type compiler error caused by a missing header with latest `VecGeom@master+cuda`

```
/builds/atlas/atlasexternals/ci_build/src/Celeritas/src/geocel/vg/detail/VecgeomSetup.cu(126): error: expression must be a pointer to a complete object type
                void operator()(ThreadId tid) { new (ptr + tid.get()) T(); }
                                                     ^
          detected during:
            instantiation of "void celeritas::detail::<unnamed>::InplaceNew<T>::operator()(celeritas::ThreadId) [with T=celeritas::VgNavStateImpl]" at line 36 of /builds/atlas/atlasexternals/ci_build/src/Celeritas/src/corecel/sys/detail/KernelLauncherImpl.device.hh
            instantiation of "void celeritas::detail::<unnamed>::launch_kernel_impl(const celeritas::Range<celeritas::ThreadId> &, F &) [with F=celeritas::detail::<unnamed>::InplaceNew<celeritas::VgNavStateImpl>]" at line 48 of /builds/atlas/atlasexternals/ci_build/src/Celeritas/src/corecel/sys/detail/KernelLauncherImpl.device.hh
            instantiation of "void celeritas::detail::<unnamed>::launch_action_impl(celeritas::Range<celeritas::ThreadId>, F) [with F=celeritas::detail::<unnamed>::InplaceNew<celeritas::VgNavStateImpl>, <unnamed>=true]" at line 93 of /builds/atlas/atlasexternals/ci_build/src/Celeritas/src/corecel/sys/KernelLauncher.device.hh
            instantiation of "celeritas::KernelLauncher<F>::KernelLauncher(std::string &&) [with F=celeritas::detail::<unnamed>::InplaceNew<celeritas::VgNavStateImpl>]" at line 206
```