### PR TITLE
Support component-specific scintillation photon generation

### DIFF
--- a/src/celeritas/optical/Types.hh
+++ b/src/celeritas/optical/Types.hh
@@ -25,6 +25,8 @@ using LocalPositionId = OpaqueId<struct LocalMat_, unsigned short int>;
 
 }  // namespace optical
 
+using ScintComponentId = OpaqueId<struct ScintDistributionRecord>;
+
 using ScintSpectrumId = OpaqueId<struct ScintSpectrumRecord>;
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/gen/GeneratorData.hh
+++ b/src/celeritas/optical/gen/GeneratorData.hh
@@ -52,6 +52,10 @@ struct GeneratorStepData
  * step to the total energy deposition over the step (including the local
  * deposition at the discrete interaction point).
  *
+ * \c component_id optionally specifies the component for the scintillation
+ * emission. If it is provided, all photons will be generated from this
+ * component; otherwise, the component will be sampled using the yield.
+ *
  * If the material is not provided, it will be determined during
  * initialization.
  */
@@ -64,6 +68,7 @@ struct GeneratorDistributionData
     units::ElementaryCharge charge;
     OptMatId material;
     real_type continuous_edep_fraction{};
+    ScintComponentId component_id;
     EnumArray<StepPoint, GeneratorStepData> points;
 
     //! Check whether the data are assigned

--- a/src/celeritas/optical/gen/GeneratorDataIO.json.cc
+++ b/src/celeritas/optical/gen/GeneratorDataIO.json.cc
@@ -45,6 +45,7 @@ void to_json(nlohmann::json& j, GeneratorDistributionData const& v)
         CELER_JSON_PAIR(v, charge),
         CELER_JSON_PAIR(v, material),
         CELER_JSON_PAIR(v, continuous_edep_fraction),
+        CELER_JSON_PAIR(v, component_id),
         {"points",
          {
              {"pre", v.points[StepPoint::pre]},
@@ -62,6 +63,7 @@ void from_json(nlohmann::json const& j, GeneratorDistributionData& v)
     CELER_JSON_LOAD_REQUIRED(j, v, charge);
     CELER_JSON_LOAD_REQUIRED(j, v, material);
     CELER_JSON_LOAD_REQUIRED(j, v, continuous_edep_fraction);
+    CELER_JSON_LOAD_OPTION(j, v, component_id);
     auto const& points = j.at("points");
     points.at("pre").get_to(v.points[StepPoint::pre]);
     points.at("post").get_to(v.points[StepPoint::post]);

--- a/src/celeritas/optical/gen/ScintillationGenerator.hh
+++ b/src/celeritas/optical/gen/ScintillationGenerator.hh
@@ -109,15 +109,23 @@ CELER_FUNCTION TrackInitializer ScintillationGenerator::operator()(
         // NOTE: material and spectrum currently have one-to-one correspondence
         auto spectrum_id = dist_.material;
         CELER_ASSERT(spectrum_id < shared_.spectra.size());
-        auto const& s = shared_.spectra[spectrum_id];
+        auto const& spectrum = shared_.spectra[spectrum_id];
 
-        auto pdf = shared_.reals[s.yield_pdf];
+        if (dist_.component_id)
+        {
+            // Use the provided component instead of sampling
+            CELER_ASSERT(dist_.component_id < spectrum.components.size());
+            return shared_.scint_records
+                [spectrum.components[dist_.component_id.get()]];
+        }
+
+        auto pdf = shared_.reals[spectrum.yield_pdf];
         auto select_idx = make_selector(
             [&pdf](size_type i) { return static_cast<real_type>(pdf[i]); },
             pdf.size());
         size_type component_idx = select_idx(rng);
-        CELER_ASSERT(component_idx < s.components.size());
-        return shared_.scint_records[s.components[component_idx]];
+        CELER_ASSERT(component_idx < spectrum.components.size());
+        return shared_.scint_records[spectrum.components[component_idx]];
     }();
 
     real_type energy_val{};

--- a/src/larceler/LarStandaloneRunner.cc
+++ b/src/larceler/LarStandaloneRunner.cc
@@ -129,7 +129,7 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
 
     // Convert SimEnergyDep input and save metadata for BTRs
     std::vector<celeritas::optical::GeneratorDistributionData> gdd;
-    gdd.reserve(sim_energy_deposits.size());
+    gdd.reserve(2 * sim_energy_deposits.size());
     step_md_.clear();
     step_md_.reserve(sim_energy_deposits.size());
     size_type num_skipped{0};
@@ -145,11 +145,8 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
         }
 
         // Convert LArSoft sim edeps to Celeritas generator distribution data
-        // TODO: use individual fast/slow spectra by multiplying with the
-        // edep's ScintYieldRatio() (fraction fast spectrum)
         celeritas::optical::GeneratorDistributionData data;
         data.type = GeneratorType::scintillation;
-        data.num_photons = edepi.NumPhotons();
         data.step_length = convert_from_larsoft<LarsoftLen>(edepi.StepLength());
         // Assume continuous energy loss along the step
         //! \todo For neutral particles, set this to 0 (LED at post-step point)
@@ -163,8 +160,26 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
         data.points[StepPoint::post].pos
             = convert_from_larsoft<LarsoftLen>(edepi.End());
         data.primary = id_cast<PrimaryId>(step_md_.size());
-        CELER_ASSERT(data);
-        gdd.push_back(data);
+
+        auto insert_component
+            = [&gdd, &data](size_type num_photons, ScintComponentId comp_id) {
+                  if (num_photons > 0)
+                  {
+                      data.num_photons = num_photons;
+                      data.component_id = comp_id;
+                      CELER_ASSERT(data);
+                      gdd.push_back(data);
+                  }
+              };
+
+        // Calculate the number of slow component photons from the total to
+        // preserve the exact number of photons: LArSoft rounds the fast and
+        // slow counts independently
+        size_type num_fast = edepi.NumFPhotons();
+        size_type num_slow = edepi.NumPhotons() - num_fast;
+
+        insert_component(num_fast, ScintComponentId{0});
+        insert_component(num_slow, ScintComponentId{1});
 
         step_md_.push_back([&edepi] {
             StepMetadata md;
@@ -208,6 +223,7 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
     auto const& gen = result.counters.generators.front();
     CELER_LOG(debug) << "Transported " << gen.num_generated
                      << " optical photons from " << gen.buffer_size
+                     << " generator distributions and " << step_md_.size()
                      << " sim energy deposits with a total of "
                      << result.counters.steps << " steps over "
                      << result.counters.step_iters << " step iterations in "

--- a/src/larceler/LarStandaloneRunner.cc
+++ b/src/larceler/LarStandaloneRunner.cc
@@ -113,7 +113,6 @@ auto LarStandaloneRunner::operator()(VecSED const& sim_energy_deposits)
     -> result_type
 {
     CELER_EXPECT(!sim_energy_deposits.empty());
-    CELER_EXPECT(lite_hits_.empty());
 
     // Allocate BTR helpers
     btr_helpers_.clear();

--- a/test/celeritas/optical/Scintillation.test.cc
+++ b/test/celeritas/optical/Scintillation.test.cc
@@ -530,6 +530,46 @@ TEST_F(MaterialScintillationGaussianTest, stress_test)
     EXPECT_SOFT_NEAR(avg_lambda, expected_lambda, 1e-4);
 }
 
+TEST_F(MaterialScintillationGaussianTest, specified_component)
+{
+    static constexpr real_type nm{units::meter * 1e-9};
+
+    auto const params = this->build_scintillation_params();
+    auto const& data = params->host_ref();
+
+    optical::GeneratorDistributionData gdd;
+    gdd.type = GeneratorType::scintillation;
+    gdd.num_photons = 100;
+    gdd.step_length = from_cm(step_length_);
+    gdd.material = opt_mat_;
+    gdd.continuous_edep_fraction = 0;
+    gdd.points[StepPoint::pre].pos = {0, 0, 0};
+    gdd.points[StepPoint::post].pos = post_pos_;
+    gdd.points[StepPoint::pre].time = 0;
+    gdd.points[StepPoint::post].time = 1.0 * units::nanosecond;
+
+    static real_type const expected_lambda[] = {100, 200, 400};
+
+    for (size_type comp_idx : range(3))
+    {
+        gdd.component_id = ScintComponentId{comp_idx};
+
+        Rng rng;
+        optical::ScintillationGenerator generate(data, gdd);
+
+        real_type avg_lambda{};
+        size_type const num_samples{10000};
+        for (size_type i = 0; i < num_samples; i++)
+        {
+            auto photon = generate(rng);
+            avg_lambda += optical::detail::energy_to_wavelength(photon.energy);
+        }
+
+        avg_lambda /= num_samples * nm;
+        EXPECT_SOFT_NEAR(expected_lambda[comp_idx], avg_lambda, 1e-3);
+    }
+}
+
 TEST_F(MaterialScintillationTabularTest, uses_nonuniform_grid_calculator)
 {
     auto const params = this->build_scintillation_params();

--- a/test/larceler/CMakeLists.txt
+++ b/test/larceler/CMakeLists.txt
@@ -16,7 +16,9 @@ celeritas_setup_tests(SERIAL
 #-----------------------------------------------------------------------------#
 
 celeritas_add_test(LarStandaloneRunner.test.cc
-  LINK_LIBRARIES lardataobj::Simulation
+  LINK_LIBRARIES
+    Celeritas::celeritas
+    lardataobj::Simulation
   SOURCES RunnerResults.cc
 )
 celeritas_add_test(LarDataReader.test.cc LINK_LIBRARIES Celeritas::celeritas)

--- a/test/larceler/LarStandaloneRunner.test.cc
+++ b/test/larceler/LarStandaloneRunner.test.cc
@@ -122,7 +122,7 @@ TEST_F(DuneCryoTest, two_sim_edeps)
     sim::SimEnergyDeposit sed(
         /* numPhotons = */ 4096,
         /* numElectrons = */ static_cast<int>(edep * 100),
-        /* scintYieldRatio = */ 1.0,
+        /* scintYieldRatio = */ 0.8,
         /* edep = */ 0.1,  // [MeV]
         /* startPos = */ geo::Point_t{5, -712, -540.0},  // [cm]
         /* endPos = */ geo::Point_t{5, -712, -480},  // [cm]
@@ -139,13 +139,13 @@ TEST_F(DuneCryoTest, two_sim_edeps)
     auto raw_result = run({sed, sed2});
     auto result = RunResult::from_btr(raw_result.backtrack);
     RunResult ref;
-    ref.num_hits = {274, 267, 15, 4};
+    ref.num_hits = {274, 273, 11, 4};
     EXPECT_REF_EQ(ref, result);
     // auto hits = raw_result.at(3).TrackIDsAndEnergies(10.0, 20.0); // [ns]
 
     // Run again (simulating second event)
     result = RunResult::from_btr(run({sed2, sed}).backtrack);
-    ref.num_hits = {237, 265, 16, 5};
+    ref.num_hits = {260, 262, 14, 5};
     EXPECT_REF_EQ(ref, result);
 }
 

--- a/test/larceler/LarStandaloneRunner.test.cc
+++ b/test/larceler/LarStandaloneRunner.test.cc
@@ -139,13 +139,13 @@ TEST_F(DuneCryoTest, two_sim_edeps)
     auto raw_result = run({sed, sed2});
     auto result = RunResult::from_btr(raw_result.backtrack);
     RunResult ref;
-    ref.num_hits = {273, 269, 15, 4};
+    ref.num_hits = {274, 267, 15, 4};
     EXPECT_REF_EQ(ref, result);
     // auto hits = raw_result.at(3).TrackIDsAndEnergies(10.0, 20.0); // [ns]
 
     // Run again (simulating second event)
     result = RunResult::from_btr(run({sed2, sed}).backtrack);
-    ref.num_hits = {233, 264, 16, 5};
+    ref.num_hits = {237, 265, 16, 5};
     EXPECT_REF_EQ(ref, result);
 }
 

--- a/test/larceler/LarStandaloneRunner.test.cc
+++ b/test/larceler/LarStandaloneRunner.test.cc
@@ -13,6 +13,7 @@
 
 #include "geocel/UnitUtils.hh"
 #include "celeritas/inp/StandaloneInput.hh"
+#include "celeritas/io/OpticalDistributionReader.hh"
 #include "celeritas/phys/PDGNumber.hh"
 
 #include "PersistentSP.hh"
@@ -34,7 +35,7 @@ class LarStandaloneRunnerTestBase : public ::celeritas::test::Test
     using VecReal3 = std::vector<Real3>;
 
     //! Construct input
-    virtual Input make_input() const = 0;
+    virtual Input make_input() = 0;
 
     //! Map of larsoft detector ID to actual
     virtual VecReal3 make_detector_point_map() const = 0;
@@ -70,12 +71,18 @@ void LarStandaloneRunnerTestBase::SetUp()
 
 class DuneCryoTest : public LarStandaloneRunnerTestBase
 {
+  protected:
     //! Construct input
-    Input make_input() const override;
+    Input make_input() override;
     VecReal3 make_detector_point_map() const override;
+    static std::string& offload_file()
+    {
+        static std::string result;
+        return result;
+    }
 };
 
-auto DuneCryoTest::make_input() const -> Input
+auto DuneCryoTest::make_input() -> Input
 {
     Input result;
     result.problem.model.geometry
@@ -93,6 +100,8 @@ auto DuneCryoTest::make_input() const -> Input
     }();
     result.problem.num_streams = 1;
     result.problem.generator = inp::OpticalOffloadGenerator{};
+    this->offload_file() = this->make_unique_filename(".jsonl");
+    result.problem.offload_file = this->offload_file();
     result.geant_setup.cherenkov = std::nullopt;
     return result;
 }
@@ -118,19 +127,23 @@ TEST_F(DuneCryoTest, two_sim_edeps)
      * - Time unit is ns (LarsoftTime)
      * - "original" track ID is always same as actual
      */
-    real_type edep{0.1};  // MeV
-    sim::SimEnergyDeposit sed(
-        /* numPhotons = */ 4096,
-        /* numElectrons = */ static_cast<int>(edep * 100),
-        /* scintYieldRatio = */ 0.8,
-        /* edep = */ 0.1,  // [MeV]
-        /* startPos = */ geo::Point_t{5, -712, -540.0},  // [cm]
-        /* endPos = */ geo::Point_t{5, -712, -480},  // [cm]
-        /* startTime = */ 1.0,  // [ns]
-        /* endTime = */ 10.0,  // [ns]
-        /* trackID = */ 123456789,
-        /* pdgCode = */ pdg::electron().get(),
-        /* origTrackID = */ 123456789);
+    auto make_sed = [](int num_photons, double yield_ratio, int track_id) {
+        real_type edep{0.1};  // MeV
+        return sim::SimEnergyDeposit(
+            /* numPhotons = */ num_photons,
+            /* numElectrons = */ static_cast<int>(edep * 100),
+            /* scintYieldRatio = */ yield_ratio,
+            /* edep = */ edep,
+            /* startPos = */ geo::Point_t{5, -712, -540.0},  // [cm]
+            /* endPos = */ geo::Point_t{5, -712, -480},  // [cm]
+            /* startTime = */ 1.0,  // [ns]
+            /* endTime = */ 10.0,  // [ns]
+            /* trackID = */ track_id,
+            /* pdgCode = */ pdg::electron().get(),
+            /* origTrackID = */ track_id);
+    };
+
+    auto sed = make_sed(4096, 0.8, 123456789);
     // Make another deposit from energy deposited by a nameless offspring
     // [i.e., no MC truth stored] of Geant4 track ID 1
     sim::SimEnergyDeposit sed2{sed};
@@ -147,6 +160,37 @@ TEST_F(DuneCryoTest, two_sim_edeps)
     result = RunResult::from_btr(run({sed2, sed}).backtrack);
     ref.num_hits = {260, 262, 14, 5};
     EXPECT_REF_EQ(ref, result);
+
+    // Run again with varying scintillation yield ratios
+    run({make_sed(10, 0.25, 1), make_sed(10, 1.0, 2), make_sed(10, 0.0, 3)});
+
+    // Read distributions written to the offload file
+    auto distributions = OpticalDistributionReader(this->offload_file())();
+    EXPECT_EQ(12, distributions.size());
+
+    std::vector<size_type> num_photons;
+    std::vector<size_type> components;
+    std::vector<size_type> primaries;
+
+    for (auto const& d : distributions)
+    {
+        num_photons.push_back(d.num_photons);
+        ASSERT_TRUE(d.component_id);
+        components.push_back(d.component_id.get());
+        ASSERT_TRUE(d.primary);
+        primaries.push_back(d.primary.get());
+    }
+
+    static unsigned int const expected_num_photons[] = {
+        3277u, 819u, 3277u, 819u, 3277u, 819u, 3277u, 819u, 3u, 7u, 10u, 10u};
+    static unsigned int const expected_components[]
+        = {0u, 1u, 0u, 1u, 0u, 1u, 0u, 1u, 0u, 1u, 0u, 1u};
+    static unsigned int const expected_primaries[]
+        = {0u, 0u, 1u, 1u, 0u, 0u, 1u, 1u, 0u, 0u, 1u, 2u};
+
+    EXPECT_VEC_EQ(expected_num_photons, num_photons);
+    EXPECT_VEC_EQ(expected_components, components);
+    EXPECT_VEC_EQ(expected_primaries, primaries);
 }
 
 TEST_F(DuneCryoTest, zero_photons)


### PR DESCRIPTION
This adds support for optionally specifying the component for scintillation emission in the generator distribution data. When provided, all photons will be generated from that component rather than sampling the component using the yield.

Because LArSoft's `SimEnergyDeposit` could be produced by particle types not supported in Celeritas, the particle-dependent scintillation yield and other data might not be available when sampling the photons. With this change we can get around this by determining the component and number of photons to generate from the yield ratio provided by the `SimEnergyDeposit` when creating the generator distributions.

One result of this is that a single distribution no longer corresponds to a single energy deposit/step, and the number of buffered distributions could be a factor of `num_compoents` larger.