### PR TITLE
Make detector construction output reproducible and debuggable

### DIFF
--- a/src/celeritas/g4/DetectorConstruction.cc
+++ b/src/celeritas/g4/DetectorConstruction.cc
@@ -15,6 +15,7 @@
 #include "corecel/Assert.hh"
 #include "corecel/io/Join.hh"
 #include "corecel/io/Logger.hh"
+#include "corecel/io/StreamableLazy.hh"
 #include "geocel/GeantGdmlLoader.hh"
 #include "geocel/GeantGeoParams.hh"
 #include "geocel/g4/Convert.hh"
@@ -103,14 +104,21 @@ void DetectorConstruction::build_worker_sd() const
 {
     CELER_LOG_LOCAL(debug) << R"(Constructing sensitive detectors)";
     auto* sd_manager = G4SDManager::GetSDMpointer();
-    auto get_vol_name = [](MapDetectors::value_type const& sdname_vol) {
-        CELER_ASSERT(sdname_vol.second);
-        return sdname_vol.second->GetName();
-    };
 
     foreach_detector(detectors_, [&](MapDetCIter start, MapDetCIter stop) {
+        // Lazily print the volume names (only if warning or debug are printed)
+        auto vol_names = StreamableLazy{[start, stop] {
+            std::vector<std::string> sorted_vol_names;
+            for (auto iter = start; iter != stop; ++iter)
+            {
+                sorted_vol_names.push_back(iter->second->GetName());
+            }
+            std::sort(sorted_vol_names.begin(), sorted_vol_names.end());
+            return to_string(
+                join(sorted_vol_names.begin(), sorted_vol_names.end(), ", "));
+        }};
+
         auto const& sd_name = start->first;
-        auto vol_names = join(start, stop, "', '", get_vol_name);
 
         // Construct an SD based on the name
         UPSD sd = build_worker_sd_(sd_name);

--- a/src/corecel/io/StreamUtils.hh
+++ b/src/corecel/io/StreamUtils.hh
@@ -14,6 +14,21 @@ namespace celeritas
 {
 //---------------------------------------------------------------------------//
 /*!
+ * Write the operand to the contained stream.
+ */
+struct GenericToStream
+{
+    std::ostream& os;
+
+    template<class T>
+    void operator()(T&& obj) const
+    {
+        this->os << std::forward<T>(obj);
+    }
+};
+
+//---------------------------------------------------------------------------//
+/*!
  * Return as a string any object that has an ostream operator.
  */
 template<class T>

--- a/src/corecel/io/StreamableLazy.hh
+++ b/src/corecel/io/StreamableLazy.hh
@@ -1,0 +1,49 @@
+//------------------------------- -*- C++ -*- -------------------------------//
+// Copyright Celeritas contributors: see top-level COPYRIGHT file for details
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file corecel/io/StreamableLazy.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <ostream>
+
+namespace celeritas
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Lazily evaluate a functor that streams content.
+ *
+ * \par Example:
+ * \code
+   std::cout << StreamableLazy{[]() {
+        return do_something_expensive_and_printable();
+    }} << std::endl;
+   \endcode
+ */
+template<class F>
+struct StreamableLazy
+{
+    F func;
+
+    //! Write to stream
+    inline friend std::ostream& operator<<(std::ostream& os,
+                                           StreamableLazy const& lazy)
+    {
+        return (os << lazy.func());
+    }
+
+    //! Save as a string
+    inline friend std::string to_string(StreamableLazy const& svar)
+    {
+        return stream_to_string(svar);
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Deduction guide (C++17)
+template<class F>
+StreamableLazy(F&&) -> StreamableLazy<F>;
+
+//---------------------------------------------------------------------------//
+}  // namespace celeritas

--- a/src/corecel/io/StreamableVariant.hh
+++ b/src/corecel/io/StreamableVariant.hh
@@ -7,8 +7,6 @@
 #pragma once
 
 #include <ostream>
-#include <sstream>
-#include <utility>
 #include <variant>
 
 #include "corecel/Assert.hh"
@@ -30,54 +28,27 @@ template<class T>
 struct StreamableVariant
 {
     T value;
+
+    //! Write to stream
+    friend std::ostream& operator<<(std::ostream& os,
+                                    StreamableVariant const& svar)
+    {
+        CELER_ASSUME(!svar.value.valueless_by_exception());
+        std::visit(GenericToStream{os}, svar.value);
+        return os;
+    }
+
+    //! Save as a string
+    friend std::string to_string(StreamableVariant const& svar)
+    {
+        return stream_to_string(svar);
+    }
 };
 
 //---------------------------------------------------------------------------//
 // Deduction guide
 template<class T>
 StreamableVariant(T&&) -> StreamableVariant<T>;
-
-//---------------------------------------------------------------------------//
-// IMPLEMENTATION
-//---------------------------------------------------------------------------//
-namespace detail
-{
-struct GenericToStream
-{
-    std::ostream& os;
-
-    template<class T>
-    void operator()(T&& obj) const
-    {
-        this->os << std::forward<T>(obj);
-    }
-};
-}  // namespace detail
-
-//---------------------------------------------------------------------------//
-// FREE FUNCTIONS
-//---------------------------------------------------------------------------//
-/*!
- * Write a variant object's value to a stream.
- */
-template<class T>
-inline std::ostream& operator<<(std::ostream& os,
-                                StreamableVariant<T> const& svar)
-{
-    CELER_ASSUME(!svar.value.valueless_by_exception());
-    std::visit(detail::GenericToStream{os}, svar.value);
-    return os;
-}
-
-//---------------------------------------------------------------------------//
-/*!
- * Save a variant object's value to a string.
- */
-template<class T>
-inline std::string to_string(StreamableVariant<T> const& svar)
-{
-    return stream_to_string(svar);
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/corecel/io/detail/Joined.hh
+++ b/src/corecel/io/detail/Joined.hh
@@ -58,37 +58,35 @@ struct Joined
     InputIterator last;
     Conjunction conjunction;
     StreamOp op;
+
+    //! Write to a stream
+    friend std::ostream& operator<<(std::ostream& os, Joined const& j)
+    {
+        auto iter = j.first;
+        auto op = j.op;
+
+        // First element is not preceded by a conjunction
+        if (iter != j.last)
+        {
+            op(os, *iter++);
+        }
+
+        // Join the rest
+        while (iter != j.last)
+        {
+            os << j.conjunction;
+            op(os, *iter++);
+        }
+
+        return os;
+    }
+
+    //! Convert to a string
+    friend std::string to_string(Joined const& j)
+    {
+        return stream_to_string(j);
+    }
 };
-
-//---------------------------------------------------------------------------//
-template<class I, class C, class S>
-inline std::ostream& operator<<(std::ostream& os, Joined<I, C, S> const& j)
-{
-    auto iter = j.first;
-    auto op = j.op;
-
-    // First element is not preceded by a conjunction
-    if (iter != j.last)
-    {
-        op(os, *iter++);
-    }
-
-    // Join the rest
-    while (iter != j.last)
-    {
-        os << j.conjunction;
-        op(os, *iter++);
-    }
-
-    return os;
-}
-
-//---------------------------------------------------------------------------//
-template<class I, class C, class S>
-inline std::string to_string(Joined<I, C, S> const& j)
-{
-    return stream_to_string(j);
-}
 
 //---------------------------------------------------------------------------//
 }  // namespace detail

--- a/src/corecel/sys/KernelRegistry.cc
+++ b/src/corecel/sys/KernelRegistry.cc
@@ -20,15 +20,25 @@ namespace celeritas
 /*!
  * Whether to record potentially expensive kernel profiling information.
  *
- * This is true if \c CELERITAS_DEBUG is set *or* if the \c
+ * In CPU-only builds, this is always false since the file is only ever called
+ * in \c KernelParamCalculator::log_launch as part of a kernel execution.
+ * Otherwise, it is true if \c CELERITAS_DEBUG is set *or* if the \c
  * CELER_PROFILE_DEVICE environment variable exists and is not empty.
  */
 bool KernelRegistry::profiling()
 {
-    static bool const result = [] {
-        return getenv_flag("CELER_PROFILE_DEVICE", CELERITAS_DEBUG).value;
-    }();
-    return result;
+    if constexpr (CELERITAS_USE_CUDA || CELERITAS_USE_HIP)
+    {
+        static bool const result = [] {
+            return getenv_flag("CELER_PROFILE_DEVICE", CELERITAS_DEBUG).value;
+        }();
+        return result;
+    }
+    else
+    {
+        // No GPU support enabled
+        return false;
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Refactored out of #2479 . This improves some of the streaming functionality, including a 'lazy streamer' that invokes a functor if and when it's streamed. We now sort detectors during construction by name rather than by pointer address.